### PR TITLE
feat(desktop): connection overlay on WS disconnect

### DIFF
--- a/packages/desktop/src/__tests__/components/ConnectionOverlay.test.tsx
+++ b/packages/desktop/src/__tests__/components/ConnectionOverlay.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../renderer/hooks/useConnectionState.js', () => ({
+  useConnectionState: vi.fn().mockReturnValue(true),
+}));
+
+import { useConnectionState } from '../../renderer/hooks/useConnectionState.js';
+import { ConnectionOverlay, ConnectionOverlayView } from '../../renderer/components/ConnectionOverlay.js';
+
+describe('ConnectionOverlayView', () => {
+  it('renders nothing when connected', () => {
+    const { container } = render(<ConnectionOverlayView connected={true} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders overlay when disconnected', () => {
+    render(<ConnectionOverlayView connected={false} />);
+    expect(screen.getByTestId('connection-overlay')).toBeInTheDocument();
+  });
+
+  it('shows reconnecting text when disconnected', () => {
+    render(<ConnectionOverlayView connected={false} />);
+    expect(screen.getByText(/Reconnecting to daemon/)).toBeInTheDocument();
+  });
+
+  it('renders a spinner when disconnected', () => {
+    const { container } = render(<ConnectionOverlayView connected={false} />);
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+});
+
+describe('ConnectionOverlay', () => {
+  it('renders nothing when useConnectionState returns true', () => {
+    vi.mocked(useConnectionState).mockReturnValue(true);
+    const { container } = render(<ConnectionOverlay />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders overlay when useConnectionState returns false', () => {
+    vi.mocked(useConnectionState).mockReturnValue(false);
+    render(<ConnectionOverlay />);
+    expect(screen.getByTestId('connection-overlay')).toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/__tests__/playwright/ConnectionOverlay.ct.test.tsx
+++ b/packages/desktop/src/__tests__/playwright/ConnectionOverlay.ct.test.tsx
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { ConnectionOverlayView } from '../../renderer/components/ConnectionOverlay.js';
+
+test('renders overlay with reconnecting text when disconnected', async ({ mount, page }) => {
+  await mount(<ConnectionOverlayView connected={false} />);
+  await expect(page.getByTestId('connection-overlay')).toBeVisible();
+  await expect(page.getByText(/Reconnecting to daemon/)).toBeVisible();
+});
+
+test('renders spinner when disconnected', async ({ mount }) => {
+  const component = await mount(<ConnectionOverlayView connected={false} />);
+  await expect(component.locator('.animate-spin')).toBeAttached();
+});
+
+test('renders nothing when connected', async ({ mount }) => {
+  const component = await mount(<ConnectionOverlayView connected={true} />);
+  await expect(component.getByTestId('connection-overlay')).not.toBeAttached();
+});

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import { CenterPanel } from './components/center/CenterPanel';
 import { SearchPalette } from './components/SearchPalette';
 import { SettingsModal } from './components/SettingsModal';
 import { TutorialOverlay } from './components/TutorialOverlay';
+import { ConnectionOverlay } from './components/ConnectionOverlay';
 import { useAppInit } from './hooks/useAppInit';
 import { useProjectsStore, useSettingsStore } from './store';
 import { daemonClient } from './lib/client';
@@ -47,6 +48,7 @@ export default function App(): React.ReactElement {
       <SearchPalette />
       <SettingsModal />
       <TutorialOverlay />
+      <ConnectionOverlay />
     </ErrorBoundary>
   );
 }

--- a/packages/desktop/src/renderer/components/ConnectionOverlay.tsx
+++ b/packages/desktop/src/renderer/components/ConnectionOverlay.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import { useConnectionState } from '../hooks/useConnectionState';
+
+export function ConnectionOverlayView({ connected }: { connected: boolean }): React.ReactElement | null {
+  if (connected) return null;
+
+  return (
+    <div
+      data-testid="connection-overlay"
+      className="fixed inset-0 z-[9998] flex items-center justify-center bg-mf-overlay/60"
+    >
+      <div className="flex flex-col items-center gap-3 text-mf-text-primary">
+        <Loader2 size={24} className="animate-spin text-mf-text-secondary" />
+        <span className="text-sm text-mf-text-secondary">Reconnecting to daemon&hellip;</span>
+      </div>
+    </div>
+  );
+}
+
+export function ConnectionOverlay(): React.ReactElement | null {
+  const connected = useConnectionState();
+  return <ConnectionOverlayView connected={connected} />;
+}

--- a/packages/desktop/src/renderer/lib/client.ts
+++ b/packages/desktop/src/renderer/lib/client.ts
@@ -1,8 +1,9 @@
 import type { ClientEvent, DaemonEvent, ControlResponse } from '@mainframe/types';
 import { createLogger } from './logger';
 
-const host: string = (import.meta.env as Record<string, string>)['VITE_DAEMON_HOST'] ?? '127.0.0.1';
-const wsPort: string = (import.meta.env as Record<string, string>)['VITE_DAEMON_WS_PORT'] ?? '31415';
+const env = (import.meta as { env?: Record<string, string> }).env ?? {};
+const host: string = env['VITE_DAEMON_HOST'] ?? '127.0.0.1';
+const wsPort: string = env['VITE_DAEMON_WS_PORT'] ?? '31415';
 const WS_URL = `ws://${host}:${wsPort}`;
 const log = createLogger('renderer:ws');
 
@@ -200,4 +201,6 @@ export class DaemonClient {
 export const daemonClient = new DaemonClient();
 
 // Expose for E2E test introspection (harmless: renderer runs inside Electron, not on the public web)
-(window as Window & { __daemonClient?: DaemonClient }).__daemonClient = daemonClient;
+if (typeof window !== 'undefined') {
+  (window as Window & { __daemonClient?: DaemonClient }).__daemonClient = daemonClient;
+}


### PR DESCRIPTION
## Summary
- Adds a full-screen overlay with spinner and "Reconnecting to daemon…" text when the WebSocket connection is lost
- Blocks user interaction until the connection is restored
- Hardens `client.ts` against undefined `import.meta.env` and `window` for Playwright CT compatibility

## Test plan
- [x] Vitest unit tests (6 tests) — connected/disconnected states for both `ConnectionOverlayView` and `ConnectionOverlay`
- [x] Playwright CT tests (3 tests) — overlay visibility, spinner, and connected state
- [x] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)