### PR TITLE
fix(desktop): tutorial flow — action-gated steps, no overlay, modal-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 AI-native development environment for orchestrating agents.
 
 # Workflow
-- Use Skills to guide your development see [Skills](#skills)
+- Before any work, check needed skills to guide your development see [Skills](#skills)
 - For Claude CLI behavior, refer to [CLAUDE-JSONL-SCHEMA.md](docs/adapters/claude/CLAUDE-JSONL-SCHEMA.md), [PROTOCOL_REVERSED.md](docs/adapters/claude/PROTOCOL_REVERSED.md), and examples in `~/.claude/projects/**` and [CLAUDE-JSONL-SAMPLES](docs/adapters/claude/CLAUDE-JSONL-SAMPLES.md)
 - Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 AI-native development environment for orchestrating agents.
 
 # Workflow
-- Use Skills to guide your development see [Skills](#skills)
+- Before any work, check needed skills to guide your development see [Skills](#skills)
 - For Claude CLI behavior, refer to [CLAUDE-JSONL-SCHEMA.md](docs/adapters/claude/CLAUDE-JSONL-SCHEMA.md), [PROTOCOL_REVERSED.md](docs/adapters/claude/PROTOCOL_REVERSED.md), and examples in `~/.claude/projects/**` and [CLAUDE-JSONL-SAMPLES](docs/adapters/claude/CLAUDE-JSONL-SAMPLES.md)
 - Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -119,6 +119,7 @@ export function TitleBar({
         <div className="relative">
           <button
             data-testid="project-selector"
+            data-tutorial="step-1"
             onClick={() => setDropdownOpen((o) => !o)}
             className={cn(
               'flex items-center gap-2 px-1.5 py-1 rounded-mf-card transition-colors',

--- a/packages/desktop/src/renderer/components/TutorialOverlay.tsx
+++ b/packages/desktop/src/renderer/components/TutorialOverlay.tsx
@@ -62,6 +62,18 @@ export function TutorialOverlay() {
   const activePrimaryTabId = useTabsStore((s) => s.activePrimaryTabId);
   const tabs = useTabsStore((s) => s.tabs);
 
+  // Existing-user guard: if any chat already has messages, the user knows the app — skip
+  // the entire tutorial. Covers upgrades where tutorial ships after the user is already active.
+  useEffect(() => {
+    if (completed) return;
+    for (const msgs of messages.values()) {
+      if (msgs.length > 0) {
+        complete();
+        return;
+      }
+    }
+  }, [completed, messages, complete]);
+
   // Step 1 → 2: a project was added
   useEffect(() => {
     if (step === 1 && projects.length > 0) nextStep();

--- a/packages/desktop/src/renderer/components/TutorialOverlay.tsx
+++ b/packages/desktop/src/renderer/components/TutorialOverlay.tsx
@@ -151,7 +151,7 @@ export function TutorialOverlay() {
   }
 
   return (
-    <div style={{ position: 'fixed', inset: 0, zIndex: 9999, pointerEvents: 'none' }}>
+    <div data-testid="tutorial-overlay" style={{ position: 'fixed', inset: 0, zIndex: 9999, pointerEvents: 'none' }}>
       {/* Outline ring around target element */}
       <div
         style={{
@@ -221,7 +221,12 @@ export function TutorialOverlay() {
           >
             Step {step} of {STEPS.length}
           </div>
-          <div style={{ color: '#fafafa', fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{stepConfig.title}</div>
+          <div
+            data-testid="tutorial-title"
+            style={{ color: '#fafafa', fontSize: 13, fontWeight: 600, marginBottom: 4 }}
+          >
+            {stepConfig.title}
+          </div>
           <div style={{ color: '#a1a1aa', fontSize: 12, lineHeight: 1.5 }}>{stepConfig.description}</div>
           {!stepConfig.requiresAction && (
             <button

--- a/packages/e2e/tests/26-tutorial.spec.ts
+++ b/packages/e2e/tests/26-tutorial.spec.ts
@@ -8,6 +8,16 @@ test.describe('§26 Tutorial overlay', () => {
 
   test.beforeAll(async () => {
     fixture = await launchApp();
+
+    // Clear all persisted Zustand stores — Electron localStorage persists across
+    // test runs. Tutorial auto-advances based on projects/chats store state, so
+    // clearing only mf:tutorial isn't enough.
+    await fixture.page.evaluate(() => localStorage.clear());
+    await fixture.page.reload();
+    await fixture.page
+      .locator('[data-testid="connection-status"]')
+      .getByText('Connected', { exact: true })
+      .waitFor({ timeout: 15_000 });
   });
   test.afterAll(async () => {
     await closeApp(fixture);

--- a/packages/e2e/tests/26-tutorial.spec.ts
+++ b/packages/e2e/tests/26-tutorial.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { launchApp, closeApp } from '../fixtures/app.js';
+import { createTestProject, cleanupProject } from '../fixtures/project.js';
+import type { ProjectFixture } from '../fixtures/project.js';
+
+test.describe('§26 Tutorial overlay', () => {
+  let fixture: Awaited<ReturnType<typeof launchApp>>;
+
+  test.beforeAll(async () => {
+    fixture = await launchApp();
+  });
+  test.afterAll(async () => {
+    await closeApp(fixture);
+  });
+
+  test('step 1 shows on fresh launch with correct content', async () => {
+    const { page } = fixture;
+
+    const overlay = page.locator('[data-testid="tutorial-overlay"]');
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
+
+    // Verify step 1 content
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Add a project');
+
+    // No "Next" button on action-required steps
+    await expect(overlay.getByRole('button', { name: /Next/ })).toHaveCount(0);
+
+    // Skip tutorial link is present
+    await expect(page.getByText('Skip tutorial')).toBeVisible();
+  });
+
+  test('tutorial hides when directory picker modal opens', async () => {
+    const { page } = fixture;
+
+    // Open dropdown and click Add project to open the modal
+    await page.locator('[data-testid="project-selector"]').click();
+    await page.locator('[data-testid="project-dropdown"]').getByText('Add project').click();
+    await page.locator('[data-testid="dir-picker-modal"]').waitFor({ timeout: 5_000 });
+
+    // Tutorial overlay should be hidden while modal is open
+    await expect(page.locator('[data-testid="tutorial-overlay"]')).toHaveCount(0);
+
+    // Close the modal
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="dir-picker-modal"]')).toHaveCount(0);
+
+    // Tutorial reappears
+    await expect(page.locator('[data-testid="tutorial-overlay"]')).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('step 1 → 2: auto-advances when project is added', async () => {
+    const { page } = fixture;
+
+    // Verify we're on step 1
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Add a project');
+
+    // Add a project (this triggers auto-advance)
+    const project = await createTestProject(page);
+
+    // Should auto-advance to step 2
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Start a session', {
+      timeout: 5_000,
+    });
+
+    // Still no "Next" button on step 2
+    await expect(page.locator('[data-testid="tutorial-overlay"]').getByRole('button', { name: /Next/ })).toHaveCount(0);
+
+    // Store project for cleanup
+    (fixture as Record<string, unknown>)._tutorialProject = project;
+  });
+
+  test('step 2 → 3: auto-advances when session is created', async () => {
+    const { page } = fixture;
+    const project = (fixture as Record<string, unknown>)._tutorialProject as ProjectFixture;
+
+    // Verify we're on step 2
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Start a session');
+
+    // Click the new session button (step-2 target)
+    await page.locator('[data-tutorial="step-2"]').click();
+
+    // Wait for composer to appear (session created)
+    await page.getByRole('textbox').waitFor({ timeout: 10_000 });
+
+    // Should auto-advance to step 3
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Chat with your agent', {
+      timeout: 5_000,
+    });
+
+    // Step 3 has a "Next" button (not action-required)
+    await expect(page.locator('[data-testid="tutorial-overlay"]').getByRole('button', { name: /Next/ })).toBeVisible();
+
+    // Clean up
+    await cleanupProject(project);
+  });
+
+  test('step 3 → 4: advances via Next button', async () => {
+    const { page } = fixture;
+
+    // Verify we're on step 3
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Chat with your agent');
+
+    // Click Next
+    await page.locator('[data-testid="tutorial-overlay"]').getByRole('button', { name: /Next/ }).click();
+
+    // Should advance to step 4
+    await expect(page.locator('[data-testid="tutorial-title"]')).toHaveText('Select a provider', {
+      timeout: 5_000,
+    });
+  });
+
+  test('skip tutorial dismisses the overlay permanently', async () => {
+    const { page } = fixture;
+
+    // Tutorial should be visible
+    await expect(page.locator('[data-testid="tutorial-overlay"]')).toBeVisible();
+
+    // Click skip
+    await page.getByText('Skip tutorial').click();
+
+    // Overlay should disappear
+    await expect(page.locator('[data-testid="tutorial-overlay"]')).toHaveCount(0);
+
+    // Reload the page — tutorial should stay dismissed (persisted in localStorage)
+    await page.reload();
+    await page
+      .locator('[data-testid="connection-status"]')
+      .getByText('Connected', { exact: true })
+      .waitFor({ timeout: 15_000 });
+
+    await expect(page.locator('[data-testid="tutorial-overlay"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix tutorial not working after "Add Project" button moved to TitleBar dropdown (missing `data-tutorial` attribute)
- Remove "Next" button on steps 1-2 — users must actually add a project / create a session to advance (auto-advance handles progression)
- Replace dark overlay with lightweight orange outline ring — app stays fully interactive during tutorial
- Hide tutorial when modal overlays open (directory picker, settings) so it doesn't point at nothing
- Clamp label card position to viewport edges to prevent top clipping
- Add MutationObserver for responsive re-measuring on DOM changes

## Test plan
- [x] Add Playwright e2e tests (`26-tutorial.spec.ts`) covering:
  - Step 1 shows on fresh launch with correct content
  - Tutorial hides when directory picker modal opens, reappears on close
  - Step 1→2 auto-advances when project is added
  - Step 2→3 auto-advances when session is created
  - Step 3→4 advances via Next button
  - Skip tutorial dismisses overlay permanently (survives reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)