### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mainframe",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "AI-native development environment for orchestrating agents",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainframe/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Mainframe daemon — session lifecycle, agent process management, and metadata storage",
   "license": "MIT",
   "repository": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainframe/desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Mainframe desktop app — Electron/React frontend for orchestrating AI agents",
   "license": "MIT",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainframe/types",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared TypeScript types for Mainframe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What changed

Bumps all workspace package versions from `0.1.0` to `0.2.0`.

## Why

`0.1.0` is released. `0.2.0` marks the next development cycle, which includes the plugin system (PR #6) and any other features landing before that release.

## Testing done

No logic changed — version strings only.

## Checklist

- [x] `pnpm test` passes
- [x] `pnpm build` passes (TypeScript compiles)
- [x] No secrets in staged files
- [x] File size limits respected (max 300 lines/file, 50 lines/function)