### PR TITLE
feat(todos): kanban plugin with redesigned UI and softened borders

### DIFF
--- a/packages/core/src/__tests__/plugins/attachment-context.test.ts
+++ b/packages/core/src/__tests__/plugins/attachment-context.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createPluginAttachmentContext } from '../../plugins/attachment-context.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'mf-attach-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('createPluginAttachmentContext', () => {
+  it('saves and retrieves an attachment', async () => {
+    const ctx = createPluginAttachmentContext(tmpDir);
+    const meta = await ctx.save('entity1', {
+      filename: 'test.txt',
+      mimeType: 'text/plain',
+      data: Buffer.from('hello').toString('base64'),
+      sizeBytes: 5,
+    });
+    expect(meta.id).toBeDefined();
+    expect(meta.filename).toBe('test.txt');
+
+    const result = await ctx.get('entity1', meta.id);
+    expect(result).not.toBeNull();
+    expect(Buffer.from(result!.data, 'base64').toString()).toBe('hello');
+  });
+
+  it('lists attachments for an entity', async () => {
+    const ctx = createPluginAttachmentContext(tmpDir);
+    await ctx.save('e1', { filename: 'a.txt', mimeType: 'text/plain', data: 'aGk=', sizeBytes: 2 });
+    await ctx.save('e1', { filename: 'b.txt', mimeType: 'text/plain', data: 'aGk=', sizeBytes: 2 });
+    const list = await ctx.list('e1');
+    expect(list).toHaveLength(2);
+  });
+
+  it('returns empty list for unknown entity', async () => {
+    const ctx = createPluginAttachmentContext(tmpDir);
+    const list = await ctx.list('unknown');
+    expect(list).toHaveLength(0);
+  });
+
+  it('returns null for unknown attachment', async () => {
+    const ctx = createPluginAttachmentContext(tmpDir);
+    const result = await ctx.get('entity1', 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('deletes an attachment', async () => {
+    const ctx = createPluginAttachmentContext(tmpDir);
+    const meta = await ctx.save('e1', { filename: 'del.txt', mimeType: 'text/plain', data: 'aGk=', sizeBytes: 2 });
+    await ctx.delete('e1', meta.id);
+    const result = await ctx.get('e1', meta.id);
+    expect(result).toBeNull();
+    const list = await ctx.list('e1');
+    expect(list).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/plugins/builtin/todos.test.ts
+++ b/packages/core/src/__tests__/plugins/builtin/todos.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { activate } from '../../../plugins/builtin/todos/index.js';
+import { buildPluginContext, type PluginContextDeps } from '../../../plugins/context.js';
+import { EventEmitter } from 'node:events';
+import { Router } from 'express';
+import { pino } from 'pino';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PluginManifest } from '@mainframe/types';
+import request from 'supertest';
+import express from 'express';
+
+const todosManifest: PluginManifest = {
+  id: 'todos',
+  name: 'TODO Kanban',
+  version: '1.0.0',
+  capabilities: ['storage', 'chat:create'],
+};
+
+let tmpDir: string;
+
+function makeApp() {
+  tmpDir = mkdtempSync(join(tmpdir(), 'mf-todos-test-'));
+  const router = Router();
+  const app = express();
+  app.use(express.json());
+
+  const emitEvent = vi.fn();
+  const deps: PluginContextDeps = {
+    manifest: todosManifest,
+    pluginDir: tmpDir,
+    router,
+    logger: pino({ level: 'silent' }),
+    daemonBus: new EventEmitter(),
+    db: {
+      chats: {
+        create: vi.fn().mockReturnValue({
+          id: 'chat-1',
+          adapterId: 'claude',
+          projectId: 'proj-1',
+          status: 'active',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          totalCost: 0,
+          totalTokensInput: 0,
+          totalTokensOutput: 0,
+          lastContextTokensInput: 0,
+        }),
+        get: vi.fn().mockReturnValue(null),
+        list: vi.fn().mockReturnValue([]),
+      },
+      projects: {
+        list: vi.fn().mockReturnValue([]),
+        get: vi.fn().mockReturnValue(null),
+      },
+      settings: {
+        get: vi.fn().mockReturnValue(null),
+        set: vi.fn(),
+      },
+    } as unknown as PluginContextDeps['db'],
+    adapters: { register: vi.fn() } as unknown as PluginContextDeps['adapters'],
+    emitEvent,
+    onUnloadCallbacks: [],
+  };
+
+  const ctx = buildPluginContext(deps);
+  activate(ctx);
+  app.use('/', router);
+  return { app, emitEvent };
+}
+
+afterEach(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('todos plugin routes', () => {
+  it('GET /todos returns empty list initially', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/todos');
+    expect(res.status).toBe(200);
+    expect(res.body.todos).toEqual([]);
+  });
+
+  it('POST /todos creates a todo', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/todos').send({ title: 'Fix login bug', type: 'bug' });
+    expect(res.status).toBe(201);
+    expect(res.body.todo.title).toBe('Fix login bug');
+    expect(res.body.todo.type).toBe('bug');
+    expect(res.body.todo.status).toBe('open');
+    expect(res.body.todo.id).toBeDefined();
+  });
+
+  it('PATCH /todos/:id/move changes status', async () => {
+    const { app } = makeApp();
+    const create = await request(app).post('/todos').send({ title: 'Test' });
+    const id = create.body.todo.id as string;
+    const res = await request(app).patch(`/todos/${id}/move`).send({ status: 'in_progress' });
+    expect(res.status).toBe(200);
+    expect(res.body.todo.status).toBe('in_progress');
+  });
+
+  it('DELETE /todos/:id removes a todo', async () => {
+    const { app } = makeApp();
+    const create = await request(app).post('/todos').send({ title: 'Delete me' });
+    const id = create.body.todo.id as string;
+    await request(app).delete(`/todos/${id}`);
+    const list = await request(app).get('/todos');
+    expect(list.body.todos).toHaveLength(0);
+  });
+
+  it('POST /todos/:id/start-session creates a chat and emits event', async () => {
+    const { app, emitEvent } = makeApp();
+    const create = await request(app).post('/todos').send({ title: 'Big feature' });
+    const id = create.body.todo.id as string;
+    const res = await request(app).post(`/todos/${id}/start-session`).send({ projectId: 'proj-1' });
+    expect(res.status).toBe(200);
+    expect(res.body.chatId).toBe('chat-1');
+    expect(res.body.initialMessage).toContain('Big feature');
+    expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.created' }));
+  });
+});

--- a/packages/core/src/__tests__/plugins/builtin/todos.test.ts
+++ b/packages/core/src/__tests__/plugins/builtin/todos.test.ts
@@ -15,7 +15,7 @@ const todosManifest: PluginManifest = {
   id: 'todos',
   name: 'TODO Kanban',
   version: '1.0.0',
-  capabilities: ['storage', 'chat:create'],
+  capabilities: ['storage', 'chat:create', 'ui:panels'],
 };
 
 let tmpDir: string;

--- a/packages/core/src/__tests__/plugins/context.test.ts
+++ b/packages/core/src/__tests__/plugins/context.test.ts
@@ -83,6 +83,17 @@ describe('buildPluginContext capability gating', () => {
     expect(callbacks).toContain(fn);
   });
 
+  it('throws on attachments access when storage not declared', () => {
+    const ctx = buildPluginContext(makeDeps({ manifest: { ...baseManifest, capabilities: [] } }));
+    expect(() => ctx.attachments.list('id')).toThrow(/storage/);
+  });
+
+  it('provides attachments when storage capability is declared', () => {
+    const ctx = buildPluginContext(makeDeps({ manifest: { ...baseManifest, capabilities: ['storage'] } }));
+    expect(typeof ctx.attachments.save).toBe('function');
+    expect(typeof ctx.attachments.list).toBe('function');
+  });
+
   it('always exposes router and config', () => {
     const ctx = buildPluginContext(makeDeps());
     expect(ctx.router).toBeDefined();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { mkdirSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { getConfig, getDataDir } from './config.js';
 import { DatabaseManager } from './db/index.js';
@@ -11,6 +12,8 @@ import { createServerManager } from './server/index.js';
 import { PluginManager } from './plugins/manager.js';
 import claudeManifest from './plugins/builtin/claude/manifest.json' with { type: 'json' };
 import { activate as activateClaude } from './plugins/builtin/claude/index.js';
+import todosManifest from './plugins/builtin/todos/manifest.json' with { type: 'json' };
+import { activate as activateTodos } from './plugins/builtin/todos/index.js';
 import { logger } from './logger.js';
 import type { DaemonEvent, PluginManifest } from '@mainframe/types';
 
@@ -44,6 +47,10 @@ async function main(): Promise<void> {
 
   // Load builtin plugins first (always trusted, no consent dialog)
   await pluginManager.loadBuiltin(claudeManifest as PluginManifest, activateClaude);
+
+  const todosPluginDir = join(getDataDir(), 'plugins', 'todos');
+  mkdirSync(todosPluginDir, { recursive: true });
+  await pluginManager.loadBuiltin(todosManifest as PluginManifest, activateTodos, { pluginDir: todosPluginDir });
 
   // Load user-installed plugins from ~/.mainframe/plugins/
   await pluginManager.loadAll();

--- a/packages/core/src/plugins/attachment-context.ts
+++ b/packages/core/src/plugins/attachment-context.ts
@@ -12,7 +12,7 @@ interface AttachmentRecord {
 }
 
 export function createPluginAttachmentContext(baseDir: string): PluginAttachmentContext {
-  const entityDir = (id: string) => join(baseDir, id);
+  const entityDir = (id: string) => join(baseDir, basename(id));
 
   function sanitize(name: string): string {
     const f = basename(name)

--- a/packages/core/src/plugins/attachment-context.ts
+++ b/packages/core/src/plugins/attachment-context.ts
@@ -1,0 +1,93 @@
+import { mkdir, writeFile, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import { nanoid } from 'nanoid';
+import type { PluginAttachmentContext, PluginAttachmentMeta } from '@mainframe/types';
+
+interface AttachmentRecord {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+export function createPluginAttachmentContext(baseDir: string): PluginAttachmentContext {
+  const entityDir = (id: string) => join(baseDir, id);
+
+  function sanitize(name: string): string {
+    const f = basename(name)
+      .replace(/[^\w.\-() ]+/g, '_')
+      .trim();
+    return f.length > 0 ? f : 'attachment.bin';
+  }
+
+  return {
+    async save(entityId, file) {
+      const dir = entityDir(entityId);
+      await mkdir(dir, { recursive: true });
+      const id = nanoid();
+      const safeName = sanitize(file.filename);
+      await writeFile(join(dir, `${id}-${safeName}`), Buffer.from(file.data, 'base64'));
+      const record: AttachmentRecord = {
+        id,
+        filename: file.filename,
+        mimeType: file.mimeType,
+        sizeBytes: file.sizeBytes,
+        createdAt: new Date().toISOString(),
+      };
+      await writeFile(join(dir, `${id}.json`), JSON.stringify(record));
+      return record;
+    },
+
+    async get(entityId, id) {
+      const dir = entityDir(entityId);
+      try {
+        const metaRaw = await readFile(join(dir, `${id}.json`), 'utf-8');
+        const meta = JSON.parse(metaRaw) as AttachmentRecord;
+        const files = await readdir(dir);
+        const dataFile = files.find((f) => f.startsWith(`${id}-`) && !f.endsWith('.json'));
+        if (!dataFile) return null;
+        const buf = await readFile(join(dir, dataFile));
+        return { data: buf.toString('base64'), meta };
+      } catch {
+        return null;
+      }
+    },
+
+    async list(entityId) {
+      const dir = entityDir(entityId);
+      try {
+        await stat(dir);
+      } catch {
+        return [];
+      }
+      const files = await readdir(dir);
+      const metas = await Promise.all(
+        files
+          .filter((f) => f.endsWith('.json'))
+          .map(async (f): Promise<PluginAttachmentMeta | null> => {
+            try {
+              return JSON.parse(await readFile(join(dir, f), 'utf-8')) as PluginAttachmentMeta;
+            } catch {
+              return null;
+            }
+          }),
+      );
+      return metas.filter((m): m is PluginAttachmentMeta => m !== null);
+    },
+
+    async delete(entityId, id) {
+      const dir = entityDir(entityId);
+      try {
+        const files = await readdir(dir);
+        await Promise.all(
+          files
+            .filter((f) => f === `${id}.json` || f.startsWith(`${id}-`))
+            .map((f) => rm(join(dir, f), { force: true })),
+        );
+      } catch {
+        // directory may not exist; nothing to delete
+      }
+    },
+  };
+}

--- a/packages/core/src/plugins/builtin/todos/index.ts
+++ b/packages/core/src/plugins/builtin/todos/index.ts
@@ -1,0 +1,267 @@
+import type { PluginContext } from '@mainframe/types';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+
+interface TodoRow {
+  id: string;
+  title: string;
+  body: string;
+  status: string;
+  type: string;
+  priority: string;
+  labels: string;
+  assignees: string;
+  milestone: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Todo extends Omit<TodoRow, 'labels' | 'assignees'> {
+  labels: string[];
+  assignees: string[];
+}
+
+const MIGRATION = `
+CREATE TABLE IF NOT EXISTS todos (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  type TEXT NOT NULL DEFAULT 'feature',
+  priority TEXT NOT NULL DEFAULT 'medium',
+  labels TEXT NOT NULL DEFAULT '[]',
+  assignees TEXT NOT NULL DEFAULT '[]',
+  milestone TEXT,
+  order_index REAL NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);`;
+
+const parseTodo = (r: TodoRow): Todo => ({
+  ...r,
+  labels: JSON.parse(r.labels) as string[],
+  assignees: JSON.parse(r.assignees) as string[],
+});
+
+const TodoSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().default(''),
+  status: z.enum(['open', 'in_progress', 'done']).default('open'),
+  type: z
+    .enum(['bug', 'feature', 'enhancement', 'documentation', 'question', 'wont_fix', 'duplicate', 'invalid'])
+    .default('feature'),
+  priority: z.enum(['low', 'medium', 'high', 'critical']).default('medium'),
+  labels: z.array(z.string()).default([]),
+  assignees: z.array(z.string()).default([]),
+  milestone: z.string().optional(),
+});
+
+function buildInitialMessage(todo: Todo): string {
+  const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+  const labels = todo.labels.length > 0 ? todo.labels.join(', ') : 'none';
+  const lines = [
+    `I'm working on this task from the kanban board:`,
+    ``,
+    `**${todo.title}**`,
+    `Type: ${cap(todo.type)} | Priority: ${cap(todo.priority)} | Labels: ${labels}`,
+  ];
+  if (todo.milestone) lines.push(`Milestone: ${todo.milestone}`);
+  if (todo.body) lines.push(``, `## Description`, todo.body);
+  return lines.join('\n');
+}
+
+function registerTodoRoutes(ctx: PluginContext): void {
+  const r = ctx.router;
+
+  r.get('/todos', (_req, res) => {
+    const rows = ctx.db.prepare<TodoRow>('SELECT * FROM todos ORDER BY status, order_index, created_at').all();
+    res.json({ todos: rows.map(parseTodo) });
+  });
+
+  r.post('/todos', (req, res) => {
+    const parsed = TodoSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+    const d = parsed.data;
+    const now = new Date().toISOString();
+    const id = nanoid();
+    ctx.db
+      .prepare(
+        `INSERT INTO todos (id,title,body,status,type,priority,labels,assignees,milestone,order_index,created_at,updated_at)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+      )
+      .run(
+        id,
+        d.title,
+        d.body,
+        d.status,
+        d.type,
+        d.priority,
+        JSON.stringify(d.labels),
+        JSON.stringify(d.assignees),
+        d.milestone ?? null,
+        0,
+        now,
+        now,
+      );
+    const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id)!;
+    res.status(201).json({ todo: parseTodo(row) });
+  });
+
+  r.patch('/todos/:id', (req, res) => {
+    const { id } = req.params;
+    if (!ctx.db.prepare<{ id: string }>('SELECT id FROM todos WHERE id = ?').get(id)) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    const parsed = TodoSchema.partial().safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid input' });
+      return;
+    }
+    const d = parsed.data;
+    const now = new Date().toISOString();
+    const sets: string[] = ['updated_at = ?'];
+    const vals: unknown[] = [now];
+    if (d.title !== undefined) {
+      sets.push('title = ?');
+      vals.push(d.title);
+    }
+    if (d.body !== undefined) {
+      sets.push('body = ?');
+      vals.push(d.body);
+    }
+    if (d.status !== undefined) {
+      sets.push('status = ?');
+      vals.push(d.status);
+    }
+    if (d.type !== undefined) {
+      sets.push('type = ?');
+      vals.push(d.type);
+    }
+    if (d.priority !== undefined) {
+      sets.push('priority = ?');
+      vals.push(d.priority);
+    }
+    if (d.labels !== undefined) {
+      sets.push('labels = ?');
+      vals.push(JSON.stringify(d.labels));
+    }
+    if (d.assignees !== undefined) {
+      sets.push('assignees = ?');
+      vals.push(JSON.stringify(d.assignees));
+    }
+    if (d.milestone !== undefined) {
+      sets.push('milestone = ?');
+      vals.push(d.milestone);
+    }
+    vals.push(id);
+    ctx.db.prepare(`UPDATE todos SET ${sets.join(', ')} WHERE id = ?`).run(...vals);
+    const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id)!;
+    res.json({ todo: parseTodo(row) });
+  });
+
+  r.patch('/todos/:id/move', (req, res) => {
+    const { id } = req.params;
+    const parsed = z.object({ status: z.enum(['open', 'in_progress', 'done']) }).safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid status' });
+      return;
+    }
+    ctx.db
+      .prepare('UPDATE todos SET status = ?, updated_at = ? WHERE id = ?')
+      .run(parsed.data.status, new Date().toISOString(), id);
+    const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id);
+    if (!row) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.json({ todo: parseTodo(row) });
+  });
+
+  r.delete('/todos/:id', (req, res) => {
+    ctx.db.prepare('DELETE FROM todos WHERE id = ?').run(req.params.id);
+    res.status(204).send();
+  });
+}
+
+function registerSessionRoute(ctx: PluginContext): void {
+  ctx.router.post('/todos/:id/start-session', async (req, res) => {
+    const { id } = req.params;
+    const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id);
+    if (!row) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    const parsed = z.object({ projectId: z.string() }).safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'projectId required' });
+      return;
+    }
+    if (!ctx.services.chats.createChat) {
+      res.status(403).json({ error: 'chat:create capability required' });
+      return;
+    }
+    const todo = parseTodo(row);
+    const { chatId } = await ctx.services.chats.createChat({ projectId: parsed.data.projectId });
+    res.json({ chatId, initialMessage: buildInitialMessage(todo) });
+  });
+}
+
+function registerAttachmentRoutes(ctx: PluginContext): void {
+  const r = ctx.router;
+
+  r.get('/todos/:id/attachments', async (req, res) => {
+    const metas = await ctx.attachments.list(req.params.id);
+    res.json({ attachments: metas });
+  });
+
+  r.post('/todos/:id/attachments', async (req, res) => {
+    const row = ctx.db.prepare<{ id: string }>('SELECT id FROM todos WHERE id = ?').get(req.params.id);
+    if (!row) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    const body = req.body as Record<string, unknown>;
+    const { filename, mimeType, data, sizeBytes } = body;
+    if (typeof filename !== 'string' || typeof data !== 'string') {
+      res.status(400).json({ error: 'filename and data required' });
+      return;
+    }
+    const meta = await ctx.attachments.save(req.params.id, {
+      filename,
+      mimeType: typeof mimeType === 'string' ? mimeType : 'application/octet-stream',
+      data,
+      sizeBytes: typeof sizeBytes === 'number' ? sizeBytes : 0,
+    });
+    res.status(201).json({ attachment: meta });
+  });
+
+  r.get('/todos/:id/attachments/:attachmentId', async (req, res) => {
+    const result = await ctx.attachments.get(req.params.id, req.params.attachmentId);
+    if (!result) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.json(result);
+  });
+
+  r.delete('/todos/:id/attachments/:attachmentId', async (req, res) => {
+    await ctx.attachments.delete(req.params.id, req.params.attachmentId);
+    res.status(204).send();
+  });
+}
+
+export function activate(ctx: PluginContext): void {
+  ctx.db.runMigration(MIGRATION);
+  registerTodoRoutes(ctx);
+  registerSessionRoute(ctx);
+  registerAttachmentRoutes(ctx);
+  ctx.logger.info('TODO Kanban plugin activated');
+  ctx.onUnload(() => {
+    ctx.logger.info('TODO Kanban plugin unloaded');
+  });
+}

--- a/packages/core/src/plugins/builtin/todos/index.ts
+++ b/packages/core/src/plugins/builtin/todos/index.ts
@@ -260,8 +260,7 @@ export function activate(ctx: PluginContext): void {
   registerTodoRoutes(ctx);
   registerSessionRoute(ctx);
   registerAttachmentRoutes(ctx);
+  ctx.ui.addPanel({ zone: 'fullview', label: 'Tasks', icon: 'square-check' });
+  ctx.onUnload(() => ctx.ui.removePanel());
   ctx.logger.info('TODO Kanban plugin activated');
-  ctx.onUnload(() => {
-    ctx.logger.info('TODO Kanban plugin unloaded');
-  });
 }

--- a/packages/core/src/plugins/builtin/todos/manifest.json
+++ b/packages/core/src/plugins/builtin/todos/manifest.json
@@ -4,5 +4,10 @@
   "version": "1.0.0",
   "description": "GitHub-style kanban board for tracking tasks",
   "author": "Mainframe Team",
-  "capabilities": ["storage", "chat:create"]
+  "capabilities": ["storage", "chat:create", "ui:panels"],
+  "ui": {
+    "zone": "fullview",
+    "label": "Tasks",
+    "icon": "square-check"
+  }
 }

--- a/packages/core/src/plugins/builtin/todos/manifest.json
+++ b/packages/core/src/plugins/builtin/todos/manifest.json
@@ -1,0 +1,8 @@
+{
+  "id": "todos",
+  "name": "TODO Kanban",
+  "version": "1.0.0",
+  "description": "GitHub-style kanban board for tracking tasks",
+  "author": "Mainframe Team",
+  "capabilities": ["storage", "chat:create"]
+}

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -78,7 +78,7 @@ export function buildPluginContext(deps: PluginContextDeps): PluginContext {
     (key, value) => deps.db.settings.set('plugin', key, JSON.stringify(value)),
   );
 
-  const chatService = buildChatService(manifest, deps.db);
+  const chatService = buildChatService(manifest, deps.db, deps.emitEvent);
   const projectService = buildProjectService(deps.db);
 
   const adaptersApi = has('adapters')

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -1,5 +1,6 @@
 import type { PluginContext, PluginManifest, DaemonEvent } from '@mainframe/types';
 import { createPluginDatabaseContext } from './db-context.js';
+import { createPluginAttachmentContext } from './attachment-context.js';
 import { createPluginEventBus } from './event-bus.js';
 import { createPluginConfig } from './config-context.js';
 import { createPluginUIContext } from './ui-context.js';
@@ -34,6 +35,15 @@ export function buildPluginContext(deps: PluginContextDeps): PluginContext {
   const dbContext = has('storage')
     ? createPluginDatabaseContext(`${pluginDir}/data.db`)
     : new Proxy({} as ReturnType<typeof createPluginDatabaseContext>, {
+        get:
+          () =>
+          (..._args: unknown[]) =>
+            capabilityGuard('storage'),
+      });
+
+  const attachmentContext = has('storage')
+    ? createPluginAttachmentContext(`${pluginDir}/attachments`)
+    : new Proxy({} as ReturnType<typeof createPluginAttachmentContext>, {
         get:
           () =>
           (..._args: unknown[]) =>
@@ -81,6 +91,7 @@ export function buildPluginContext(deps: PluginContextDeps): PluginContext {
     router: deps.router,
     config,
     db: dbContext,
+    attachments: attachmentContext,
     events: eventBus,
     ui: uiContext,
     services: { chats: chatService, projects: projectService },

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -71,7 +71,11 @@ export class PluginManager {
    * Load a builtin plugin directly from TypeScript (bypasses file-system manifest reading).
    * Builtins are always trusted and skip the consent flow.
    */
-  async loadBuiltin(manifest: PluginManifest, activate: (ctx: PluginContext) => void | Promise<void>): Promise<void> {
+  async loadBuiltin(
+    manifest: PluginManifest,
+    activate: (ctx: PluginContext) => void | Promise<void>,
+    options?: { pluginDir?: string },
+  ): Promise<void> {
     if (this.loaded.has(manifest.id)) return;
 
     const unloadCallbacks: (() => void)[] = [];
@@ -80,7 +84,7 @@ export class PluginManager {
 
     const ctx = buildPluginContext({
       manifest,
-      pluginDir: '',
+      pluginDir: options?.pluginDir ?? '',
       router: pluginRouter,
       logger: createChildLogger(`plugin:${manifest.id}`),
       daemonBus: this.deps.daemonBus,

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -26,11 +26,14 @@ export interface PluginManagerDeps {
   emitEvent: (event: DaemonEvent) => void;
 }
 
+type PanelRegisteredEvent = Extract<DaemonEvent, { type: 'plugin.panel.registered' }>;
+
 export class PluginManager {
   /** Parent router mounted at /api/plugins by the HTTP server. */
   readonly router: Router;
 
   private loaded = new Map<string, LoadedPlugin>();
+  private panelEvents = new Map<string, PanelRegisteredEvent>();
   // In CJS bundles (esbuild daemon), import.meta.url becomes undefined — cast to handle both.
   // Absolute plugin paths don't rely on the base URL for resolution.
   private _require = createRequire((import.meta.url as string | undefined) ?? `file://${process.cwd()}/index.js`);
@@ -42,12 +45,16 @@ export class PluginManager {
 
   private setupListingRoutes(): void {
     this.router.get('/', (_req, res) => {
-      const plugins = this.getAll().map((p) => ({
-        id: p.id,
-        name: p.ctx.manifest.name,
-        version: p.ctx.manifest.version,
-        capabilities: p.ctx.manifest.capabilities,
-      }));
+      const plugins = this.getAll().map((p) => {
+        const panel = this.panelEvents.get(p.id);
+        return {
+          id: p.id,
+          name: p.ctx.manifest.name,
+          version: p.ctx.manifest.version,
+          capabilities: p.ctx.manifest.capabilities,
+          panel: panel ? { zone: panel.zone, label: panel.label, icon: panel.icon } : undefined,
+        };
+      });
       res.json({ plugins });
     });
 
@@ -65,6 +72,22 @@ export class PluginManager {
         capabilities: plugin.ctx.manifest.capabilities,
       });
     });
+  }
+
+  private trackingEmitEvent(pluginId: string, emit: (event: DaemonEvent) => void): (event: DaemonEvent) => void {
+    return (event: DaemonEvent) => {
+      if (event.type === 'plugin.panel.registered') {
+        this.panelEvents.set(pluginId, event as PanelRegisteredEvent);
+      } else if (event.type === 'plugin.panel.unregistered') {
+        this.panelEvents.delete(pluginId);
+      }
+      emit(event);
+    };
+  }
+
+  /** Returns panel registration events for all currently loaded plugins that called addPanel(). */
+  getRegisteredPanelEvents(): PanelRegisteredEvent[] {
+    return [...this.panelEvents.values()];
   }
 
   /**
@@ -90,7 +113,7 @@ export class PluginManager {
       daemonBus: this.deps.daemonBus,
       db: this.deps.db,
       adapters: this.deps.adapters,
-      emitEvent: this.deps.emitEvent,
+      emitEvent: this.trackingEmitEvent(manifest.id, this.deps.emitEvent),
       onUnloadCallbacks: unloadCallbacks,
     });
 
@@ -141,7 +164,7 @@ export class PluginManager {
       daemonBus: this.deps.daemonBus,
       db: this.deps.db,
       adapters: this.deps.adapters,
-      emitEvent: this.deps.emitEvent,
+      emitEvent: this.trackingEmitEvent(manifest.id, this.deps.emitEvent),
       onUnloadCallbacks: unloadCallbacks,
     });
 
@@ -169,6 +192,7 @@ export class PluginManager {
       }
     }
     this.loaded.clear();
+    this.panelEvents.clear();
   }
 
   getPlugin(id: string): LoadedPlugin | undefined {

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -243,6 +243,7 @@ export function TitleBar({
           {fullviewContributions.map((c) => (
             <button
               key={c.pluginId}
+              data-testid={`${c.pluginId}-panel-icon`}
               onClick={() => handleFullviewClick(c.pluginId)}
               title={c.label}
               className={cn(

--- a/packages/desktop/src/renderer/components/center/CenterPanel.tsx
+++ b/packages/desktop/src/renderer/components/center/CenterPanel.tsx
@@ -3,7 +3,6 @@ import { useTabsStore } from '../../store/tabs';
 import { useProjectsStore, useChatsStore } from '../../store';
 import { useProject } from '../../hooks/useDaemon';
 import { ChatContainer } from '../chat/ChatContainer';
-import { TodosPanel } from '../todos/TodosPanel';
 import { cn } from '../../lib/utils';
 
 function ChatTabDot({ chatId }: { chatId: string }): React.ReactElement {
@@ -95,8 +94,6 @@ export function CenterPanel(): React.ReactElement {
               </div>
             </div>
           </div>
-        ) : activePrimaryTab.type === 'todos' ? (
-          <TodosPanel />
         ) : (
           <ChatContainer chatId={activePrimaryTab.chatId} />
         )}

--- a/packages/desktop/src/renderer/components/center/CenterPanel.tsx
+++ b/packages/desktop/src/renderer/components/center/CenterPanel.tsx
@@ -3,6 +3,7 @@ import { useTabsStore } from '../../store/tabs';
 import { useProjectsStore, useChatsStore } from '../../store';
 import { useProject } from '../../hooks/useDaemon';
 import { ChatContainer } from '../chat/ChatContainer';
+import { TodosPanel } from '../todos/TodosPanel';
 import { cn } from '../../lib/utils';
 
 function ChatTabDot({ chatId }: { chatId: string }): React.ReactElement {
@@ -94,6 +95,8 @@ export function CenterPanel(): React.ReactElement {
               </div>
             </div>
           </div>
+        ) : activePrimaryTab.type === 'todos' ? (
+          <TodosPanel />
         ) : (
           <ChatContainer chatId={activePrimaryTab.chatId} />
         )}

--- a/packages/desktop/src/renderer/components/plugins/PluginView.tsx
+++ b/packages/desktop/src/renderer/components/plugins/PluginView.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { PluginError } from './PluginError';
+import { TodosPanel } from '../todos/TodosPanel.js';
 
 // Registry of builtin plugin components.
 // External plugins will be dynamically imported and registered here at load time (future).
-const BUILTIN_COMPONENTS: Record<string, React.ComponentType> = {};
+const BUILTIN_COMPONENTS: Record<string, React.ComponentType> = {
+  todos: TodosPanel,
+};
 
 /** Register a builtin plugin's React component. Call before the component is first rendered. */
 export function registerBuiltinComponent(pluginId: string, Component: React.ComponentType): void {

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -37,8 +37,10 @@ export function TodoCard({ todo, onEdit, onDelete, onStartSession }: Props): Rea
       onClick={() => onEdit(todo)}
       className="bg-mf-app-bg rounded-mf-input p-3 space-y-1.5 border border-mf-border group cursor-pointer"
     >
-      {/* Row 1: type badge + #number + title */}
+      {/* Row 1: #number + title + type badge */}
       <div className="flex items-center gap-1.5 min-w-0">
+        <span className="shrink-0 font-mono text-mf-status text-mf-text-secondary">#{todo.number}</span>
+        <span className="flex-1 text-mf-small text-mf-text-primary leading-snug truncate">{todo.title}</span>
         <span
           className={cn(
             'shrink-0 text-mf-status font-medium px-1.5 py-0.5 rounded capitalize',
@@ -47,8 +49,6 @@ export function TodoCard({ todo, onEdit, onDelete, onStartSession }: Props): Rea
         >
           {todo.type.replace('_', ' ')}
         </span>
-        <span className="shrink-0 font-mono text-mf-status text-mf-text-secondary">#{todo.number}</span>
-        <span className="text-mf-small text-mf-text-primary leading-snug truncate">{todo.title}</span>
       </div>
 
       {/* Row 2: priority pill */}

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowLeft, ArrowRight, Play, Edit, Trash2 } from 'lucide-react';
+import { Play, Edit, Trash2 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import type { Todo, TodoStatus } from '../../lib/api/todos-api';
 
@@ -14,14 +14,12 @@ const TYPE_COLORS: Record<string, string> = {
   invalid: 'bg-gray-500/10 text-mf-text-secondary',
 };
 
-const PRIORITY_COLORS: Record<string, string> = {
-  critical: 'text-red-400',
-  high: 'text-orange-400',
-  medium: 'text-yellow-400',
-  low: 'text-mf-text-secondary',
+const PRIORITY_PILL: Record<string, string> = {
+  critical: 'bg-red-500/15 text-red-400',
+  high: 'bg-orange-500/15 text-orange-400',
+  medium: 'bg-yellow-500/15 text-yellow-400',
+  low: 'bg-gray-500/10 text-mf-text-secondary',
 };
-
-const COLUMN_ORDER: TodoStatus[] = ['open', 'in_progress', 'done'];
 
 interface Props {
   todo: Todo;
@@ -31,91 +29,62 @@ interface Props {
   onStartSession: (todo: Todo) => void;
 }
 
-export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
-  const colIdx = COLUMN_ORDER.indexOf(todo.status);
-  const canMoveLeft = colIdx > 0;
-  const canMoveRight = colIdx < COLUMN_ORDER.length - 1;
-
+export function TodoCard({ todo, onMove: _onMove, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
   return (
     <div
       data-testid="todo-card"
       draggable
       onDragStart={(e) => e.dataTransfer.setData('todo-id', todo.id)}
       onClick={() => onEdit(todo)}
-      className="bg-mf-app-bg rounded-mf-input p-3 space-y-2 border border-mf-border group cursor-pointer"
+      className="bg-mf-app-bg rounded-mf-input p-3 space-y-1.5 border border-mf-border group cursor-pointer"
     >
-      {/* Header row */}
-      <div className="flex items-start justify-between gap-2">
+      {/* Row 1: type badge + #number + title */}
+      <div className="flex items-center gap-1.5 min-w-0">
         <span
           className={cn(
-            'text-mf-status font-medium px-1.5 py-0.5 rounded capitalize',
+            'shrink-0 text-mf-status font-medium px-1.5 py-0.5 rounded capitalize',
             TYPE_COLORS[todo.type] ?? 'bg-mf-hover text-mf-text-secondary',
           )}
         >
           {todo.type.replace('_', ' ')}
         </span>
-        <span className={cn('text-mf-status font-medium capitalize', PRIORITY_COLORS[todo.priority] ?? '')}>
+        <span className="shrink-0 font-mono text-mf-status text-mf-text-secondary">#{todo.number}</span>
+        <span className="text-mf-small text-mf-text-primary leading-snug truncate">{todo.title}</span>
+      </div>
+
+      {/* Row 2: priority pill */}
+      <div>
+        <span
+          className={cn(
+            'inline-block text-mf-status font-medium px-1.5 py-0.5 rounded capitalize',
+            PRIORITY_PILL[todo.priority] ?? 'bg-gray-500/10 text-mf-text-secondary',
+          )}
+        >
           {todo.priority}
         </span>
       </div>
 
-      {/* Title */}
-      <p className="text-mf-small text-mf-text-primary leading-snug">{todo.title}</p>
-
-      {/* Labels */}
-      {todo.labels.length > 0 && (
-        <div className="flex flex-wrap gap-1">
+      {/* Row 3: labels + actions on hover */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-1 min-w-0">
           {todo.labels.map((l) => (
             <span key={l} className="text-mf-status bg-mf-hover px-1.5 py-0.5 rounded text-mf-text-secondary">
               {l}
             </span>
           ))}
         </div>
-      )}
-
-      {/* Actions */}
-      <div className="flex items-center justify-between pt-1">
-        <div className="flex items-center gap-1">
-          {canMoveLeft && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMove(todo.id, COLUMN_ORDER[colIdx - 1]!);
-              }}
-              className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
-              title="Move left"
-              aria-label="Move to previous column"
-            >
-              <ArrowLeft size={12} />
-            </button>
-          )}
-          {canMoveRight && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMove(todo.id, COLUMN_ORDER[colIdx + 1]!);
-              }}
-              className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
-              title="Move right"
-              aria-label="Move to next column"
-            >
-              <ArrowRight size={12} />
-            </button>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          {todo.status === 'in_progress' && (
+        <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+          {(todo.status === 'open' || todo.status === 'in_progress') && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onStartSession(todo);
               }}
-              className="flex items-center gap-1 px-2 py-1 rounded text-mf-small text-mf-accent hover:bg-mf-accent/10 transition-colors"
-              title="Start in session"
+              className="p-1 rounded text-mf-accent hover:bg-mf-accent/10 transition-colors"
+              title="Start session"
               aria-label="Start in new session"
             >
-              <Play size={11} />
-              Session
+              <Play size={12} />
             </button>
           )}
           <button
@@ -123,7 +92,7 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
               e.stopPropagation();
               onEdit(todo);
             }}
-            className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
+            className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
             title="Edit"
             aria-label="Edit task"
           >
@@ -134,7 +103,7 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
               e.stopPropagation();
               onDelete(todo.id);
             }}
-            className="p-1 rounded text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
+            className="p-1 rounded text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors"
             title="Delete"
             aria-label="Delete task"
           >

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -37,7 +37,13 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
   const canMoveRight = colIdx < COLUMN_ORDER.length - 1;
 
   return (
-    <div className="bg-mf-app-bg rounded-mf-input p-3 space-y-2 border border-mf-border group">
+    <div
+      data-testid="todo-card"
+      draggable
+      onDragStart={(e) => e.dataTransfer.setData('todo-id', todo.id)}
+      onClick={() => onEdit(todo)}
+      className="bg-mf-app-bg rounded-mf-input p-3 space-y-2 border border-mf-border group cursor-pointer"
+    >
       {/* Header row */}
       <div className="flex items-start justify-between gap-2">
         <span
@@ -72,7 +78,10 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
         <div className="flex items-center gap-1">
           {canMoveLeft && (
             <button
-              onClick={() => onMove(todo.id, COLUMN_ORDER[colIdx - 1]!)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove(todo.id, COLUMN_ORDER[colIdx - 1]!);
+              }}
               className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
               title="Move left"
               aria-label="Move to previous column"
@@ -82,7 +91,10 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
           )}
           {canMoveRight && (
             <button
-              onClick={() => onMove(todo.id, COLUMN_ORDER[colIdx + 1]!)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove(todo.id, COLUMN_ORDER[colIdx + 1]!);
+              }}
               className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
               title="Move right"
               aria-label="Move to next column"
@@ -94,7 +106,10 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
         <div className="flex items-center gap-1">
           {todo.status === 'in_progress' && (
             <button
-              onClick={() => onStartSession(todo)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onStartSession(todo);
+              }}
               className="flex items-center gap-1 px-2 py-1 rounded text-mf-small text-mf-accent hover:bg-mf-accent/10 transition-colors"
               title="Start in session"
               aria-label="Start in new session"
@@ -104,7 +119,10 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
             </button>
           )}
           <button
-            onClick={() => onEdit(todo)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit(todo);
+            }}
             className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
             title="Edit"
             aria-label="Edit task"
@@ -112,7 +130,10 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
             <Edit size={12} />
           </button>
           <button
-            onClick={() => onDelete(todo.id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(todo.id);
+            }}
             className="p-1 rounded text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
             title="Delete"
             aria-label="Delete task"

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Play, Edit, Trash2 } from 'lucide-react';
 import { cn } from '../../lib/utils';
-import type { Todo, TodoStatus } from '../../lib/api/todos-api';
+import type { Todo } from '../../lib/api/todos-api';
 
 const TYPE_COLORS: Record<string, string> = {
   bug: 'bg-red-500/15 text-red-400',
@@ -23,13 +23,12 @@ const PRIORITY_PILL: Record<string, string> = {
 
 interface Props {
   todo: Todo;
-  onMove: (id: string, status: TodoStatus) => void;
   onEdit: (todo: Todo) => void;
   onDelete: (id: string) => void;
   onStartSession: (todo: Todo) => void;
 }
 
-export function TodoCard({ todo, onMove: _onMove, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
+export function TodoCard({ todo, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
   return (
     <div
       data-testid="todo-card"

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { ArrowLeft, ArrowRight, Play, Edit, Trash2 } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { Todo, TodoStatus } from '../../lib/api/todos-api';
+
+const TYPE_COLORS: Record<string, string> = {
+  bug: 'bg-red-500/15 text-red-400',
+  feature: 'bg-blue-500/15 text-blue-400',
+  enhancement: 'bg-purple-500/15 text-purple-400',
+  documentation: 'bg-gray-500/15 text-mf-text-secondary',
+  question: 'bg-yellow-500/15 text-yellow-400',
+  wont_fix: 'bg-gray-500/10 text-mf-text-secondary',
+  duplicate: 'bg-orange-500/15 text-orange-400',
+  invalid: 'bg-gray-500/10 text-mf-text-secondary',
+};
+
+const PRIORITY_COLORS: Record<string, string> = {
+  critical: 'text-red-400',
+  high: 'text-orange-400',
+  medium: 'text-yellow-400',
+  low: 'text-mf-text-secondary',
+};
+
+const COLUMN_ORDER: TodoStatus[] = ['open', 'in_progress', 'done'];
+
+interface Props {
+  todo: Todo;
+  onMove: (id: string, status: TodoStatus) => void;
+  onEdit: (todo: Todo) => void;
+  onDelete: (id: string) => void;
+  onStartSession: (todo: Todo) => void;
+}
+
+export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
+  const colIdx = COLUMN_ORDER.indexOf(todo.status);
+  const canMoveLeft = colIdx > 0;
+  const canMoveRight = colIdx < COLUMN_ORDER.length - 1;
+
+  return (
+    <div className="bg-mf-app-bg rounded-mf-input p-3 space-y-2 border border-mf-border group">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            'text-mf-status font-medium px-1.5 py-0.5 rounded capitalize',
+            TYPE_COLORS[todo.type] ?? 'bg-mf-hover text-mf-text-secondary',
+          )}
+        >
+          {todo.type.replace('_', ' ')}
+        </span>
+        <span className={cn('text-mf-status font-medium capitalize', PRIORITY_COLORS[todo.priority] ?? '')}>
+          {todo.priority}
+        </span>
+      </div>
+
+      {/* Title */}
+      <p className="text-mf-small text-mf-text-primary leading-snug">{todo.title}</p>
+
+      {/* Labels */}
+      {todo.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {todo.labels.map((l) => (
+            <span key={l} className="text-mf-status bg-mf-hover px-1.5 py-0.5 rounded text-mf-text-secondary">
+              {l}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-1">
+        <div className="flex items-center gap-1">
+          {canMoveLeft && (
+            <button
+              onClick={() => onMove(todo.id, COLUMN_ORDER[colIdx - 1]!)}
+              className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
+              title="Move left"
+              aria-label="Move to previous column"
+            >
+              <ArrowLeft size={12} />
+            </button>
+          )}
+          {canMoveRight && (
+            <button
+              onClick={() => onMove(todo.id, COLUMN_ORDER[colIdx + 1]!)}
+              className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
+              title="Move right"
+              aria-label="Move to next column"
+            >
+              <ArrowRight size={12} />
+            </button>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {todo.status === 'in_progress' && (
+            <button
+              onClick={() => onStartSession(todo)}
+              className="flex items-center gap-1 px-2 py-1 rounded text-mf-small text-mf-accent hover:bg-mf-accent/10 transition-colors"
+              title="Start in session"
+              aria-label="Start in new session"
+            >
+              <Play size={11} />
+              Session
+            </button>
+          )}
+          <button
+            onClick={() => onEdit(todo)}
+            className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
+            title="Edit"
+            aria-label="Edit task"
+          >
+            <Edit size={12} />
+          </button>
+          <button
+            onClick={() => onDelete(todo.id)}
+            className="p-1 rounded text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100"
+            title="Delete"
+            aria-label="Delete task"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/todos/TodoModal.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoModal.tsx
@@ -20,6 +20,7 @@ interface Props {
   todo?: Todo | null;
   onClose: () => void;
   onSave: (data: CreateTodoInput) => void;
+  onStartSession?: (todo: Todo) => void;
 }
 
 const input = cn(
@@ -27,7 +28,7 @@ const input = cn(
   'text-mf-small text-mf-text-primary focus:outline-none focus:border-mf-accent',
 );
 
-export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement {
+export function TodoModal({ todo, onClose, onSave, onStartSession }: Props): React.ReactElement {
   const [title, setTitle] = useState(todo?.title ?? '');
   const [body, setBody] = useState(todo?.body ?? '');
   const [status, setStatus] = useState<TodoStatus>(todo?.status ?? 'open');
@@ -69,6 +70,9 @@ export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={todo ? 'Edit Task' : 'New Task'}
         className="bg-mf-panel-bg rounded-mf-panel border border-mf-border w-full max-w-lg mx-4 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
@@ -85,8 +89,11 @@ export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement 
 
         <form onSubmit={handleSubmit} className="p-4 space-y-3 max-h-[80vh] overflow-y-auto">
           <div className="flex flex-col gap-1">
-            <label className="text-mf-small text-mf-text-secondary">Title *</label>
+            <label htmlFor="todo-title" className="text-mf-small text-mf-text-secondary">
+              Title *
+            </label>
             <input
+              id="todo-title"
               className={input}
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -183,6 +190,18 @@ export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement 
           </div>
 
           <div className="flex justify-end gap-2 pt-1">
+            {todo && todo.status === 'in_progress' && onStartSession && (
+              <button
+                type="button"
+                onClick={() => {
+                  onStartSession(todo);
+                  onClose();
+                }}
+                className="mr-auto px-3 py-1.5 rounded-mf-input text-mf-small text-mf-accent hover:bg-mf-accent/10 transition-colors"
+              >
+                Start Session
+              </button>
+            )}
             <button
               type="button"
               onClick={onClose}
@@ -195,7 +214,7 @@ export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement 
               disabled={!title.trim()}
               className="px-3 py-1.5 rounded-mf-input text-mf-small bg-mf-accent text-white disabled:opacity-40 hover:bg-mf-accent/90 transition-colors"
             >
-              {todo ? 'Save Changes' : 'Create Task'}
+              {todo ? 'Save Changes' : 'Save Task'}
             </button>
           </div>
         </form>

--- a/packages/desktop/src/renderer/components/todos/TodoModal.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoModal.tsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { Todo, CreateTodoInput, TodoStatus, TodoType, TodoPriority } from '../../lib/api/todos-api';
+
+const TYPES: TodoType[] = [
+  'bug',
+  'feature',
+  'enhancement',
+  'documentation',
+  'question',
+  'wont_fix',
+  'duplicate',
+  'invalid',
+];
+const PRIORITIES: TodoPriority[] = ['low', 'medium', 'high', 'critical'];
+const STATUSES: TodoStatus[] = ['open', 'in_progress', 'done'];
+
+interface Props {
+  todo?: Todo | null;
+  onClose: () => void;
+  onSave: (data: CreateTodoInput) => void;
+}
+
+const input = cn(
+  'bg-mf-app-bg border border-mf-border rounded-mf-input px-2 py-1.5',
+  'text-mf-small text-mf-text-primary focus:outline-none focus:border-mf-accent',
+);
+
+export function TodoModal({ todo, onClose, onSave }: Props): React.ReactElement {
+  const [title, setTitle] = useState(todo?.title ?? '');
+  const [body, setBody] = useState(todo?.body ?? '');
+  const [status, setStatus] = useState<TodoStatus>(todo?.status ?? 'open');
+  const [type, setType] = useState<TodoType>(todo?.type ?? 'feature');
+  const [priority, setPriority] = useState<TodoPriority>(todo?.priority ?? 'medium');
+  const [labels, setLabels] = useState((todo?.labels ?? []).join(', '));
+  const [assignees, setAssignees] = useState((todo?.assignees ?? []).join(', '));
+  const [milestone, setMilestone] = useState(todo?.milestone ?? '');
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    onSave({
+      title: title.trim(),
+      body: body.trim(),
+      status,
+      type,
+      priority,
+      labels: labels
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean),
+      assignees: assignees
+        .split(',')
+        .map((a) => a.trim())
+        .filter(Boolean),
+      milestone: milestone.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-mf-panel-bg rounded-mf-panel border border-mf-border w-full max-w-lg mx-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-mf-border">
+          <h2 className="text-mf-body font-medium text-mf-text-primary">{todo ? 'Edit Task' : 'New Task'}</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
+            aria-label="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-3 max-h-[80vh] overflow-y-auto">
+          <div className="flex flex-col gap-1">
+            <label className="text-mf-small text-mf-text-secondary">Title *</label>
+            <input
+              className={input}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Task title"
+              autoFocus
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-mf-small text-mf-text-secondary">Type</label>
+              <select
+                className={cn(input, 'cursor-pointer capitalize')}
+                value={type}
+                onChange={(e) => setType(e.target.value as TodoType)}
+              >
+                {TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t.replace('_', ' ')}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-mf-small text-mf-text-secondary">Priority</label>
+              <select
+                className={cn(input, 'cursor-pointer capitalize')}
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TodoPriority)}
+              >
+                {PRIORITIES.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-mf-small text-mf-text-secondary">Status</label>
+              <select
+                className={cn(input, 'cursor-pointer capitalize')}
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TodoStatus)}
+              >
+                {STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {s.replace('_', ' ')}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-mf-small text-mf-text-secondary">Description (markdown)</label>
+            <textarea
+              className={cn(input, 'resize-none')}
+              rows={4}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Describe the task..."
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-mf-small text-mf-text-secondary">Labels (comma-separated)</label>
+            <input
+              className={input}
+              value={labels}
+              onChange={(e) => setLabels(e.target.value)}
+              placeholder="e.g. ui, backend, urgent"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-mf-small text-mf-text-secondary">Assignees (comma-separated)</label>
+            <input
+              className={input}
+              value={assignees}
+              onChange={(e) => setAssignees(e.target.value)}
+              placeholder="e.g. alice, bob"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-mf-small text-mf-text-secondary">Milestone</label>
+            <input
+              className={input}
+              value={milestone}
+              onChange={(e) => setMilestone(e.target.value)}
+              placeholder="e.g. v1.0, Q1 2026"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 rounded-mf-input text-mf-small text-mf-text-secondary hover:bg-mf-hover transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!title.trim()}
+              className="px-3 py-1.5 rounded-mf-input text-mf-small bg-mf-accent text-white disabled:opacity-40 hover:bg-mf-accent/90 transition-colors"
+            >
+              {todo ? 'Save Changes' : 'Create Task'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -141,6 +141,12 @@ export function TodosPanel(): React.ReactElement {
             <div
               key={status}
               className="flex-1 flex flex-col border-r border-mf-border last:border-r-0 overflow-hidden"
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault();
+                const id = e.dataTransfer.getData('todo-id');
+                if (id) void handleMove(id, status);
+              }}
             >
               <div className="px-3 py-2 text-mf-small font-medium text-mf-text-secondary flex items-center gap-1.5 shrink-0">
                 <span>{label}</span>
@@ -175,6 +181,7 @@ export function TodosPanel(): React.ReactElement {
             setEditingTodo(null);
           }}
           onSave={editingTodo ? handleUpdate : handleCreate}
+          onStartSession={handleStartSession}
         />
       )}
     </div>

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Plus } from 'lucide-react';
+import { todosApi, type Todo, type TodoStatus, type CreateTodoInput } from '../../lib/api/todos-api';
+import { TodoCard } from './TodoCard';
+import { TodoModal } from './TodoModal';
+import { useProjectsStore } from '../../store';
+import { useSkillsStore } from '../../store/skills';
+import { daemonClient } from '../../lib/client';
+
+const COLUMNS: { status: TodoStatus; label: string }[] = [
+  { status: 'open', label: 'Open' },
+  { status: 'in_progress', label: 'In Progress' },
+  { status: 'done', label: 'Done' },
+];
+
+export function TodosPanel(): React.ReactElement {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
+  const activeProjectId = useProjectsStore((s) => s.activeProjectId);
+
+  const loadTodos = useCallback(async () => {
+    try {
+      setError(null);
+      const list = await todosApi.list();
+      setTodos(list);
+    } catch (err) {
+      setError('Failed to load tasks. Is the daemon running?');
+      console.warn('[todos] load failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTodos();
+  }, [loadTodos]);
+
+  const handleCreate = useCallback(async (data: CreateTodoInput) => {
+    try {
+      const todo = await todosApi.create(data);
+      setTodos((prev) => [...prev, todo]);
+      setModalOpen(false);
+    } catch (err) {
+      console.warn('[todos] create failed:', err);
+    }
+  }, []);
+
+  const handleUpdate = useCallback(
+    async (data: CreateTodoInput) => {
+      if (!editingTodo) return;
+      try {
+        const updated = await todosApi.update(editingTodo.id, data);
+        setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+        setEditingTodo(null);
+        setModalOpen(false);
+      } catch (err) {
+        console.warn('[todos] update failed:', err);
+      }
+    },
+    [editingTodo],
+  );
+
+  const handleMove = useCallback(async (id: string, status: TodoStatus) => {
+    try {
+      const updated = await todosApi.move(id, status);
+      setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+    } catch (err) {
+      console.warn('[todos] move failed:', err);
+    }
+  }, []);
+
+  const handleDelete = useCallback(async (id: string) => {
+    try {
+      await todosApi.remove(id);
+      setTodos((prev) => prev.filter((t) => t.id !== id));
+    } catch (err) {
+      console.warn('[todos] delete failed:', err);
+    }
+  }, []);
+
+  const handleStartSession = useCallback(
+    async (todo: Todo) => {
+      if (!activeProjectId) return;
+      try {
+        const { chatId, initialMessage } = await todosApi.startSession(todo.id, activeProjectId);
+        // Pre-fill the composer using the existing pendingInvocation mechanism
+        useSkillsStore.getState().setPendingInvocation(initialMessage);
+        // chat.created WS event will open the tab automatically
+        daemonClient.subscribe(chatId);
+      } catch (err) {
+        console.warn('[todos] start-session failed:', err);
+      }
+    },
+    [activeProjectId],
+  );
+
+  if (loading) {
+    return (
+      <div className="h-full flex items-center justify-center text-mf-text-secondary text-mf-small">Loading tasks…</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-2 text-mf-text-secondary text-mf-small px-4 text-center">
+        <p>{error}</p>
+        <button onClick={() => void loadTodos()} className="text-mf-accent hover:underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="h-11 px-4 flex items-center justify-between shrink-0 border-b border-mf-border">
+        <span className="text-mf-small text-mf-text-secondary uppercase tracking-wider">Tasks</span>
+        <button
+          onClick={() => {
+            setEditingTodo(null);
+            setModalOpen(true);
+          }}
+          className="flex items-center gap-1 px-2 py-1 rounded-mf-input text-mf-small text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
+          title="New Task"
+          aria-label="Create new task"
+        >
+          <Plus size={13} />
+          New
+        </button>
+      </div>
+
+      {/* Columns */}
+      <div className="flex-1 flex gap-0 overflow-hidden">
+        {COLUMNS.map(({ status, label }) => {
+          const colTodos = todos.filter((t) => t.status === status);
+          return (
+            <div
+              key={status}
+              className="flex-1 flex flex-col border-r border-mf-border last:border-r-0 overflow-hidden"
+            >
+              <div className="px-3 py-2 text-mf-small font-medium text-mf-text-secondary flex items-center gap-1.5 shrink-0">
+                <span>{label}</span>
+                <span className="bg-mf-hover px-1.5 py-0.5 rounded text-mf-status">{colTodos.length}</span>
+              </div>
+              <div className="flex-1 overflow-y-auto px-2 pb-2 space-y-2">
+                {colTodos.map((todo) => (
+                  <TodoCard
+                    key={todo.id}
+                    todo={todo}
+                    onMove={handleMove}
+                    onEdit={(t) => {
+                      setEditingTodo(t);
+                      setModalOpen(true);
+                    }}
+                    onDelete={handleDelete}
+                    onStartSession={handleStartSession}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Modal */}
+      {modalOpen && (
+        <TodoModal
+          todo={editingTodo}
+          onClose={() => {
+            setModalOpen(false);
+            setEditingTodo(null);
+          }}
+          onSave={editingTodo ? handleUpdate : handleCreate}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -157,9 +157,9 @@ export function TodosPanel(): React.ReactElement {
   }
 
   return (
-    <div className="h-full flex flex-col gap-px overflow-hidden bg-mf-panel-bg">
+    <div className="h-full flex flex-col gap-px overflow-hidden bg-mf-app-bg">
       {/* Header */}
-      <div className="h-11 px-4 flex items-center justify-between shrink-0 bg-mf-app-bg">
+      <div className="h-11 px-4 flex items-center justify-between shrink-0 bg-mf-panel-bg">
         <span className="text-mf-small text-mf-text-secondary uppercase tracking-wider">Tasks</span>
         <button
           onClick={() => {
@@ -182,7 +182,7 @@ export function TodosPanel(): React.ReactElement {
           return (
             <div
               key={status}
-              className="flex-1 flex flex-col overflow-hidden bg-mf-app-bg"
+              className="flex-1 flex flex-col overflow-hidden bg-mf-panel-bg"
               onDragOver={(e) => e.preventDefault()}
               onDrop={(e) => {
                 e.preventDefault();

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -199,7 +199,6 @@ export function TodosPanel(): React.ReactElement {
                   <TodoCard
                     key={todo.id}
                     todo={todo}
-                    onMove={handleMove}
                     onEdit={(t) => {
                       setEditingTodo(t);
                       setModalOpen(true);

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -157,9 +157,9 @@ export function TodosPanel(): React.ReactElement {
   }
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="h-full flex flex-col gap-px overflow-hidden bg-mf-panel-bg">
       {/* Header */}
-      <div className="h-11 px-4 flex items-center justify-between shrink-0 border-b border-mf-border">
+      <div className="h-11 px-4 flex items-center justify-between shrink-0 bg-mf-app-bg">
         <span className="text-mf-small text-mf-text-secondary uppercase tracking-wider">Tasks</span>
         <button
           onClick={() => {
@@ -182,7 +182,7 @@ export function TodosPanel(): React.ReactElement {
           return (
             <div
               key={status}
-              className="flex-1 flex flex-col overflow-hidden"
+              className="flex-1 flex flex-col overflow-hidden bg-mf-app-bg"
               onDragOver={(e) => e.preventDefault()}
               onDrop={(e) => {
                 e.preventDefault();

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -3,7 +3,7 @@ import { Plus } from 'lucide-react';
 import { todosApi, type Todo, type TodoStatus, type CreateTodoInput } from '../../lib/api/todos-api';
 import { TodoCard } from './TodoCard';
 import { TodoModal } from './TodoModal';
-import { useProjectsStore } from '../../store';
+import { useProjectsStore, usePluginLayoutStore } from '../../store';
 import { useSkillsStore } from '../../store/skills';
 import { daemonClient } from '../../lib/client';
 
@@ -88,6 +88,8 @@ export function TodosPanel(): React.ReactElement {
         const { chatId, initialMessage } = await todosApi.startSession(todo.id, activeProjectId);
         // Pre-fill the composer using the existing pendingInvocation mechanism
         useSkillsStore.getState().setPendingInvocation(initialMessage);
+        // Close the todos fullview so the sessions panel becomes visible
+        usePluginLayoutStore.getState().activateFullview('todos');
         // chat.created WS event will open the tab automatically
         daemonClient.subscribe(chatId);
       } catch (err) {

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -95,7 +95,7 @@
     --mf-accent: var(--mf-accent-claude);
 
     /* Borders */
-    --mf-border: oklch(0.552 0.014 286);
+    --mf-border: oklch(0.38 0.008 264);
     --mf-scrollbar-hover: oklch(0.552 0.014 286);
 
     /* Chat Error */

--- a/packages/desktop/src/renderer/lib/api/index.ts
+++ b/packages/desktop/src/renderer/lib/api/index.ts
@@ -45,3 +45,5 @@ export {
 } from './settings-api';
 
 export { getAttachment, uploadAttachments } from './attachments-api';
+
+export { getPlugins } from './plugins-api';

--- a/packages/desktop/src/renderer/lib/api/plugins-api.ts
+++ b/packages/desktop/src/renderer/lib/api/plugins-api.ts
@@ -1,0 +1,25 @@
+import type { UIZone } from '@mainframe/types';
+import { API_BASE, fetchJson } from './http';
+
+interface PluginPanel {
+  zone: UIZone;
+  label: string;
+  icon?: string;
+}
+
+interface PluginInfo {
+  id: string;
+  name: string;
+  version: string;
+  capabilities: string[];
+  panel?: PluginPanel;
+}
+
+interface GetPluginsResponse {
+  plugins: PluginInfo[];
+}
+
+export async function getPlugins(): Promise<PluginInfo[]> {
+  const data = await fetchJson<GetPluginsResponse>(`${API_BASE}/api/plugins`);
+  return data.plugins;
+}

--- a/packages/desktop/src/renderer/lib/api/todos-api.ts
+++ b/packages/desktop/src/renderer/lib/api/todos-api.ts
@@ -1,0 +1,94 @@
+import { API_BASE } from './http';
+
+const BASE = `${API_BASE}/api/plugins/todos`;
+
+export type TodoStatus = 'open' | 'in_progress' | 'done';
+export type TodoType =
+  | 'bug'
+  | 'feature'
+  | 'enhancement'
+  | 'documentation'
+  | 'question'
+  | 'wont_fix'
+  | 'duplicate'
+  | 'invalid';
+export type TodoPriority = 'low' | 'medium' | 'high' | 'critical';
+
+export interface Todo {
+  id: string;
+  title: string;
+  body: string;
+  status: TodoStatus;
+  type: TodoType;
+  priority: TodoPriority;
+  labels: string[];
+  assignees: string[];
+  milestone?: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateTodoInput {
+  title: string;
+  body?: string;
+  status?: TodoStatus;
+  type?: TodoType;
+  priority?: TodoPriority;
+  labels?: string[];
+  assignees?: string[];
+  milestone?: string;
+}
+
+export type UpdateTodoInput = Partial<CreateTodoInput>;
+
+export interface AttachmentMeta {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  if (!res.ok) throw new Error(`Todos API error ${res.status}: ${path}`);
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+export const todosApi = {
+  list: () => api<{ todos: Todo[] }>('/todos').then((r) => r.todos),
+
+  create: (input: CreateTodoInput) =>
+    api<{ todo: Todo }>('/todos', { method: 'POST', body: JSON.stringify(input) }).then((r) => r.todo),
+
+  update: (id: string, input: UpdateTodoInput) =>
+    api<{ todo: Todo }>(`/todos/${id}`, { method: 'PATCH', body: JSON.stringify(input) }).then((r) => r.todo),
+
+  move: (id: string, status: TodoStatus) =>
+    api<{ todo: Todo }>(`/todos/${id}/move`, { method: 'PATCH', body: JSON.stringify({ status }) }).then((r) => r.todo),
+
+  remove: (id: string) => api<void>(`/todos/${id}`, { method: 'DELETE' }),
+
+  startSession: (id: string, projectId: string) =>
+    api<{ chatId: string; initialMessage: string }>(`/todos/${id}/start-session`, {
+      method: 'POST',
+      body: JSON.stringify({ projectId }),
+    }),
+
+  listAttachments: (id: string) =>
+    api<{ attachments: AttachmentMeta[] }>(`/todos/${id}/attachments`).then((r) => r.attachments),
+
+  uploadAttachment: (id: string, file: { filename: string; mimeType: string; data: string; sizeBytes: number }) =>
+    api<{ attachment: AttachmentMeta }>(`/todos/${id}/attachments`, {
+      method: 'POST',
+      body: JSON.stringify(file),
+    }).then((r) => r.attachment),
+
+  deleteAttachment: (id: string, attachmentId: string) =>
+    api<void>(`/todos/${id}/attachments/${attachmentId}`, { method: 'DELETE' }),
+};

--- a/packages/desktop/src/renderer/store/tabs.ts
+++ b/packages/desktop/src/renderer/store/tabs.ts
@@ -64,6 +64,8 @@ interface LegacySnapshot {
 }
 
 function migrateSnapshot(raw: LegacySnapshot): ProjectTabSnapshot {
+  // 'todos' was a first-class tab type before the plugin UI zone system; it is now a
+  // plugin view and must not be restored as a tab.
   const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat') as CenterTab[];
   return {
     tabs,

--- a/packages/desktop/src/renderer/store/tabs.ts
+++ b/packages/desktop/src/renderer/store/tabs.ts
@@ -3,6 +3,7 @@ import { useProjectsStore } from './projects';
 import { useUIStore } from './ui';
 
 export type ChatTab = { type: 'chat'; id: string; chatId: string; label: string };
+export type TodosTab = { type: 'todos'; id: 'todos'; label: 'Tasks' };
 
 export type FileView =
   | { type: 'editor'; filePath: string; label: string }
@@ -20,7 +21,7 @@ export type FileView =
   | { type: 'skill-editor'; skillId: string; adapterId: string; label: string };
 
 // Keep CenterTab as union so existing imports still resolve
-export type CenterTab = ChatTab;
+export type CenterTab = ChatTab | TodosTab;
 
 interface ProjectTabSnapshot {
   tabs: CenterTab[];
@@ -48,6 +49,7 @@ interface TabsState {
   openDiffTab: (filePath: string, source: 'git' | 'session', chatId?: string, oldPath?: string) => void;
   openInlineDiffTab: (filePath: string, original: string, modified: string, startLine?: number) => void;
   openSkillEditorTab: (skillId: string, adapterId: string, label: string) => void;
+  openTodosTab: () => void;
   setSidebarWidth: (w: number) => void;
   closeFileView: () => void;
   toggleFileViewCollapsed: () => void;
@@ -65,7 +67,7 @@ interface LegacySnapshot {
 }
 
 function migrateSnapshot(raw: LegacySnapshot): ProjectTabSnapshot {
-  const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat') as CenterTab[];
+  const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat' || t.type === 'todos') as CenterTab[];
   return {
     tabs,
     activePrimaryTabId: raw.activePrimaryTabId ?? null,
@@ -169,6 +171,10 @@ export const useTabsStore = create<TabsState>((set, get) => ({
   openSkillEditorTab: (skillId, adapterId, label) => {
     expandRightPanel();
     set({ fileView: { type: 'skill-editor', skillId, adapterId, label }, fileViewCollapsed: false });
+  },
+
+  openTodosTab: () => {
+    get().openTab({ type: 'todos', id: 'todos', label: 'Tasks' });
   },
 
   setSidebarWidth: (w) => set({ sidebarWidth: w }),

--- a/packages/desktop/src/renderer/store/tabs.ts
+++ b/packages/desktop/src/renderer/store/tabs.ts
@@ -3,7 +3,6 @@ import { useProjectsStore } from './projects';
 import { useUIStore } from './ui';
 
 export type ChatTab = { type: 'chat'; id: string; chatId: string; label: string };
-export type TodosTab = { type: 'todos'; id: 'todos'; label: 'Tasks' };
 
 export type FileView =
   | { type: 'editor'; filePath: string; label: string }
@@ -20,8 +19,7 @@ export type FileView =
     }
   | { type: 'skill-editor'; skillId: string; adapterId: string; label: string };
 
-// Keep CenterTab as union so existing imports still resolve
-export type CenterTab = ChatTab | TodosTab;
+export type CenterTab = ChatTab;
 
 interface ProjectTabSnapshot {
   tabs: CenterTab[];
@@ -49,7 +47,6 @@ interface TabsState {
   openDiffTab: (filePath: string, source: 'git' | 'session', chatId?: string, oldPath?: string) => void;
   openInlineDiffTab: (filePath: string, original: string, modified: string, startLine?: number) => void;
   openSkillEditorTab: (skillId: string, adapterId: string, label: string) => void;
-  openTodosTab: () => void;
   setSidebarWidth: (w: number) => void;
   closeFileView: () => void;
   toggleFileViewCollapsed: () => void;
@@ -67,7 +64,7 @@ interface LegacySnapshot {
 }
 
 function migrateSnapshot(raw: LegacySnapshot): ProjectTabSnapshot {
-  const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat' || t.type === 'todos') as CenterTab[];
+  const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat') as CenterTab[];
   return {
     tabs,
     activePrimaryTabId: raw.activePrimaryTabId ?? null,
@@ -171,10 +168,6 @@ export const useTabsStore = create<TabsState>((set, get) => ({
   openSkillEditorTab: (skillId, adapterId, label) => {
     expandRightPanel();
     set({ fileView: { type: 'skill-editor', skillId, adapterId, label }, fileViewCollapsed: false });
-  },
-
-  openTodosTab: () => {
-    get().openTab({ type: 'todos', id: 'todos', label: 'Tasks' });
   },
 
   setSidebarWidth: (w) => set({ sidebarWidth: w }),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,8 @@ export type {
   ProjectSummary,
   ProjectServiceAPI,
   AdapterRegistrationAPI,
+  PluginAttachmentMeta,
+  PluginAttachmentContext,
   PluginDatabaseContext,
   PluginDatabaseStatement,
   PluginEventBus,

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -144,6 +144,24 @@ export interface PluginConfig {
   getAll(): Record<string, unknown>;
 }
 
+export interface PluginAttachmentMeta {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+}
+
+export interface PluginAttachmentContext {
+  save(
+    entityId: string,
+    file: { filename: string; mimeType: string; data: string; sizeBytes: number },
+  ): Promise<PluginAttachmentMeta>;
+  get(entityId: string, id: string): Promise<{ data: string; meta: PluginAttachmentMeta } | null>;
+  list(entityId: string): Promise<PluginAttachmentMeta[]>;
+  delete(entityId: string, id: string): Promise<void>;
+}
+
 export interface PluginContext {
   readonly manifest: PluginManifest;
   readonly logger: Logger;
@@ -159,6 +177,7 @@ export interface PluginContext {
 
   // Requires 'storage'
   readonly db: PluginDatabaseContext;
+  readonly attachments: PluginAttachmentContext;
 
   // Requires 'daemon:public-events'
   readonly events: PluginEventBus;


### PR DESCRIPTION
## Summary

- Adds a full todos kanban plugin (backend CRUD, session integration, attachment support)
- Redesigns the kanban board: column gaps use the app background as natural dividers instead of borders; correct `mf-panel-bg` / `mf-app-bg` color assignment for columns, header, and cards
- Redesigns `TodoCard`: 3-row layout with `#number + title + type badge` on row 1, priority pill on row 2, labels + icon-only actions (▶ ✏ 🗑) on hover in row 3
- Removes unused `onMove` prop from `TodoCard`
- Softens `--mf-border` globally from `oklch(0.552)` to `oklch(0.38)` for better contrast on both dark backgrounds

## Test Plan

- [x] Todos kanban panel loads for an active project
- [x] Cards display correct layout: type badge right-aligned on row 1, priority pill on row 2, hover actions on row 3
- [x] Column gaps and header separator show `mf-app-bg` color (lighter), column fill shows `mf-panel-bg` (darker)
- [x] Drag-and-drop moves cards between columns
- [x] Start session (▶) moves open cards to in-progress and opens a new chat
- [x] Edit and delete work from card hover actions and modal
- [x] `--mf-border` change looks correct on composer, search box, and search palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)