### PR TITLE
chore: publish @mainframe/types to GitHub Packages

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -1,0 +1,35 @@
+name: Publish @mainframe/types
+
+on:
+  push:
+    tags:
+      - 'types-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build types
+        run: pnpm --filter @mainframe/types build
+
+      - name: Publish
+        run: pnpm --filter @mainframe/types publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,8 +17,15 @@
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "pnpm run build",
     "clean": "rm -rf dist",
     "dev": "tsc --watch",
     "lint": "eslint ."


### PR DESCRIPTION
## Summary
- Configure `@mainframe/types` for publishing to GitHub Packages (registry, files field, prepublishOnly script)
- Add `publish-types.yml` workflow triggered by `types-v*` tags
- Update mobile submodule: `workspace:*` → `^0.2.0` + `.npmrc` for GitHub Packages registry

## After merge
1. Tag `types-v0.2.0` on main to trigger the first publish
2. Add `NPM_TOKEN` EAS secret with a GitHub PAT (`read:packages` scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)