### PR TITLE
feat(core): DisplayMessage pipeline for client-ready messages

### DIFF
--- a/docs/plans/2026-02-28-display-message-pipeline-design.md
+++ b/docs/plans/2026-02-28-display-message-pipeline-design.md
@@ -1,0 +1,143 @@
+# Display Message Pipeline
+
+**Date:** 2026-02-28
+**Status:** Approved
+
+## Problem
+
+Message transformations are scattered across daemon and desktop:
+
+1. **Tag stripping** (`stripMainframeCommandTags`) only ran on live events, not history — raw XML tags visible after restart.
+2. **`groupMessages()`** (turn merging, tool-result attachment, dedup) runs on the desktop — business logic leaked into the UI layer.
+3. **Tool categorization** (`CLAUDE_CATEGORIES`) is hardcoded in desktop's `convert-message.ts` — Claude adapter details leaked into adapter-agnostic UI.
+4. **User message parsing** (command detection, file-path extraction) happens at render time in `UserMessage.tsx` — duplicated regex work on every render.
+5. **`<mainframe-command>` filtering** placed inside Claude adapter's `history.ts` — mainframe commands are adapter-agnostic.
+
+## Design Principle
+
+**Messages served to clients are display-ready.** The desktop does nothing beyond mapping `DisplayMessage` to the UI framework's native message type (e.g., `ThreadMessageLike` for assistant-ui).
+
+## Approach: Serve-Time Transformation
+
+Raw `MessageCache` stays unchanged. A `prepareMessagesForClient()` pipeline transforms raw messages into `DisplayMessage[]` on demand when serving via REST or WS. This avoids a second cache and keeps the raw cache as the single source of truth.
+
+## 1. New Types (`@mainframe/types`)
+
+```typescript
+// Display-ready content blocks — superset of raw MessageContent
+export type DisplayContent =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'image'; mediaType: string; data: string }
+  | { type: 'tool_call'; id: string; name: string; input: Record<string, unknown>;
+      category: 'default' | 'explore' | 'hidden' | 'progress' | 'subagent';
+      result?: ToolCallResult }
+  | { type: 'tool_group'; calls: DisplayContent[] }  // collapsed explore tools
+  | { type: 'task_group'; agentId: string; calls: DisplayContent[] }  // subagent tools
+  | { type: 'permission_request'; request: unknown }
+  | { type: 'error'; message: string };
+
+export interface ToolCallResult {
+  content: string;
+  isError: boolean;
+  structuredPatch?: DiffHunk[];
+  originalFile?: string;
+  modifiedFile?: string;
+}
+
+export interface DisplayMessage {
+  id: string;
+  chatId: string;
+  type: 'user' | 'assistant' | 'system' | 'error' | 'permission';
+  content: DisplayContent[];
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+Key differences from `ChatMessage`:
+- `tool_use` and `tool_result` collapsed into `tool_call` with inline `result`.
+- Tool categories applied server-side.
+- `tool_group` and `task_group` virtual content types for collapsed/grouped tools.
+- No `tool_use` or `tool_result` message types — those are merged into `assistant` turns.
+
+## 2. Display Pipeline (`core/messages/display-pipeline.ts`)
+
+Single function: `prepareMessagesForClient(messages: ChatMessage[], categories?: ToolCategories): DisplayMessage[]`
+
+Steps (in order):
+1. Filter internal user messages (`<mainframe-command>` wrappers, `<command-name>` skill markers).
+2. Strip `<mainframe-command-response>` tags from assistant text blocks.
+3. Group consecutive assistant/tool_use messages into turns.
+4. Attach tool_result data to preceding tool_call blocks.
+5. Deduplicate tool_call blocks by id.
+6. Apply tool categories and create `tool_group`/`task_group` wrappers.
+7. Attach `turnDurationMs` from system metadata markers.
+8. Pre-process user messages: extract `metadata.command`, `metadata.attachedFiles`.
+
+This consolidates logic currently in `groupMessages()`, `groupToolCallParts()`, `groupTaskChildren()`, `stripMainframeCommandTags()`, and desktop-side parsing.
+
+## 3. Event Handler Updates
+
+`onMessage()` and `onToolResult()` continue appending raw `ChatMessage` to `MessageCache`. No display transformation on the hot path.
+
+New: after appending, prepare the incremental display delta and emit it:
+- `display.message.added` — new display message ready for the client.
+- `display.message.updated` — existing display message updated (e.g., tool_result attached to assistant turn).
+
+The event handler calls `prepareMessagesForClient()` on the relevant slice to produce the delta.
+
+## 4. WS & REST Events
+
+New WS event types:
+- `display.message.added` — carries a single `DisplayMessage`.
+- `display.message.updated` — carries an updated `DisplayMessage` (same `id`, new content).
+- `display.messages.set` — full replacement (used on history load).
+
+Existing `message.added` stays for internal daemon use but is not forwarded to desktop clients.
+
+REST `GET /chats/:id/messages` returns `DisplayMessage[]` instead of `ChatMessage[]`.
+
+## 5. Tool Categories on Adapters
+
+Move `CLAUDE_CATEGORIES` from desktop to Claude adapter registration:
+
+```typescript
+// In AgentAdapter or adapter registration
+getToolCategories?(): ToolCategories;
+```
+
+`ClaudeAdapter` provides the concrete categories. The pipeline reads them from the adapter instance. If no categories provided, all tools default to `'default'`.
+
+## 6. User Message Pre-Processing
+
+Instead of parsing at render time, the pipeline extracts structured metadata:
+
+```typescript
+// In DisplayMessage.metadata for user messages:
+{
+  command?: { name: string; args?: string };
+  attachedFiles?: string[];
+}
+```
+
+`UserMessage.tsx` reads these fields instead of running regexes.
+
+## 7. Desktop Simplification
+
+After this change, the desktop:
+- Removes `groupMessages()` call from `MainframeRuntimeProvider.tsx`.
+- Removes `CLAUDE_CATEGORIES` and `getToolCategoriesForAdapter()` from `convert-message.ts`.
+- Simplifies `convertMessage()` to a thin mapper from `DisplayMessage` → `ThreadMessageLike`.
+- Removes regex parsing from `UserMessage.tsx` — reads `metadata.command` and `metadata.attachedFiles`.
+
+## 8. `<mainframe-command>` Filtering Location
+
+- **Claude adapter's `history.ts`**: reverts to `filterSkillExpansions()` — only filters `<command-name>` markers (Claude-specific skill injection pattern).
+- **`display-pipeline.ts`**: filters `<mainframe-command>` wrappers (adapter-agnostic, mainframe concern).
+
+## 9. Migration
+
+- No database migration needed — raw messages unchanged.
+- Desktop receives `DisplayMessage[]` from daemon; `ChatMessage` types no longer used client-side for rendering.
+- `groupMessages()`, `tool-grouping.ts` functions remain in core (used by pipeline) but are no longer exported to desktop.

--- a/docs/plans/2026-02-28-display-message-pipeline-plan.md
+++ b/docs/plans/2026-02-28-display-message-pipeline-plan.md
@@ -1,0 +1,904 @@
+# Display Message Pipeline Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move all message transformations from the desktop to the daemon so clients receive display-ready messages.
+
+**Architecture:** A `prepareMessagesForClient()` pipeline in `@mainframe/core/messages` transforms raw `ChatMessage[]` into `DisplayMessage[]`. The daemon runs this pipeline when serving messages via REST and when emitting WS events. The desktop becomes a thin mapper from `DisplayMessage` to the UI framework's `ThreadMessageLike`.
+
+**Tech Stack:** TypeScript, Node.js, Vitest, React, assistant-ui, pnpm workspaces
+
+---
+
+### Task 1: Create feature branch
+
+**Step 1: Create and switch to feature branch**
+
+Run: `git checkout -b feat/display-message-pipeline`
+
+**Step 2: Revert intermediate fixes from previous debugging session**
+
+The working tree has uncommitted changes from the tag-stripping bug investigation. Revert them — the full pipeline supersedes these point fixes.
+
+Run: `git checkout -- packages/core/src/__tests__/message-loading.test.ts packages/core/src/__tests__/messages/message-grouping.test.ts packages/core/src/chat/event-handler.ts packages/core/src/messages/message-grouping.ts packages/core/src/plugins/builtin/claude/history.ts`
+
+**Step 3: Verify clean state**
+
+Run: `git status`
+Expected: clean working tree on `feat/display-message-pipeline`
+
+---
+
+### Task 2: Add DisplayMessage types to `@mainframe/types`
+
+**Files:**
+- Create: `packages/types/src/display.ts`
+- Modify: `packages/types/src/index.ts`
+
+**Step 1: Write the failing test**
+
+Create: `packages/types/src/__tests__/display-types.test.ts`
+
+```typescript
+import { describe, it, expectTypeOf } from 'vitest';
+import type { DisplayMessage, DisplayContent, ToolCallResult } from '../display.js';
+
+describe('DisplayMessage types', () => {
+  it('DisplayMessage has required fields', () => {
+    expectTypeOf<DisplayMessage>().toHaveProperty('id');
+    expectTypeOf<DisplayMessage>().toHaveProperty('chatId');
+    expectTypeOf<DisplayMessage>().toHaveProperty('type');
+    expectTypeOf<DisplayMessage>().toHaveProperty('content');
+    expectTypeOf<DisplayMessage>().toHaveProperty('timestamp');
+  });
+
+  it('DisplayContent includes tool_call variant', () => {
+    const tc: DisplayContent = {
+      type: 'tool_call',
+      id: 'tc1',
+      name: 'Bash',
+      input: {},
+      category: 'default',
+    };
+    expectTypeOf(tc).toMatchTypeOf<DisplayContent>();
+  });
+
+  it('ToolCallResult has required fields', () => {
+    expectTypeOf<ToolCallResult>().toHaveProperty('content');
+    expectTypeOf<ToolCallResult>().toHaveProperty('isError');
+  });
+
+  it('DisplayMessage type union covers all message types', () => {
+    const msg: DisplayMessage = {
+      id: '1',
+      chatId: 'c1',
+      type: 'assistant',
+      content: [],
+      timestamp: new Date().toISOString(),
+    };
+    expectTypeOf(msg.type).toEqualTypeOf<'user' | 'assistant' | 'system' | 'error' | 'permission'>();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @mainframe/types test -- --run display-types`
+Expected: FAIL — module `../display.js` not found
+
+**Step 3: Create the types file**
+
+Create: `packages/types/src/display.ts`
+
+```typescript
+import type { DiffHunk } from './chat.js';
+
+export interface ToolCallResult {
+  content: string;
+  isError: boolean;
+  structuredPatch?: DiffHunk[];
+  originalFile?: string;
+  modifiedFile?: string;
+}
+
+export type DisplayContent =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'image'; mediaType: string; data: string }
+  | {
+      type: 'tool_call';
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+      category: 'default' | 'explore' | 'hidden' | 'progress' | 'subagent';
+      result?: ToolCallResult;
+    }
+  | { type: 'tool_group'; calls: DisplayContent[] }
+  | { type: 'task_group'; agentId: string; calls: DisplayContent[] }
+  | { type: 'permission_request'; request: unknown }
+  | { type: 'error'; message: string };
+
+export interface DisplayMessage {
+  id: string;
+  chatId: string;
+  type: 'user' | 'assistant' | 'system' | 'error' | 'permission';
+  content: DisplayContent[];
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+**Step 4: Export from index**
+
+Modify: `packages/types/src/index.ts` — add `export * from './display.js';`
+
+**Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @mainframe/types test -- --run display-types`
+Expected: PASS
+
+**Step 6: Typecheck**
+
+Run: `pnpm --filter @mainframe/types build`
+Expected: no errors
+
+**Step 7: Commit**
+
+```bash
+git add packages/types/src/display.ts packages/types/src/index.ts packages/types/src/__tests__/display-types.test.ts
+git commit -m "feat(types): add DisplayMessage, DisplayContent, ToolCallResult types"
+```
+
+---
+
+### Task 3: Add `getToolCategories()` to `Adapter` interface
+
+**Files:**
+- Modify: `packages/types/src/adapter.ts:146` (Adapter interface)
+
+**Step 1: Add optional method to Adapter interface**
+
+In `packages/types/src/adapter.ts`, add to the `Adapter` interface (after line 155, the `killAll()` method):
+
+```typescript
+  getToolCategories?(): import('./tool-categorization.js').ToolCategories;
+```
+
+Wait — `ToolCategories` is defined in `@mainframe/core`, not `@mainframe/types`. We need to either:
+- Move `ToolCategories` to types, OR
+- Define a simpler version in types
+
+Since `ToolCategories` uses `Set<string>` and is a simple interface, move it to types.
+
+**Step 1a: Move ToolCategories to types**
+
+Create or add to `packages/types/src/display.ts`:
+
+```typescript
+export interface ToolCategories {
+  explore: Set<string>;
+  hidden: Set<string>;
+  progress: Set<string>;
+  subagent: Set<string>;
+}
+```
+
+**Step 1b: Update core to re-export from types**
+
+Modify: `packages/core/src/messages/tool-categorization.ts` — change to import and re-export from types:
+
+```typescript
+export type { ToolCategories } from '@mainframe/types';
+// keep predicate functions as-is
+```
+
+**Step 1c: Add to Adapter interface**
+
+In `packages/types/src/adapter.ts`, add to the `Adapter` interface after `killAll()`:
+
+```typescript
+  getToolCategories?(): import('./display.js').ToolCategories;
+```
+
+**Step 2: Typecheck**
+
+Run: `pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build`
+Expected: no errors (ClaudeAdapter already has `getToolCategories()` — it now satisfies the interface)
+
+**Step 3: Commit**
+
+```bash
+git add packages/types/src/display.ts packages/types/src/adapter.ts packages/core/src/messages/tool-categorization.ts
+git commit -m "feat(types): add ToolCategories to Adapter interface"
+```
+
+---
+
+### Task 4: Add display event types to DaemonEvent
+
+**Files:**
+- Modify: `packages/types/src/events.ts:7-29` (DaemonEvent union)
+
+**Step 1: Add new event variants**
+
+Add to the `DaemonEvent` union in `packages/types/src/events.ts`:
+
+```typescript
+  | { type: 'display.message.added'; chatId: string; message: import('./display.js').DisplayMessage }
+  | { type: 'display.message.updated'; chatId: string; message: import('./display.js').DisplayMessage }
+  | { type: 'display.messages.set'; chatId: string; messages: import('./display.js').DisplayMessage[] }
+```
+
+**Step 2: Typecheck**
+
+Run: `pnpm --filter @mainframe/types build`
+Expected: no errors
+
+**Step 3: Commit**
+
+```bash
+git add packages/types/src/events.ts
+git commit -m "feat(types): add display.message.added/updated/set event types"
+```
+
+---
+
+### Task 5: Create the display pipeline — core transform function
+
+This is the heart of the refactor. Creates `prepareMessagesForClient()` which transforms raw `ChatMessage[]` → `DisplayMessage[]`.
+
+**Files:**
+- Create: `packages/core/src/messages/display-pipeline.ts`
+- Create: `packages/core/src/__tests__/messages/display-pipeline.test.ts`
+- Modify: `packages/core/src/messages/index.ts` (export)
+
+**Step 1: Write failing tests**
+
+Create: `packages/core/src/__tests__/messages/display-pipeline.test.ts`
+
+Write comprehensive tests covering:
+
+1. **Empty input** → empty output
+2. **Single user message** → DisplayMessage with type 'user'
+3. **Single assistant text** → DisplayMessage with type 'assistant', content has text DisplayContent
+4. **Assistant with tool_use + tool_result** → single assistant DisplayMessage with tool_call having inline result
+5. **Consecutive assistant messages** → merged into one turn
+6. **Tag stripping** → `<mainframe-command-response>` tags stripped from assistant text
+7. **Internal message filtering** → `<mainframe-command>` wrapper messages filtered out
+8. **Tool deduplication** → duplicate tool_use IDs collapsed
+9. **System compact_boundary** → passed through as system DisplayMessage
+10. **Error messages** → passed through as error DisplayMessage
+11. **Tool categories applied** → tool_call blocks get correct `category` field
+12. **turnDurationMs attachment** → system metadata marker attached to preceding assistant
+13. **User message pre-processing** → `parseCommandMessage` results in metadata
+14. **User message file tags** → `parseAttachedFilePathTags` results in metadata
+
+Test helper structure:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { prepareMessagesForClient } from '../../messages/display-pipeline.js';
+import type { ChatMessage, MessageContent, ToolCategories } from '@mainframe/types';
+
+let idCounter = 0;
+function resetIds() { idCounter = 0; }
+
+function rawMsg(
+  type: ChatMessage['type'],
+  content: MessageContent[],
+  overrides?: Partial<ChatMessage>,
+): ChatMessage {
+  idCounter++;
+  return {
+    id: `msg-${idCounter}`,
+    chatId: 'chat-1',
+    type,
+    content,
+    timestamp: new Date(2026, 0, 1, 0, 0, idCounter).toISOString(),
+    ...overrides,
+  };
+}
+
+const CATEGORIES: ToolCategories = {
+  explore: new Set(['Read', 'Glob', 'Grep']),
+  hidden: new Set(['TodoWrite', 'Skill']),
+  progress: new Set(['TaskCreate', 'TaskUpdate']),
+  subagent: new Set(['Task']),
+};
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @mainframe/core test -- --run display-pipeline`
+Expected: FAIL — module not found
+
+**Step 3: Implement `prepareMessagesForClient()`**
+
+Create: `packages/core/src/messages/display-pipeline.ts`
+
+The function does the following steps in order:
+
+1. **Filter internal user messages**: remove messages containing `<mainframe-command>` wrappers or `<command-name>` skill markers. Re-use the regex patterns from `message-parsing.ts`.
+2. **Group turns**: merge consecutive assistant/tool_use messages into one turn (same logic as `groupMessages`).
+3. **Attach tool_results**: find tool_result messages and attach to preceding assistant turn.
+4. **Handle system turnDurationMs markers**: attach to preceding assistant turn, don't include in output.
+5. **Convert to DisplayMessage**: for each grouped raw message, create a DisplayMessage:
+   - Strip `<mainframe-command-response>` tags from assistant text blocks
+   - Convert `tool_use` + matched `tool_result` into `tool_call` with inline `result`
+   - Deduplicate tool_call by id
+   - Apply tool categories to each tool_call
+   - Pre-process user messages: extract command/skill info and file attachment tags into metadata
+6. **Apply tool grouping**: run `groupToolCallParts` and `groupTaskChildren` on assistant DisplayMessages to create `tool_group` and `task_group` virtual entries.
+
+Signature:
+
+```typescript
+export function prepareMessagesForClient(
+  messages: ChatMessage[],
+  categories?: ToolCategories,
+): DisplayMessage[];
+```
+
+If `categories` is not provided, all tools get `category: 'default'` and no grouping/hiding is applied.
+
+**Step 4: Run tests**
+
+Run: `pnpm --filter @mainframe/core test -- --run display-pipeline`
+Expected: PASS
+
+**Step 5: Export from index**
+
+Add to `packages/core/src/messages/index.ts`:
+
+```typescript
+export { prepareMessagesForClient } from './display-pipeline.js';
+```
+
+**Step 6: Typecheck**
+
+Run: `pnpm --filter @mainframe/core build`
+
+**Step 7: Commit**
+
+```bash
+git add packages/core/src/messages/display-pipeline.ts packages/core/src/__tests__/messages/display-pipeline.test.ts packages/core/src/messages/index.ts
+git commit -m "feat(core): add prepareMessagesForClient display pipeline"
+```
+
+---
+
+### Task 6: Add `getDisplayMessages()` to ChatManager and update REST endpoint
+
+**Files:**
+- Modify: `packages/core/src/chat/chat-manager.ts:276-313` (add new method after `getMessages`)
+- Modify: `packages/core/src/server/routes/chats.ts:39-45` (use display messages)
+
+**Step 1: Write failing test**
+
+Add a test to an existing or new test file that calls `getDisplayMessages()` and verifies it returns `DisplayMessage[]`.
+
+**Step 2: Add `getDisplayMessages()` to ChatManager**
+
+```typescript
+async getDisplayMessages(chatId: string): Promise<DisplayMessage[]> {
+  const raw = await this.getMessages(chatId);
+  const chat = this.getChat(chatId);
+  const adapter = chat ? this.adapters.get(chat.adapterId) : undefined;
+  const categories = adapter?.getToolCategories?.();
+  return prepareMessagesForClient(raw, categories);
+}
+```
+
+**Step 3: Update REST endpoint**
+
+In `packages/core/src/server/routes/chats.ts`, change line 42:
+
+```typescript
+// Before:
+const messages = await ctx.chats.getMessages(param(req, 'id'));
+// After:
+const messages = await ctx.chats.getDisplayMessages(param(req, 'id'));
+```
+
+**Step 4: Run tests and typecheck**
+
+Run: `pnpm --filter @mainframe/core test -- --run` (relevant tests)
+Run: `pnpm --filter @mainframe/core build`
+
+**Step 5: Commit**
+
+```bash
+git add packages/core/src/chat/chat-manager.ts packages/core/src/server/routes/chats.ts
+git commit -m "feat(core): serve DisplayMessage[] from REST endpoint"
+```
+
+---
+
+### Task 7: Update event handler to emit display events
+
+This is the critical WS path — when raw messages are appended, emit display events for clients.
+
+**Files:**
+- Modify: `packages/core/src/chat/event-handler.ts`
+
+**Step 1: Design the incremental approach**
+
+After each raw message append, re-run `prepareMessagesForClient()` on the full raw cache for that chat. Compare the count and last message against the previous display state to determine whether to emit `display.message.added` or `display.message.updated`.
+
+Store the last display state in a simple `Map<string, DisplayMessage[]>` on the EventHandler class.
+
+**Step 2: Add display state tracking to EventHandler**
+
+Add a `displayCache: Map<string, DisplayMessage[]>` field to EventHandler. Add a private method `emitDisplayDelta(chatId)` that:
+
+1. Gets raw messages from `this.messages.get(chatId)`
+2. Gets tool categories from the active chat's adapter
+3. Runs `prepareMessagesForClient(raw, categories)`
+4. Compares with `this.displayCache.get(chatId)`
+5. Emits appropriate display events
+6. Updates `this.displayCache`
+
+**Step 3: Call `emitDisplayDelta()` after each raw message append**
+
+In `onMessage()`, `onToolResult()`, `onCompact()`, and `onSkillFile()` — after appending to cache and emitting the raw `message.added` event, call `emitDisplayDelta(chatId)`.
+
+**Step 4: Also emit display events on history load**
+
+When `doLoadChat()` populates the message cache, emit `display.messages.set` with the full display messages. This happens in `lifecycle-manager.ts` but can be triggered via the event handler.
+
+**Step 5: Tests**
+
+Write tests verifying:
+- `onMessage()` emits `display.message.added` for the first assistant message
+- `onToolResult()` emits `display.message.updated` (tool result merges into existing turn)
+- Consecutive `onMessage()` calls emit `display.message.updated` (turn merging)
+
+**Step 6: Commit**
+
+```bash
+git add packages/core/src/chat/event-handler.ts
+git commit -m "feat(core): emit display.message events from event handler"
+```
+
+---
+
+### Task 8: Update desktop store for DisplayMessage
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/store/chats.ts`
+- Modify: `packages/desktop/src/renderer/lib/ws-event-router.ts`
+
+**Step 1: Change message store type**
+
+In `packages/desktop/src/renderer/store/chats.ts`:
+- Change `messages: Map<string, ChatMessage[]>` to `messages: Map<string, DisplayMessage[]>`
+- Update `addMessage` and `setMessages` signatures
+- Import `DisplayMessage` from `@mainframe/types`
+- Remove `ChatMessage` import if no longer needed
+
+**Step 2: Update WS event router**
+
+In `packages/desktop/src/renderer/lib/ws-event-router.ts`:
+- Handle `display.message.added` → `chats.addMessage(chatId, message)`
+- Handle `display.message.updated` → replace last message with matching id
+- Handle `display.messages.set` → `chats.setMessages(chatId, messages)`
+- Keep `message.added` handler for now (backward compat during migration) but mark deprecated
+
+Add an `updateMessage` action to the store:
+
+```typescript
+updateMessage: (chatId, message) =>
+  set((state) => {
+    const newMessages = new Map(state.messages);
+    const existing = newMessages.get(chatId) || [];
+    const idx = existing.findIndex((m) => m.id === message.id);
+    if (idx >= 0) {
+      const updated = [...existing];
+      updated[idx] = message;
+      newMessages.set(chatId, updated);
+    } else {
+      newMessages.set(chatId, [...existing, message]);
+    }
+    return { messages: newMessages };
+  }),
+```
+
+**Step 3: Typecheck**
+
+Run: `pnpm --filter @mainframe/desktop build`
+
+**Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/store/chats.ts packages/desktop/src/renderer/lib/ws-event-router.ts
+git commit -m "feat(desktop): handle display.message events in store"
+```
+
+---
+
+### Task 9: Update useChatSession and API client for DisplayMessage
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/hooks/useChatSession.ts`
+- Modify: `packages/desktop/src/renderer/lib/api.ts` (getChatMessages return type)
+
+**Step 1: Update API client return type**
+
+In `packages/desktop/src/renderer/lib/api.ts`, change `getChatMessages()` return type from `ChatMessage[]` to `DisplayMessage[]`.
+
+**Step 2: Update useChatSession**
+
+The hook should work with `DisplayMessage[]` now. The types flow from the store. Verify the hook compiles.
+
+**Step 3: Typecheck**
+
+Run: `pnpm --filter @mainframe/desktop build`
+
+**Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/hooks/useChatSession.ts packages/desktop/src/renderer/lib/api.ts
+git commit -m "feat(desktop): update useChatSession for DisplayMessage"
+```
+
+---
+
+### Task 10: Simplify convert-message.ts
+
+This is where the desktop sheds most of its message transformation logic.
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts`
+
+**Step 1: Remove CLAUDE_CATEGORIES and tool grouping imports**
+
+Remove:
+- `CLAUDE_CATEGORIES` constant (lines 14-28)
+- `getToolCategoriesForAdapter` function (lines 31-34)
+- Imports of `groupMessages`, `GroupedMessage`, `ToolGroupItem`, `TaskProgressItem`, `PartEntry`, `ToolCategories`, `groupToolCallParts`, `groupTaskChildren` from `@mainframe/core/messages`
+- Re-exports on line 40
+
+**Step 2: Rewrite convertMessage for DisplayMessage**
+
+The function now maps `DisplayMessage` → `ThreadMessageLike`. It's much simpler:
+
+```typescript
+import type { ThreadMessageLike } from '@assistant-ui/react';
+import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+
+export const ERROR_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_ERROR__' });
+export const PERMISSION_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_PERMISSION__' });
+
+type ContentPart = Exclude<ThreadMessageLike['content'], string>[number];
+
+export function convertMessage(message: DisplayMessage): ThreadMessageLike {
+  switch (message.type) {
+    case 'user': {
+      const parts = message.content
+        .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text')
+        .map((c) => ({ type: 'text' as const, text: c.text }));
+      return {
+        role: 'user',
+        content: parts.length > 0 ? parts : [{ type: 'text', text: '' }],
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+    }
+
+    case 'system':
+      return {
+        role: 'system',
+        content: message.content
+          .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text')
+          .map((c) => ({ type: 'text', text: c.text })),
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+
+    case 'assistant': {
+      const parts: ContentPart[] = [];
+      for (const block of message.content) {
+        switch (block.type) {
+          case 'text':
+            parts.push({ type: 'text', text: block.text });
+            break;
+          case 'thinking':
+            parts.push({ type: 'reasoning' as const, text: block.thinking });
+            break;
+          case 'tool_call':
+            parts.push({
+              type: 'tool-call',
+              toolCallId: block.id,
+              toolName: block.name,
+              args: block.input,
+              result: block.result
+                ? block.result.structuredPatch
+                  ? {
+                      content: block.result.content,
+                      structuredPatch: block.result.structuredPatch,
+                      originalFile: block.result.originalFile,
+                      modifiedFile: block.result.modifiedFile,
+                    }
+                  : block.result.content
+                : undefined,
+              isError: block.result?.isError,
+            });
+            break;
+          case 'tool_group':
+            // Virtual group — map to _ToolGroup tool-call
+            parts.push({
+              type: 'tool-call',
+              toolCallId: (block.calls[0] as any)?.id ?? '',
+              toolName: '_ToolGroup',
+              args: { items: block.calls },
+              result: 'grouped',
+            });
+            break;
+          case 'task_group':
+            parts.push({
+              type: 'tool-call',
+              toolCallId: block.agentId,
+              toolName: '_TaskGroup',
+              args: { taskArgs: (block.calls[0] as any)?.input ?? {}, children: block.calls },
+              result: (block.calls[0] as any)?.result,
+            });
+            break;
+          case 'error':
+            parts.push(ERROR_PLACEHOLDER);
+            break;
+          case 'permission_request':
+            parts.push(PERMISSION_PLACEHOLDER);
+            break;
+        }
+      }
+      return {
+        role: 'assistant',
+        content: parts.length > 0 ? parts : [{ type: 'text', text: '' }],
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+    }
+
+    case 'error':
+      return {
+        role: 'assistant',
+        content: [ERROR_PLACEHOLDER],
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+
+    case 'permission':
+      return {
+        role: 'assistant',
+        content: [PERMISSION_PLACEHOLDER],
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+
+    default:
+      return {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+        id: message.id,
+        createdAt: new Date(message.timestamp),
+      };
+  }
+}
+```
+
+**Step 3: Typecheck**
+
+Run: `pnpm --filter @mainframe/desktop build`
+
+**Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+git commit -m "refactor(desktop): simplify convertMessage for DisplayMessage input"
+```
+
+---
+
+### Task 11: Update MainframeRuntimeProvider — remove groupMessages
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx`
+
+**Step 1: Remove groupMessages import and usage**
+
+- Line 11: Remove `groupMessages` from imports
+- Line 83: Remove `const groupedMessages = useMemo(() => groupMessages(rawMessages), [rawMessages]);`
+- Use `rawMessages` directly (they are now `DisplayMessage[]`)
+- Update the `useExternalStoreRuntime` call to use `rawMessages` instead of `groupedMessages`
+
+**Step 2: Update getExternalStoreMessages usage**
+
+Components that call `getExternalStoreMessages<ChatMessage>` should use `getExternalStoreMessages<DisplayMessage>` instead.
+
+**Step 3: Typecheck**
+
+Run: `pnpm --filter @mainframe/desktop build`
+
+**Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+git commit -m "refactor(desktop): remove groupMessages from MainframeRuntimeProvider"
+```
+
+---
+
+### Task 12: Simplify UserMessage — read structured metadata
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx`
+
+**Step 1: Remove parsing imports**
+
+Remove imports of `parseCommandMessage`, `parseRawCommand`, `parseAttachedFilePathTags`, `resolveSkillName` from `../message-parsing`.
+
+**Step 2: Read structured metadata instead**
+
+The display pipeline now puts command/skill info and file attachments into `metadata`:
+
+```typescript
+// Before (parsing at render time):
+const { files: parsedFileTags, cleanText } = parseAttachedFilePathTags(rawUserText);
+let parsed = cleanText ? parseCommandMessage(cleanText) : null;
+
+// After (reading pre-computed metadata):
+const original = ...; // from getExternalStoreMessages<DisplayMessage>
+const command = original?.metadata?.command as { name: string; args?: string; isCommand?: boolean } | undefined;
+const attachedFiles = original?.metadata?.attachedFiles as { name: string }[] | undefined;
+const cleanText = original?.metadata?.cleanText as string | undefined ?? firstText?.text ?? '';
+```
+
+**Step 3: Update rendering logic**
+
+Replace `parsed` references with `command`, replace `parsedFileTags` with `attachedFiles`.
+
+**Step 4: Typecheck**
+
+Run: `pnpm --filter @mainframe/desktop build`
+
+**Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+git commit -m "refactor(desktop): read structured metadata instead of parsing in UserMessage"
+```
+
+---
+
+### Task 13: Revert `filterInternalMessages` in history.ts
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/history.ts:202-214`
+
+**Step 1: Revert to filterSkillExpansions**
+
+The `<mainframe-command>` filtering now happens in `display-pipeline.ts`. The Claude adapter should only filter `<command-name>` skill markers (Claude-specific concern).
+
+```typescript
+// Rename back and remove <mainframe-command> pattern
+const SKILL_EXPANSION_RE = /<command-name>/;
+
+export function filterSkillExpansions(messages: ChatMessage[]): ChatMessage[] {
+  return messages.filter((msg) => {
+    if (msg.type !== 'user') return true;
+    return !msg.content.some(
+      (b) => b.type === 'text' && SKILL_EXPANSION_RE.test((b as { text: string }).text),
+    );
+  });
+}
+```
+
+Update the call site at line 271: `filterSkillExpansions(messages)`.
+
+**Step 2: Update tests**
+
+Modify `packages/core/src/__tests__/message-loading.test.ts`:
+- Remove the test for `<mainframe-command>` filtering (it's now in display-pipeline tests)
+- Keep tests for `<command-name>` filtering
+- Update function name references from `filterInternalMessages` to `filterSkillExpansions`
+
+**Step 3: Run tests**
+
+Run: `pnpm --filter @mainframe/core test -- --run message-loading`
+
+**Step 4: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/history.ts packages/core/src/__tests__/message-loading.test.ts
+git commit -m "fix(claude): revert to filterSkillExpansions, move mainframe-command filtering to pipeline"
+```
+
+---
+
+### Task 14: Clean up dead code and unused exports
+
+**Files:**
+- Modify: `packages/core/src/messages/index.ts` — review exports
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/message-parsing.tsx` — remove unused re-exports
+- Check for unused imports across desktop
+
+**Step 1: Audit exports**
+
+- `groupMessages` — still needed internally by the pipeline but should NOT be re-exported for desktop use
+- `GroupedMessage` — no longer needed by desktop
+- Tool grouping functions — used internally by pipeline, not by desktop
+- `CLAUDE_CATEGORIES` — deleted from desktop, no replacement needed (lives on adapter)
+
+**Step 2: Clean up desktop message-parsing.tsx**
+
+Remove re-exports that are no longer used by desktop components:
+- `parseCommandMessage`, `parseRawCommand`, `parseAttachedFilePathTags` — only if no other desktop component uses them
+- `COMMAND_NAME_RE`, `ATTACHED_FILE_PATH_RE` — check usage
+
+Keep: `PLAN_PREFIX`, `highlightMentions`, `renderHighlights`, `formatTurnDuration` — still used by desktop
+
+**Step 3: Typecheck both packages**
+
+Run: `pnpm --filter @mainframe/core build && pnpm --filter @mainframe/desktop build`
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "chore: clean up unused exports after display pipeline migration"
+```
+
+---
+
+### Task 15: Run full test suite and typecheck
+
+**Step 1: Build all packages**
+
+Run: `pnpm build`
+
+**Step 2: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests pass (except known flaky title-generation tests)
+
+**Step 3: Fix any issues**
+
+If tests fail, diagnose and fix. Pay attention to:
+- Import path changes
+- Type mismatches between `ChatMessage` and `DisplayMessage`
+- Missing exports
+
+**Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "test: verify full suite passes after display pipeline migration"
+```
+
+---
+
+## Notes for Implementer
+
+### Key Design Decisions
+
+1. **No display cache**: The pipeline runs on-demand. For WS events, the event handler maintains a lightweight display state (`Map<string, DisplayMessage[]>`) to compute deltas — this is NOT a full cache, just the last pipeline output for diffing.
+
+2. **Raw `message.added` events stay**: The daemon continues emitting `message.added` with raw `ChatMessage` for internal consumers. New `display.*` events are added alongside. Desktop switches to consuming only display events.
+
+3. **Tool grouping in pipeline**: `groupToolCallParts()` and `groupTaskChildren()` run inside `prepareMessagesForClient()`, producing `tool_group` and `task_group` DisplayContent blocks. The desktop no longer calls these.
+
+4. **User message metadata**: The pipeline extracts command/skill info and file attachments into `metadata.command`, `metadata.attachedFiles`, and `metadata.cleanText` so UserMessage.tsx doesn't parse at render time.
+
+### Files NOT Modified
+
+- `packages/core/src/chat/message-cache.ts` — unchanged, stores raw messages
+- `packages/core/src/messages/message-grouping.ts` — unchanged, used internally by pipeline (or inlined)
+- `packages/core/src/messages/tool-grouping.ts` — unchanged, used internally by pipeline
+- `packages/core/src/messages/message-parsing.ts` — unchanged, functions used by pipeline
+
+### Testing Strategy
+
+- **Unit tests** for `prepareMessagesForClient()` covering all transform steps
+- **Existing tests** for `groupMessages()`, `groupToolCallParts()`, `groupTaskChildren()` remain unchanged
+- **Integration tests** for event handler display event emission
+- **Type-level tests** for DisplayMessage type shape

--- a/packages/core/src/__tests__/daemon-restart-messages.test.ts
+++ b/packages/core/src/__tests__/daemon-restart-messages.test.ts
@@ -229,12 +229,14 @@ describe('message resilience across daemon restart', () => {
     const json = await res.json();
 
     expect(json.success).toBe(true);
-    expect(json.data).toHaveLength(10);
 
-    // Verify messages are in order
-    for (let i = 0; i < 10; i++) {
-      const content = json.data[i].content[0];
-      expect(content.text).toBe(`Message ${i + 1}`);
+    // REST now returns DisplayMessage[] which groups consecutive assistant turns.
+    // All 10 text blocks should be present (merged into grouped turns).
+    const allTexts = json.data.flatMap((m: any) =>
+      m.content.filter((c: any) => c.type === 'text').map((c: any) => c.text),
+    );
+    for (let i = 1; i <= 10; i++) {
+      expect(allTexts).toContain(`Message ${i}`);
     }
   }, 15_000);
 });

--- a/packages/core/src/__tests__/event-handler-display.test.ts
+++ b/packages/core/src/__tests__/event-handler-display.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventHandler } from '../chat/event-handler.js';
+import { MessageCache } from '../chat/message-cache.js';
+import { PermissionManager } from '../chat/permission-manager.js';
+import { AdapterRegistry } from '../adapters/index.js';
+import type { DaemonEvent, SessionSink } from '@mainframe/types';
+
+function createRespondToPermission() {
+  return vi.fn().mockResolvedValue(undefined);
+}
+
+describe('EventHandler display event emission', () => {
+  let db: any;
+  let adapters: AdapterRegistry;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: DaemonEvent) => void>>;
+  let activeChats: Map<string, any>;
+
+  const chatId = 'chat-display';
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    adapters = new AdapterRegistry();
+    messages = new MessageCache();
+    permissions = new PermissionManager(db, adapters);
+    emitEvent = vi.fn();
+    activeChats = new Map();
+    activeChats.set(chatId, {
+      chat: {
+        id: chatId,
+        adapterId: 'claude',
+        totalCost: 0,
+        totalTokensInput: 0,
+        totalTokensOutput: 0,
+        processState: 'working',
+      },
+      session: { id: 'session-1', adapterId: 'claude' },
+    });
+  });
+
+  function buildHandler(): EventHandler {
+    return new EventHandler(
+      db,
+      messages,
+      permissions,
+      (id) => activeChats.get(id),
+      emitEvent,
+      () => undefined,
+    );
+  }
+
+  function filterEvents(type: string): DaemonEvent[] {
+    return emitEvent.mock.calls.map((call) => call[0] as DaemonEvent).filter((e) => e.type === type);
+  }
+
+  it('emits display.messages.set on first onMessage', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'text', text: 'hello' }]);
+
+    const setEvents = filterEvents('display.messages.set');
+    expect(setEvents).toHaveLength(1);
+    const payload = setEvents[0] as Extract<DaemonEvent, { type: 'display.messages.set' }>;
+    expect(payload.chatId).toBe(chatId);
+    expect(payload.messages).toHaveLength(1);
+    expect(payload.messages[0]!.type).toBe('assistant');
+  });
+
+  it('emits display.message.added for second assistant message', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'text', text: 'first' }]);
+    emitEvent.mockClear();
+
+    // Insert a user message so grouping does not merge the two assistant turns
+    const userMsg = messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'user input' }]);
+    messages.append(chatId, userMsg);
+
+    sink.onMessage([{ type: 'text', text: 'second' }]);
+
+    const addedEvents = filterEvents('display.message.added');
+    expect(addedEvents.length).toBeGreaterThanOrEqual(1);
+    const added = addedEvents[addedEvents.length - 1] as Extract<DaemonEvent, { type: 'display.message.added' }>;
+    expect(added.message.type).toBe('assistant');
+  });
+
+  it('emits display.message.updated when tool_result merges into existing turn', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([
+      { type: 'text', text: 'thinking...' },
+      { type: 'tool_use', id: 'tool-1', name: 'Read', input: { path: '/tmp/file.txt' } },
+    ]);
+    emitEvent.mockClear();
+
+    sink.onToolResult([{ type: 'tool_result', toolUseId: 'tool-1', content: 'file contents here', isError: false }]);
+
+    const updatedEvents = filterEvents('display.message.updated');
+    expect(updatedEvents).toHaveLength(1);
+    const updated = updatedEvents[0] as Extract<DaemonEvent, { type: 'display.message.updated' }>;
+    expect(updated.chatId).toBe(chatId);
+    expect(updated.message.type).toBe('assistant');
+  });
+
+  it('emits display events on onCompact', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onCompact();
+
+    const setEvents = filterEvents('display.messages.set');
+    expect(setEvents).toHaveLength(1);
+    const payload = setEvents[0] as Extract<DaemonEvent, { type: 'display.messages.set' }>;
+    expect(payload.messages).toHaveLength(1);
+    expect(payload.messages[0]!.type).toBe('system');
+  });
+
+  it('emits display events on onResult error', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onResult({
+      subtype: 'error_during_execution',
+      is_error: true,
+      total_cost_usd: 0,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+
+    const setEvents = filterEvents('display.messages.set');
+    expect(setEvents).toHaveLength(1);
+    const payload = setEvents[0] as Extract<DaemonEvent, { type: 'display.messages.set' }>;
+    expect(payload.messages).toHaveLength(1);
+    expect(payload.messages[0]!.type).toBe('error');
+  });
+
+  it('still emits raw message.added alongside display events', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'text', text: 'hello' }]);
+
+    const rawEvents = filterEvents('message.added');
+    const displayEvents = filterEvents('display.messages.set');
+    expect(rawEvents).toHaveLength(1);
+    expect(displayEvents).toHaveLength(1);
+  });
+
+  it('consecutive onMessage calls for same turn emit display.message.updated', () => {
+    const sink: SessionSink = buildHandler().buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'text', text: 'part 1' }]);
+    emitEvent.mockClear();
+    sink.onMessage([{ type: 'text', text: 'part 2' }]);
+
+    const updatedEvents = filterEvents('display.message.updated');
+    expect(updatedEvents).toHaveLength(1);
+    const updated = updatedEvents[0] as Extract<DaemonEvent, { type: 'display.message.updated' }>;
+    expect(updated.message.type).toBe('assistant');
+  });
+});

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { prepareMessagesForClient } from '../../messages/display-pipeline.js';
+import type { ChatMessage, MessageContent, ToolCategories } from '@mainframe/types';
+
+/* ── helpers ─────────────────────────────────────────────────────── */
+
+let idCounter = 0;
+function resetIds() {
+  idCounter = 0;
+}
+
+function rawMsg(type: ChatMessage['type'], content: MessageContent[], overrides?: Partial<ChatMessage>): ChatMessage {
+  idCounter++;
+  return {
+    id: `msg-${idCounter}`,
+    chatId: 'chat-1',
+    type,
+    content,
+    timestamp: new Date(2026, 0, 1, 0, 0, idCounter).toISOString(),
+    ...overrides,
+  };
+}
+
+const txt = (t: string): MessageContent & { type: 'text' } => ({ type: 'text', text: t });
+const tu = (id: string, name: string, input: Record<string, unknown> = {}): MessageContent & { type: 'tool_use' } => ({
+  type: 'tool_use',
+  id,
+  name,
+  input,
+});
+const tr = (toolUseId: string, content: string, isError = false): MessageContent & { type: 'tool_result' } => ({
+  type: 'tool_result',
+  toolUseId,
+  content,
+  isError,
+});
+
+const TEST_CATEGORIES: ToolCategories = {
+  explore: new Set(['Read', 'Glob', 'Grep']),
+  hidden: new Set(['TodoWrite', 'Skill']),
+  progress: new Set(['TaskCreate', 'TaskUpdate']),
+  subagent: new Set(['Task']),
+};
+
+/* ── tests ───────────────────────────────────────────────────────── */
+
+describe('prepareMessagesForClient', () => {
+  beforeEach(resetIds);
+
+  it('returns empty array for empty input', () => {
+    expect(prepareMessagesForClient([])).toEqual([]);
+  });
+
+  it('converts a single user text message', () => {
+    const messages = [rawMsg('user', [txt('hello')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('user');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('converts a single assistant text message', () => {
+    const messages = [rawMsg('assistant', [txt('hi there')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: 'hi there' }]);
+  });
+
+  it('converts assistant with tool_use + subsequent tool_result into tool_call with result', () => {
+    const messages = [
+      rawMsg('assistant', [txt('Let me check'), tu('tu1', 'Bash', { command: 'ls' })]),
+      rawMsg('tool_result', [tr('tu1', 'file.ts\nindex.ts')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+
+    const content = result[0]!.content;
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ type: 'text', text: 'Let me check' });
+    expect(content[1]).toMatchObject({
+      type: 'tool_call',
+      id: 'tu1',
+      name: 'Bash',
+      input: { command: 'ls' },
+      category: 'default',
+      result: { content: 'file.ts\nindex.ts', isError: false },
+    });
+  });
+
+  it('merges consecutive assistant messages into one turn', () => {
+    const messages = [rawMsg('assistant', [txt('part 1')]), rawMsg('assistant', [txt('part 2')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content).toEqual([
+      { type: 'text', text: 'part 1' },
+      { type: 'text', text: 'part 2' },
+    ]);
+  });
+
+  it('strips mainframe-command-response tags from assistant text', () => {
+    const messages = [
+      rawMsg('assistant', [txt('<mainframe-command-response id="x">inner content</mainframe-command-response>')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content[0]).toEqual({ type: 'text', text: 'inner content' });
+  });
+
+  it('filters out internal user messages with mainframe-command', () => {
+    const messages = [
+      rawMsg('user', [txt('<mainframe-command type="status">check</mainframe-command>')]),
+      rawMsg('assistant', [txt('response')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+  });
+
+  it('filters out internal user messages with command-name skill marker', () => {
+    const messages = [
+      rawMsg('user', [txt('<command-name>systematic-debugging</command-name> some text')]),
+      rawMsg('assistant', [txt('response')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+  });
+
+  it('deduplicates tool_use blocks by id (keeps first occurrence)', () => {
+    const messages = [
+      rawMsg('assistant', [
+        tu('tu1', 'Bash', { command: 'ls' }),
+        tu('tu1', 'Bash', { command: 'ls' }),
+        tu('tu2', 'Read', { file: '/a.ts' }),
+      ]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    const toolCalls = result[0]!.content.filter((c) => c.type === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+  });
+
+  it('passes through system compact_boundary as system DisplayMessage', () => {
+    const messages = [rawMsg('system', [txt('[compact_boundary]')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('system');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: '[compact_boundary]' }]);
+  });
+
+  it('passes through error messages', () => {
+    const messages = [rawMsg('error', [{ type: 'error', message: 'something broke' }])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('error');
+    expect(result[0]!.content).toEqual([{ type: 'error', message: 'something broke' }]);
+  });
+
+  it('attaches turnDurationMs to preceding assistant and omits system msg', () => {
+    const messages = [
+      rawMsg('assistant', [txt('answer')]),
+      rawMsg('system', [], { metadata: { turnDurationMs: 1234 } }),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+    expect(result[0]!.metadata?.turnDurationMs).toBe(1234);
+  });
+
+  it('applies tool categories: explore tool gets explore category', () => {
+    const messages = [
+      rawMsg('assistant', [tu('tu1', 'Read', { file: '/a.ts' })]),
+      rawMsg('tool_result', [tr('tu1', 'content')]),
+    ];
+    const result = prepareMessagesForClient(messages, TEST_CATEGORIES);
+    const tc = result[0]!.content.find((c) => c.type === 'tool_call');
+    expect(tc).toMatchObject({ type: 'tool_call', category: 'explore' });
+  });
+
+  it('passes through permission messages', () => {
+    const request = { tool: 'Bash', type: 'tool' };
+    const messages = [rawMsg('permission', [{ type: 'permission_request', request: request as never }])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('permission');
+    expect(result[0]!.content[0]).toMatchObject({ type: 'permission_request' });
+  });
+
+  it('filters [Request interrupted text from user messages', () => {
+    const messages = [rawMsg('user', [txt('fix the bug'), txt('[Request interrupted by user]')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content).toEqual([{ type: 'text', text: 'fix the bug' }]);
+  });
+
+  it('populates metadata.attachedFiles for file path tags in user messages', () => {
+    const messages = [rawMsg('user', [txt('check this <attached_file_path name="foo.ts"/>')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.metadata?.attachedFiles).toEqual([{ name: 'foo.ts' }]);
+    // Text should have the tag stripped
+    expect((result[0]!.content[0] as { type: 'text'; text: string }).text).toBe('check this');
+  });
+
+  it('does not mutate original messages', () => {
+    const original: ChatMessage = rawMsg('assistant', [tu('tu1', 'Bash', { command: 'ls' })]);
+    const contentBefore = [...original.content];
+    const metaBefore = original.metadata;
+
+    prepareMessagesForClient([
+      original,
+      rawMsg('assistant', [txt('more')]),
+      rawMsg('tool_result', [tr('tu1', 'output')]),
+      rawMsg('system', [], { metadata: { turnDurationMs: 100 } }),
+    ]);
+
+    expect(original.content).toEqual(contentBefore);
+    expect(original.metadata).toBe(metaBefore);
+  });
+
+  it('keeps thinking blocks as-is in assistant messages', () => {
+    const messages = [rawMsg('assistant', [{ type: 'thinking', thinking: 'let me think...' }, txt('response')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result[0]!.content[0]).toEqual({ type: 'thinking', thinking: 'let me think...' });
+    expect(result[0]!.content[1]).toEqual({ type: 'text', text: 'response' });
+  });
+
+  it('keeps image blocks in user messages', () => {
+    const messages = [
+      rawMsg('user', [txt('look at this'), { type: 'image', mediaType: 'image/png', data: 'base64data' }]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result[0]!.content).toHaveLength(2);
+    expect(result[0]!.content[1]).toEqual({
+      type: 'image',
+      mediaType: 'image/png',
+      data: 'base64data',
+    });
+  });
+
+  it('handles orphan tool_result (not attached to assistant) as assistant message', () => {
+    const messages = [rawMsg('user', [txt('question')]), rawMsg('tool_result', [tr('tu1', 'orphan result')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(2);
+    expect(result[1]!.type).toBe('assistant');
+  });
+
+  describe('tool grouping with categories', () => {
+    it('groups consecutive explore tools into a tool_group', () => {
+      const messages = [
+        rawMsg('assistant', [
+          tu('tu1', 'Read', { file: '/a.ts' }),
+          tu('tu2', 'Grep', { pattern: 'foo' }),
+          tu('tu3', 'Glob', { pattern: '*.ts' }),
+        ]),
+        rawMsg('tool_result', [tr('tu1', 'a-content'), tr('tu2', 'grep-result'), tr('tu3', 'glob-result')]),
+      ];
+      const result = prepareMessagesForClient(messages, TEST_CATEGORIES);
+      const groups = result[0]!.content.filter((c) => c.type === 'tool_group');
+      expect(groups).toHaveLength(1);
+    });
+
+    it('wraps subagent tool + children into a task_group', () => {
+      const messages = [
+        rawMsg('assistant', [tu('tu1', 'Task', { description: 'do something' }), tu('tu2', 'Bash', { command: 'ls' })]),
+        rawMsg('tool_result', [tr('tu1', 'task-result'), tr('tu2', 'bash-result')]),
+      ];
+      const result = prepareMessagesForClient(messages, TEST_CATEGORIES);
+      const taskGroups = result[0]!.content.filter((c) => c.type === 'task_group');
+      expect(taskGroups).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -59,6 +59,7 @@ function makeContext(hasActiveSession = true): PlanModeContext & {
     } as any,
     getActiveChat: vi.fn().mockReturnValue(activeChat),
     emitEvent: vi.fn(),
+    clearDisplayCache: vi.fn(),
     startChat: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     session,

--- a/packages/core/src/__tests__/routes/chats.test.ts
+++ b/packages/core/src/__tests__/routes/chats.test.ts
@@ -15,6 +15,7 @@ function createMockContext(): RouteContext {
       getChat: vi.fn(),
       archiveChat: vi.fn(),
       getMessages: vi.fn(),
+      getDisplayMessages: vi.fn(),
       getPendingPermission: vi.fn(),
       on: vi.fn(),
     } as any,
@@ -119,9 +120,9 @@ describe('chatRoutes', () => {
   });
 
   describe('GET /api/chats/:id/messages', () => {
-    it('returns messages for chat', async () => {
-      const messages = [{ id: 'm1', role: 'user', content: 'hello' }];
-      (ctx.chats.getMessages as any).mockResolvedValue(messages);
+    it('returns display messages for chat', async () => {
+      const messages = [{ id: 'm1', type: 'user', content: [{ type: 'text', text: 'hello' }] }];
+      (ctx.chats.getDisplayMessages as any).mockResolvedValue(messages);
 
       const router = chatRoutes(ctx);
       const handler = extractHandler(router, 'get', '/api/chats/:id/messages');
@@ -130,7 +131,7 @@ describe('chatRoutes', () => {
       handler({ params: { id: 'c1' }, query: {} }, res, vi.fn());
       await flushPromises();
 
-      expect(ctx.chats.getMessages).toHaveBeenCalledWith('c1');
+      expect(ctx.chats.getDisplayMessages).toHaveBeenCalledWith('c1');
       expect(res.json).toHaveBeenCalledWith({ success: true, data: messages });
     });
   });

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -52,6 +52,11 @@ export class ChatManager {
       this.permissions,
       (chatId) => this.activeChats.get(chatId),
       (e) => this.emitEvent(e),
+      (chatId) => {
+        const chat = this.activeChats.get(chatId)?.chat ?? this.db.chats.get(chatId);
+        const adapter = chat ? this.adapters.get(chat.adapterId) : undefined;
+        return adapter?.getToolCategories?.();
+      },
     );
     this.planMode = new PlanModeHandler({
       permissions: this.permissions,

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -85,6 +85,7 @@ export class ChatManager {
       getActiveChat: (chatId) => this.activeChats.get(chatId),
       startChat: (chatId) => this.lifecycle.startChat(chatId),
       emitEvent: (event) => this.emitEvent(event),
+      emitDisplay: (chatId) => this.eventHandler.emitDisplay(chatId),
       getChat: (chatId) => this.getChat(chatId),
       getMessages: (chatId) => this.getMessages(chatId),
     });
@@ -173,6 +174,7 @@ export class ChatManager {
       const userMessage = this.messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: content }]);
       this.messages.append(chatId, userMessage);
       this.emitEvent({ type: 'message.added', chatId, message: userMessage });
+      this.eventHandler.emitDisplay(chatId);
 
       if (source === 'mainframe') {
         const resolvedArgs = args ?? findMainframeCommand(name)?.promptTemplate ?? '';
@@ -210,6 +212,7 @@ export class ChatManager {
     );
     this.messages.append(chatId, message);
     this.emitEvent({ type: 'message.added', chatId, message });
+    this.eventHandler.emitDisplay(chatId);
     if (attachmentIds && attachmentIds.length > 0) {
       this.emitEvent({ type: 'context.updated', chatId });
     }
@@ -240,11 +243,13 @@ export class ChatManager {
   }
 
   async archiveChat(chatId: string): Promise<void> {
-    return this.lifecycle.archiveChat(chatId);
+    await this.lifecycle.archiveChat(chatId);
+    this.eventHandler.clearDisplayCache(chatId);
   }
 
   async endChat(chatId: string): Promise<void> {
-    return this.lifecycle.endChat(chatId);
+    await this.lifecycle.endChat(chatId);
+    this.eventHandler.clearDisplayCache(chatId);
   }
 
   async removeProject(projectId: string): Promise<void> {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -64,6 +64,7 @@ export class ChatManager {
       db: this.db,
       getActiveChat: (chatId) => this.activeChats.get(chatId),
       emitEvent: (event) => this.emitEvent(event),
+      clearDisplayCache: (chatId) => this.eventHandler.clearDisplayCache(chatId),
       startChat: (chatId) => this.lifecycle.startChat(chatId),
       sendMessage: (chatId, content) => this.sendMessage(chatId, content),
     });
@@ -267,6 +268,7 @@ export class ChatManager {
       this.activeChats.delete(chat.id);
       this.messages.delete(chat.id);
       this.permissions.clear(chat.id);
+      this.eventHandler.clearDisplayCache(chat.id);
     }
     this.db.projects.removeWithChats(projectId);
   }

--- a/packages/core/src/chat/display-emitter.ts
+++ b/packages/core/src/chat/display-emitter.ts
@@ -1,0 +1,49 @@
+import type { DaemonEvent, DisplayMessage, ToolCategories } from '@mainframe/types';
+import type { MessageCache } from './message-cache.js';
+import { prepareMessagesForClient } from '../messages/display-pipeline.js';
+
+/**
+ * Compares old and new display message arrays and emits the appropriate
+ * display.message.added / display.message.updated / display.messages.set
+ * events. Updates the display cache in place.
+ */
+export function emitDisplayDelta(
+  chatId: string,
+  messages: MessageCache,
+  displayCache: Map<string, DisplayMessage[]>,
+  categories: ToolCategories | undefined,
+  emitEvent: (event: DaemonEvent) => void,
+): void {
+  const raw = messages.get(chatId) ?? [];
+  const newDisplay = prepareMessagesForClient(raw, categories);
+  const oldDisplay = displayCache.get(chatId) ?? [];
+
+  if (oldDisplay.length === 0) {
+    if (newDisplay.length > 0) {
+      emitEvent({ type: 'display.messages.set', chatId, messages: newDisplay });
+    }
+  } else if (newDisplay.length > oldDisplay.length) {
+    // Check if the last existing message was updated (tool_result merged)
+    if (oldDisplay.length > 0) {
+      const lastOld = oldDisplay[oldDisplay.length - 1]!;
+      const lastNewAtOldIdx = newDisplay[oldDisplay.length - 1];
+      if (
+        lastNewAtOldIdx &&
+        lastNewAtOldIdx.id === lastOld.id &&
+        lastNewAtOldIdx.content.length !== lastOld.content.length
+      ) {
+        emitEvent({ type: 'display.message.updated', chatId, message: lastNewAtOldIdx });
+      }
+    }
+    // Emit added events for new messages
+    for (let i = oldDisplay.length; i < newDisplay.length; i++) {
+      emitEvent({ type: 'display.message.added', chatId, message: newDisplay[i]! });
+    }
+  } else if (newDisplay.length === oldDisplay.length && newDisplay.length > 0) {
+    // Same count — the last message was probably updated
+    const lastNew = newDisplay[newDisplay.length - 1]!;
+    emitEvent({ type: 'display.message.updated', chatId, message: lastNew });
+  }
+
+  displayCache.set(chatId, newDisplay);
+}

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -44,6 +44,17 @@ export class EventHandler {
       this.getToolCategories,
     );
   }
+
+  /** Emit display delta for a chat (for use by code paths outside the session sink). */
+  emitDisplay(chatId: string): void {
+    const categories = this.getToolCategories(chatId);
+    emitDisplayDelta(chatId, this.messages, this.displayCache, categories, this.emitEvent);
+  }
+
+  /** Remove display cache entry for a chat (call on chat end/archive). */
+  clearDisplayCache(chatId: string): void {
+    this.displayCache.delete(chatId);
+  }
 }
 
 function buildSessionSink(

--- a/packages/core/src/chat/permission-handler.ts
+++ b/packages/core/src/chat/permission-handler.ts
@@ -16,6 +16,7 @@ export interface PermissionHandlerDeps {
   getActiveChat: (chatId: string) => ActiveChat | undefined;
   startChat: (chatId: string) => Promise<void>;
   emitEvent: (event: DaemonEvent) => void;
+  emitDisplay: (chatId: string) => void;
   getChat: (chatId: string) => Chat | null;
   getMessages: (chatId: string) => Promise<ChatMessage[]>;
 }
@@ -45,6 +46,7 @@ export class ChatPermissionHandler {
       ]);
       this.deps.messages.append(chatId, message);
       this.deps.emitEvent({ type: 'message.added', chatId, message });
+      this.deps.emitDisplay(chatId);
     }
 
     if (response.clearContext && response.behavior === 'allow' && response.toolName === 'ExitPlanMode') {

--- a/packages/core/src/chat/plan-mode-handler.ts
+++ b/packages/core/src/chat/plan-mode-handler.ts
@@ -11,6 +11,7 @@ export interface PlanModeContext {
   db: DatabaseManager;
   getActiveChat(chatId: string): ActiveChat | undefined;
   emitEvent(event: DaemonEvent): void;
+  clearDisplayCache(chatId: string): void;
   startChat(chatId: string): Promise<void>;
   sendMessage(chatId: string, content: string): Promise<void>;
 }
@@ -64,6 +65,7 @@ export class PlanModeHandler {
     this.ctx.emitEvent({ type: 'chat.updated', chat: active.chat });
 
     this.ctx.messages.set(chatId, []);
+    this.ctx.clearDisplayCache(chatId);
     this.ctx.emitEvent({ type: 'messages.cleared', chatId });
 
     await this.ctx.startChat(chatId);

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -79,8 +79,7 @@ export function convertUserContent(content: MessageContent[]): {
       if (block.text.startsWith('[Request interrupted')) continue;
 
       const cmdInfo = parseCommandMessage(block.text);
-      if (cmdInfo)
-        metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText, isCommand: cmdInfo.isCommand };
+      if (cmdInfo) metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText };
 
       const { files, cleanText } = parseAttachedFilePathTags(block.text);
       if (files.length > 0) metadata.attachedFiles = files;

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -1,0 +1,210 @@
+import type { MessageContent, ToolCategories, DisplayContent, ToolCallResult } from '@mainframe/types';
+import { stripMainframeCommandTags, parseCommandMessage, parseAttachedFilePathTags } from './message-parsing.js';
+import type { GroupedMessage } from './message-grouping.js';
+import type { PartEntry } from './tool-grouping.js';
+import { groupToolCallParts, groupTaskChildren } from './tool-grouping.js';
+
+const INTERNAL_USER_RE = /<command-name>|<mainframe-command[\s>]/;
+
+/** Returns true if a user message is internal (mainframe commands or skill invocations). */
+export function isInternalUserMessage(content: MessageContent[]): boolean {
+  return content.some((block) => block.type === 'text' && INTERNAL_USER_RE.test(block.text));
+}
+
+/** Categorize a tool by name, returning its display category. */
+export function categorizeToolCall(
+  name: string,
+  categories?: ToolCategories,
+): 'default' | 'explore' | 'hidden' | 'progress' | 'subagent' {
+  if (!categories) return 'default';
+  if (categories.explore.has(name)) return 'explore';
+  if (categories.hidden.has(name)) return 'hidden';
+  if (categories.progress.has(name)) return 'progress';
+  if (categories.subagent.has(name)) return 'subagent';
+  return 'default';
+}
+
+/** Build a ToolCallResult from a tool_result content block. */
+function toToolCallResult(block: MessageContent & { type: 'tool_result' }): ToolCallResult {
+  return {
+    content: block.content,
+    isError: block.isError,
+    ...(block.structuredPatch && { structuredPatch: block.structuredPatch }),
+    ...(block.originalFile && { originalFile: block.originalFile }),
+    ...(block.modifiedFile && { modifiedFile: block.modifiedFile }),
+  };
+}
+
+/** Convert a grouped assistant message to DisplayContent[]. */
+export function convertAssistantContent(grouped: GroupedMessage, categories?: ToolCategories): DisplayContent[] {
+  const seenToolIds = new Set<string>();
+  const content: DisplayContent[] = [];
+
+  for (const block of grouped.content) {
+    if (block.type === 'text') {
+      const stripped = stripMainframeCommandTags(block.text);
+      if (stripped) content.push({ type: 'text', text: stripped });
+    } else if (block.type === 'thinking') {
+      content.push({ type: 'thinking', thinking: block.thinking });
+    } else if (block.type === 'tool_use') {
+      if (seenToolIds.has(block.id)) continue;
+      seenToolIds.add(block.id);
+
+      const resultBlock = grouped._toolResults?.get(block.id);
+      const call: DisplayContent & { type: 'tool_call' } = {
+        type: 'tool_call',
+        id: block.id,
+        name: block.name,
+        input: block.input,
+        category: categorizeToolCall(block.name, categories),
+      };
+      if (resultBlock) call.result = toToolCallResult(resultBlock);
+      content.push(call);
+    }
+  }
+
+  return content;
+}
+
+/** Convert a user message's content blocks to DisplayContent[] and extract metadata. */
+export function convertUserContent(content: MessageContent[]): {
+  displayContent: DisplayContent[];
+  metadata: Record<string, unknown>;
+} {
+  const metadata: Record<string, unknown> = {};
+  const displayContent: DisplayContent[] = [];
+
+  for (const block of content) {
+    if (block.type === 'text') {
+      if (block.text.startsWith('[Request interrupted')) continue;
+
+      const cmdInfo = parseCommandMessage(block.text);
+      if (cmdInfo) metadata.command = cmdInfo.commandName;
+
+      const { files, cleanText } = parseAttachedFilePathTags(block.text);
+      if (files.length > 0) metadata.attachedFiles = files;
+
+      const textToStore = files.length > 0 ? cleanText : block.text;
+      if (cmdInfo) metadata.cleanText = cmdInfo.userText;
+
+      if (textToStore) displayContent.push({ type: 'text', text: textToStore });
+    } else if (block.type === 'image') {
+      displayContent.push({ type: 'image', mediaType: block.mediaType, data: block.data });
+    }
+  }
+
+  return { displayContent, metadata };
+}
+
+/** Apply tool grouping (explore groups, task groups, progress accumulation). */
+export function applyToolGrouping(content: DisplayContent[], categories: ToolCategories): DisplayContent[] {
+  const parts: PartEntry[] = content.map((c) => {
+    if (c.type === 'tool_call') {
+      return {
+        type: 'tool-call' as const,
+        toolCallId: c.id,
+        toolName: c.name,
+        args: c.input,
+        result: c.result,
+        isError: c.result?.isError,
+      };
+    }
+    if (c.type === 'text') return { type: 'text' as const, text: c.text };
+    // Pass non-groupable content through by encoding as a sentinel tool call
+    return { type: 'text' as const, text: '' };
+  });
+
+  let grouped = groupToolCallParts(parts, categories);
+  grouped = groupTaskChildren(grouped, categories);
+
+  return convertGroupedPartsToDisplay(grouped, content, categories);
+}
+
+/** Convert PartEntry[] back to DisplayContent[], handling virtual group entries. */
+function convertGroupedPartsToDisplay(
+  parts: PartEntry[],
+  originalContent: DisplayContent[],
+  categories: ToolCategories,
+): DisplayContent[] {
+  const result: DisplayContent[] = [];
+
+  // Re-insert non-text/non-tool_call content (thinking, image, etc.) at the front
+  for (const c of originalContent) {
+    if (c.type !== 'tool_call' && c.type !== 'text') result.push(c);
+  }
+
+  for (const part of parts) {
+    if (part.type === 'text') {
+      if (part.text) result.push({ type: 'text', text: part.text });
+      continue;
+    }
+
+    if (part.toolName === '_ToolGroup') {
+      const items = part.args.items as Array<{
+        toolCallId: string;
+        toolName: string;
+        args: Record<string, unknown>;
+        result: unknown;
+        isError: boolean | undefined;
+      }>;
+      result.push({
+        type: 'tool_group',
+        calls: items.map((item) => ({
+          type: 'tool_call' as const,
+          id: item.toolCallId,
+          name: item.toolName,
+          input: item.args,
+          category: categorizeToolCall(item.toolName, categories),
+          ...(item.result != null && {
+            result: item.result as ToolCallResult,
+          }),
+        })),
+      });
+    } else if (part.toolName === '_TaskGroup') {
+      const children = part.args.children as PartEntry[];
+      const taskArgs = part.args.taskArgs as Record<string, unknown>;
+      const agentId = (taskArgs?.description as string) ?? part.toolCallId;
+      result.push({
+        type: 'task_group',
+        agentId,
+        calls: children.map((child) => {
+          if (child.type !== 'tool-call') return { type: 'text' as const, text: child.text };
+          return {
+            type: 'tool_call' as const,
+            id: child.toolCallId,
+            name: child.toolName,
+            input: child.args,
+            category: categorizeToolCall(child.toolName, categories),
+            ...(child.result != null && {
+              result: child.result as ToolCallResult,
+            }),
+          };
+        }),
+      });
+    } else if (part.toolName === '_TaskProgress') {
+      result.push({
+        type: 'tool_call',
+        id: part.toolCallId,
+        name: '_TaskProgress',
+        input: part.args,
+        category: 'progress',
+        ...(part.result != null && { result: part.result as ToolCallResult }),
+      });
+    } else {
+      // Regular tool call — find original DisplayContent to preserve result
+      const orig = originalContent.find((c) => c.type === 'tool_call' && c.id === part.toolCallId) as
+        | (DisplayContent & { type: 'tool_call' })
+        | undefined;
+      result.push({
+        type: 'tool_call',
+        id: part.toolCallId,
+        name: part.toolName,
+        input: part.args,
+        category: categorizeToolCall(part.toolName, categories),
+        ...(orig?.result && { result: orig.result }),
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -79,7 +79,8 @@ export function convertUserContent(content: MessageContent[]): {
       if (block.text.startsWith('[Request interrupted')) continue;
 
       const cmdInfo = parseCommandMessage(block.text);
-      if (cmdInfo) metadata.command = cmdInfo.commandName;
+      if (cmdInfo)
+        metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText, isCommand: cmdInfo.isCommand };
 
       const { files, cleanText } = parseAttachedFilePathTags(block.text);
       if (files.length > 0) metadata.attachedFiles = files;

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -1,0 +1,133 @@
+import type { ChatMessage, ToolCategories, DisplayMessage } from '@mainframe/types';
+import { groupMessages } from './message-grouping.js';
+import {
+  isInternalUserMessage,
+  convertAssistantContent,
+  convertUserContent,
+  applyToolGrouping,
+} from './display-helpers.js';
+
+/**
+ * Transforms raw ChatMessage[] into display-ready DisplayMessage[].
+ *
+ * Pipeline steps:
+ * 1. Filter internal user messages (mainframe commands, skill markers)
+ * 2. Group consecutive assistant/tool_use turns, attach tool_results
+ * 3. Handle turnDurationMs system markers
+ * 4. Convert each grouped message to DisplayMessage
+ * 5. Apply tool grouping when categories are provided
+ */
+export function prepareMessagesForClient(messages: ChatMessage[], categories?: ToolCategories): DisplayMessage[] {
+  if (messages.length === 0) return [];
+
+  // Step 1: Filter internal user messages
+  const filtered = messages.filter((msg) => !(msg.type === 'user' && isInternalUserMessage(msg.content)));
+
+  // Steps 2–3: Group consecutive assistant turns, attach tool_results,
+  // handle turnDurationMs (all handled by groupMessages)
+  const grouped = groupMessages(filtered);
+
+  // Steps 4–5: Convert to DisplayMessage
+  const result: DisplayMessage[] = [];
+
+  for (const gMsg of grouped) {
+    const display = convertGroupedToDisplay(gMsg, categories);
+    if (display) result.push(display);
+  }
+
+  return result;
+}
+
+function convertGroupedToDisplay(
+  msg: ReturnType<typeof groupMessages>[number],
+  categories?: ToolCategories,
+): DisplayMessage | null {
+  const base = {
+    id: msg.id,
+    chatId: msg.chatId,
+    timestamp: msg.timestamp,
+  };
+
+  switch (msg.type) {
+    case 'assistant':
+    case 'tool_use': {
+      let content = convertAssistantContent(msg, categories);
+      if (categories) content = applyToolGrouping(content, categories);
+
+      return {
+        ...base,
+        type: 'assistant',
+        content,
+        ...(msg.metadata && { metadata: { ...msg.metadata } }),
+      };
+    }
+
+    case 'user': {
+      const { displayContent, metadata: extraMeta } = convertUserContent(msg.content);
+      const metadata = {
+        ...(msg.metadata ?? {}),
+        ...extraMeta,
+      };
+      return {
+        ...base,
+        type: 'user',
+        content: displayContent,
+        ...(Object.keys(metadata).length > 0 && { metadata }),
+      };
+    }
+
+    case 'system':
+      return {
+        ...base,
+        type: 'system',
+        content: msg.content.map((c) => {
+          if (c.type === 'text') return { type: 'text' as const, text: c.text };
+          return { type: 'text' as const, text: '' };
+        }),
+        ...(msg.metadata && { metadata: { ...msg.metadata } }),
+      };
+
+    case 'error':
+      return {
+        ...base,
+        type: 'error',
+        content: msg.content.map((c) => {
+          if (c.type === 'error') return { type: 'error' as const, message: c.message };
+          return { type: 'text' as const, text: '' };
+        }),
+        ...(msg.metadata && { metadata: { ...msg.metadata } }),
+      };
+
+    case 'permission':
+      return {
+        ...base,
+        type: 'permission',
+        content: msg.content.map((c) => {
+          if (c.type === 'permission_request') {
+            return { type: 'permission_request' as const, request: c.request };
+          }
+          return { type: 'text' as const, text: '' };
+        }),
+        ...(msg.metadata && { metadata: { ...msg.metadata } }),
+      };
+
+    case 'tool_result': {
+      // Orphan tool_result: show as assistant text
+      const textParts = msg.content.map((c) => {
+        if (c.type === 'tool_result') {
+          return { type: 'text' as const, text: c.content };
+        }
+        return { type: 'text' as const, text: '' };
+      });
+      return {
+        ...base,
+        type: 'assistant',
+        content: textParts,
+        ...(msg.metadata && { metadata: { ...msg.metadata } }),
+      };
+    }
+
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/messages/index.ts
+++ b/packages/core/src/messages/index.ts
@@ -16,6 +16,8 @@ export {
 
 export { type GroupedMessage, groupMessages } from './message-grouping.js';
 
+export { prepareMessagesForClient } from './display-pipeline.js';
+
 export {
   COMMAND_NAME_RE,
   ATTACHED_FILE_PATH_RE,

--- a/packages/core/src/messages/tool-categorization.ts
+++ b/packages/core/src/messages/tool-categorization.ts
@@ -1,11 +1,7 @@
 /* ── Adapter-declared tool categorization ──────────────────────── */
 
-export interface ToolCategories {
-  explore: Set<string>;
-  hidden: Set<string>;
-  progress: Set<string>;
-  subagent: Set<string>;
-}
+import type { ToolCategories } from '@mainframe/types';
+export type { ToolCategories } from '@mainframe/types';
 
 export function isExploreTool(name: string, categories: ToolCategories): boolean {
   return categories.explore.has(name);

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -39,7 +39,7 @@ export function chatRoutes(ctx: RouteContext): Router {
   router.get(
     '/api/chats/:id/messages',
     asyncHandler(async (req: Request, res: Response) => {
-      const messages = await ctx.chats.getMessages(param(req, 'id'));
+      const messages = await ctx.chats.getDisplayMessages(param(req, 'id'));
       res.json({ success: true, data: messages });
     }),
   );

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
@@ -8,7 +8,7 @@ import {
 } from '@assistant-ui/react';
 import type { AttachmentAdapter, ExternalStoreThreadListAdapter } from '@assistant-ui/react';
 import { useChatSession } from '../../../hooks/useChatSession';
-import { groupMessages, convertMessage } from './convert-message';
+import { convertMessage } from './convert-message';
 import { daemonClient } from '../../../lib/client';
 import { archiveChat } from '../../../lib/api';
 import { useChatsStore } from '../../../store/chats';
@@ -80,7 +80,6 @@ function formatComposerError(error: unknown): string {
 
 export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeProviderProps) {
   const { messages: rawMessages, pendingPermission, sendMessage, respondToPermission } = useChatSession(chatId);
-  const groupedMessages = useMemo(() => groupMessages(rawMessages), [rawMessages]);
   const commands = useSkillsStore((s) => s.commands);
 
   const [composerError, setComposerError] = useState<string | null>(null);
@@ -282,7 +281,7 @@ export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeP
 
   const runtime = useExternalStoreRuntime({
     isRunning,
-    messages: groupedMessages,
+    messages: rawMessages,
     convertMessage,
     onNew,
     onCancel,

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -1,63 +1,52 @@
-import type { ThreadMessageLike, TextMessagePart } from '@assistant-ui/react';
-import type { MessageContent } from '@mainframe/types';
-import {
-  type GroupedMessage,
-  groupMessages,
-  type ToolGroupItem,
-  type TaskProgressItem,
-  type PartEntry,
-  type ToolCategories,
-  groupToolCallParts,
-  groupTaskChildren,
-} from '@mainframe/core/messages';
-
-const CLAUDE_CATEGORIES: ToolCategories = {
-  explore: new Set(['Read', 'Glob', 'Grep']),
-  hidden: new Set([
-    'TaskList',
-    'TaskGet',
-    'TaskOutput',
-    'TaskStop',
-    'TodoWrite',
-    'Skill',
-    'EnterPlanMode',
-    'AskUserQuestion',
-  ]),
-  progress: new Set(['TaskCreate', 'TaskUpdate']),
-  subagent: new Set(['Task']),
-};
-
-/** Returns tool categories for a given adapterId, defaulting to Claude's categories. */
-export function getToolCategoriesForAdapter(adapterId: string | undefined): ToolCategories {
-  if (!adapterId || adapterId === 'claude') return CLAUDE_CATEGORIES;
-  return { explore: new Set(), hidden: new Set(), progress: new Set(), subagent: new Set() };
-}
+import type { ThreadMessageLike } from '@assistant-ui/react';
+import type { DisplayMessage, DisplayContent } from '@mainframe/types';
 
 // Mutable version of the content array element type (ThreadMessageLike['content'] is readonly)
 type ContentPart = Exclude<ThreadMessageLike['content'], string>[number];
 
 // Re-export for consumers that import from this module
-export { type GroupedMessage, groupMessages, type ToolGroupItem, type TaskProgressItem, type PartEntry };
+export type { ToolGroupItem, TaskProgressItem, PartEntry } from '@mainframe/core/messages';
 
 // Sentinel placeholders — null-byte prefix prevents collision with user content
 export const ERROR_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_ERROR__' });
 export const PERMISSION_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_PERMISSION__' });
 
+function mapDisplayContentToToolCall(block: DisplayContent & { type: 'tool_call' }): ContentPart {
+  const result = block.result
+    ? block.result.structuredPatch
+      ? {
+          content: block.result.content,
+          structuredPatch: block.result.structuredPatch,
+          originalFile: block.result.originalFile,
+          modifiedFile: block.result.modifiedFile,
+        }
+      : block.result.content
+    : undefined;
+
+  return {
+    type: 'tool-call',
+    toolCallId: block.id,
+    toolName: block.name,
+    args: block.input as import('assistant-stream/utils').ReadonlyJSONObject,
+    result,
+    isError: block.result?.isError,
+  };
+}
+
 /**
- * Maps a single ChatMessage → ThreadMessageLike for the external store runtime.
+ * Maps a single DisplayMessage → ThreadMessageLike for the external store runtime.
+ * All transformation (grouping, tag stripping, metadata extraction) is done by the daemon pipeline.
  */
-export function convertMessage(message: GroupedMessage): ThreadMessageLike {
+export function convertMessage(message: DisplayMessage): ThreadMessageLike {
   switch (message.type) {
     case 'user': {
-      const userParts: TextMessagePart[] = [];
-      for (const c of message.content) {
-        if (c.type === 'text' && c.text) {
-          userParts.push({ type: 'text' as const, text: c.text });
-        }
-      }
+      const parts: ContentPart[] = message.content
+        .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text' && !!c.text)
+        .map((c) => ({ type: 'text' as const, text: c.text }));
+
       return {
         role: 'user',
-        content: userParts.length > 0 ? userParts : [{ type: 'text' as const, text: '' }],
+        content: parts.length > 0 ? parts : [{ type: 'text' as const, text: '' }],
         id: message.id,
         createdAt: new Date(message.timestamp),
       };
@@ -67,14 +56,13 @@ export function convertMessage(message: GroupedMessage): ThreadMessageLike {
       return {
         role: 'system',
         content: message.content
-          .filter((c): c is MessageContent & { type: 'text' } => c.type === 'text')
+          .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text')
           .map((c) => ({ type: 'text' as const, text: c.text })),
         id: message.id,
         createdAt: new Date(message.timestamp),
       };
 
-    case 'assistant':
-    case 'tool_use': {
+    case 'assistant': {
       const parts: ContentPart[] = [];
 
       for (const block of message.content) {
@@ -85,32 +73,53 @@ export function convertMessage(message: GroupedMessage): ThreadMessageLike {
           case 'thinking':
             parts.push({ type: 'reasoning' as const, text: block.thinking });
             break;
-          case 'tool_use': {
-            const tr = message._toolResults?.get(block.id);
+          case 'image':
+            // Images in user messages are handled by UserMessage component; skip here
+            break;
+          case 'tool_call':
+            parts.push(mapDisplayContentToToolCall(block));
+            break;
+          case 'tool_group': {
+            const calls = block.calls.filter(
+              (c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call',
+            );
             parts.push({
               type: 'tool-call',
-              toolCallId: block.id,
-              toolName: block.name,
-              args: block.input as import('assistant-stream/utils').ReadonlyJSONObject,
-              result: tr
-                ? tr.structuredPatch
-                  ? {
-                      content: tr.content,
-                      structuredPatch: tr.structuredPatch,
-                      originalFile: tr.originalFile,
-                      modifiedFile: tr.modifiedFile,
-                    }
-                  : tr.content
-                : undefined,
-              isError: tr?.isError,
+              toolCallId: calls[0]?.id ?? '',
+              toolName: '_ToolGroup',
+              args: {
+                items: calls.map((c) => ({
+                  toolCallId: c.id,
+                  toolName: c.name,
+                  args: c.input,
+                  result: c.result,
+                  isError: c.result?.isError,
+                })),
+              } as import('assistant-stream/utils').ReadonlyJSONObject,
+              result: 'grouped',
             });
             break;
           }
-          case 'tool_result': {
-            // Orphan tool_result not matched to a tool_use — show as text
+          case 'task_group': {
+            const calls = block.calls.filter(
+              (c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call',
+            );
+            const firstCall = calls[0];
             parts.push({
-              type: 'text',
-              text: `[Tool Result] ${block.content}`,
+              type: 'tool-call',
+              toolCallId: block.agentId,
+              toolName: '_TaskGroup',
+              args: {
+                taskArgs: firstCall?.input ?? {},
+                children: calls.map((c) => ({
+                  toolCallId: c.id,
+                  toolName: c.name,
+                  args: c.input,
+                  result: c.result,
+                  isError: c.result?.isError,
+                })),
+              } as import('assistant-stream/utils').ReadonlyJSONObject,
+              result: firstCall?.result,
             });
             break;
           }
@@ -123,13 +132,9 @@ export function convertMessage(message: GroupedMessage): ThreadMessageLike {
         }
       }
 
-      const categories = getToolCategoriesForAdapter(message.metadata?.adapterId as string | undefined);
-      const afterGrouping = groupToolCallParts(parts as PartEntry[], categories);
-      const grouped = groupTaskChildren(afterGrouping, categories) as ThreadMessageLike['content'];
-
       return {
         role: 'assistant',
-        content: (grouped as Array<unknown>).length > 0 ? grouped : [{ type: 'text', text: '' }],
+        content: parts.length > 0 ? parts : [{ type: 'text', text: '' }],
         id: message.id,
         createdAt: new Date(message.timestamp),
       };

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
-import type { ChatMessage } from '@mainframe/types';
+import type { DisplayMessage } from '@mainframe/types';
 import { formatTurnDuration } from '../message-parsing';
 
 export function TurnFooter() {
   const message = useMessage();
-  const [original] = getExternalStoreMessages<ChatMessage>(message);
+  const [original] = getExternalStoreMessages<DisplayMessage>(message);
   if (!original?.timestamp) return null;
   const durationMs = typeof original.metadata?.turnDurationMs === 'number' ? original.metadata.turnDurationMs : null;
   const time = new Date(original.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -7,15 +7,8 @@ import remarkGfm from 'remark-gfm';
 import { markdownComponents } from '../parts/markdown-text';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
 import { useSkillsStore } from '../../../../store/skills';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
-import {
-  PLAN_PREFIX,
-  highlightMentions,
-  parseCommandMessage,
-  resolveSkillName,
-  parseRawCommand,
-  parseAttachedFilePathTags,
-} from '../message-parsing';
+import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+import { PLAN_PREFIX, highlightMentions, resolveSkillName, parseRawCommand } from '../message-parsing';
 import { ImageThumbs, FileAttachmentThumbs } from './ImageThumbs';
 
 const REMARK_PLUGINS = [remarkGfm];
@@ -32,26 +25,48 @@ export function UserMessage() {
   const skills = useSkillsStore((s) => s.skills);
   const commands = useSkillsStore((s) => s.commands);
 
-  const [original] = getExternalStoreMessages<ChatMessage>(message);
-  const imageBlocks = (original?.content?.filter((c): c is MessageContent & { type: 'image' } => c.type === 'image') ??
+  const [original] = getExternalStoreMessages<DisplayMessage>(message);
+
+  // Images from DisplayContent
+  const imageBlocks = (original?.content?.filter((c): c is DisplayContent & { type: 'image' } => c.type === 'image') ??
     []) as { type: 'image'; mediaType: string; data: string }[];
-  const fileAttachmentBlocks = Array.isArray(original?.metadata?.attachments)
+
+  // File attachments from raw attachment metadata
+  const rawAttachments = Array.isArray(original?.metadata?.attachments)
     ? (original!.metadata!.attachments as Array<{ name?: string; kind?: string }>)
-        .filter((attachment) => attachment.kind === 'file' && !!attachment.name)
-        .map((attachment) => ({ name: attachment.name! }))
+        .filter((a) => a.kind === 'file' && !!a.name)
+        .map((a) => ({ name: a.name! }))
     : [];
 
+  // File attachments extracted by pipeline from <attached_file_path> tags
+  const pipelineFiles = (original?.metadata?.attachedFiles as { name: string }[] | undefined) ?? [];
+
+  // Command info from pipeline metadata (richer object stored by convertUserContent)
+  const pipelineCommand = original?.metadata?.command as
+    | { name: string; userText: string; isCommand: boolean }
+    | undefined;
+
   const firstText = message.content.find((p): p is { type: 'text'; text: string } => p.type === 'text');
-
   const rawUserText = firstText?.text ?? '';
-  const { files: parsedFileTags, cleanText } = parseAttachedFilePathTags(rawUserText);
 
-  let parsed = cleanText ? parseCommandMessage(cleanText) : null;
-  if (parsed) {
-    parsed = { ...parsed, commandName: resolveSkillName(parsed.commandName, skills) };
-  } else if (cleanText) {
-    parsed = parseRawCommand(cleanText, skills, commands);
+  // Use pipeline metadata when available, fall back to runtime parsing
+  let parsed: { commandName: string; userText: string; isCommand: boolean } | null = null;
+  if (pipelineCommand) {
+    parsed = {
+      commandName: resolveSkillName(pipelineCommand.name, skills),
+      userText: pipelineCommand.userText,
+      isCommand: pipelineCommand.isCommand,
+    };
+  } else if (rawUserText) {
+    parsed = parseRawCommand(rawUserText, skills, commands);
   }
+
+  // cleanText from pipeline metadata, or raw text as fallback
+  const cleanText = (original?.metadata?.cleanText as string | undefined) ?? rawUserText;
+
+  const mergedFileAttachments = [...rawAttachments, ...pipelineFiles].filter(
+    (file, i, arr) => arr.findIndex((f) => f.name === file.name) === i,
+  );
 
   if (cleanText.startsWith(PLAN_PREFIX)) {
     const planBody = cleanText.slice(PLAN_PREFIX.length);
@@ -73,10 +88,6 @@ export function UserMessage() {
       </MessagePrimitive.Root>
     );
   }
-
-  const mergedFileAttachments = [...fileAttachmentBlocks, ...parsedFileTags].filter(
-    (file, i, arr) => arr.findIndex((f) => f.name === file.name) === i,
-  );
 
   if (parsed) {
     const Icon = parsed.isCommand ? Wrench : Zap;

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { TextMessagePartComponent } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { useMessage } from '@assistant-ui/react';
-import type { ChatMessage } from '@mainframe/types';
+import type { DisplayMessage } from '@mainframe/types';
 import { ERROR_PLACEHOLDER, PERMISSION_PLACEHOLDER } from '../convert-message';
 import { ErrorPart } from './ErrorPart';
 import { MarkdownText } from './markdown-text';
@@ -24,18 +24,13 @@ export const MainframeText: TextMessagePartComponent = (props) => {
 };
 
 function ErrorPartFromMessage() {
-  const originalMessages = useMessage((m) => getExternalStoreMessages<ChatMessage>(m));
+  const originalMessages = useMessage((m) => getExternalStoreMessages<DisplayMessage>(m));
   const errorMessage = findErrorMessage(originalMessages);
   return <ErrorPart message={errorMessage} />;
 }
 
-function findErrorMessage(messages: ChatMessage[]): string {
+function findErrorMessage(messages: DisplayMessage[]): string {
   for (const msg of messages) {
-    if (msg.type === 'error') {
-      for (const block of msg.content) {
-        if (block.type === 'error') return block.message;
-      }
-    }
     for (const block of msg.content) {
       if (block.type === 'error') return block.message;
     }

--- a/packages/desktop/src/renderer/lib/api/projects-api.ts
+++ b/packages/desktop/src/renderer/lib/api/projects-api.ts
@@ -1,4 +1,4 @@
-import type { Project, Chat, ChatMessage, AdapterInfo } from '@mainframe/types';
+import type { Project, Chat, DisplayMessage, AdapterInfo } from '@mainframe/types';
 import { postJson, deleteRequest, API_BASE } from './http';
 import { createLogger } from '../logger';
 
@@ -42,7 +42,7 @@ export async function archiveChat(chatId: string): Promise<void> {
   await postJson(`${API_BASE}/api/chats/${chatId}/archive`);
 }
 
-export async function getChatMessages(chatId: string): Promise<ChatMessage[]> {
+export async function getChatMessages(chatId: string): Promise<DisplayMessage[]> {
   const res = await fetch(`${API_BASE}/api/chats/${chatId}/messages`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const json = await res.json();

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -30,9 +30,17 @@ export function routeEvent(event: DaemonEvent): void {
       chats.removeChat(event.chatId);
       chats.removeProcess(event.chatId);
       break;
-    case 'message.added':
-      log.debug('event:message.added', { chatId: event.chatId, type: event.message.type });
+    case 'display.message.added':
+      log.debug('event:display.message.added', { chatId: event.chatId });
       chats.addMessage(event.chatId, event.message);
+      break;
+    case 'display.message.updated':
+      log.debug('event:display.message.updated', { chatId: event.chatId, messageId: event.message.id });
+      chats.updateMessage(event.chatId, event.message);
+      break;
+    case 'display.messages.set':
+      log.debug('event:display.messages.set', { chatId: event.chatId, count: event.messages.length });
+      chats.setMessages(event.chatId, event.messages);
       break;
     case 'messages.cleared':
       log.info('event:messages.cleared', { chatId: event.chatId });

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -1,12 +1,12 @@
 import { create } from 'zustand';
-import type { Chat, ChatMessage, ControlRequest, AdapterProcess } from '@mainframe/types';
+import type { Chat, DisplayMessage, ControlRequest, AdapterProcess } from '@mainframe/types';
 
 export type SessionStatus = 'idle' | 'working' | 'waiting';
 
 interface ChatsState {
   chats: Chat[];
   activeChatId: string | null;
-  messages: Map<string, ChatMessage[]>;
+  messages: Map<string, DisplayMessage[]>;
   pendingPermissions: Map<string, ControlRequest>;
   processes: Map<string, AdapterProcess>;
 
@@ -15,8 +15,9 @@ interface ChatsState {
   addChat: (chat: Chat) => void;
   updateChat: (chat: Chat) => void;
   removeChat: (id: string) => void;
-  addMessage: (chatId: string, message: ChatMessage) => void;
-  setMessages: (chatId: string, messages: ChatMessage[]) => void;
+  addMessage: (chatId: string, message: DisplayMessage) => void;
+  setMessages: (chatId: string, messages: DisplayMessage[]) => void;
+  updateMessage: (chatId: string, message: DisplayMessage) => void;
   addPendingPermission: (chatId: string, request: ControlRequest) => void;
   removePendingPermission: (chatId: string) => void;
   setProcess: (chatId: string, process: AdapterProcess) => void;
@@ -54,6 +55,20 @@ export const useChatsStore = create<ChatsState>((set) => ({
     set((state) => {
       const newMessages = new Map(state.messages);
       newMessages.set(chatId, messages);
+      return { messages: newMessages };
+    }),
+  updateMessage: (chatId, message) =>
+    set((state) => {
+      const newMessages = new Map(state.messages);
+      const existing = newMessages.get(chatId) || [];
+      const idx = existing.findIndex((m) => m.id === message.id);
+      if (idx >= 0) {
+        const updated = [...existing];
+        updated[idx] = message;
+        newMessages.set(chatId, updated);
+      } else {
+        newMessages.set(chatId, [...existing, message]);
+      }
       return { messages: newMessages };
     }),
   addPendingPermission: (chatId, request) =>

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -153,6 +153,7 @@ export interface Adapter {
 
   createSession(options: SessionOptions): AdapterSession;
   killAll(): void;
+  getToolCategories?(): import('./display.js').ToolCategories;
 
   getContextFiles?(projectPath: string): {
     global: import('./context.js').ContextFile[];

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -1,0 +1,42 @@
+import type { DiffHunk } from './chat.js';
+
+export interface ToolCallResult {
+  content: string;
+  isError: boolean;
+  structuredPatch?: DiffHunk[];
+  originalFile?: string;
+  modifiedFile?: string;
+}
+
+export interface ToolCategories {
+  explore: Set<string>;
+  hidden: Set<string>;
+  progress: Set<string>;
+  subagent: Set<string>;
+}
+
+export type DisplayContent =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'image'; mediaType: string; data: string }
+  | {
+      type: 'tool_call';
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+      category: 'default' | 'explore' | 'hidden' | 'progress' | 'subagent';
+      result?: ToolCallResult;
+    }
+  | { type: 'tool_group'; calls: DisplayContent[] }
+  | { type: 'task_group'; agentId: string; calls: DisplayContent[] }
+  | { type: 'permission_request'; request: unknown }
+  | { type: 'error'; message: string };
+
+export interface DisplayMessage {
+  id: string;
+  chatId: string;
+  type: 'user' | 'assistant' | 'system' | 'error' | 'permission';
+  content: DisplayContent[];
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -12,6 +12,9 @@ export type DaemonEvent =
   | { type: 'process.ready'; processId: string; claudeSessionId: string }
   | { type: 'process.stopped'; processId: string }
   | { type: 'message.added'; chatId: string; message: ChatMessage }
+  | { type: 'display.message.added'; chatId: string; message: import('./display.js').DisplayMessage }
+  | { type: 'display.message.updated'; chatId: string; message: import('./display.js').DisplayMessage }
+  | { type: 'display.messages.set'; chatId: string; messages: import('./display.js').DisplayMessage[] }
   | { type: 'messages.cleared'; chatId: string }
   | { type: 'permission.requested'; chatId: string; request: ControlRequest }
   | { type: 'context.updated'; chatId: string }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from './adapter.js';
 export * from './chat.js';
+export * from './display.js';
 export * from './events.js';
 export * from './skill.js';
 export * from './context.js';


### PR DESCRIPTION
## Summary
- Introduces `DisplayMessage` types and a server-side pipeline (`prepareMessagesForClient`) that transforms raw adapter messages into structured, UI-ready messages
- Migrates REST endpoint (`/chats/:id/messages`) and WS event router to serve `DisplayMessage[]` instead of raw grouped messages
- Simplifies desktop `convert-message` and UI components to consume the pre-processed format
- Emits `display.message` events from the daemon event handler for real-time updates
- Adds display cache clearing on message clear and project removal

## Test plan
- [x] Existing daemon-restart test updated for DisplayMessage grouping
- [x] User messages emit display events with correct content order
- [x] Command metadata shape aligned between pipeline and UserMessage
- [x] Display cache cleared on message clear and project removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)