### PR TITLE
fix(core): defer CLI process spawn until first message

### DIFF
--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -61,8 +61,9 @@ export class ChatConfigManager {
       }
     }
 
-    if (active.session?.isSpawned) {
-      await active.session.kill();
+    const wasSpawned = active.session?.isSpawned ?? false;
+    if (wasSpawned) {
+      await active.session!.kill();
       active.session = null;
     }
 
@@ -82,7 +83,9 @@ export class ChatConfigManager {
 
     this.deps.db.chats.update(chatId, updates);
     this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
-    await this.deps.startChat(chatId);
+    if (wasSpawned) {
+      await this.deps.startChat(chatId);
+    }
   }
 
   async enableWorktree(chatId: string): Promise<void> {

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -62,7 +62,6 @@ export class WebSocketManager {
           event.permissionMode,
         );
         client.subscriptions.add(chat.id);
-        await this.chats.startChat(chat.id);
         break;
       }
 


### PR DESCRIPTION
## Summary

- Removed eager `startChat()` call from the `chat.create` WebSocket handler — the CLI process no longer spawns immediately on chat creation
- Changed `updateChatConfig` to only restart the process if one was already running; pre-message config changes (adapter/model/mode picker) now save to DB without spawning
- The existing `sendMessage` guard (`if (!session.isSpawned) startChat()`) handles lazy process creation on first user message

## Test plan

- [x] Create a new chat — verify no CLI process spawns (no "claude session spawned" in daemon logs)
- [x] Change adapter/model/mode in composer dropdowns — verify no process spawns
- [x] Send first message — verify process spawns with correct adapter, model, and permission mode
- [x] Change model mid-conversation — verify the running session receives the update without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)