### PR TITLE
feat: import external agent sessions

### DIFF
--- a/docs/plans/2026-03-06-external-session-import-design.md
+++ b/docs/plans/2026-03-06-external-session-import-design.md
@@ -1,0 +1,106 @@
+# External Session Import — Design
+
+Import agent sessions created outside Mainframe (e.g. via Claude CLI directly) into a project's chat list, making them browsable and resumable.
+
+## Scope
+
+- Same-project only — sessions from `~/.claude/projects/<encoded-path>/`
+- Resumable — imported sessions become full Mainframe chats with `--resume` support
+- Auto-detection — daemon scans on project load and periodically, emits count via WebSocket
+- Generic adapter API — `listExternalSessions()` on the `Adapter` interface; Claude implements first
+
+## Adapter Interface
+
+```typescript
+// packages/types/src/adapter.ts
+export interface ExternalSession {
+  sessionId: string;        // CLI's native session UUID
+  projectPath: string;
+  firstPrompt?: string;     // First user message (truncated)
+  summary?: string;         // AI-generated summary if available
+  messageCount?: number;
+  createdAt: string;        // ISO-8601
+  modifiedAt: string;
+  gitBranch?: string;
+  model?: string;
+}
+
+// Added to Adapter interface as optional method
+listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>;
+```
+
+## Claude Adapter Implementation
+
+Reads `~/.claude/projects/<encoded-path>/sessions-index.json` (written by newer Claude CLI versions). No JSONL-scan fallback — sessions without an index file are not listed.
+
+The index format:
+```json
+{
+  "version": 1,
+  "entries": [{
+    "sessionId": "uuid",
+    "firstPrompt": "...",
+    "summary": "...",
+    "messageCount": 28,
+    "created": "ISO-8601",
+    "modified": "ISO-8601",
+    "gitBranch": "main",
+    "projectPath": "/path/to/project"
+  }]
+}
+```
+
+Filter out entries whose `sessionId` is in `excludeSessionIds`.
+
+File: `packages/core/src/plugins/builtin/claude/external-sessions.ts`
+
+## Daemon — ExternalSessionService
+
+New service at `packages/core/src/chat/external-session-service.ts`:
+
+- `scan(projectId)` — resolves project path, gets adapter, calls `listExternalSessions(path, alreadyImportedIds)`, returns list
+- `importSession(projectId, sessionId, adapterId)` — creates Chat row with `claudeSessionId = sessionId`, returns Chat
+- Auto-scan on project load — emits `sessions.external.count` over WebSocket
+- Periodic refresh — every 5 minutes while project is active, re-emits if count changed
+
+## API
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/projects/:projectId/external-sessions` | GET | List importable sessions |
+| `/api/projects/:projectId/external-sessions/import` | POST | Import a session → creates Chat |
+
+Body for import: `{ sessionId: string, adapterId: string }`
+
+## WebSocket Events
+
+- `sessions.external.count` — `{ projectId: string, count: number }` — server → client
+
+## UI — ChatsPanel
+
+- Badge next to header showing count of available external sessions
+- Collapsible "Import" section at top of chat list showing external sessions
+- Each entry: first prompt/summary as title, relative time, branch, "Import" button
+- On import: session appears as normal chat, count decreases
+
+## Data Flow
+
+```
+Project opened
+  → ExternalSessionService.scan(projectId)
+    → adapter.listExternalSessions(path, excludeIds)
+      → reads sessions-index.json, filters
+    → emits sessions.external.count via WS
+  → Desktop shows badge
+
+User imports
+  → POST /external-sessions/import { sessionId }
+  → creates Chat with claudeSessionId = sessionId
+  → chat appears in list, resumable via --resume
+```
+
+## Error Handling
+
+- `sessions-index.json` missing/malformed → empty list, log warning
+- Session already imported (race) → return existing chat
+- No data duplication — messages stay in Claude's JSONL files

--- a/docs/plans/2026-03-06-external-session-import-plan.md
+++ b/docs/plans/2026-03-06-external-session-import-plan.md
@@ -1,0 +1,74 @@
+# External Session Import — Implementation Plan
+
+Design: `2026-03-06-external-session-import-design.md`
+
+## Steps
+
+### Step 1: Types — ExternalSession + Adapter interface extension
+**Files:** `packages/types/src/adapter.ts`, `packages/types/src/chat.ts`
+- Add `ExternalSession` interface to `adapter.ts`
+- Add optional `listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>` to `Adapter`
+- Add `imported?: boolean` field to `Chat` interface (to distinguish imported chats in UI)
+
+### Step 2: Claude adapter — external session listing
+**Files:** `packages/core/src/plugins/builtin/claude/external-sessions.ts` (new)
+- Implement `listExternalSessions()` function
+- Read `sessions-index.json` from `~/.claude/projects/<encoded-path>/`
+- Parse entries, filter by `excludeSessionIds`, map to `ExternalSession[]`
+- Sort by `modifiedAt` descending
+- Handle missing/malformed index gracefully (return empty array, log warning)
+
+### Step 3: Wire Claude adapter to implement interface method
+**Files:** `packages/core/src/plugins/builtin/claude/adapter.ts`
+- Add `listExternalSessions()` method to `ClaudeAdapter` class
+- Delegates to the function from step 2
+
+### Step 4: DB — query for imported session IDs
+**Files:** `packages/core/src/db/chats.ts`
+- Add `getImportedSessionIds(projectId: string): string[]` — returns all non-null `claude_session_id` values for a project
+- Add `findByClaudeSessionId(sessionId: string): Chat | undefined` — for duplicate detection on import
+
+### Step 5: ExternalSessionService
+**Files:** `packages/core/src/chat/external-session-service.ts` (new)
+- `scan(projectId)` — gets project, adapter, calls `listExternalSessions`, returns list
+- `importSession(projectId, sessionId, adapterId)` — creates chat, sets claudeSessionId, returns Chat
+- `startAutoScan(projectId)` — sets interval (5 min), emits `sessions.external.count` on change
+- `stopAutoScan(projectId)` — clears interval
+- Duplicate detection: if `findByClaudeSessionId` returns a chat, return it instead of creating
+
+### Step 6: API routes
+**Files:** `packages/core/src/server/routes/external-sessions.ts` (new), `packages/core/src/server/index.ts`
+- `GET /api/projects/:projectId/external-sessions` — Zod-validated, returns ExternalSession[]
+- `POST /api/projects/:projectId/external-sessions/import` — body `{ sessionId, adapterId }`, returns Chat
+- Register routes in server setup
+
+### Step 7: WebSocket event for external session count
+**Files:** `packages/core/src/server/ws-handler.ts` (or relevant event emitter)
+- On project load / focus, trigger scan and emit `sessions.external.count`
+- Hook into project switching to start/stop auto-scan
+
+### Step 8: Desktop — API client + store
+**Files:** `packages/desktop/src/renderer/lib/api.ts`, `packages/desktop/src/renderer/store/chats.ts`
+- Add `fetchExternalSessions(projectId)` and `importExternalSession(projectId, sessionId, adapterId)` API functions
+- Add `externalSessionCount` and `externalSessions` state to chats store (or a new store)
+- Listen for `sessions.external.count` WebSocket event
+
+### Step 9: Desktop — ChatsPanel UI
+**Files:** `packages/desktop/src/renderer/components/panels/ChatsPanel.tsx`
+- Add badge showing external session count next to header
+- Add collapsible import section with session list
+- Each entry: title (firstPrompt/summary), time, branch, Import button
+- On import: call API, add to chat list, update count
+
+### Step 10: Tests
+- Unit test for `listExternalSessions` (mock sessions-index.json)
+- Unit test for `ExternalSessionService.scan()` and `importSession()`
+- Unit test for DB methods
+- Unit test for API routes
+
+## Parallelization
+
+Steps 1-4 are sequential (types → implementation → DB).
+Steps 5-6 depend on 1-4 but can be worked in parallel with each other.
+Steps 8-9 (desktop) depend on 6-7 (API/WS) being defined but can be developed in parallel.
+Step 10 can be parallelized per-layer.

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listExternalSessions } from '../plugins/builtin/claude/external-sessions.js';
+
+// Mock fs/promises
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'node:fs/promises';
+const mockReadFile = vi.mocked(readFile);
+
+describe('listExternalSessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty array when sessions-index.json does not exist', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for malformed JSON', async () => {
+    mockReadFile.mockResolvedValue('not json' as unknown as ArrayBuffer);
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when entries is missing', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ version: 1 }) as unknown as ArrayBuffer);
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toEqual([]);
+  });
+
+  it('returns sessions from valid index', async () => {
+    const index = {
+      version: 1,
+      entries: [
+        {
+          sessionId: 'abc-123',
+          firstPrompt: 'Hello',
+          summary: 'Test session',
+          messageCount: 5,
+          created: '2026-01-01T00:00:00Z',
+          modified: '2026-01-02T00:00:00Z',
+          gitBranch: 'main',
+          isSidechain: false,
+        },
+      ],
+    };
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('abc-123');
+    expect(result[0]!.adapterId).toBe('claude');
+    expect(result[0]!.firstPrompt).toBe('Hello');
+    expect(result[0]!.summary).toBe('Test session');
+    expect(result[0]!.messageCount).toBe(5);
+    expect(result[0]!.gitBranch).toBe('main');
+  });
+
+  it('filters out excluded session IDs', async () => {
+    const index = {
+      version: 1,
+      entries: [
+        { sessionId: 'keep-me', created: '2026-01-01T00:00:00Z' },
+        { sessionId: 'exclude-me', created: '2026-01-01T00:00:00Z' },
+      ],
+    };
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+    const result = await listExternalSessions('/test/project', ['exclude-me']);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('keep-me');
+  });
+
+  it('filters out sidechain sessions', async () => {
+    const index = {
+      version: 1,
+      entries: [
+        { sessionId: 'main-session', created: '2026-01-01T00:00:00Z', isSidechain: false },
+        { sessionId: 'sidechain', created: '2026-01-01T00:00:00Z', isSidechain: true },
+      ],
+    };
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('main-session');
+  });
+
+  it('sorts by modifiedAt descending', async () => {
+    const index = {
+      version: 1,
+      entries: [
+        { sessionId: 'older', created: '2026-01-01T00:00:00Z', modified: '2026-01-01T00:00:00Z' },
+        { sessionId: 'newer', created: '2026-01-02T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
+      ],
+    };
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+    const result = await listExternalSessions('/test/project', []);
+    expect(result[0]!.sessionId).toBe('newer');
+    expect(result[1]!.sessionId).toBe('older');
+  });
+
+  it('filters out entries with no sessionId', async () => {
+    const index = {
+      version: 1,
+      entries: [
+        { sessionId: '', created: '2026-01-01T00:00:00Z' },
+        { sessionId: 'valid', created: '2026-01-01T00:00:00Z' },
+      ],
+    };
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('valid');
+  });
+});

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -1,122 +1,183 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { listExternalSessions } from '../plugins/builtin/claude/external-sessions.js';
 
-// Mock fs/promises
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  readdir: vi.fn(),
+  stat: vi.fn(),
 }));
 
-import { readFile } from 'node:fs/promises';
+vi.mock('node:fs', () => ({
+  createReadStream: vi.fn(),
+}));
+
+vi.mock('node:readline', () => ({
+  createInterface: vi.fn(),
+}));
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
 const mockReadFile = vi.mocked(readFile);
+const mockReaddir = vi.mocked(readdir);
+const mockStat = vi.mocked(stat);
+const mockCreateReadStream = vi.mocked(createReadStream);
+const mockCreateInterface = vi.mocked(createInterface);
+
+/** Helper: make createInterface return an async iterable of lines. */
+function mockJsonlFile(lines: string[]): void {
+  const rl = {
+    [Symbol.asyncIterator]: async function* () {
+      for (const line of lines) yield line;
+    },
+    close: vi.fn(),
+  };
+  mockCreateReadStream.mockReturnValue({} as ReturnType<typeof createReadStream>);
+  mockCreateInterface.mockReturnValue(rl as unknown as ReturnType<typeof createInterface>);
+}
 
 describe('listExternalSessions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('returns empty array when sessions-index.json does not exist', async () => {
+    // Default: no index, no JSONL files
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toEqual([]);
+    mockReaddir.mockRejectedValue(new Error('ENOENT'));
   });
 
-  it('returns empty array for malformed JSON', async () => {
-    mockReadFile.mockResolvedValue('not json' as unknown as ArrayBuffer);
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toEqual([]);
+  describe('from sessions-index.json', () => {
+    it('returns sessions from valid index', async () => {
+      const index = {
+        version: 1,
+        entries: [
+          {
+            sessionId: 'abc-123',
+            firstPrompt: 'Hello',
+            summary: 'Test session',
+            messageCount: 5,
+            created: '2026-01-01T00:00:00Z',
+            modified: '2026-01-02T00:00:00Z',
+            gitBranch: 'main',
+            isSidechain: false,
+          },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+      const result = await listExternalSessions('/test/project', []);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('abc-123');
+      expect(result[0]!.adapterId).toBe('claude');
+      expect(result[0]!.firstPrompt).toBe('Hello');
+      expect(result[0]!.summary).toBe('Test session');
+      expect(result[0]!.messageCount).toBe(5);
+      expect(result[0]!.gitBranch).toBe('main');
+    });
+
+    it('filters out excluded session IDs', async () => {
+      const index = {
+        version: 1,
+        entries: [
+          { sessionId: 'keep-me', created: '2026-01-01T00:00:00Z' },
+          { sessionId: 'exclude-me', created: '2026-01-01T00:00:00Z' },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+      const result = await listExternalSessions('/test/project', ['exclude-me']);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('keep-me');
+    });
+
+    it('filters out sidechain sessions', async () => {
+      const index = {
+        version: 1,
+        entries: [
+          { sessionId: 'main-session', created: '2026-01-01T00:00:00Z', isSidechain: false },
+          { sessionId: 'sidechain', created: '2026-01-01T00:00:00Z', isSidechain: true },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+      const result = await listExternalSessions('/test/project', []);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('main-session');
+    });
+
+    it('sorts by modifiedAt descending', async () => {
+      const index = {
+        version: 1,
+        entries: [
+          { sessionId: 'older', created: '2026-01-01T00:00:00Z', modified: '2026-01-01T00:00:00Z' },
+          { sessionId: 'newer', created: '2026-01-02T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
+        ],
+      };
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+
+      const result = await listExternalSessions('/test/project', []);
+      expect(result[0]!.sessionId).toBe('newer');
+      expect(result[1]!.sessionId).toBe('older');
+    });
   });
 
-  it('returns empty array when entries is missing', async () => {
-    mockReadFile.mockResolvedValue(JSON.stringify({ version: 1 }) as unknown as ArrayBuffer);
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toEqual([]);
-  });
+  describe('JSONL fallback (no sessions-index.json)', () => {
+    it('returns empty when no index and no directory', async () => {
+      const result = await listExternalSessions('/test/project', []);
+      expect(result).toEqual([]);
+    });
 
-  it('returns sessions from valid index', async () => {
-    const index = {
-      version: 1,
-      entries: [
-        {
-          sessionId: 'abc-123',
-          firstPrompt: 'Hello',
-          summary: 'Test session',
-          messageCount: 5,
-          created: '2026-01-01T00:00:00Z',
-          modified: '2026-01-02T00:00:00Z',
-          gitBranch: 'main',
-          isSidechain: false,
-        },
-      ],
-    };
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+    it('scans JSONL files and extracts first user message', async () => {
+      mockReaddir.mockResolvedValue(['abc-123.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-01-15T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
 
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.sessionId).toBe('abc-123');
-    expect(result[0]!.adapterId).toBe('claude');
-    expect(result[0]!.firstPrompt).toBe('Hello');
-    expect(result[0]!.summary).toBe('Test session');
-    expect(result[0]!.messageCount).toBe(5);
-    expect(result[0]!.gitBranch).toBe('main');
-  });
+      const lines = [
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-01-10T00:00:00Z',
+          gitBranch: 'feat/test',
+          message: { content: [{ type: 'text', text: 'Fix the login bug' }] },
+        }),
+      ];
+      mockJsonlFile(lines);
 
-  it('filters out excluded session IDs', async () => {
-    const index = {
-      version: 1,
-      entries: [
-        { sessionId: 'keep-me', created: '2026-01-01T00:00:00Z' },
-        { sessionId: 'exclude-me', created: '2026-01-01T00:00:00Z' },
-      ],
-    };
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      const result = await listExternalSessions('/test/project', []);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('abc-123');
+      expect(result[0]!.adapterId).toBe('claude');
+      expect(result[0]!.firstPrompt).toBe('Fix the login bug');
+      expect(result[0]!.gitBranch).toBe('feat/test');
+      expect(result[0]!.createdAt).toBe('2026-01-10T00:00:00Z');
+    });
 
-    const result = await listExternalSessions('/test/project', ['exclude-me']);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.sessionId).toBe('keep-me');
-  });
+    it('filters out excluded sessions in JSONL scan', async () => {
+      mockReaddir.mockResolvedValue(['keep.jsonl', 'skip.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
 
-  it('filters out sidechain sessions', async () => {
-    const index = {
-      version: 1,
-      entries: [
-        { sessionId: 'main-session', created: '2026-01-01T00:00:00Z', isSidechain: false },
-        { sessionId: 'sidechain', created: '2026-01-01T00:00:00Z', isSidechain: true },
-      ],
-    };
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      const result = await listExternalSessions('/test/project', ['skip']);
+      // 'skip' is excluded, only 'keep' should be processed
+      expect(mockStat).toHaveBeenCalledTimes(1);
+    });
 
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.sessionId).toBe('main-session');
-  });
+    it('filters out sidechain sessions in JSONL scan', async () => {
+      mockReaddir.mockResolvedValue(['side.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
 
-  it('sorts by modifiedAt descending', async () => {
-    const index = {
-      version: 1,
-      entries: [
-        { sessionId: 'older', created: '2026-01-01T00:00:00Z', modified: '2026-01-01T00:00:00Z' },
-        { sessionId: 'newer', created: '2026-01-02T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
-      ],
-    };
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      const lines = [JSON.stringify({ type: 'user', isSidechain: true, timestamp: '2026-01-01T00:00:00Z' })];
+      mockJsonlFile(lines);
 
-    const result = await listExternalSessions('/test/project', []);
-    expect(result[0]!.sessionId).toBe('newer');
-    expect(result[1]!.sessionId).toBe('older');
-  });
+      const result = await listExternalSessions('/test/project', []);
+      expect(result).toEqual([]);
+    });
 
-  it('filters out entries with no sessionId', async () => {
-    const index = {
-      version: 1,
-      entries: [
-        { sessionId: '', created: '2026-01-01T00:00:00Z' },
-        { sessionId: 'valid', created: '2026-01-01T00:00:00Z' },
-      ],
-    };
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+    it('ignores non-jsonl files', async () => {
+      mockReaddir.mockResolvedValue(['readme.md', 'data.json', 'session.jsonl'] as unknown as Awaited<
+        ReturnType<typeof readdir>
+      >);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
+      mockJsonlFile([JSON.stringify({ type: 'system', timestamp: '2026-01-01T00:00:00Z' })]);
 
-    const result = await listExternalSessions('/test/project', []);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.sessionId).toBe('valid');
+      const result = await listExternalSessions('/test/project', []);
+      // Only session.jsonl should be processed
+      expect(mockStat).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -455,4 +455,67 @@ describe('ChatsRepository', () => {
       expect(fetched!.processState).toBe('idle');
     });
   });
+
+  describe('external session queries', () => {
+    it('getImportedSessionIds returns empty array when no sessions imported', () => {
+      expect(chats.getImportedSessionIds(projectId)).toEqual([]);
+    });
+
+    it('getImportedSessionIds returns session IDs for project', () => {
+      const c1 = chats.create(projectId, 'claude');
+      const c2 = chats.create(projectId, 'claude');
+      chats.update(c1.id, { claudeSessionId: 'session-aaa' });
+      chats.update(c2.id, { claudeSessionId: 'session-bbb' });
+
+      const ids = chats.getImportedSessionIds(projectId);
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain('session-aaa');
+      expect(ids).toContain('session-bbb');
+    });
+
+    it('getImportedSessionIds excludes chats without claudeSessionId', () => {
+      chats.create(projectId, 'claude'); // no session ID
+      const c2 = chats.create(projectId, 'claude');
+      chats.update(c2.id, { claudeSessionId: 'session-ccc' });
+
+      const ids = chats.getImportedSessionIds(projectId);
+      expect(ids).toEqual(['session-ccc']);
+    });
+
+    it('getImportedSessionIds only returns for specified project', () => {
+      const p2 = projects.create('/other/project', 'Other');
+      const c1 = chats.create(projectId, 'claude');
+      const c2 = chats.create(p2.id, 'claude');
+      chats.update(c1.id, { claudeSessionId: 'session-ddd' });
+      chats.update(c2.id, { claudeSessionId: 'session-eee' });
+
+      expect(chats.getImportedSessionIds(projectId)).toEqual(['session-ddd']);
+      expect(chats.getImportedSessionIds(p2.id)).toEqual(['session-eee']);
+    });
+
+    it('findByExternalSessionId returns matching chat', () => {
+      const c = chats.create(projectId, 'claude');
+      chats.update(c.id, { claudeSessionId: 'session-fff' });
+
+      const found = chats.findByExternalSessionId('session-fff', projectId);
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(c.id);
+      expect(found!.claudeSessionId).toBe('session-fff');
+    });
+
+    it('findByExternalSessionId returns null when not found', () => {
+      expect(chats.findByExternalSessionId('nonexistent', projectId)).toBeNull();
+    });
+
+    it('findByExternalSessionId scopes to project', () => {
+      const p2 = projects.create('/other/project2', 'Other2');
+      const c = chats.create(p2.id, 'claude');
+      chats.update(c.id, { claudeSessionId: 'session-ggg' });
+
+      // Same session ID but different project — should not find
+      expect(chats.findByExternalSessionId('session-ggg', projectId)).toBeNull();
+      // Correct project — should find
+      expect(chats.findByExternalSessionId('session-ggg', p2.id)).not.toBeNull();
+    });
+  });
 });

--- a/packages/core/src/__tests__/external-session-service.test.ts
+++ b/packages/core/src/__tests__/external-session-service.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../db/schema.js';
+import { ExternalSessionService } from '../chat/external-session-service.js';
+import type { Adapter, ExternalSession, DaemonEvent } from '@mainframe/types';
+import { AdapterRegistry } from '../adapters/index.js';
+import { ChatsRepository } from '../db/chats.js';
+import { ProjectsRepository } from '../db/projects.js';
+
+function createMockAdapter(sessions: ExternalSession[] = []): Adapter {
+  return {
+    id: 'claude',
+    name: 'Claude',
+    isInstalled: async () => true,
+    getVersion: async () => '1.0',
+    listModels: async () => [],
+    createSession: vi.fn() as unknown as Adapter['createSession'],
+    killAll: vi.fn(),
+    listExternalSessions: vi.fn().mockResolvedValue(sessions),
+  };
+}
+
+describe('ExternalSessionService', () => {
+  let db: Database.Database;
+  let chatsRepo: ChatsRepository;
+  let projectsRepo: ProjectsRepository;
+  let projectId: string;
+  let emittedEvents: DaemonEvent[];
+  let service: ExternalSessionService;
+  let mockAdapter: Adapter;
+  let adapterRegistry: AdapterRegistry;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    chatsRepo = new ChatsRepository(db);
+    projectsRepo = new ProjectsRepository(db);
+
+    const project = projectsRepo.create('/test/project', 'Test');
+    projectId = project.id;
+
+    emittedEvents = [];
+    mockAdapter = createMockAdapter([]);
+
+    adapterRegistry = new AdapterRegistry();
+    adapterRegistry.register(mockAdapter);
+
+    const mockDb = {
+      projects: projectsRepo,
+      chats: chatsRepo,
+    };
+
+    service = new ExternalSessionService(mockDb as any, adapterRegistry, (event) => {
+      emittedEvents.push(event);
+    });
+  });
+
+  afterEach(() => {
+    service.stopAll();
+    db.close();
+  });
+
+  describe('scan', () => {
+    it('returns empty array for unknown project', async () => {
+      const result = await service.scan('nonexistent');
+      expect(result).toEqual([]);
+    });
+
+    it('returns sessions from adapter', async () => {
+      const sessions: ExternalSession[] = [
+        {
+          sessionId: 'ext-1',
+          adapterId: 'claude',
+          projectPath: '/test',
+          createdAt: '2026-01-01T00:00:00Z',
+          modifiedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      (mockAdapter.listExternalSessions as ReturnType<typeof vi.fn>).mockResolvedValue(sessions);
+
+      const result = await service.scan(projectId);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('ext-1');
+    });
+
+    it('passes exclude IDs to adapter', async () => {
+      const chat = chatsRepo.create(projectId, 'claude');
+      chatsRepo.update(chat.id, { claudeSessionId: 'already-imported' });
+
+      await service.scan(projectId);
+      expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith('/test/project', ['already-imported']);
+    });
+
+    it('returns empty array when adapter has no listExternalSessions', async () => {
+      const adapterWithoutList: Adapter = {
+        id: 'other',
+        name: 'Other',
+        isInstalled: async () => true,
+        getVersion: async () => '1.0',
+        listModels: async () => [],
+        createSession: vi.fn() as unknown as Adapter['createSession'],
+        killAll: vi.fn(),
+        // no listExternalSessions
+      };
+
+      const registryWithout = new AdapterRegistry();
+      registryWithout.register(adapterWithoutList);
+
+      const mockDb = { projects: projectsRepo, chats: chatsRepo };
+      const serviceWithout = new ExternalSessionService(mockDb as any, registryWithout, vi.fn());
+
+      try {
+        const result = await serviceWithout.scan(projectId);
+        expect(result).toEqual([]);
+      } finally {
+        serviceWithout.stopAll();
+      }
+    });
+  });
+
+  describe('importSession', () => {
+    it('creates a new chat with claudeSessionId', async () => {
+      const chat = await service.importSession(projectId, 'ext-session-1', 'claude');
+
+      expect(chat.claudeSessionId).toBe('ext-session-1');
+      expect(chat.projectId).toBe(projectId);
+      expect(chat.adapterId).toBe('claude');
+    });
+
+    it('emits chat.created event', async () => {
+      await service.importSession(projectId, 'ext-session-2', 'claude');
+
+      expect(emittedEvents).toHaveLength(1);
+      expect(emittedEvents[0]!.type).toBe('chat.created');
+    });
+
+    it('returns existing chat on duplicate import', async () => {
+      const first = await service.importSession(projectId, 'ext-dup', 'claude');
+      const second = await service.importSession(projectId, 'ext-dup', 'claude');
+
+      expect(second.id).toBe(first.id);
+      // Only one chat.created event (first import only)
+      const chatCreatedEvents = emittedEvents.filter((e) => e.type === 'chat.created');
+      expect(chatCreatedEvents).toHaveLength(1);
+    });
+
+    it('persists claudeSessionId to database', async () => {
+      const chat = await service.importSession(projectId, 'ext-persist', 'claude');
+      const fromDb = chatsRepo.get(chat.id);
+
+      expect(fromDb).not.toBeNull();
+      expect(fromDb!.claudeSessionId).toBe('ext-persist');
+    });
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -22,6 +22,7 @@ import { ChatPermissionHandler } from './permission-handler.js';
 import { ChatConfigManager } from './config-manager.js';
 import { ChatLifecycleManager } from './lifecycle-manager.js';
 import { EventHandler } from './event-handler.js';
+import { ExternalSessionService } from './external-session-service.js';
 import type { ActiveChat } from './types.js';
 import { wrapMainframeCommand } from '../commands/wrap.js';
 import { findMainframeCommand } from '../commands/registry.js';
@@ -38,6 +39,7 @@ export class ChatManager {
   private configManager: ChatConfigManager;
   private lifecycle: ChatLifecycleManager;
   private eventHandler: EventHandler;
+  private externalSessions: ExternalSessionService;
 
   constructor(
     private db: DatabaseManager,
@@ -98,10 +100,15 @@ export class ChatManager {
       startChat: (chatId) => this.lifecycle.startChat(chatId),
       emitEvent: (event) => this.emitEvent(event),
     });
+    this.externalSessions = new ExternalSessionService(this.db, this.adapters, (e) => this.emitEvent(e));
   }
 
   setPushService(service: import('../push/push-service.js').PushService): void {
     this.eventHandler.setPushService(service);
+  }
+
+  getExternalSessionService(): ExternalSessionService {
+    return this.externalSessions;
   }
 
   async createChat(

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -111,6 +111,14 @@ export class ChatManager {
     return this.externalSessions;
   }
 
+  startExternalSessionScan(projectId: string): void {
+    this.externalSessions.startAutoScan(projectId);
+  }
+
+  stopExternalSessionScan(projectId: string): void {
+    this.externalSessions.stopAutoScan(projectId);
+  }
+
   async createChat(
     projectId: string,
     adapterId: string,

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -1,0 +1,102 @@
+import type { Chat, DaemonEvent, ExternalSession } from '@mainframe/types';
+import type { DatabaseManager } from '../db/index.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import { createChildLogger } from '../logger.js';
+
+const logger = createChildLogger('chat:external-sessions');
+
+const SCAN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class ExternalSessionService {
+  private scanIntervals = new Map<string, ReturnType<typeof setInterval>>();
+  private lastCounts = new Map<string, number>();
+
+  constructor(
+    private db: DatabaseManager,
+    private adapters: AdapterRegistry,
+    private emitEvent: (event: DaemonEvent) => void,
+  ) {}
+
+  /** Scan for importable external sessions for a project */
+  async scan(projectId: string): Promise<ExternalSession[]> {
+    const project = this.db.projects.get(projectId);
+    if (!project) return [];
+
+    const allAdapters = this.adapters.getAll();
+    const allSessions: ExternalSession[] = [];
+
+    for (const adapter of allAdapters) {
+      if (!adapter.listExternalSessions) continue;
+
+      const excludeIds = this.db.chats.getImportedSessionIds(projectId);
+      try {
+        const sessions = await adapter.listExternalSessions(project.path, excludeIds);
+        allSessions.push(...sessions);
+      } catch (err) {
+        logger.warn({ err, adapterId: adapter.id, projectId }, 'Failed to scan external sessions');
+      }
+    }
+
+    return allSessions;
+  }
+
+  /** Import an external session, creating a Mainframe chat for it */
+  async importSession(projectId: string, sessionId: string, adapterId: string): Promise<Chat> {
+    const existing = this.db.chats.findByExternalSessionId(sessionId, projectId);
+    if (existing) return existing;
+
+    const chat = this.db.chats.create(projectId, adapterId);
+    this.db.chats.update(chat.id, { claudeSessionId: sessionId });
+    chat.claudeSessionId = sessionId;
+
+    logger.info({ chatId: chat.id, sessionId, projectId }, 'external session imported');
+    return chat;
+  }
+
+  /** Start auto-scanning for a project (on project open) */
+  startAutoScan(projectId: string): void {
+    this.stopAutoScan(projectId);
+
+    this.emitCount(projectId).catch((err) => logger.warn({ err, projectId }, 'Initial external session scan failed'));
+
+    const interval = setInterval(() => {
+      this.emitCount(projectId).catch((err) =>
+        logger.warn({ err, projectId }, 'Periodic external session scan failed'),
+      );
+    }, SCAN_INTERVAL_MS);
+
+    this.scanIntervals.set(projectId, interval);
+  }
+
+  /** Stop auto-scanning for a project */
+  stopAutoScan(projectId: string): void {
+    const interval = this.scanIntervals.get(projectId);
+    if (interval) {
+      clearInterval(interval);
+      this.scanIntervals.delete(projectId);
+      this.lastCounts.delete(projectId);
+    }
+  }
+
+  /** Stop all auto-scans (for shutdown) */
+  stopAll(): void {
+    for (const [projectId] of this.scanIntervals) {
+      this.stopAutoScan(projectId);
+    }
+  }
+
+  private async emitCount(projectId: string): Promise<void> {
+    const sessions = await this.scan(projectId);
+    const count = sessions.length;
+    const lastCount = this.lastCounts.get(projectId);
+
+    if (lastCount !== count) {
+      this.lastCounts.set(projectId, count);
+      this.emitEvent({
+        type: 'sessions.external.count',
+        projectId,
+        count,
+      } as DaemonEvent);
+    }
+  }
+}

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -44,16 +44,17 @@ export class ExternalSessionService {
   }
 
   /** Import an external session, creating a Mainframe chat for it */
-  async importSession(projectId: string, sessionId: string, adapterId: string): Promise<Chat> {
+  async importSession(projectId: string, sessionId: string, adapterId: string, title?: string): Promise<Chat> {
     const existing = this.db.chats.findByExternalSessionId(sessionId, projectId);
     if (existing) return existing;
 
     const chat = this.db.chats.create(projectId, adapterId);
-    this.db.chats.update(chat.id, { claudeSessionId: sessionId });
+    this.db.chats.update(chat.id, { claudeSessionId: sessionId, ...(title ? { title } : {}) });
     chat.claudeSessionId = sessionId;
+    if (title) chat.title = title;
 
     logger.info({ chatId: chat.id, sessionId, projectId }, 'external session imported');
-    this.emitEvent({ type: 'chat.created', chat });
+    this.emitEvent({ type: 'chat.created', chat, source: 'import' });
     return chat;
   }
 

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -50,6 +50,7 @@ export class ExternalSessionService {
     chat.claudeSessionId = sessionId;
 
     logger.info({ chatId: chat.id, sessionId, projectId }, 'external session imported');
+    this.emitEvent({ type: 'chat.created', chat });
     return chat;
   }
 

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -31,6 +31,9 @@ export class ExternalSessionService {
       const excludeIds = this.db.chats.getImportedSessionIds(projectId);
       try {
         const sessions = await adapter.listExternalSessions(project.path, excludeIds);
+        for (const session of sessions) {
+          session.adapterId = adapter.id;
+        }
         allSessions.push(...sessions);
       } catch (err) {
         logger.warn({ err, adapterId: adapter.id, projectId }, 'Failed to scan external sessions');

--- a/packages/core/src/chat/index.ts
+++ b/packages/core/src/chat/index.ts
@@ -1,2 +1,3 @@
 export { ChatManager } from './chat-manager.js';
+export { ExternalSessionService } from './external-session-service.js';
 export type { ActiveChat } from './types.js';

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -197,4 +197,39 @@ export class ChatsRepository {
     this.db.prepare('UPDATE chats SET skill_files = ? WHERE id = ?').run(JSON.stringify(existing), chatId);
     return true;
   }
+
+  getImportedSessionIds(projectId: string): string[] {
+    const stmt = this.db.prepare(`
+      SELECT claude_session_id FROM chats
+      WHERE project_id = ? AND claude_session_id IS NOT NULL
+    `);
+    const rows = stmt.all(projectId) as { claude_session_id: string }[];
+    return rows.map((r) => r.claude_session_id);
+  }
+
+  findByExternalSessionId(sessionId: string, projectId: string): Chat | null {
+    const stmt = this.db.prepare(`
+      SELECT
+        id, adapter_id as adapterId, project_id as projectId,
+        title, claude_session_id as claudeSessionId, model,
+        permission_mode as permissionMode, status,
+        created_at as createdAt, updated_at as updatedAt,
+        total_cost as totalCost, total_tokens_input as totalTokensInput,
+        total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
+        mentions, modified_files as modifiedFiles,
+        worktree_path as worktreePath, branch_name as branchName,
+        process_state as processState
+      FROM chats WHERE claude_session_id = ? AND project_id = ?
+    `);
+    const row = stmt.get(sessionId, projectId) as (Chat & { mentions: string; modifiedFiles: string }) | null;
+    if (!row) return null;
+    return {
+      ...row,
+      mentions: parseJsonColumn(row.mentions, []),
+      modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
+      worktreePath: row.worktreePath || undefined,
+      branchName: row.branchName || undefined,
+      processState: (row.processState as Chat['processState']) || null,
+    };
+  }
 }

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -4,6 +4,7 @@ import type {
   AdapterModel,
   AdapterSession,
   CustomCommand,
+  ExternalSession,
   SessionOptions,
   Skill,
   AgentConfig,
@@ -12,6 +13,7 @@ import type {
 } from '@mainframe/types';
 import { ClaudeSession } from './session.js';
 import * as skills from './skills.js';
+import { listExternalSessions } from './external-sessions.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import manifest from './manifest.json' with { type: 'json' };
 
@@ -121,5 +123,9 @@ export class ClaudeAdapter implements Adapter {
 
   async deleteAgent(agentId: string, projectPath: string): Promise<void> {
     return skills.deleteAgent(agentId, projectPath);
+  }
+
+  async listExternalSessions(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]> {
+    return listExternalSessions(projectPath, excludeSessionIds);
   }
 }

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -1,0 +1,78 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { homedir } from 'node:os';
+import { createChildLogger } from '../../../logger.js';
+import type { ExternalSession } from '@mainframe/types';
+
+const logger = createChildLogger('claude:external-sessions');
+
+interface SessionIndexEntry {
+  sessionId: string;
+  fullPath?: string;
+  fileMtime?: number;
+  firstPrompt?: string;
+  summary?: string;
+  messageCount?: number;
+  created?: string;
+  modified?: string;
+  gitBranch?: string;
+  projectPath?: string;
+  isSidechain?: boolean;
+}
+
+interface SessionIndex {
+  version: number;
+  entries: SessionIndexEntry[];
+}
+
+export async function listExternalSessions(
+  projectPath: string,
+  excludeSessionIds: string[],
+): Promise<ExternalSession[]> {
+  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+  const indexPath = path.join(homedir(), '.claude', 'projects', encodedPath, 'sessions-index.json');
+
+  let raw: string;
+  try {
+    raw = await readFile(indexPath, 'utf-8');
+  } catch {
+    // No index file — return empty (no fallback to JSONL scan by design)
+    return [];
+  }
+
+  let index: SessionIndex;
+  try {
+    index = JSON.parse(raw) as SessionIndex;
+  } catch {
+    logger.warn({ indexPath }, 'Malformed sessions-index.json');
+    return [];
+  }
+
+  if (!index.entries || !Array.isArray(index.entries)) {
+    logger.warn({ indexPath }, 'sessions-index.json has no entries array');
+    return [];
+  }
+
+  const excludeSet = new Set(excludeSessionIds);
+
+  return index.entries
+    .filter((entry) => {
+      if (!entry.sessionId) return false;
+      if (excludeSet.has(entry.sessionId)) return false;
+      if (entry.isSidechain) return false;
+      return true;
+    })
+    .map(
+      (entry): ExternalSession => ({
+        sessionId: entry.sessionId,
+        projectPath,
+        firstPrompt: entry.firstPrompt,
+        summary: entry.summary,
+        messageCount: entry.messageCount,
+        createdAt: entry.created ?? new Date().toISOString(),
+        modifiedAt: entry.modified ?? entry.created ?? new Date().toISOString(),
+        gitBranch: entry.gitBranch || undefined,
+      }),
+    )
+    .sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+}

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -1,4 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import path from 'node:path';
 import { homedir } from 'node:os';
 import { createChildLogger } from '../../../logger.js';
@@ -25,19 +27,37 @@ interface SessionIndex {
   entries: SessionIndexEntry[];
 }
 
+function getProjectDir(projectPath: string): string {
+  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+  return path.join(homedir(), '.claude', 'projects', encodedPath);
+}
+
+/** Try sessions-index.json first; fall back to JSONL scan. */
 export async function listExternalSessions(
   projectPath: string,
   excludeSessionIds: string[],
 ): Promise<ExternalSession[]> {
-  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
-  const indexPath = path.join(homedir(), '.claude', 'projects', encodedPath, 'sessions-index.json');
+  const projectDir = getProjectDir(projectPath);
+  const excludeSet = new Set(excludeSessionIds);
+
+  const fromIndex = await listFromIndex(projectDir, projectPath, excludeSet);
+  if (fromIndex !== null) return fromIndex;
+
+  return listFromJsonl(projectDir, projectPath, excludeSet);
+}
+
+async function listFromIndex(
+  projectDir: string,
+  projectPath: string,
+  excludeSet: Set<string>,
+): Promise<ExternalSession[] | null> {
+  const indexPath = path.join(projectDir, 'sessions-index.json');
 
   let raw: string;
   try {
     raw = await readFile(indexPath, 'utf-8');
   } catch {
-    // No index file — return empty (no fallback to JSONL scan by design)
-    return [];
+    return null; // No index — use fallback
   }
 
   let index: SessionIndex;
@@ -45,23 +65,16 @@ export async function listExternalSessions(
     index = JSON.parse(raw) as SessionIndex;
   } catch {
     logger.warn({ indexPath }, 'Malformed sessions-index.json');
-    return [];
+    return null;
   }
 
   if (!index.entries || !Array.isArray(index.entries)) {
     logger.warn({ indexPath }, 'sessions-index.json has no entries array');
-    return [];
+    return null;
   }
 
-  const excludeSet = new Set(excludeSessionIds);
-
   return index.entries
-    .filter((entry) => {
-      if (!entry.sessionId) return false;
-      if (excludeSet.has(entry.sessionId)) return false;
-      if (entry.isSidechain) return false;
-      return true;
-    })
+    .filter((e) => e.sessionId && !excludeSet.has(e.sessionId) && !e.isSidechain)
     .map(
       (entry): ExternalSession => ({
         sessionId: entry.sessionId,
@@ -76,4 +89,102 @@ export async function listExternalSessions(
       }),
     )
     .sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+}
+
+/** Scan *.jsonl files, reading the first user message from each for metadata. */
+async function listFromJsonl(
+  projectDir: string,
+  projectPath: string,
+  excludeSet: Set<string>,
+): Promise<ExternalSession[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(projectDir);
+  } catch {
+    return [];
+  }
+
+  const jsonlFiles = entries.filter((e) => e.endsWith('.jsonl'));
+  const sessions: ExternalSession[] = [];
+
+  for (const file of jsonlFiles) {
+    const sessionId = file.replace('.jsonl', '');
+    if (excludeSet.has(sessionId)) continue;
+
+    const filePath = path.join(projectDir, file);
+    try {
+      const session = await extractSessionMeta(filePath, sessionId, projectPath);
+      if (session) sessions.push(session);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return sessions.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+}
+
+async function extractSessionMeta(
+  filePath: string,
+  sessionId: string,
+  projectPath: string,
+): Promise<ExternalSession | null> {
+  const fileStat = await stat(filePath);
+  const modifiedAt = fileStat.mtime.toISOString();
+
+  const rl = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
+  let firstPrompt: string | undefined;
+  let createdAt: string | undefined;
+  let gitBranch: string | undefined;
+  let isSidechain = false;
+  let linesRead = 0;
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    linesRead++;
+    if (linesRead > 30) break; // Only scan first 30 lines for metadata
+
+    try {
+      const entry = JSON.parse(line);
+
+      if (entry.isSidechain) {
+        isSidechain = true;
+        break;
+      }
+
+      if (!createdAt && entry.timestamp) createdAt = entry.timestamp;
+      if (!gitBranch && entry.gitBranch) gitBranch = entry.gitBranch;
+
+      if (!firstPrompt && entry.type === 'user' && entry.message?.content) {
+        const content = entry.message.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block?.type === 'text' && block.text) {
+              firstPrompt = block.text.slice(0, 200);
+              break;
+            }
+          }
+        } else if (typeof content === 'string') {
+          firstPrompt = content.slice(0, 200);
+        }
+      }
+
+      if (firstPrompt && createdAt && gitBranch) break; // Got everything we need
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  rl.close();
+
+  if (isSidechain) return null;
+
+  return {
+    sessionId,
+    adapterId: 'claude',
+    projectPath,
+    firstPrompt,
+    createdAt: createdAt ?? modifiedAt,
+    modifiedAt,
+    gitBranch: gitBranch || undefined,
+  };
 }

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -65,6 +65,7 @@ export async function listExternalSessions(
     .map(
       (entry): ExternalSession => ({
         sessionId: entry.sessionId,
+        adapterId: 'claude',
         projectPath,
         firstPrompt: entry.firstPrompt,
         summary: entry.summary,

--- a/packages/core/src/server/http.ts
+++ b/packages/core/src/server/http.ts
@@ -19,6 +19,7 @@ import {
   settingRoutes,
   commandRoutes,
   launchRoutes,
+  externalSessionRoutes,
 } from './routes/index.js';
 import { authRoutes } from './routes/auth.js';
 import { PushService } from '../push/index.js';
@@ -79,6 +80,7 @@ export function createHttpServer(
   app.use(agentRoutes(ctx));
   app.use(settingRoutes(ctx));
   app.use(launchRoutes(ctx));
+  app.use(externalSessionRoutes(ctx));
 
   // Plugin routes — the PluginManager owns a parent router with listing + per-plugin sub-routers
   if (pluginManager) {

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -52,6 +52,22 @@ export function chatRoutes(ctx: RouteContext): Router {
     }),
   );
 
+  router.post('/api/chats/:id/unarchive', (req: Request, res: Response) => {
+    const chatId = param(req, 'id');
+    try {
+      ctx.db.chats.update(chatId, { status: 'active' });
+      const chat = ctx.db.chats.get(chatId);
+      if (!chat) {
+        res.status(404).json({ success: false, error: 'Chat not found' });
+        return;
+      }
+      res.json({ success: true, data: chat });
+    } catch (err) {
+      logger.warn({ err, chatId }, 'Failed to unarchive chat');
+      res.status(500).json({ success: false, error: 'Operation failed' });
+    }
+  });
+
   router.get('/api/chats/:id/changes', (req: Request, res: Response) => {
     const files = ctx.db.chats.getModifiedFilesList(param(req, 'id'));
     res.json({ files });

--- a/packages/core/src/server/routes/external-sessions.ts
+++ b/packages/core/src/server/routes/external-sessions.ts
@@ -1,0 +1,50 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import type { RouteContext } from './types.js';
+import { param } from './types.js';
+import { asyncHandler } from './async-handler.js';
+import { createChildLogger } from '../../logger.js';
+
+const logger = createChildLogger('routes:external-sessions');
+
+const importBodySchema = z.object({
+  sessionId: z.string().regex(/^[a-zA-Z0-9-]+$/),
+  adapterId: z.string().min(1),
+});
+
+export function externalSessionRoutes(ctx: RouteContext): Router {
+  const router = Router();
+
+  // List importable external sessions (also ensures periodic scanning is active)
+  router.get(
+    '/api/projects/:projectId/external-sessions',
+    asyncHandler(async (req: Request, res: Response) => {
+      const projectId = param(req, 'projectId');
+      const service = ctx.chats.getExternalSessionService();
+      service.startAutoScan(projectId);
+      const sessions = await service.scan(projectId);
+      res.json({ success: true, data: sessions });
+    }),
+  );
+
+  // Import an external session
+  router.post(
+    '/api/projects/:projectId/external-sessions/import',
+    asyncHandler(async (req: Request, res: Response) => {
+      const projectId = param(req, 'projectId');
+      const result = importBodySchema.safeParse(req.body);
+      if (!result.success) {
+        logger.warn({ projectId, issues: result.error.issues }, 'invalid import request body');
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      const { sessionId, adapterId } = result.data;
+
+      const service = ctx.chats.getExternalSessionService();
+      const chat = await service.importSession(projectId, sessionId, adapterId);
+      res.json({ success: true, data: chat });
+    }),
+  );
+
+  return router;
+}

--- a/packages/core/src/server/routes/external-sessions.ts
+++ b/packages/core/src/server/routes/external-sessions.ts
@@ -10,6 +10,7 @@ const logger = createChildLogger('routes:external-sessions');
 const importBodySchema = z.object({
   sessionId: z.string().regex(/^[a-zA-Z0-9-]+$/),
   adapterId: z.string().min(1),
+  title: z.string().max(500).optional(),
 });
 
 export function externalSessionRoutes(ctx: RouteContext): Router {
@@ -38,10 +39,10 @@ export function externalSessionRoutes(ctx: RouteContext): Router {
         res.status(400).json({ success: false, error: 'Invalid request body' });
         return;
       }
-      const { sessionId, adapterId } = result.data;
+      const { sessionId, adapterId, title } = result.data;
 
       const service = ctx.chats.getExternalSessionService();
-      const chat = await service.importSession(projectId, sessionId, adapterId);
+      const chat = await service.importSession(projectId, sessionId, adapterId, title);
       res.json({ success: true, data: chat });
     }),
   );

--- a/packages/core/src/server/routes/index.ts
+++ b/packages/core/src/server/routes/index.ts
@@ -10,5 +10,6 @@ export { adapterRoutes } from './adapters.js';
 export { settingRoutes } from './settings.js';
 export { commandRoutes } from './commands.js';
 export { launchRoutes } from './launch.js';
+export { externalSessionRoutes } from './external-sessions.js';
 export { asyncHandler } from './async-handler.js';
 export type { RouteContext } from './types.js';

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -78,7 +78,7 @@ export function ChatsPanel(): React.ReactElement {
       if (!activeProjectId) return;
       setLoadingImport(session.sessionId);
       try {
-        await importExternalSession(activeProjectId, session.sessionId, 'claude');
+        await importExternalSession(activeProjectId, session.sessionId, session.adapterId);
         setExternalSessions((prev) => prev.filter((s) => s.sessionId !== session.sessionId));
         useChatsStore.getState().setExternalSessionCount(useChatsStore.getState().externalSessionCount - 1);
       } catch (err) {

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import { Plus, Archive } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
+import { Plus, Archive, Download, ChevronDown, ChevronRight } from 'lucide-react';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:panels');
@@ -8,10 +8,11 @@ import type { SessionStatus } from '../../store/chats';
 import { useTabsStore } from '../../store/tabs';
 import { useProject } from '../../hooks/useAppInit';
 import { daemonClient } from '../../lib/client';
-import { archiveChat } from '../../lib/api';
+import { archiveChat, getExternalSessions, importExternalSession } from '../../lib/api';
 import { cn } from '../../lib/utils';
 import { getAdapterLabel } from '../../lib/adapters';
 import { useAdaptersStore } from '../../store/adapters';
+import type { ExternalSession } from '@mainframe/types';
 
 function SessionStatusDot({ status }: { status: SessionStatus }) {
   const isWorking = status === 'working' || status === 'waiting';
@@ -31,6 +32,11 @@ export function ChatsPanel(): React.ReactElement {
   const { chats, activeChatId, setActiveChat, removeChat } = useChatsStore();
   const adapters = useAdaptersStore((s) => s.adapters);
   const { createChat } = useProject(activeProjectId);
+  const externalSessionCount = useChatsStore((s) => s.externalSessionCount);
+
+  const [showImport, setShowImport] = useState(false);
+  const [externalSessions, setExternalSessions] = useState<ExternalSession[]>([]);
+  const [loadingImport, setLoadingImport] = useState<string | null>(null);
 
   const handleSelectChat = useCallback(
     (chatId: string, title?: string) => {
@@ -52,6 +58,36 @@ export function ChatsPanel(): React.ReactElement {
         .catch((err) => log.warn('archive failed', { err: String(err) }));
     },
     [removeChat],
+  );
+
+  const handleToggleImport = useCallback(async () => {
+    if (!activeProjectId) return;
+    if (!showImport) {
+      try {
+        const sessions = await getExternalSessions(activeProjectId);
+        setExternalSessions(sessions);
+      } catch (err) {
+        log.warn('failed to fetch external sessions', { err: String(err) });
+      }
+    }
+    setShowImport((prev) => !prev);
+  }, [activeProjectId, showImport]);
+
+  const handleImportSession = useCallback(
+    async (session: ExternalSession) => {
+      if (!activeProjectId) return;
+      setLoadingImport(session.sessionId);
+      try {
+        await importExternalSession(activeProjectId, session.sessionId, 'claude');
+        setExternalSessions((prev) => prev.filter((s) => s.sessionId !== session.sessionId));
+        useChatsStore.getState().setExternalSessionCount(useChatsStore.getState().externalSessionCount - 1);
+      } catch (err) {
+        log.warn('failed to import session', { err: String(err) });
+      } finally {
+        setLoadingImport(null);
+      }
+    },
+    [activeProjectId],
   );
 
   const formatRelativeTime = (isoString: string): string => {
@@ -87,6 +123,59 @@ export function ChatsPanel(): React.ReactElement {
           <Plus size={14} />
         </button>
       </div>
+
+      {/* External Sessions Import Section */}
+      {activeProjectId && externalSessionCount > 0 && (
+        <div className="px-[10px] pb-2">
+          <button
+            onClick={handleToggleImport}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label text-mf-text-secondary hover:bg-mf-hover/50 transition-colors"
+          >
+            {showImport ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            <Download size={12} />
+            <span>Import external sessions</span>
+            <span className="ml-auto text-mf-status bg-mf-accent/20 text-mf-accent px-1.5 py-0.5 rounded-full">
+              {externalSessionCount}
+            </span>
+          </button>
+          {showImport && (
+            <div className="mt-1 space-y-1">
+              {externalSessions.length === 0 ? (
+                <div className="px-3 py-2 text-mf-status text-mf-text-secondary">Loading...</div>
+              ) : (
+                externalSessions.map((session) => (
+                  <div
+                    key={session.sessionId}
+                    className="group flex items-center gap-2 px-3 py-2 rounded-mf-input hover:bg-mf-hover/50 transition-colors"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-mf-small text-mf-text-secondary truncate">
+                        {session.summary ?? session.firstPrompt ?? 'Untitled session'}
+                      </div>
+                      <div className="text-mf-status text-mf-text-secondary mt-0.5">
+                        {session.gitBranch && (
+                          <>
+                            {session.gitBranch}
+                            <span className="mx-0.5">•</span>
+                          </>
+                        )}
+                        {formatRelativeTime(session.modifiedAt)}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleImportSession(session)}
+                      disabled={loadingImport === session.sessionId}
+                      className="shrink-0 px-2 py-1 rounded text-mf-status text-mf-accent hover:bg-mf-accent/20 transition-colors disabled:opacity-40"
+                    >
+                      {loadingImport === session.sessionId ? '...' : 'Import'}
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Chat list */}
       <div className="flex-1 overflow-y-auto px-[10px]">

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -78,7 +78,8 @@ export function ChatsPanel(): React.ReactElement {
       if (!activeProjectId) return;
       setLoadingImport(session.sessionId);
       try {
-        await importExternalSession(activeProjectId, session.sessionId, session.adapterId);
+        const title = session.summary ?? session.firstPrompt ?? undefined;
+        await importExternalSession(activeProjectId, session.sessionId, session.adapterId, title);
         setExternalSessions((prev) => prev.filter((s) => s.sessionId !== session.sessionId));
         useChatsStore.getState().setExternalSessionCount(useChatsStore.getState().externalSessionCount - 1);
       } catch (err) {
@@ -124,61 +125,66 @@ export function ChatsPanel(): React.ReactElement {
         </button>
       </div>
 
-      {/* External Sessions Import Section */}
-      {activeProjectId && externalSessionCount > 0 && (
-        <div className="px-[10px] pb-2">
-          <button
-            onClick={handleToggleImport}
-            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label text-mf-text-secondary hover:bg-mf-hover/50 transition-colors"
-          >
-            {showImport ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-            <Download size={12} />
-            <span>Import external sessions</span>
-            <span className="ml-auto text-mf-status bg-mf-accent/20 text-mf-accent px-1.5 py-0.5 rounded-full">
-              {externalSessionCount}
-            </span>
-          </button>
-          {showImport && (
-            <div className="mt-1 space-y-1">
-              {externalSessions.length === 0 ? (
-                <div className="px-3 py-2 text-mf-status text-mf-text-secondary">Loading...</div>
-              ) : (
-                externalSessions.map((session) => (
-                  <div
-                    key={session.sessionId}
-                    className="group flex items-center gap-2 px-3 py-2 rounded-mf-input hover:bg-mf-hover/50 transition-colors"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-mf-small text-mf-text-secondary truncate">
-                        {session.summary ?? session.firstPrompt ?? 'Untitled session'}
-                      </div>
-                      <div className="text-mf-status text-mf-text-secondary mt-0.5">
-                        {session.gitBranch && (
-                          <>
-                            {session.gitBranch}
-                            <span className="mx-0.5">•</span>
-                          </>
-                        )}
-                        {formatRelativeTime(session.modifiedAt)}
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => handleImportSession(session)}
-                      disabled={loadingImport === session.sessionId}
-                      className="shrink-0 px-2 py-1 rounded text-mf-status text-mf-accent hover:bg-mf-accent/20 transition-colors disabled:opacity-40"
-                    >
-                      {loadingImport === session.sessionId ? '...' : 'Import'}
-                    </button>
-                  </div>
-                ))
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
       {/* Chat list */}
       <div className="flex-1 overflow-y-auto px-[10px]">
+        {/* External Sessions Import Section */}
+        {activeProjectId && externalSessionCount > 0 && (
+          <div className="pb-2" data-testid="external-sessions-section">
+            <button
+              data-testid="external-sessions-toggle"
+              onClick={handleToggleImport}
+              className="w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label text-mf-text-secondary hover:bg-mf-hover/50 transition-colors"
+            >
+              {showImport ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              <Download size={12} />
+              <span>Import external sessions</span>
+              <span className="ml-auto text-mf-status bg-mf-accent/20 text-mf-accent px-1.5 py-0.5 rounded-full">
+                {externalSessionCount}
+              </span>
+            </button>
+            {showImport && (
+              <div className="mt-1 space-y-1">
+                {externalSessions.length === 0 ? (
+                  <div className="px-3 py-2 text-mf-status text-mf-text-secondary">Loading...</div>
+                ) : (
+                  externalSessions.map((session) => (
+                    <div
+                      key={session.sessionId}
+                      data-testid="external-session-item"
+                      className="group flex items-center gap-2 px-3 py-2 rounded-mf-input hover:bg-mf-hover/50 transition-colors"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div
+                          className="text-mf-small text-mf-text-secondary truncate"
+                          title={session.summary ?? session.firstPrompt ?? 'Untitled session'}
+                        >
+                          {session.summary ?? session.firstPrompt ?? 'Untitled session'}
+                        </div>
+                        <div className="text-mf-status text-mf-text-secondary mt-0.5">
+                          {session.gitBranch && (
+                            <>
+                              {session.gitBranch}
+                              <span className="mx-0.5">•</span>
+                            </>
+                          )}
+                          {formatRelativeTime(session.modifiedAt)}
+                        </div>
+                      </div>
+                      <button
+                        data-testid="import-session-btn"
+                        onClick={() => handleImportSession(session)}
+                        disabled={loadingImport === session.sessionId}
+                        className="shrink-0 px-2 py-1 rounded text-mf-status text-mf-accent hover:bg-mf-accent/20 transition-colors disabled:opacity-40"
+                      >
+                        {loadingImport === session.sessionId ? '...' : 'Import'}
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        )}
         {!activeProjectId ? (
           <div className="py-4 text-center text-mf-text-secondary text-mf-label">Select a project to view sessions</div>
         ) : chats.length === 0 ? (

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { daemonClient } from '../lib/client';
-import { getProjects, getAdapters, getProviderSettings, getChats, getPlugins } from '../lib/api';
+import { getProjects, getAdapters, getProviderSettings, getChats, getPlugins, getExternalSessions } from '../lib/api';
 import { useProjectsStore } from '../store/projects';
 import { useChatsStore } from '../store/chats';
 import { useTabsStore } from '../store/tabs';
@@ -127,7 +127,17 @@ export function useProject(projectId: string | null) {
       }
     };
 
+    const loadExternalSessions = async () => {
+      try {
+        const sessions = await getExternalSessions(projectId);
+        useChatsStore.getState().setExternalSessionCount(sessions.length);
+      } catch (err) {
+        log.warn('external sessions fetch failed', { err: String(err) });
+      }
+    };
+
     loadChats();
+    loadExternalSessions();
     syncLaunchStatuses();
 
     // Eagerly load skills, agents & commands so menus (/ and @) work immediately
@@ -142,6 +152,7 @@ export function useProject(projectId: string | null) {
     const unsubConnection = daemonClient.subscribeConnection(() => {
       if (daemonClient.connected) {
         loadChats();
+        loadExternalSessions();
         syncLaunchStatuses();
       }
     });

--- a/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
+++ b/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
@@ -1,0 +1,17 @@
+import type { Chat, ExternalSession } from '@mainframe/types';
+import { API_BASE, postJson } from './http';
+
+export async function getExternalSessions(projectId: string): Promise<ExternalSession[]> {
+  const res = await fetch(`${API_BASE}/api/projects/${projectId}/external-sessions`);
+  if (!res.ok) return [];
+  const json = (await res.json()) as { data: ExternalSession[] };
+  return json.data;
+}
+
+export async function importExternalSession(projectId: string, sessionId: string, adapterId: string): Promise<Chat> {
+  const json = await postJson<{ success: boolean; data: Chat }>(
+    `${API_BASE}/api/projects/${projectId}/external-sessions/import`,
+    { sessionId, adapterId },
+  );
+  return json.data;
+}

--- a/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
+++ b/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
@@ -8,10 +8,15 @@ export async function getExternalSessions(projectId: string): Promise<ExternalSe
   return json.data;
 }
 
-export async function importExternalSession(projectId: string, sessionId: string, adapterId: string): Promise<Chat> {
+export async function importExternalSession(
+  projectId: string,
+  sessionId: string,
+  adapterId: string,
+  title?: string,
+): Promise<Chat> {
   const json = await postJson<{ success: boolean; data: Chat }>(
     `${API_BASE}/api/projects/${projectId}/external-sessions/import`,
-    { sessionId, adapterId },
+    { sessionId, adapterId, title },
   );
   return json.data;
 }

--- a/packages/desktop/src/renderer/lib/api/index.ts
+++ b/packages/desktop/src/renderer/lib/api/index.ts
@@ -51,3 +51,5 @@ export { getAttachment, uploadAttachments } from './attachments-api';
 export { getPlugins } from './plugins-api';
 
 export { getCommands } from './commands-api';
+
+export { getExternalSessions, importExternalSession } from './external-sessions-api';

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -93,6 +93,10 @@ export function routeEvent(event: DaemonEvent): void {
     case 'launch.port.timeout':
       log.warn('event:launch.port.timeout', { projectId: event.projectId, name: event.name, port: event.port });
       break;
+    case 'sessions.external.count':
+      log.debug('event:sessions.external.count', { projectId: event.projectId, count: event.count });
+      chats.setExternalSessionCount(event.count);
+      break;
     case 'error':
       log.error('daemon error event', { error: event.error });
       useProjectsStore.getState().setError(event.error);

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -13,10 +13,12 @@ export function routeEvent(event: DaemonEvent): void {
 
   switch (event.type) {
     case 'chat.created':
-      log.info('event:chat.created', { chatId: event.chat.id, title: event.chat.title });
+      log.info('event:chat.created', { chatId: event.chat.id, title: event.chat.title, source: event.source });
       chats.addChat(event.chat);
-      chats.setActiveChat(event.chat.id);
-      tabs.openChatTab(event.chat.id, event.chat.title);
+      if (event.source !== 'import') {
+        chats.setActiveChat(event.chat.id);
+        tabs.openChatTab(event.chat.id, event.chat.title);
+      }
       break;
     case 'chat.updated':
       log.debug('event:chat.updated', { chatId: event.chat.id });

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -23,6 +23,8 @@ interface ChatsState {
   setProcess: (chatId: string, process: AdapterProcess) => void;
   updateProcessStatus: (processId: string, status: AdapterProcess['status']) => void;
   removeProcess: (chatId: string) => void;
+  externalSessionCount: number;
+  setExternalSessionCount: (count: number) => void;
 }
 
 export const useChatsStore = create<ChatsState>((set) => ({
@@ -31,6 +33,7 @@ export const useChatsStore = create<ChatsState>((set) => ({
   messages: new Map(),
   pendingPermissions: new Map(),
   processes: new Map(),
+  externalSessionCount: 0,
 
   setChats: (chats) => set({ chats }),
   setActiveChat: (id) => set({ activeChatId: id }),
@@ -106,4 +109,5 @@ export const useChatsStore = create<ChatsState>((set) => ({
       newProcesses.delete(chatId);
       return { processes: newProcesses };
     }),
+  setExternalSessionCount: (count) => set({ externalSessionCount: count }),
 }));

--- a/packages/e2e/tests/35-external-sessions.spec.ts
+++ b/packages/e2e/tests/35-external-sessions.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+import { launchApp, closeApp } from '../fixtures/app.js';
+import { createTestProject, cleanupProject } from '../fixtures/project.js';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
+
+const DAEMON_BASE = `http://127.0.0.1:${process.env['PORT'] ?? '31415'}`;
+
+/** Encode a project path the same way the Claude adapter does. */
+function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+}
+
+/** Create a fake JSONL session file in the Claude project directory. */
+function seedExternalSession(
+  projectPath: string,
+  sessionId: string,
+  opts: { firstPrompt?: string; gitBranch?: string } = {},
+): string {
+  const claudeDir = path.join(homedir(), '.claude', 'projects', encodeProjectPath(projectPath));
+  mkdirSync(claudeDir, { recursive: true });
+
+  const filePath = path.join(claudeDir, `${sessionId}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      type: 'user',
+      timestamp: new Date().toISOString(),
+      gitBranch: opts.gitBranch ?? 'main',
+      message: {
+        content: [{ type: 'text', text: opts.firstPrompt ?? 'Test external session' }],
+      },
+    }),
+  ];
+  writeFileSync(filePath, lines.join('\n') + '\n');
+  return claudeDir;
+}
+
+test.describe('§35 External session import', () => {
+  let fixture: Awaited<ReturnType<typeof launchApp>>;
+  let project: Awaited<ReturnType<typeof createTestProject>>;
+  let claudeDir: string;
+
+  test.beforeAll(async () => {
+    fixture = await launchApp();
+    project = await createTestProject(fixture.page);
+
+    // Seed two external sessions
+    claudeDir = seedExternalSession(project.projectPath, 'ext-session-aaa', {
+      firstPrompt: 'Fix the login bug',
+      gitBranch: 'feat/login-fix',
+    });
+    seedExternalSession(project.projectPath, 'ext-session-bbb', {
+      firstPrompt: 'Add unit tests for auth module',
+      gitBranch: 'feat/auth-tests',
+    });
+
+    // Trigger a re-scan so the daemon picks up the seeded sessions
+    await fixture.page.request.get(`${DAEMON_BASE}/api/projects/${project.projectId}/external-sessions`);
+    // Wait for the WS count event to propagate
+    await fixture.page.waitForTimeout(1000);
+  });
+
+  test.afterAll(async () => {
+    // Clean up seeded Claude session files
+    rmSync(claudeDir, { recursive: true, force: true });
+    await cleanupProject(project);
+    await closeApp(fixture);
+  });
+
+  test('shows external sessions badge', async () => {
+    const section = fixture.page.locator('[data-testid="external-sessions-section"]');
+    await expect(section).toBeVisible({ timeout: 10_000 });
+    // Badge should show count
+    await expect(section.locator('[data-testid="external-sessions-toggle"]')).toContainText('2');
+  });
+
+  test('expands to show importable sessions', async () => {
+    await fixture.page.locator('[data-testid="external-sessions-toggle"]').click();
+    const items = fixture.page.locator('[data-testid="external-session-item"]');
+    await expect(items).toHaveCount(2, { timeout: 10_000 });
+    // Verify session content is displayed
+    await expect(items.first()).toContainText(/(Fix the login bug|Add unit tests)/);
+  });
+
+  test('external session titles have tooltips', async () => {
+    const firstTitle = fixture.page.locator('[data-testid="external-session-item"]').first().locator('.truncate');
+    const titleAttr = await firstTitle.getAttribute('title');
+    expect(titleAttr).toBeTruthy();
+  });
+
+  test('imports an external session', async () => {
+    const chatsBefore = await fixture.page.locator('[data-testid="chat-list-item"]').count();
+
+    // Click the first Import button
+    const firstItem = fixture.page.locator('[data-testid="external-session-item"]').first();
+    await firstItem.locator('[data-testid="import-session-btn"]').click();
+
+    // Session should disappear from import list
+    await expect(fixture.page.locator('[data-testid="external-session-item"]')).toHaveCount(1, { timeout: 10_000 });
+
+    // Chat list should have one more entry
+    await expect(fixture.page.locator('[data-testid="chat-list-item"]')).toHaveCount(chatsBefore + 1, {
+      timeout: 10_000,
+    });
+  });
+
+  test('imported session has a title', async () => {
+    // The most recently imported chat should be at the top of the list
+    const firstChat = fixture.page.locator('[data-testid="chat-list-item"]').first();
+    // It should NOT say "New Chat" — it should have the firstPrompt as title
+    const text = await firstChat.textContent();
+    expect(text).not.toContain('New Chat');
+  });
+
+  test('import does not switch active chat', async () => {
+    // Click the first chat to make it active
+    const firstChat = fixture.page.locator('[data-testid="chat-list-item"]').first();
+    await firstChat.click();
+    // Wait for active state (font-medium class)
+    await expect(firstChat.locator('.font-medium')).toBeVisible({ timeout: 5_000 });
+    const activeTextBefore = await firstChat.locator('.font-medium').textContent();
+
+    // Import the remaining session
+    const remainingItem = fixture.page.locator('[data-testid="external-session-item"]').first();
+    await remainingItem.locator('[data-testid="import-session-btn"]').click();
+
+    // Wait for import to complete
+    await expect(fixture.page.locator('[data-testid="external-session-item"]')).toHaveCount(0, { timeout: 10_000 });
+
+    // Active chat should NOT have changed
+    const activeAfter = fixture.page.locator('[data-testid="chat-list-item"]').locator('.font-medium');
+    await expect(activeAfter).toHaveText(activeTextBefore!);
+  });
+});

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -144,6 +144,18 @@ export interface AdapterModel {
   contextWindow?: number;
 }
 
+export interface ExternalSession {
+  sessionId: string; // CLI's native session UUID
+  projectPath: string;
+  firstPrompt?: string; // First user message (truncated)
+  summary?: string; // AI-generated summary if available
+  messageCount?: number;
+  createdAt: string; // ISO-8601
+  modifiedAt: string;
+  gitBranch?: string;
+  model?: string;
+}
+
 export interface Adapter {
   id: string;
   name: string;
@@ -173,4 +185,5 @@ export interface Adapter {
   ): Promise<import('./skill.js').AgentConfig>;
   updateAgent?(agentId: string, projectPath: string, content: string): Promise<import('./skill.js').AgentConfig>;
   deleteAgent?(agentId: string, projectPath: string): Promise<void>;
+  listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>;
 }

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -146,6 +146,7 @@ export interface AdapterModel {
 
 export interface ExternalSession {
   sessionId: string; // CLI's native session UUID
+  adapterId: string; // Which adapter discovered this session
   projectPath: string;
   firstPrompt?: string; // First user message (truncated)
   summary?: string; // AI-generated summary if available

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -33,7 +33,8 @@ export type DaemonEvent =
   | { type: 'launch.status'; projectId: string; name: string; status: LaunchProcessStatus }
   | { type: 'launch.tunnel'; projectId: string; name: string; url: string }
   | { type: 'launch.tunnel.failed'; projectId: string; name: string; error: string }
-  | { type: 'launch.port.timeout'; projectId: string; name: string; port: number };
+  | { type: 'launch.port.timeout'; projectId: string; name: string; port: number }
+  | { type: 'sessions.external.count'; projectId: string; count: number };
 
 export type ClientEvent =
   | { type: 'chat.create'; projectId: string; adapterId: string; model?: string; permissionMode?: PermissionMode }

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -5,7 +5,7 @@ import type { UIZone } from './plugin.js';
 import type { LaunchProcessStatus } from './launch.js';
 
 export type DaemonEvent =
-  | { type: 'chat.created'; chat: Chat }
+  | { type: 'chat.created'; chat: Chat; source?: 'import' }
   | { type: 'chat.updated'; chat: Chat }
   | { type: 'chat.ended'; chatId: string }
   | { type: 'process.started'; chatId: string; process: AdapterProcess }


### PR DESCRIPTION
## Summary
- Adds ability to discover and import agent sessions created outside Mainframe (e.g. via Claude CLI directly) into a project's chat list
- Supports both `sessions-index.json` (primary) and JSONL file scanning (fallback) for session discovery
- Auto-detects importable sessions on project load with a badge count, periodic 5-min re-scan
- Imported sessions become full Mainframe chats with `--resume` support, titles, and metadata

## Changes
- **Types**: `ExternalSession` interface, `listExternalSessions` on `Adapter`, `source` field on `chat.created` event
- **Core**: Claude adapter external session discovery, `ExternalSessionService` (scan/import/auto-scan), DB query methods, API routes, unarchive route
- **Desktop**: Import UI in ChatsPanel (collapsible section inside scrollable area), API client, store integration, WS event handling (imports don't hijack active chat)
- **E2E**: 6 Playwright tests covering badge, expand, tooltips, import, title, and active-chat stability

## Test plan
- [x] Unit tests pass (claude-external-sessions, external-session-service, db/chats)
- [x] E2E tests pass (35-external-sessions.spec.ts — 6/6)
- [x] TypeScript compiles with no errors
- [x] Import sets title from session metadata (summary/firstPrompt)
- [x] Import does not switch active chat or open tabs
- [x] Import section scrolls with the chat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)