### PR TITLE
chore: rename packages to @qlan-ro scope for npm publishing

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,19 +4,19 @@
     {
       "name": "Core Daemon",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/core", "run", "dev"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-core", "run", "dev"],
       "port": 31415
     },
     {
       "name": "Desktop App",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/desktop", "run", "dev:web"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-desktop", "run", "dev:web"],
       "port": 5173
     },
     {
       "name": "Types Watch",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/types", "run", "dev"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-types", "run", "dev"],
       "port": null
     }
   ]

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -1,4 +1,4 @@
-name: Publish @mainframe/types
+name: Publish @qlan-ro/mainframe-types
 
 on:
   push:
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -21,15 +20,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build types
-        run: pnpm --filter @mainframe/types build
+        run: pnpm --filter @qlan-ro/mainframe-types build
 
       - name: Publish
-        run: pnpm --filter @mainframe/types publish --no-git-checks
+        run: pnpm --filter @qlan-ro/mainframe-types publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,6 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Package
-        run: pnpm --filter @mainframe/desktop package -- --publish always
+        run: pnpm --filter @qlan-ro/mainframe-desktop package -- --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mainframe/launch.json
+++ b/.mainframe/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "Core Daemon",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/core", "run", "dev"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-core", "run", "dev"],
       "port": 31416,
       "url": null,
       "env": {
@@ -14,7 +14,7 @@
     {
       "name": "Desktop App",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/desktop", "run", "dev:web"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-desktop", "run", "dev:web"],
       "port": 5174,
       "url": null,
       "preview": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,18 +20,18 @@ AI-native development environment for orchestrating agents.
 
 - `pnpm install` — Install dependencies
 - `pnpm build` — Build all packages
-- `pnpm --filter @mainframe/core build` — Build a specific package
+- `pnpm --filter @qlan-ro/mainframe-core build` — Build a specific package
 - `pnpm test` — Run all tests
-- `pnpm --filter @mainframe/core test` — Test a specific package
+- `pnpm --filter @qlan-ro/mainframe-core test` — Test a specific package
 
 ## Architecture
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full design.
 
 - **Monorepo Structure**: Uses pnpm workspaces with three main packages:
-  - `@mainframe/types`: Shared TypeScript interfaces and domain models.
-  - `@mainframe/core`: The background Daemon (Node.js). Responsible for process management, session lifecycle, and metadata storage.
-  - `@mainframe/desktop`: The Frontend (Electron/React). Provides the user interface for chatting and workspace orchestration.
+  - `@qlan-ro/mainframe-types`: Shared TypeScript interfaces and domain models.
+  - `@qlan-ro/mainframe-core`: The background Daemon (Node.js). Responsible for process management, session lifecycle, and metadata storage.
+  - `@qlan-ro/mainframe-desktop`: The Frontend (Electron/React). Provides the user interface for chatting and workspace orchestration.
 - **Facilitator Model**: The app manages CLI agent processes (like Claude CLI) via a structured JSON-RPC-like interface over stdio. It respects existing `~/.agents/` configurations and `CLAUDE.md` files in target projects.
 - **Data Flow**: User Input (Desktop) → ChatManager (Daemon) → CLI Adapter (Process Stdin) → Agent Logic → NDJSON Events (Process Stdout) → Daemon Event Stream → UI Update (WebSocket).
 - **Metadata Storage**: Uses SQLite (`better-sqlite3`) for project tracking and chat metadata (costs, tokens, session IDs). Message history is NOT duplicated; it is replayed by the CLI agents using `--resume` flags.
@@ -83,7 +83,7 @@ Invoke the listed skill **before** taking the described action. No exceptions.
 - **Comments**: Omit notes about removed or missing features. Focus on *why*, not *what*.
 - **Strict TypeScript**: Uses strict mode with `NodeNext` module resolution and `noUncheckedIndexedAccess`.
 - **Adapter-Provider Decoupling**: New agents must implement the `AgentAdapter` interface in `packages/types/src/adapter.ts`.
-- **Stateless UI**: The desktop app is a "thin" client; business logic and pure functions belong in `@mainframe/core`, not `@mainframe/desktop`.
+- **Stateless UI**: The desktop app is a "thin" client; business logic and pure functions belong in `@qlan-ro/mainframe-core`, not `@qlan-ro/mainframe-desktop`.
 
 ## Code Rules
 
@@ -110,9 +110,9 @@ These rules exist because every one was violated before and required cleanup. Fo
 - **No `execFileSync` in route handlers.** Use the promisified `execGit` helper.
 
 ### Architecture & Types
-- **Single canonical type.** Never duplicate a type across packages. Define once in `@mainframe/types`, import everywhere.
+- **Single canonical type.** Never duplicate a type across packages. Define once in `@qlan-ro/mainframe-types`, import everywhere.
 - **Workspace deps only.** Desktop must depend on core via `workspace:*` in `package.json`. Never alias core source paths directly.
-- **Pure logic in core.** Message parsing, status derivation, and data transforms belong in `@mainframe/core`, not in React components.
+- **Pure logic in core.** Message parsing, status derivation, and data transforms belong in `@qlan-ro/mainframe-core`, not in React components.
 
 ### Testing
 - **New public methods need tests.** Route handlers, DB methods, and core logic must have corresponding test files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,18 +20,18 @@ AI-native development environment for orchestrating agents.
 
 - `pnpm install` — Install dependencies
 - `pnpm build` — Build all packages
-- `pnpm --filter @mainframe/core build` — Build a specific package
+- `pnpm --filter @qlan-ro/mainframe-core build` — Build a specific package
 - `pnpm test` — Run all tests
-- `pnpm --filter @mainframe/core test` — Test a specific package
+- `pnpm --filter @qlan-ro/mainframe-core test` — Test a specific package
 
 ## Architecture
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full design.
 
 - **Monorepo Structure**: Uses pnpm workspaces with three main packages:
-    - `@mainframe/types`: Shared TypeScript interfaces and domain models.
-    - `@mainframe/core`: The background Daemon (Node.js). Responsible for process management, session lifecycle, and metadata storage.
-    - `@mainframe/desktop`: The Frontend (Electron/React). Provides the user interface for chatting and workspace orchestration.
+    - `@qlan-ro/mainframe-types`: Shared TypeScript interfaces and domain models.
+    - `@qlan-ro/mainframe-core`: The background Daemon (Node.js). Responsible for process management, session lifecycle, and metadata storage.
+    - `@qlan-ro/mainframe-desktop`: The Frontend (Electron/React). Provides the user interface for chatting and workspace orchestration.
 - **Facilitator Model**: The app manages CLI agent processes (like Claude CLI) via a structured JSON-RPC-like interface over stdio. It respects existing `~/.agents/` configurations and `CLAUDE.md` files in target projects.
 - **Data Flow**: User Input (Desktop) → ChatManager (Daemon) → CLI Adapter (Process Stdin) → Agent Logic → NDJSON Events (Process Stdout) → Daemon Event Stream → UI Update (WebSocket).
 - **Metadata Storage**: Uses SQLite (`better-sqlite3`) for project tracking and chat metadata (costs, tokens, session IDs). Message history is NOT duplicated; it is replayed by the CLI agents using `--resume` flags.
@@ -83,7 +83,7 @@ Invoke the listed skill **before** taking the described action. No exceptions.
 - **Comments**: Omit notes about removed or missing features. Focus on *why*, not *what*.
 - **Strict TypeScript**: Uses strict mode with `NodeNext` module resolution and `noUncheckedIndexedAccess`.
 - **Adapter-Provider Decoupling**: New agents must implement the `AgentAdapter` interface in `packages/types/src/adapter.ts`.
-- **Stateless UI**: The desktop app is a "thin" client; business logic and pure functions belong in `@mainframe/core`, not `@mainframe/desktop`.
+- **Stateless UI**: The desktop app is a "thin" client; business logic and pure functions belong in `@qlan-ro/mainframe-core`, not `@qlan-ro/mainframe-desktop`.
 
 ## Code Rules
 
@@ -110,9 +110,9 @@ These rules exist because every one was violated before and required cleanup. Fo
 - **No `execFileSync` in route handlers.** Use the promisified `execGit` helper.
 
 ### Architecture & Types
-- **Single canonical type.** Never duplicate a type across packages. Define once in `@mainframe/types`, import everywhere.
+- **Single canonical type.** Never duplicate a type across packages. Define once in `@qlan-ro/mainframe-types`, import everywhere.
 - **Workspace deps only.** Desktop must depend on core via `workspace:*` in `package.json`. Never alias core source paths directly.
-- **Pure logic in core.** Message parsing, status derivation, and data transforms belong in `@mainframe/core`, not in React components.
+- **Pure logic in core.** Message parsing, status derivation, and data transforms belong in `@qlan-ro/mainframe-core`, not in React components.
 
 ### Testing
 - **New public methods need tests.** Route handlers, DB methods, and core logic must have corresponding test files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,25 +23,25 @@ pnpm build
 pnpm build
 
 # Build a specific package
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 
 # Run tests
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 
 # Dev mode
-pnpm --filter @mainframe/core dev
-pnpm --filter @mainframe/desktop dev
+pnpm --filter @qlan-ro/mainframe-core dev
+pnpm --filter @qlan-ro/mainframe-desktop dev
 ```
 
 ### Monorepo Structure
 
 | Package | Description                                                    |
 |---------|----------------------------------------------------------------|
-| `@mainframe/types` | Shared TypeScript contracts (interfaces, event types)          |
-| `@mainframe/core` | Daemon process — chat orchestration, CLI adapters, persistence |
-| `@mainframe/desktop` | Electron + React frontend                                      |
-| `@mainframe/mobile` | [Private Repo] React Native companion app                      |
-| `@mainframe/e2e` | Playwright end-to-end tests                                    |
+| `@qlan-ro/mainframe-types` | Shared TypeScript contracts (interfaces, event types)          |
+| `@qlan-ro/mainframe-core` | Daemon process — chat orchestration, CLI adapters, persistence |
+| `@qlan-ro/mainframe-desktop` | Electron + React frontend                                      |
+| `@qlan-ro/mainframe-mobile` | [Private Repo] React Native companion app                      |
+| `@qlan-ro/mainframe-e2e` | Playwright end-to-end tests                                    |
 
 ---
 
@@ -71,7 +71,7 @@ pnpm --filter @mainframe/desktop dev
 ```
 server/ ──> chat/ ──> plugins/
    │          │            │
-   │          ├──> db/     └──> @mainframe/types
+   │          ├──> db/     └──> @qlan-ro/mainframe-types
    │          ├──> attachment/
    │          └──> workspace/
    │
@@ -125,7 +125,7 @@ server/ ──> chat/ ──> plugins/
 
 ## Testing Standards
 
-**Framework:** Vitest (`pnpm --filter @mainframe/core test`)
+**Framework:** Vitest (`pnpm --filter @qlan-ro/mainframe-core test`)
 
 ### Test File Location
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY packages/core/package.json packages/core/
 RUN pnpm install --frozen-lockfile
 COPY packages/types/ packages/types/
 COPY packages/core/ packages/core/
-RUN pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build
+RUN pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build
 RUN pnpm exec esbuild packages/core/dist/index.js --bundle --platform=node --target=node20 --format=cjs \
     --external:better-sqlite3 "--external:*.node" --log-override:empty-import-meta=silent \
     --outfile=daemon.cjs

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,6 +1,6 @@
 # Mainframe API Reference
 
-> Complete HTTP REST and WebSocket API documentation for `@mainframe/core`
+> Complete HTTP REST and WebSocket API documentation for `@qlan-ro/mainframe-core`
 
 **Base URL**: `http://127.0.0.1:31415`
 **WebSocket**: `ws://127.0.0.1:31415` (upgrades on the same HTTP port)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,11 +7,11 @@
 Mainframe is a monorepo with five packages that form a layered architecture:
 
 ```
-@mainframe/types   →  Shared TypeScript type definitions (zero runtime deps)
-@mainframe/core    →  Node.js daemon (HTTP + WebSocket server)
-@mainframe/desktop →  Electron + React application
-@mainframe/mobile  →  React Native companion app (Private Repo)
-@mainframe/e2e     →  Playwright end-to-end tests
+@qlan-ro/mainframe-types   →  Shared TypeScript type definitions (zero runtime deps)
+@qlan-ro/mainframe-core    →  Node.js daemon (HTTP + WebSocket server)
+@qlan-ro/mainframe-desktop →  Electron + React application
+@qlan-ro/mainframe-mobile  →  React Native companion app (Private Repo)
+@qlan-ro/mainframe-e2e     →  Playwright end-to-end tests
 ```
 
 ```mermaid
@@ -26,7 +26,7 @@ graph TB
         MobileApp[React Native]
     end
 
-    subgraph "Daemon (@mainframe/core)"
+    subgraph "Daemon (@qlan-ro/mainframe-core)"
         HTTP[HTTP Server<br/>Express + Routes]
         WS[WebSocket Server<br/>ws]
         CM[ChatManager]
@@ -73,7 +73,7 @@ graph TB
 
 ## Package Architecture
 
-### @mainframe/types
+### @qlan-ro/mainframe-types
 
 Pure TypeScript type definitions shared across all packages. Zero runtime dependencies.
 
@@ -91,7 +91,7 @@ Pure TypeScript type definitions shared across all packages. Zero runtime depend
 | `settings.ts` | `PermissionMode`, `ProviderConfig` |
 | `skill.ts` | `Skill`, `AgentConfig`, `CreateSkillInput`, `CreateAgentInput` |
 
-### @mainframe/core
+### @qlan-ro/mainframe-core
 
 Node.js daemon that manages CLI adapter processes and exposes APIs to frontends.
 
@@ -203,7 +203,7 @@ packages/core/src/
 └── index.ts
 ```
 
-### @mainframe/desktop
+### @qlan-ro/mainframe-desktop
 
 Electron application with React frontend.
 
@@ -259,7 +259,7 @@ packages/desktop/src/
         └── ui/                 # Radix UI primitives
 ```
 
-### @mainframe/mobile
+### @qlan-ro/mainframe-mobile
 
 React Native companion app built with Expo. Connects to the daemon over HTTP/WebSocket for remote session management.
 
@@ -268,7 +268,7 @@ React Native companion app built with Expo. Connects to the daemon over HTTP/Web
 - Push notifications for permission requests when the app is backgrounded
 - Context picker for @-mentioning files
 
-### @mainframe/e2e
+### @qlan-ro/mainframe-e2e
 
 Playwright end-to-end test suite that runs against the full desktop app (daemon + Electron).
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -45,11 +45,11 @@ pnpm dev:desktop
 ```
 mainframe/
 ├── packages/
-│   ├── types/      # @mainframe/types — shared TypeScript definitions
-│   ├── core/       # @mainframe/core  — Node.js daemon server
-│   ├── desktop/    # @mainframe/desktop — Electron + React app
-│   ├── mobile/     # @mainframe/mobile — React Native companion (Expo)
-│   └── e2e/        # @mainframe/e2e — Playwright E2E tests
+│   ├── types/      # @qlan-ro/mainframe-types — shared TypeScript definitions
+│   ├── core/       # @qlan-ro/mainframe-core  — Node.js daemon server
+│   ├── desktop/    # @qlan-ro/mainframe-desktop — Electron + React app
+│   ├── mobile/     # @qlan-ro/mainframe-mobile — React Native companion (Expo)
+│   └── e2e/        # @qlan-ro/mainframe-e2e — Playwright E2E tests
 ├── scripts/        # Build/deploy scripts (install.sh, etc.)
 ├── docs/           # Documentation
 ├── package.json    # Root workspace config
@@ -60,22 +60,22 @@ mainframe/
 ### Dependency Graph
 
 ```
-@mainframe/desktop → @mainframe/types
-@mainframe/core    → @mainframe/types
-@mainframe/mobile  → @mainframe/types
-@mainframe/e2e     → (runtime dependency on desktop + core)
+@qlan-ro/mainframe-desktop → @qlan-ro/mainframe-types
+@qlan-ro/mainframe-core    → @qlan-ro/mainframe-types
+@qlan-ro/mainframe-mobile  → @qlan-ro/mainframe-types
+@qlan-ro/mainframe-e2e     → (runtime dependency on desktop + core)
 ```
 
 Both `core` and `desktop` depend on `types`. They do **not** depend on each other — communication happens over HTTP/WebSocket at runtime. The mobile app communicates with the daemon over HTTP/WebSocket at runtime, like desktop.
 
 ## Package Details
 
-### @mainframe/types
+### @qlan-ro/mainframe-types
 
 Pure TypeScript type definitions. Zero runtime dependencies.
 
 ```bash
-pnpm --filter @mainframe/types build    # Compile types
+pnpm --filter @qlan-ro/mainframe-types build    # Compile types
 ```
 
 **When to modify**: Adding new API endpoints, changing data models, adding adapter capabilities.
@@ -89,14 +89,14 @@ pnpm --filter @mainframe/types build    # Compile types
 - `src/context.ts` — Session context, mentions, attachments
 - `src/settings.ts` — Permission modes, provider config
 
-### @mainframe/core
+### @qlan-ro/mainframe-core
 
 Node.js daemon that manages CLI adapters and serves the API.
 
 ```bash
-pnpm --filter @mainframe/core build    # Compile
-pnpm --filter @mainframe/core dev      # Watch mode (tsx)
-pnpm --filter @mainframe/core test     # Run tests (vitest)
+pnpm --filter @qlan-ro/mainframe-core build    # Compile
+pnpm --filter @qlan-ro/mainframe-core dev      # Watch mode (tsx)
+pnpm --filter @qlan-ro/mainframe-core test     # Run tests (vitest)
 ```
 
 **Key files**:
@@ -118,14 +118,14 @@ pnpm --filter @mainframe/core test     # Run tests (vitest)
 
 **Data directory**: `~/.mainframe/` (SQLite DB, attachments, config)
 
-### @mainframe/desktop
+### @qlan-ro/mainframe-desktop
 
 Electron application with React frontend.
 
 ```bash
-pnpm --filter @mainframe/desktop build     # Build for production
-pnpm --filter @mainframe/desktop dev       # Development mode
-pnpm --filter @mainframe/desktop package   # Create distributable
+pnpm --filter @qlan-ro/mainframe-desktop build     # Build for production
+pnpm --filter @qlan-ro/mainframe-desktop dev       # Development mode
+pnpm --filter @qlan-ro/mainframe-desktop package   # Create distributable
 ```
 
 **Key files**:
@@ -139,7 +139,7 @@ pnpm --filter @mainframe/desktop package   # Create distributable
 - `src/renderer/hooks/useChatSession.ts` — Chat session management
 - `src/renderer/store/` — Zustand state stores
 
-### @mainframe/mobile
+### @qlan-ro/mainframe-mobile
 
 React Native companion app built with Expo.
 
@@ -156,7 +156,7 @@ npx expo run:ios        # Run on iOS simulator
 - `lib/` — API client, utilities
 - `store/` — Zustand state management
 
-### @mainframe/e2e
+### @qlan-ro/mainframe-e2e
 
 Playwright end-to-end test suite.
 
@@ -209,7 +209,7 @@ Tests live in `packages/e2e/tests/` and cover the full desktop app (daemon + Ele
 Adapters are implemented as builtin plugins. See `packages/core/src/plugins/builtin/claude/` for the reference implementation.
 
 1. Create a new directory under `packages/core/src/plugins/builtin/<name>/`
-2. Implement the `Adapter` interface from `@mainframe/types`
+2. Implement the `Adapter` interface from `@qlan-ro/mainframe-types`
 3. Create an `index.ts` that exports a plugin activation function
 4. Register the plugin in `PluginManager`
 
@@ -255,10 +255,10 @@ Tests use [Vitest](https://vitest.dev/) and live in `packages/core/src/__tests__
 pnpm test
 
 # Run core tests only
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 
 # Watch mode
-pnpm --filter @mainframe/core test -- --watch
+pnpm --filter @qlan-ro/mainframe-core test -- --watch
 ```
 
 ### E2E Tests

--- a/docs/PLUGIN-DEVELOPER-GUIDE.md
+++ b/docs/PLUGIN-DEVELOPER-GUIDE.md
@@ -728,7 +728,7 @@ Adapter plugins register new AI CLI tool integrations. The builtin Claude adapte
 
 ### Entry point
 
-Your adapter class must implement the `Adapter` interface from `@mainframe/types`. Register it via `ctx.adapters.register()`.
+Your adapter class must implement the `Adapter` interface from `@qlan-ro/mainframe-types`. Register it via `ctx.adapters.register()`.
 
 ```js
 // index.js

--- a/docs/TECH-DEBT-REPORT.md
+++ b/docs/TECH-DEBT-REPORT.md
@@ -81,10 +81,10 @@
 
 | # | Issue | Resolution |
 |---|-------|------------|
-| 1 | Message grouping/parsing in desktop | Moved to `@mainframe/core/messages` (pure functions, no React deps) |
+| 1 | Message grouping/parsing in desktop | Moved to `@qlan-ro/mainframe-core/messages` (pure functions, no React deps) |
 | 2 | Status derivation in desktop | Added `displayStatus` and `isRunning` computed fields to Chat type |
 | 3 | Tool result metadata not pre-computed | Core populates `structuredPatch`, `originalFile`, `modifiedFile` |
-| 4 | Command/mention XML parsing in desktop | Moved pure functions to `@mainframe/core` |
+| 4 | Command/mention XML parsing in desktop | Moved pure functions to `@qlan-ro/mainframe-core` |
 | 5 | `@types/diff` redundant | Removed (diff@8 ships own types) |
 | 6 | vitest 1.x → 4.x | Upgraded |
 | 7 | better-sqlite3 9.x → 12.x | Upgraded for Node 25 support |
@@ -121,7 +121,7 @@
 | 4 | `tar` dependency vulnerability (3 HIGH) | Added `pnpm.overrides` for `tar >= 7.5.7` |
 | 5 | `tsconfig.web.json` inconsistency | Added `module: ESNext` for bundler resolution |
 | 6 | `PermissionMode` type duplication | Consolidated to canonical type from `settings.ts` across events/adapter/base |
-| 7 | Desktop→core source alias violation | Declared `@mainframe/core` as workspace dep, removed raw source alias |
+| 7 | Desktop→core source alias violation | Declared `@qlan-ro/mainframe-core` as workspace dep, removed raw source alias |
 | 8 | `handleEvent()` 142-line switch | Decomposed into 5 per-type handler functions |
 | 9 | `convertHistoryEntry()` 101 lines | Split into `convertUserEntry()` + `convertAssistantEntry()` |
 | 10 | `ChatsRepository.update()` 13 sequential ifs | Replaced with data-driven column map loop |

--- a/docs/plans/2026-02-18-workflows-design.md
+++ b/docs/plans/2026-02-18-workflows-design.md
@@ -185,7 +185,7 @@ interface PluginContext {
 
 Permissive model: plugins receive the full `PluginContext` with no permission gating. To be hardened in a future iteration if needed.
 
-### New Files in `@mainframe/core`
+### New Files in `@qlan-ro/mainframe-core`
 
 ```
 src/plugins/

--- a/docs/plans/2026-02-18-workflows-plan.md
+++ b/docs/plans/2026-02-18-workflows-plan.md
@@ -14,7 +14,7 @@
 
 ## Phase 1: Plugin System (OSS Core)
 
-### Task 1: Plugin types in @mainframe/types
+### Task 1: Plugin types in @qlan-ro/mainframe-types
 
 **Files:**
 - Create: `packages/types/src/plugin.ts`
@@ -44,7 +44,7 @@ describe('plugin types', () => {
 **Step 2: Run to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/types test
+pnpm --filter @qlan-ro/mainframe-types test
 ```
 Expected: FAIL — `plugin.ts` not found.
 
@@ -139,8 +139,8 @@ export * from './plugin.js';
 **Step 5: Run to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/types test
-pnpm --filter @mainframe/types build
+pnpm --filter @qlan-ro/mainframe-types test
+pnpm --filter @qlan-ro/mainframe-types build
 ```
 
 **Step 6: Commit**
@@ -215,7 +215,7 @@ describe('PluginManager', () => {
 **Step 2: Run to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test src/__tests__/plugins/plugin-manager.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/plugins/plugin-manager.test.ts
 ```
 
 **Step 3: Implement `packages/core/src/plugins/plugin-manager.ts`**
@@ -226,7 +226,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { z } from 'zod';
 import { createChildLogger } from '../logger.js';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 
 const logger = createChildLogger('plugin-manager');
 
@@ -321,7 +321,7 @@ export class PluginManager {
 **Step 4: Run to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test src/__tests__/plugins/plugin-manager.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/plugins/plugin-manager.test.ts
 ```
 
 **Step 5: Commit**
@@ -409,14 +409,14 @@ describe('buildPluginContext', () => {
 **Step 2: Run to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test src/__tests__/plugins/plugin-context.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/plugins/plugin-context.test.ts
 ```
 
 **Step 3: Implement the context builder files**
 
 `packages/core/src/plugins/plugin-event-bus.ts`:
 ```typescript
-import type { PluginEventBus } from '@mainframe/types';
+import type { PluginEventBus } from '@qlan-ro/mainframe-types';
 import { EventEmitter } from 'node:events';
 
 export function buildPluginEventBus(pluginId: string, emitter: EventEmitter): PluginEventBus {
@@ -432,7 +432,7 @@ export function buildPluginEventBus(pluginId: string, emitter: EventEmitter): Pl
 `packages/core/src/plugins/plugin-router.ts`:
 ```typescript
 import { Router } from 'express';
-import type { PluginRouter } from '@mainframe/types';
+import type { PluginRouter } from '@qlan-ro/mainframe-types';
 
 export function buildPluginRouter(pluginId: string): { router: Router; api: PluginRouter } {
   const router = Router();
@@ -450,7 +450,7 @@ export function buildPluginRouter(pluginId: string): { router: Router; api: Plug
 `packages/core/src/plugins/plugin-db-context.ts`:
 ```typescript
 import type Database from 'better-sqlite3';
-import type { PluginDatabaseContext } from '@mainframe/types';
+import type { PluginDatabaseContext } from '@qlan-ro/mainframe-types';
 
 export function buildPluginDbContext(db: Database.Database): PluginDatabaseContext {
   return {
@@ -463,7 +463,7 @@ export function buildPluginDbContext(db: Database.Database): PluginDatabaseConte
 
 `packages/core/src/plugins/plugin-ui-context.ts`:
 ```typescript
-import type { PluginUIContext, PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContext, PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 export function buildPluginUIContext(
   pluginId: string,
@@ -484,7 +484,7 @@ export function buildPluginUIContext(
 `packages/core/src/plugins/plugin-context.ts`:
 ```typescript
 import type Database from 'better-sqlite3';
-import type { PluginContext, PluginUIContribution } from '@mainframe/types';
+import type { PluginContext, PluginUIContribution } from '@qlan-ro/mainframe-types';
 import { EventEmitter } from 'node:events';
 import { createChildLogger } from '../logger.js';
 import { buildPluginEventBus } from './plugin-event-bus.js';
@@ -551,7 +551,7 @@ export function buildPluginContext(opts: PluginContextBuildOptions): PluginConte
 **Step 4: Run to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test src/__tests__/plugins/plugin-context.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/plugins/plugin-context.test.ts
 ```
 
 **Step 5: Commit**
@@ -646,7 +646,7 @@ raw(): Database.Database { return this.db; }
 **Step 5: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 **Step 6: Commit**
@@ -689,7 +689,7 @@ describe('workflow types', () => {
 **Step 2: Run to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/types test
+pnpm --filter @qlan-ro/mainframe-types test
 ```
 
 **Step 3: Create `packages/types/src/workflow.ts`**
@@ -818,7 +818,7 @@ export * from './workflow.js';
 **Step 5: Run and verify**
 
 ```bash
-pnpm --filter @mainframe/types test && pnpm --filter @mainframe/types build
+pnpm --filter @qlan-ro/mainframe-types test && pnpm --filter @qlan-ro/mainframe-types build
 ```
 
 **Step 6: Commit**
@@ -856,7 +856,7 @@ git commit -m "feat(types): add workflow domain types"
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mainframe/types": "workspace:*",
+    "@qlan-ro/mainframe-types": "workspace:*",
     "@temporalio/client": "^1.12.0",
     "@temporalio/worker": "^1.12.0",
     "@temporalio/workflow": "^1.12.0",
@@ -906,7 +906,7 @@ Create `packages/plugin-workflows/tsconfig.build.json`:
 
 `packages/plugin-workflows/src/activate.ts`:
 ```typescript
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 
 export async function activate(_ctx: PluginContext): Promise<void> {
   // implemented in later tasks
@@ -1015,7 +1015,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import yaml from 'js-yaml';
 import { z } from 'zod';
-import type { WorkflowDefinition } from '@mainframe/types';
+import type { WorkflowDefinition } from '@qlan-ro/mainframe-types';
 
 const AgentConfigSchema = z.object({
   adapterId: z.string(),
@@ -1138,7 +1138,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { runWorkflowMigrations } from '../db-migrations.js';
 import { WorkflowRegistry } from '../workflow-registry.js';
-import type { WorkflowDefinition } from '@mainframe/types';
+import type { WorkflowDefinition } from '@qlan-ro/mainframe-types';
 
 const SAMPLE_DEF: WorkflowDefinition = {
   name: 'test',
@@ -1243,7 +1243,7 @@ export function runWorkflowMigrations(db: Database.Database): void {
 ```typescript
 import type Database from 'better-sqlite3';
 import { nanoid } from 'nanoid';
-import type { WorkflowDefinition, WorkflowRecord, WorkflowRun, WorkflowStepRun, TriggerType, RunStatus, StepStatus } from '@mainframe/types';
+import type { WorkflowDefinition, WorkflowRecord, WorkflowRun, WorkflowStepRun, TriggerType, RunStatus, StepStatus } from '@qlan-ro/mainframe-types';
 
 export class WorkflowRegistry {
   constructor(private db: Database.Database) {}
@@ -1702,8 +1702,8 @@ Expected: FAIL — none of the step files exist yet.
 **Step 3: Implement `steps/handler.ts`**
 
 ```typescript
-import type { PluginConfig } from '@mainframe/types';
-import type { ChatServiceAPI } from '@mainframe/types';
+import type { PluginConfig } from '@qlan-ro/mainframe-types';
+import type { ChatServiceAPI } from '@qlan-ro/mainframe-types';
 import type { Logger } from 'pino';
 import type { StepDefinition } from '../workflow-loader.js';
 
@@ -1865,7 +1865,7 @@ export class HttpStepHandler implements WorkflowStepHandler {
 ```typescript
 import type { WorkflowStepHandler, StepExecutionContext, StepOutput, StepValidationResult } from './handler.js';
 import type { StepDefinition } from '../workflow-loader.js';
-import type { PluginConfig } from '@mainframe/types';
+import type { PluginConfig } from '@qlan-ro/mainframe-types';
 import type { Logger } from 'pino';
 import { ValidationError } from './registry.js';
 
@@ -2012,7 +2012,7 @@ pnpm --filter @mainframe/plugin-workflows test src/__tests__/activities/prompt-a
 
 ```typescript
 import { sleep } from '@temporalio/activity';
-import type { AgentConfig } from '@mainframe/types';
+import type { AgentConfig } from '@qlan-ro/mainframe-types';
 
 export interface PromptStepInput {
   runId: string;
@@ -2154,7 +2154,7 @@ Expected: FAIL.
 ```typescript
 import type { StepHandlerRegistry } from '../../steps/registry.js';
 import type { StepDefinition } from '../../workflow-loader.js';
-import type { PluginConfig } from '@mainframe/types';
+import type { PluginConfig } from '@qlan-ro/mainframe-types';
 
 export interface ToolActivityDeps {
   registry: StepHandlerRegistry;
@@ -2214,7 +2214,7 @@ pnpm --filter @mainframe/plugin-workflows test src/__tests__/activities/tool-act
 ```typescript
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import type { ToolType } from '@mainframe/types';
+import type { ToolType } from '@qlan-ro/mainframe-types';
 
 const execFileAsync = promisify(execFile);
 
@@ -2346,7 +2346,7 @@ export async function waitForHumanInput(timeoutMs: number): Promise<HumanInputRe
 import { proxyActivities, sleep, ApplicationFailure } from '@temporalio/workflow';
 import type { createPromptActivityFunctions } from '../activities/prompt-activity.js';
 import type { runToolStep } from '../activities/tool-activity.js';
-import type { WorkflowDefinition } from '@mainframe/types';
+import type { WorkflowDefinition } from '@qlan-ro/mainframe-types';
 import { waitForHumanInput } from '../activities/human-input-activity.js';
 
 const { runPromptStep } = proxyActivities<ReturnType<typeof createPromptActivityFunctions>>({
@@ -2523,7 +2523,7 @@ git commit -m "feat(plugin-workflows): add Temporal worker, runner workflow, and
 ```typescript
 import type { Client } from '@temporalio/client';
 import type { WorkflowRegistry } from './workflow-registry.js';
-import type { WorkflowRun, TriggerType } from '@mainframe/types';
+import type { WorkflowRun, TriggerType } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 
 export class WorkflowManager {
@@ -2777,7 +2777,7 @@ export function createWebhookRoutes(registry: WorkflowRegistry, manager: Workflo
 import type { Client, ScheduleHandle } from '@temporalio/client';
 import type { WorkflowRegistry } from './workflow-registry.js';
 import type { WorkflowManager } from './workflow-manager.js';
-import type { PluginEventBus } from '@mainframe/types';
+import type { PluginEventBus } from '@qlan-ro/mainframe-types';
 
 export class TriggerManager {
   private scheduleHandles = new Map<string, ScheduleHandle>();
@@ -3005,7 +3005,7 @@ git commit -m "feat(plugin-workflows): add license key validation with 7-day off
 **Step 1: Implement the full activate function**
 
 ```typescript
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { runWorkflowMigrations } from './db-migrations.js';
 import { WorkflowRegistry } from './workflow-registry.js';
 import { WorkflowManager } from './workflow-manager.js';
@@ -3194,7 +3194,7 @@ import { createReadStream } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs/promises';
-import mime from 'mime-types';  // add: pnpm --filter @mainframe/core add mime-types
+import mime from 'mime-types';  // add: pnpm --filter @qlan-ro/mainframe-core add mime-types
 
 // GET /api/plugins/ui-contributions — returns all registered panel contributions
 app.get('/api/plugins/ui-contributions', (_req, res) => {
@@ -3265,14 +3265,14 @@ describe('plugin UI static serving', () => {
 **Step 5: Run the test**
 
 ```bash
-pnpm --filter @mainframe/core test src/__tests__/routes/plugin-ui.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/routes/plugin-ui.test.ts
 ```
 
 **Step 6: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/types build
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 **Step 7: Commit**
@@ -3326,14 +3326,14 @@ describe('usePluginContributions', () => {
 **Step 2: Run to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/__tests__/usePluginContributions.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/__tests__/usePluginContributions.test.ts
 ```
 
 **Step 3: Implement `usePluginContributions.ts`**
 
 ```typescript
 import { useState, useEffect } from 'react';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 const DAEMON_URL = 'http://localhost:31415';
 
@@ -3358,7 +3358,7 @@ export function usePluginContributions() {
 This module sends context to iframes and listens for navigation messages from them:
 
 ```typescript
-import type { HostToPluginMessage, PluginToHostMessage } from '@mainframe/types';
+import type { HostToPluginMessage, PluginToHostMessage } from '@qlan-ro/mainframe-types';
 
 export interface PluginBridgeOptions {
   pluginId: string;
@@ -3420,7 +3420,7 @@ export function sendNavigationToPlugin(
 
 ```tsx
 import { useRef, useEffect, useState } from 'react';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 import { attachPluginBridge, sendNavigationToPlugin } from '../../lib/plugin-bridge.js';
 
 const DAEMON_URL = 'http://localhost:31415';
@@ -3551,7 +3551,7 @@ export function LeftPanel(): React.ReactElement {
 **Step 7: Run tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/__tests__/usePluginContributions.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/__tests__/usePluginContributions.test.ts
 ```
 
 **Step 8: Commit**
@@ -3566,7 +3566,7 @@ git commit -m "feat(desktop): dynamic plugin panel tabs with iframe rendering an
 ### Task 20: Workflows plugin UI (self-contained Vite app)
 
 > **Key principle:** This Vite app lives inside `packages/plugin-workflows/ui/` and is entirely
-> separate from `@mainframe/desktop`. It bundles its own React and React Flow. The daemon serves
+> separate from `@qlan-ro/mainframe-desktop`. It bundles its own React and React Flow. The daemon serves
 > its built output as static files. No workflow UI code lives in the desktop package.
 
 **Files:**
@@ -3665,7 +3665,7 @@ This is the iframe side of the bridge (mirrors `plugin-bridge.ts` in the desktop
 ```typescript
 import type { PluginToHostMessage, HostToPluginMessage } from '../types.js';
 
-// Re-declare the types locally since this app doesn't depend on @mainframe/types
+// Re-declare the types locally since this app doesn't depend on @qlan-ro/mainframe-types
 export interface Context {
   projectId: string | null;
   theme: 'dark' | 'light';
@@ -3845,7 +3845,7 @@ describe('graph-serializer', () => {
 **Step 7: Implement `src/lib/graph-serializer.ts`**
 
 ```typescript
-// Minimal local types (mirrors @mainframe/types without the dependency)
+// Minimal local types (mirrors @qlan-ro/mainframe-types without the dependency)
 export interface WorkflowStep {
   id: string; type: string; depends_on?: string[]; condition?: string;
   agent?: { adapterId: string }; prompt?: string;
@@ -4193,7 +4193,7 @@ sqlite3 ~/.mainframe/mainframe.db "INSERT INTO settings (id, category, key, valu
 **Step 5: Start the daemon and trigger a run**
 
 ```bash
-pnpm --filter @mainframe/core dev
+pnpm --filter @qlan-ro/mainframe-core dev
 # In another terminal:
 curl -X POST http://localhost:31415/api/plugins/workflows/workflows/proj-id:hello/runs \
   -H 'Content-Type: application/json' \
@@ -4344,7 +4344,7 @@ git commit -m "chore: document submodule workflow and configure OSS CI to skip s
 | Phase | Tasks | Deliverable |
 |-------|-------|-------------|
 | 1 — Plugin System | 1–4 | PluginManager, PluginContext, Express integration |
-| 2 — Types | 5 | WorkflowDefinition, WorkflowRun types in @mainframe/types |
+| 2 — Types | 5 | WorkflowDefinition, WorkflowRun types in @qlan-ro/mainframe-types |
 | 3 — Plugin Foundation | 6–8 | Package scaffold, YAML parser, DB + registry |
 | 4 — Temporal | 9–13 | Worker, PromptActivity, ToolActivity, HumanInput, runner |
 | 5 — Routes + Triggers | 14–15 | REST API, webhook, cron, event triggers |
@@ -4359,6 +4359,6 @@ git commit -m "chore: document submodule workflow and configure OSS CI to skip s
 - `git submodule update --remote --merge` — pull latest plugin code
 - `pnpm --filter @mainframe/plugin-workflows test` — run plugin tests
 - `pnpm --filter @mainframe/plugin-workflows-ui build` — build the iframe UI
-- `pnpm --filter @mainframe/core test` — run core tests
-- `pnpm --filter @mainframe/desktop dev` — start desktop in dev mode
+- `pnpm --filter @qlan-ro/mainframe-core test` — run core tests
+- `pnpm --filter @qlan-ro/mainframe-desktop dev` — start desktop in dev mode
 - `temporal workflow list` — check Temporal for running workflows

--- a/docs/plans/completed/2026-02-04-mainframe-m1.md
+++ b/docs/plans/completed/2026-02-04-mainframe-m1.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build the foundation of Mainframe - a Node.js daemon that manages Claude CLI sessions, and an Electron desktop app with JetBrains-style configurable panels for AI-assisted development.
 
-**Architecture:** Monorepo with three packages: `@mainframe/types` (shared TypeScript types), `@mainframe/core` (Node.js daemon with WebSocket/REST API), and `@mainframe/desktop` (Electron + React app). The daemon manages Claude CLI processes via the adapter pattern and exposes APIs for the desktop app.
+**Architecture:** Monorepo with three packages: `@qlan-ro/mainframe-types` (shared TypeScript types), `@qlan-ro/mainframe-core` (Node.js daemon with WebSocket/REST API), and `@qlan-ro/mainframe-desktop` (Electron + React app). The daemon manages Claude CLI processes via the adapter pattern and exposes APIs for the desktop app.
 
 **Tech Stack:** Node.js 20+, TypeScript, pnpm workspaces, Electron 28+, React 18+, Vite, shadcn/ui, Tailwind CSS, Zustand, react-resizable-panels, Monaco Editor, better-sqlite3, ws (WebSocket)
 
@@ -143,7 +143,7 @@ Run: `git init && git add . && git commit -m "chore: initialize monorepo structu
 
 ```json
 {
-  "name": "@mainframe/types",
+  "name": "@qlan-ro/mainframe-types",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -369,7 +369,7 @@ Run: `git add . && git commit -m "feat(types): add shared type definitions"`
 
 ```json
 {
-  "name": "@mainframe/core",
+  "name": "@qlan-ro/mainframe-core",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -387,7 +387,7 @@ Run: `git add . && git commit -m "feat(types): add shared type definitions"`
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@mainframe/types": "workspace:*",
+    "@qlan-ro/mainframe-types": "workspace:*",
     "better-sqlite3": "^9.4.3",
     "express": "^4.18.2",
     "nanoid": "^5.0.4",
@@ -553,7 +553,7 @@ export function initializeSchema(db: Database.Database): void {
 
 ```typescript
 import type Database from 'better-sqlite3';
-import type { Project } from '@mainframe/types';
+import type { Project } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 import { basename } from 'node:path';
 
@@ -615,7 +615,7 @@ export class ProjectsRepository {
 
 ```typescript
 import type Database from 'better-sqlite3';
-import type { Session, SessionMessage, MessageContent } from '@mainframe/types';
+import type { Session, SessionMessage, MessageContent } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 
 export class SessionsRepository {
@@ -800,7 +800,7 @@ Run: `git add . && git commit -m "feat(core): add SQLite database layer"`
 
 ```typescript
 import { EventEmitter } from 'node:events';
-import type { AgentAdapter, AgentProcess, SpawnOptions, PermissionResponse, PermissionRequest, MessageContent } from '@mainframe/types';
+import type { AgentAdapter, AgentProcess, SpawnOptions, PermissionResponse, PermissionRequest, MessageContent } from '@qlan-ro/mainframe-types';
 
 export interface AdapterEvents {
   init: (processId: string, claudeSessionId: string, model: string, tools: string[]) => void;
@@ -837,7 +837,7 @@ export abstract class BaseAdapter extends EventEmitter implements AgentAdapter {
 ```typescript
 import { spawn, ChildProcess } from 'node:child_process';
 import { nanoid } from 'nanoid';
-import type { AgentProcess, SpawnOptions, PermissionResponse, PermissionRequest, MessageContent } from '@mainframe/types';
+import type { AgentProcess, SpawnOptions, PermissionResponse, PermissionRequest, MessageContent } from '@qlan-ro/mainframe-types';
 import { BaseAdapter } from './base';
 
 interface ClaudeProcess extends AgentProcess {
@@ -1060,7 +1060,7 @@ export class ClaudeAdapter extends BaseAdapter {
 **Step 3: Create packages/core/src/adapters/index.ts**
 
 ```typescript
-import type { AgentAdapter, AgentInfo } from '@mainframe/types';
+import type { AgentAdapter, AgentInfo } from '@qlan-ro/mainframe-types';
 import { ClaudeAdapter } from './claude';
 
 export class AdapterRegistry {
@@ -1117,7 +1117,7 @@ Run: `git add . && git commit -m "feat(core): add Claude CLI adapter with NDJSON
 
 ```typescript
 import { EventEmitter } from 'node:events';
-import type { Session, SessionMessage, AgentProcess, PermissionRequest, PermissionResponse, MessageContent, DaemonEvent } from '@mainframe/types';
+import type { Session, SessionMessage, AgentProcess, PermissionRequest, PermissionResponse, MessageContent, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from './db';
 import type { AdapterRegistry } from './adapters';
 import { ClaudeAdapter } from './adapters';
@@ -1416,7 +1416,7 @@ export function createHttpServer(
 import { WebSocketServer, WebSocket } from 'ws';
 import type { Server } from 'node:http';
 import type { SessionManager } from '../session-manager';
-import type { ClientEvent, DaemonEvent } from '@mainframe/types';
+import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 interface ClientConnection {
   ws: WebSocket;
@@ -1640,7 +1640,7 @@ Run: `git add . && git commit -m "feat(core): add HTTP and WebSocket servers"`
 
 ```json
 {
-  "name": "@mainframe/desktop",
+  "name": "@qlan-ro/mainframe-desktop",
   "version": "0.1.0",
   "private": true,
   "main": "./out/main/index.js",
@@ -1653,7 +1653,7 @@ Run: `git add . && git commit -m "feat(core): add HTTP and WebSocket servers"`
     "package": "electron-builder"
   },
   "dependencies": {
-    "@mainframe/types": "workspace:*",
+    "@qlan-ro/mainframe-types": "workspace:*",
     "@radix-ui/react-context-menu": "^2.1.5",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -2120,7 +2120,7 @@ Run: `git add . && git commit -m "feat(desktop): add React renderer with Tailwin
 
 ```typescript
 import { create } from 'zustand';
-import type { Project } from '@mainframe/types';
+import type { Project } from '@qlan-ro/mainframe-types';
 
 interface ProjectsState {
   projects: Project[];
@@ -2158,7 +2158,7 @@ export const useProjectsStore = create<ProjectsState>((set) => ({
 
 ```typescript
 import { create } from 'zustand';
-import type { Session, SessionMessage, PermissionRequest } from '@mainframe/types';
+import type { Session, SessionMessage, PermissionRequest } from '@qlan-ro/mainframe-types';
 
 interface SessionsState {
   sessions: Session[];
@@ -2289,7 +2289,7 @@ Run: `git add . && git commit -m "feat(desktop): add Zustand state stores"`
 import type {
   Project, Session, SessionMessage, AgentInfo,
   ClientEvent, DaemonEvent, PermissionResponse
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 const API_BASE = 'http://localhost:31415';
 const WS_URL = 'ws://localhost:31415';
@@ -2439,7 +2439,7 @@ export const daemonClient = new DaemonClient();
 import { useEffect, useCallback } from 'react';
 import { daemonClient } from '../lib/client';
 import { useProjectsStore, useSessionsStore } from '../store';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 
 export function useDaemon(): void {
   const { setProjects, addProject, setLoading, setError } = useProjectsStore();
@@ -2853,7 +2853,7 @@ Run: `git add . && git commit -m "feat(desktop): add panel layout system with pr
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { User, Bot, Terminal, AlertTriangle } from 'lucide-react';
-import type { SessionMessage, MessageContent } from '@mainframe/types';
+import type { SessionMessage, MessageContent } from '@qlan-ro/mainframe-types';
 import { cn } from '../../lib/utils';
 
 interface MessageItemProps {
@@ -2944,7 +2944,7 @@ export function MessageItem({ message }: MessageItemProps): React.ReactElement {
 
 ```typescript
 import React, { useRef, useEffect } from 'react';
-import type { SessionMessage } from '@mainframe/types';
+import type { SessionMessage } from '@qlan-ro/mainframe-types';
 import { MessageItem } from './MessageItem';
 
 interface MessageListProps {
@@ -3388,7 +3388,7 @@ Run: `git add . && git commit -m "feat(desktop): add session list and left panel
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { ShieldAlert, Check, X, Shield } from 'lucide-react';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 import { cn } from '../../lib/utils';
 
 interface PermissionDialogProps {
@@ -3956,17 +3956,17 @@ Run: `git add . && git commit -m "feat(desktop): add project directory picker"`
   "private": true,
   "description": "AI-native development environment for orchestrating agents",
   "scripts": {
-    "dev": "pnpm --filter @mainframe/core run dev & sleep 2 && pnpm --filter @mainframe/desktop run dev",
-    "dev:core": "pnpm --filter @mainframe/core run dev",
-    "dev:desktop": "pnpm --filter @mainframe/desktop run dev",
+    "dev": "pnpm --filter @qlan-ro/mainframe-core run dev & sleep 2 && pnpm --filter @qlan-ro/mainframe-desktop run dev",
+    "dev:core": "pnpm --filter @qlan-ro/mainframe-core run dev",
+    "dev:desktop": "pnpm --filter @qlan-ro/mainframe-desktop run dev",
     "build": "pnpm -r run build",
-    "build:types": "pnpm --filter @mainframe/types run build",
-    "build:core": "pnpm --filter @mainframe/core run build",
-    "build:desktop": "pnpm --filter @mainframe/desktop run build",
+    "build:types": "pnpm --filter @qlan-ro/mainframe-types run build",
+    "build:core": "pnpm --filter @qlan-ro/mainframe-core run build",
+    "build:desktop": "pnpm --filter @qlan-ro/mainframe-desktop run build",
     "lint": "pnpm -r run lint",
     "test": "pnpm -r run test",
     "clean": "pnpm -r run clean",
-    "package": "pnpm build && pnpm --filter @mainframe/desktop run package"
+    "package": "pnpm build && pnpm --filter @qlan-ro/mainframe-desktop run package"
   },
   "devDependencies": {
     "typescript": "^5.3.3"
@@ -4000,9 +4000,9 @@ pnpm dev
 
 ## Architecture
 
-- **@mainframe/types** - Shared TypeScript types
-- **@mainframe/core** - Node.js daemon (WebSocket + REST API)
-- **@mainframe/desktop** - Electron + React desktop app
+- **@qlan-ro/mainframe-types** - Shared TypeScript types
+- **@qlan-ro/mainframe-core** - Node.js daemon (WebSocket + REST API)
+- **@qlan-ro/mainframe-desktop** - Electron + React desktop app
 
 ## Development
 

--- a/docs/plans/completed/2026-02-05-spec-alignment-and-ui-gaps.md
+++ b/docs/plans/completed/2026-02-05-spec-alignment-and-ui-gaps.md
@@ -763,7 +763,7 @@ git commit -m "feat(desktop): add Agents tab to left panel"
 
 Run from project root:
 ```bash
-pnpm --filter @mainframe/desktop add @monaco-editor/react monaco-editor
+pnpm --filter @qlan-ro/mainframe-desktop add @monaco-editor/react monaco-editor
 ```
 
 **Step 2: Create MonacoEditor wrapper component**
@@ -1615,7 +1615,7 @@ Run: `pnpm build`
 
 **Step 3: Visual verification**
 
-Run: `pnpm --filter @mainframe/desktop dev`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop dev`
 - Verify all three tabs render in the right panel
 - Verify Context tab loads project context files with expandable previews
 - Verify Files tab shows directory tree with expand/collapse; clicking a file opens an editor tab in the center panel

--- a/docs/plans/completed/2026-02-09-git-worktrees.md
+++ b/docs/plans/completed/2026-02-09-git-worktrees.md
@@ -45,7 +45,7 @@ In `packages/types/src/events.ts`, add two new variants to the `ClientEvent` uni
 
 **Step 3: Build types**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 
 **Step 4: Commit**
 
@@ -104,7 +104,7 @@ if (updates.branchName !== undefined) {
 
 **Step 5: Build core**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 6: Commit**
 
@@ -305,7 +305,7 @@ getEffectivePath(chatId: string): string | null {
 
 **Step 10: Build core**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 11: Commit**
 
@@ -336,7 +336,7 @@ case 'chat.disableWorktree': {
 
 **Step 2: Build core**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 3: Commit**
 
@@ -396,7 +396,7 @@ const context = chats.getSessionContext(req.params.id, effectivePath);
 
 **Step 5: Build core**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 6: Commit**
 
@@ -555,7 +555,7 @@ const activeChatId = useChatsStore((s) => s.activeChatId);
 
 **Step 3: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 

--- a/docs/plans/completed/2026-02-14-full-review-fixes.md
+++ b/docs/plans/completed/2026-02-14-full-review-fixes.md
@@ -60,7 +60,7 @@ describe('ChatManager.isChatRunning', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/chat-manager-is-running.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/chat-manager-is-running.test.ts`
 Expected: FAIL — first test returns `true` instead of `false`
 
 **Step 3: Fix the bug**
@@ -76,7 +76,7 @@ return active?.process != null;
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/chat-manager-is-running.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/chat-manager-is-running.test.ts`
 Expected: PASS (all 3 tests)
 
 **Step 5: Commit**
@@ -196,7 +196,7 @@ describe('EventHandler token accumulation', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/event-handler.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/event-handler.test.ts`
 Expected: FAIL — `totalTokensInput` is 200 (overwritten) not 300 (accumulated)
 
 **Step 3: Fix the bug**
@@ -214,7 +214,7 @@ to:
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/event-handler.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/event-handler.test.ts`
 Expected: PASS
 
 **Step 5: Commit**
@@ -287,7 +287,7 @@ describe('CORS policy', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/cors.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/cors.test.ts`
 Expected: FAIL — currently reflects `https://evil.com`
 
 **Step 3: Fix the CORS middleware**
@@ -320,12 +320,12 @@ In `packages/core/src/server/http.ts`, replace the CORS middleware block (lines 
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/cors.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/cors.test.ts`
 Expected: PASS
 
 **Step 5: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All existing tests pass
 
 **Step 6: Commit**
@@ -404,7 +404,7 @@ In the `walk` function, add containment check after constructing the full path.
 
 **Step 4: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 5: Commit**
@@ -446,7 +446,7 @@ Also add `import { realpathSync } from 'node:fs';` to imports.
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 3: Commit**
@@ -534,7 +534,7 @@ export { asyncHandler } from './async-handler.js';
 
 **Step 6: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 7: Commit**
@@ -585,7 +585,7 @@ Replace lines 50-61 in `handleClearContext`:
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 3: Commit**
@@ -643,7 +643,7 @@ Replace lines 297-311:
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 3: Commit**
@@ -688,12 +688,12 @@ The import for `ClaudeEventEmitter` from `claude-types.ts` stays the same, but t
 
 **Step 3: Verify build**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: No type errors
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 5: Commit**
@@ -723,7 +723,7 @@ Fixes: CQ-H5, BP-H1, AR-L3"
 
 ```typescript
 // packages/core/src/chat/types.ts
-import type { Chat, AdapterProcess } from '@mainframe/types';
+import type { Chat, AdapterProcess } from '@qlan-ro/mainframe-types';
 
 export interface ActiveChat {
   chat: Chat;
@@ -749,7 +749,7 @@ export type { ActiveChat } from './types.js';
 
 **Step 4: Build & test**
 
-Run: `pnpm --filter @mainframe/core build && pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core build && pnpm --filter @qlan-ro/mainframe-core test`
 Expected: Pass
 
 **Step 5: Commit**
@@ -795,7 +795,7 @@ Replace the message handler in `websocket.ts`:
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 3: Commit**
@@ -848,7 +848,7 @@ Replace the `fs:readFile` IPC handler:
 
 **Step 2: Verify desktop builds**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Build succeeds
 
 **Step 3: Commit**
@@ -895,7 +895,7 @@ export function handleStderr(processId: string, chunk: Buffer, emitter: ClaudeEv
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass
 
 **Step 3: Commit**
@@ -935,7 +935,7 @@ const DEFAULT_CONFIG: MainframeConfig = {
 
 **Step 2: Verify build**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: No errors (wsPort is not referenced anywhere else)
 
 **Step 3: Commit**
@@ -994,7 +994,7 @@ Fixes: PERF-H2"
 
 ```typescript
 import { nanoid } from 'nanoid';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 const MAX_MESSAGES_PER_CHAT = 2000;
 const MAX_CHATS = 50;
@@ -1319,7 +1319,7 @@ Fixes: OPS-C4"
 // packages/core/src/__tests__/permission-manager.test.ts
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PermissionManager } from '../chat/permission-manager.js';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
   return {
@@ -1410,7 +1410,7 @@ describe('PermissionManager', () => {
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/permission-manager.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/permission-manager.test.ts`
 Expected: All pass
 
 **Step 3: Commit**
@@ -1914,7 +1914,7 @@ After all phases complete:
 
 1. `pnpm build` — all packages compile
 2. `pnpm test` — all tests pass
-3. `pnpm --filter @mainframe/core test` — core tests pass
+3. `pnpm --filter @qlan-ro/mainframe-core test` — core tests pass
 4. Verify no `console.error` debug logging in hot paths
 5. Verify CORS rejects arbitrary origins
 6. Verify path traversal is blocked in all file routes

--- a/docs/plans/completed/2026-02-15-async-routes-and-cleanup.md
+++ b/docs/plans/completed/2026-02-15-async-routes-and-cleanup.md
@@ -60,7 +60,7 @@ describe('execGit', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/exec-git.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/exec-git.test.ts`
 Expected: FAIL — module not found
 
 **Step 3: Write minimal implementation**
@@ -80,7 +80,7 @@ export async function execGit(args: string[], cwd: string): Promise<string> {
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/exec-git.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/exec-git.test.ts`
 Expected: PASS
 
 **Step 5: Commit**
@@ -239,7 +239,7 @@ export function gitRoutes(ctx: RouteContext): Router {
 
 **Step 2: Run all tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run`
 Expected: PASS (no git route tests exist, but ensure nothing else broke)
 
 **Step 3: Commit**
@@ -476,7 +476,7 @@ export function fileRoutes(ctx: RouteContext): Router {
 
 **Step 2: Run all tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run`
 Expected: PASS
 
 **Step 3: Commit**
@@ -527,7 +527,7 @@ The handler becomes:
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/context.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/context.test.ts`
 Expected: PASS
 
 **Step 3: Commit**
@@ -578,7 +578,7 @@ Add `asyncHandler` import and wrap the handler:
 
 **Step 2: Run tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/settings.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/settings.test.ts`
 Expected: PASS
 
 **Step 3: Commit**
@@ -661,7 +661,7 @@ Update the mock context to include `removeWithChats`:
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/projects.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/projects.test.ts`
 Expected: PASS
 
 **Step 5: Commit**
@@ -721,7 +721,7 @@ export function FileViewContent(): React.ReactElement | null {
 
 **Step 2: Build to verify**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: PASS — Vite will now code-split Monaco into a separate chunk
 
 **Step 3: Commit**
@@ -751,7 +751,7 @@ perf: lazy-load Monaco editor via React.lazy
 
 **Step 2: Run type check to see what breaks**
 
-Run: `pnpm --filter @mainframe/core exec tsc --noEmit && pnpm --filter @mainframe/types exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit && pnpm --filter @qlan-ro/mainframe-types exec tsc --noEmit`
 Expected: Type errors where indexed access returns `T | undefined`
 
 **Step 3: Fix each error**

--- a/docs/plans/completed/2026-02-15-tech-debt-remediation.md
+++ b/docs/plans/completed/2026-02-15-tech-debt-remediation.md
@@ -71,7 +71,7 @@ describe('CreateAgentBody', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/schemas.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/schemas.test.ts`
 Expected: FAIL — `../evil` and `foo/bar` currently pass validation.
 
 **Step 3: Add regex validation to Zod schemas**
@@ -101,12 +101,12 @@ export const CreateAgentBody = z.object({
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/schemas.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/schemas.test.ts`
 Expected: PASS
 
 **Step 5: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 6: Commit**
@@ -128,7 +128,7 @@ git commit -m "fix: add path character validation to skill/agent name schemas"
 Run:
 ```bash
 cd /Users/doruchiulan/Projects/qlan/mainframe
-pnpm --filter @mainframe/desktop remove @radix-ui/react-context-menu @radix-ui/react-dialog @radix-ui/react-dropdown-menu @radix-ui/react-select postcss
+pnpm --filter @qlan-ro/mainframe-desktop remove @radix-ui/react-context-menu @radix-ui/react-dialog @radix-ui/react-dropdown-menu @radix-ui/react-select postcss
 ```
 
 **Step 2: Verify build still works**
@@ -196,7 +196,7 @@ Keep `escapeXmlAttr` in `attachment-helpers.ts` (used internally by `buildAttach
 **Step 5: Verify build**
 
 Run: `pnpm build`
-Expected: All packages build. If anything imports `ApiResponse`, `ProjectsApi`, etc. from `@mainframe/types`, it will fail here — but our audit confirmed nothing does.
+Expected: All packages build. If anything imports `ApiResponse`, `ProjectsApi`, etc. from `@qlan-ro/mainframe-types`, it will fail here — but our audit confirmed nothing does.
 
 **Step 6: Run tests**
 
@@ -334,8 +334,8 @@ import type { PermissionMode } from './settings.js';
 In `packages/core/src/adapters/base.ts`, update the import and line 30:
 
 ```typescript
-// Add PermissionMode to existing @mainframe/types import (line 2):
-import type { ..., PermissionMode } from '@mainframe/types';
+// Add PermissionMode to existing @qlan-ro/mainframe-types import (line 2):
+import type { ..., PermissionMode } from '@qlan-ro/mainframe-types';
 
 // FROM (line 30):
   async setPermissionMode(_process: AdapterProcess, _mode: string): Promise<void> {}
@@ -362,7 +362,7 @@ git commit -m "refactor: consolidate PermissionMode type across all definitions"
 
 ---
 
-### Task 7: Declare `@mainframe/core` as Desktop Dependency
+### Task 7: Declare `@qlan-ro/mainframe-core` as Desktop Dependency
 
 **Files:**
 - Modify: `packages/desktop/package.json` (add dependency)
@@ -373,12 +373,12 @@ git commit -m "refactor: consolidate PermissionMode type across all definitions"
 Run:
 ```bash
 cd /Users/doruchiulan/Projects/qlan/mainframe
-pnpm --filter @mainframe/desktop add @mainframe/core@workspace:*
+pnpm --filter @qlan-ro/mainframe-desktop add @qlan-ro/mainframe-core@workspace:*
 ```
 
 **Step 2: Update the Vite alias to use the published export**
 
-In `packages/desktop/electron.vite.config.ts`, check if the alias can be removed entirely. The `@mainframe/core` package exports `"./messages": "./dist/messages/index.js"` in its `package.json`. With the dependency declared, the bundler should resolve `@mainframe/core/messages` automatically.
+In `packages/desktop/electron.vite.config.ts`, check if the alias can be removed entirely. The `@qlan-ro/mainframe-core` package exports `"./messages": "./dist/messages/index.js"` in its `package.json`. With the dependency declared, the bundler should resolve `@qlan-ro/mainframe-core/messages` automatically.
 
 Try removing the alias:
 
@@ -386,7 +386,7 @@ Try removing the alias:
 // FROM (lines 38-42):
     resolve: {
       alias: {
-        '@mainframe/core/messages': resolve(__dirname, '../core/src/messages/index.ts'),
+        '@qlan-ro/mainframe-core/messages': resolve(__dirname, '../core/src/messages/index.ts'),
       },
     },
 // TO:
@@ -399,12 +399,12 @@ Or remove the entire `resolve` block if empty.
 
 Run: `pnpm build`
 
-If the build fails because Vite can't resolve `@mainframe/core/messages` from `dist/`, we keep the alias but point it to the compiled output:
+If the build fails because Vite can't resolve `@qlan-ro/mainframe-core/messages` from `dist/`, we keep the alias but point it to the compiled output:
 
 ```typescript
 resolve: {
   alias: {
-    '@mainframe/core/messages': resolve(__dirname, '../core/dist/messages/index.js'),
+    '@qlan-ro/mainframe-core/messages': resolve(__dirname, '../core/dist/messages/index.js'),
   },
 },
 ```
@@ -418,7 +418,7 @@ Expected: All tests pass.
 
 ```bash
 git add packages/desktop/package.json packages/desktop/electron.vite.config.ts pnpm-lock.yaml
-git commit -m "refactor: declare @mainframe/core as desktop dependency, use published export"
+git commit -m "refactor: declare @qlan-ro/mainframe-core as desktop dependency, use published export"
 ```
 
 ---
@@ -475,12 +475,12 @@ export function handleEvent(event: ClaudeEvent, state: AdapterState, emit: EmitF
 
 **Step 3: Run existing tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/claude-events.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/claude-events.test.ts`
 Expected: All existing tests pass (pure refactor, no behavior change).
 
 **Step 4: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 5: Commit**
@@ -538,12 +538,12 @@ export function convertHistoryEntry(
 
 **Step 3: Run existing tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/message-loading.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/message-loading.test.ts`
 Expected: All 21 test cases pass (pure refactor).
 
 **Step 4: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 5: Commit**
@@ -609,12 +609,12 @@ update(id: string, fields: Partial<ChatUpdateFields>): void {
 
 **Step 3: Run existing tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/chats.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/chats.test.ts`
 Expected: All tests pass.
 
 **Step 4: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 5: Commit**
@@ -671,12 +671,12 @@ export function gitRoutes(router: Router, db: DatabaseManager, adapters: Adapter
 
 **Step 3: Run route tests**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes-files.test.ts src/__tests__/routes-git.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes-files.test.ts src/__tests__/routes-git.test.ts`
 Expected: All tests pass (pure refactor).
 
 **Step 4: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 5: Commit**
@@ -715,7 +715,7 @@ Key breaking changes (v1→v2→v3→v4):
 
 Run:
 ```bash
-pnpm --filter @mainframe/desktop add react-resizable-panels@^4
+pnpm --filter @qlan-ro/mainframe-desktop add react-resizable-panels@^4
 ```
 
 **Step 4: Fix breaking changes**
@@ -796,7 +796,7 @@ Expected: Build succeeds.
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All tests pass.
 
 **Step 5: Commit**
@@ -817,7 +817,7 @@ git commit -m "fix: add logging to bare catch blocks in server routes"
 
 Run:
 ```bash
-pnpm --filter @mainframe/desktop add -D @vitejs/plugin-react@^5
+pnpm --filter @qlan-ro/mainframe-desktop add -D @vitejs/plugin-react@^5
 ```
 
 **Step 2: Check for breaking changes**

--- a/docs/plans/completed/2026-02-16-adapter-models-via-interface-design.md
+++ b/docs/plans/completed/2026-02-16-adapter-models-via-interface-design.md
@@ -32,7 +32,7 @@ Expose model availability through the Adapter interface and surface it via `/api
 
 ### Type contract changes
 
-In `@mainframe/types`:
+In `@qlan-ro/mainframe-types`:
 
 - Add `AdapterModel` type:
   - `id: string`

--- a/docs/plans/completed/2026-02-16-adapter-models-via-interface.md
+++ b/docs/plans/completed/2026-02-16-adapter-models-via-interface.md
@@ -4,7 +4,7 @@
 
 **Goal:** Expose available models via the Adapter interface and drive desktop model selectors from `/api/adapters`.
 
-**Architecture:** Add model metadata types to `@mainframe/types`, extend adapter contract with `listModels()`, implement it in `ClaudeAdapter`, and include models in `AdapterRegistry.list()`. On desktop, load adapters from API into store state and replace hardcoded model-source usage in settings/composer and model helpers.
+**Architecture:** Add model metadata types to `@qlan-ro/mainframe-types`, extend adapter contract with `listModels()`, implement it in `ClaudeAdapter`, and include models in `AdapterRegistry.list()`. On desktop, load adapters from API into store state and replace hardcoded model-source usage in settings/composer and model helpers.
 
 **Tech Stack:** TypeScript (strict), Node.js/Express, React, Zustand, Vitest
 
@@ -21,7 +21,7 @@
 
 **Step 2: Run single test to verify failure**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/adapters.test.ts`
 Expected: FAIL due missing `models` typing/shape.
 
 **Step 3: Add shared types and interface method**
@@ -32,7 +32,7 @@ Expected: FAIL due missing `models` typing/shape.
 
 **Step 4: Run core adapters route test**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/adapters.test.ts`
 Expected: still failing until core implementation is updated (next task).
 
 ### Task 2: Implement adapter model listing in core and expose via `/api/adapters`
@@ -55,7 +55,7 @@ Expected: still failing until core implementation is updated (next task).
 
 **Step 3: Run core adapters test**
 
-Run: `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/adapters.test.ts`
 Expected: PASS.
 
 ### Task 3: Add desktop adapters API client and store
@@ -80,7 +80,7 @@ Expected: PASS.
 
 **Step 4: Run targeted desktop test(s)**
 
-Run: `pnpm --filter @mainframe/desktop exec vitest run src/renderer/lib/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/lib/adapters.test.ts`
 Expected: FAIL until utility refactor in next task.
 
 ### Task 4: Refactor desktop adapter/model utilities to use API metadata
@@ -104,7 +104,7 @@ Expected: FAIL until utility refactor in next task.
 
 **Step 3: Run utility test**
 
-Run: `pnpm --filter @mainframe/desktop exec vitest run src/renderer/lib/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/lib/adapters.test.ts`
 Expected: PASS.
 
 ### Task 5: Switch settings and composer UI to adapter store metadata
@@ -127,7 +127,7 @@ Expected: PASS.
 
 **Step 3: Run targeted desktop tests**
 
-Run: `pnpm --filter @mainframe/desktop exec vitest run src/__tests__/stores/chats.test.ts src/renderer/lib/adapters.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/__tests__/stores/chats.test.ts src/renderer/lib/adapters.test.ts`
 Expected: PASS.
 
 ### Task 6: Verify types and package builds
@@ -143,7 +143,7 @@ Expected: PASS for all workspaces.
 **Step 2: Run focused tests touched by change**
 
 Run: 
-- `pnpm --filter @mainframe/core exec vitest run src/__tests__/routes/adapters.test.ts`
-- `pnpm --filter @mainframe/desktop exec vitest run src/renderer/lib/adapters.test.ts`
+- `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/routes/adapters.test.ts`
+- `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/lib/adapters.test.ts`
 
 Expected: PASS.

--- a/docs/plans/completed/2026-02-17-adapter-event-handlers-plan.md
+++ b/docs/plans/completed/2026-02-17-adapter-event-handlers-plan.md
@@ -56,7 +56,7 @@ describe('parameterized categorization', () => {
 
 **Step 2: Run test to verify failure**
 
-Run: `pnpm --filter @mainframe/core test -- tool-categorization`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- tool-categorization`
 Expected: FAIL — `ToolCategories` and parameterized signatures don't exist yet.
 
 **Step 3: Implement ToolCategories type and parameterized functions**
@@ -118,7 +118,7 @@ export {
 
 **Step 7: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- tool-categorization`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- tool-categorization`
 Expected: PASS.
 
 **Step 8: Commit**
@@ -156,7 +156,7 @@ describe('ClaudeAdapter.getToolCategories', () => {
 
 **Step 2: Run test to verify failure**
 
-Run: `pnpm --filter @mainframe/core test -- adapter-registry`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- adapter-registry`
 Expected: FAIL — `getToolCategories` returns empty sets from BaseAdapter default.
 
 **Step 3: Override in ClaudeAdapter**
@@ -182,7 +182,7 @@ override getToolCategories(): ToolCategories {
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- adapter-registry`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- adapter-registry`
 Expected: PASS.
 
 **Step 5: Commit**
@@ -256,7 +256,7 @@ describe('with empty categories (no grouping)', () => {
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- tool-grouping`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- tool-grouping`
 Expected: PASS.
 
 **Step 5: Commit**
@@ -282,7 +282,7 @@ Update the two call sites inside the function:
 - `groupToolCallParts(parts as PartEntry[])` → `groupToolCallParts(parts as PartEntry[], categories)`
 - `groupTaskChildren(afterGrouping)` → `groupTaskChildren(afterGrouping, categories)`
 
-Add the import: `import type { ToolCategories } from '@mainframe/core/messages';`
+Add the import: `import type { ToolCategories } from '@qlan-ro/mainframe-core/messages';`
 
 **Step 2: Update existing tests**
 
@@ -294,12 +294,12 @@ Search for `convertMessage(` in the desktop package. Update each call site to pa
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/desktop test -- convert-message`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- convert-message`
 Expected: PASS.
 
 **Step 5: Run typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: PASS — no type errors from callers passing the new param.
 
 **Step 6: Commit**
@@ -342,7 +342,7 @@ import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { ChatLookup, AdapterEventHandler } from './event-handler.js';
 import type { BaseAdapter } from '../adapters/base.js';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { trackFileActivity } from './context-tracker.js';
 
 export class ClaudeEventHandler implements AdapterEventHandler {
@@ -403,7 +403,7 @@ all(): Adapter[] {
 
 **Step 5: Run existing event-handler tests — they must still pass unchanged**
 
-Run: `pnpm --filter @mainframe/core test -- event-handler`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- event-handler`
 Expected: PASS — behavior is identical, only the code location changed.
 
 **Step 6: Remove the `ClaudeAdapter` import from `event-handler.ts`**
@@ -412,7 +412,7 @@ The only import of `ClaudeAdapter` in event-handler.ts was for the cast. Now eve
 
 **Step 7: Run typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS.
 
 **Step 8: Commit**
@@ -479,7 +479,7 @@ Expected: No matches (all renamed).
 
 **Step 5: Run typecheck**
 
-Run: `pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS.
 
 **Step 6: Commit**
@@ -522,7 +522,7 @@ it('stamps adapterId on emitted messages', () => {
 
 **Step 2: Run test to verify failure**
 
-Run: `pnpm --filter @mainframe/core test -- event-handler`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- event-handler`
 Expected: FAIL — metadata doesn't include `adapterId` yet.
 
 **Step 3: Add adapterId to metadata in ClaudeEventHandler**
@@ -544,7 +544,7 @@ Update the EventHandler constructor to pass `'claude'` when creating ClaudeEvent
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- event-handler`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- event-handler`
 Expected: PASS.
 
 **Step 5: Commit**

--- a/docs/plans/completed/2026-02-17-adapter-session-refactor.md
+++ b/docs/plans/completed/2026-02-17-adapter-session-refactor.md
@@ -242,9 +242,9 @@ interface SpawnOptions {
 
 ## Verification
 
-1. `pnpm --filter @mainframe/types build` — types compile
-2. `pnpm --filter @mainframe/core build` — core compiles
-3. `pnpm --filter @mainframe/core test` — all tests pass
+1. `pnpm --filter @qlan-ro/mainframe-types build` — types compile
+2. `pnpm --filter @qlan-ro/mainframe-core build` — core compiles
+3. `pnpm --filter @qlan-ro/mainframe-core test` — all tests pass
 4. `pnpm build` — full monorepo builds
 5. Manual: start daemon, create a chat, send a message, verify events flow correctly
 6. Manual: resume a chat (tests session re-creation + history loading without spawn)

--- a/docs/plans/completed/2026-02-17-diff-view-commenting-plan.md
+++ b/docs/plans/completed/2026-02-17-diff-view-commenting-plan.md
@@ -103,7 +103,7 @@ Remove the `Send` import from lucide-react.
 
 **Step 3: Verify typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 4: Commit**
@@ -301,7 +301,7 @@ export function MonacoDiffEditor({
 
 **Step 2: Verify typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 3: Commit**
@@ -374,7 +374,7 @@ function ensureResumedAndSend(chatId: string, content: string): void {
 
 **Step 2: Verify typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 3: Commit**
@@ -418,7 +418,7 @@ const handleLineComment = useCallback(
 
 **Step 2: Verify typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 3: Commit**
@@ -457,7 +457,7 @@ Remove unused imports: `useChatsStore`, `daemonClient`.
 
 **Step 2: Verify typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 3: Commit**
@@ -473,7 +473,7 @@ git commit -m "fix: EditorTab comments auto-create session when none active"
 
 **Step 1: Full typecheck**
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 Expected: PASS
 
 **Step 2: Verify no unused imports or dead code**

--- a/docs/plans/completed/2026-02-17-unified-event-pipeline.md
+++ b/docs/plans/completed/2026-02-17-unified-event-pipeline.md
@@ -107,7 +107,7 @@ describe('buildToolResultBlocks', () => {
 
 **Step 2: Run test to verify failure**
 
-Run: `pnpm --filter @mainframe/core test -- message-loading`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- message-loading`
 Expected: FAIL — `buildToolResultBlocks` is not exported.
 
 **Step 3: Extract `buildToolResultBlocks` from `convertUserEntry`**
@@ -175,7 +175,7 @@ Replace the inline tool_result extraction in `convertUserEntry` with:
 
 **Step 5: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- message-loading`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- message-loading`
 Expected: PASS.
 
 **Step 6: Commit**
@@ -241,7 +241,7 @@ describe('handleUserEvent — tool_result blocks', () => {
 
 **Step 2: Run test to verify it passes (it should already pass)**
 
-Run: `pnpm --filter @mainframe/core test -- claude-events`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- claude-events`
 Expected: If the test was already correct, PASS. If FAIL, it reveals an actual mismatch.
 
 **Step 3: Update `handleUserEvent` to use `buildToolResultBlocks`**
@@ -292,12 +292,12 @@ function handleUserEvent(processId: string, event: Record<string, unknown>, emit
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- claude-events`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- claude-events`
 Expected: PASS.
 
 **Step 5: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS — no circular imports (claude-events imports from claude-history, not the other way around).
 
 **Step 6: Commit**
@@ -323,7 +323,7 @@ Create `packages/core/src/__tests__/event-pipeline-parity.test.ts`:
 ```ts
 import { describe, it, expect } from 'vitest';
 import { buildToolResultBlocks, convertHistoryEntry } from '../adapters/claude-history.js';
-import type { ToolResultMessageContent } from '@mainframe/types';
+import type { ToolResultMessageContent } from '@qlan-ro/mainframe-types';
 
 /**
  * Ensures that tool_result blocks produced by history loading and live stream
@@ -411,13 +411,13 @@ describe('event pipeline parity', () => {
 
 **Step 2: Run test to verify failure (before Task 1/2 are done)**
 
-Run: `pnpm --filter @mainframe/core test -- event-pipeline-parity`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- event-pipeline-parity`
 Expected: FAIL — `buildToolResultBlocks` not exported yet (if running before Task 1).
 After Tasks 1 and 2: PASS.
 
 **Step 3: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- event-pipeline-parity`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- event-pipeline-parity`
 Expected: PASS.
 
 **Step 4: Commit**
@@ -464,12 +464,12 @@ In `claude-history.ts`, in `convertUserEntry`, add:
 
 **Step 3: Run full test suite**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: PASS — all existing tests plus the new parity and helper tests.
 
 **Step 4: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS.
 
 **Step 5: Commit**
@@ -487,7 +487,7 @@ git commit -m "docs(code): document intentional live-stream vs history divergenc
 
 **Step 1: Run all core tests**
 
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: PASS — all tests including the new event-pipeline-parity suite.
 
 **Step 2: Run full monorepo build**

--- a/docs/plans/completed/2026-02-18-open-source-publication.md
+++ b/docs/plans/completed/2026-02-18-open-source-publication.md
@@ -615,7 +615,7 @@ Open `packages/desktop/src/renderer/index.html`. Find the `<head>` section and a
 **Step 4: TypeScript check**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: Builds without errors.
@@ -658,7 +658,7 @@ jobs:
         run: pnpm build
 
       - name: Package
-        run: pnpm --filter @mainframe/desktop package -- --publish always
+        run: pnpm --filter @qlan-ro/mainframe-desktop package -- --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/plans/completed/2026-02-19-about-modal.md
+++ b/docs/plans/completed/2026-02-19-about-modal.md
@@ -32,7 +32,7 @@ it('opens directly to a given tab', () => {
 **Step 2: Run the test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/__tests__/stores/settings.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/__tests__/stores/settings.test.ts
 ```
 
 Expected: FAIL — `open` doesn't accept a second argument, `activeTab` will be `'general'` instead of `'about'`.
@@ -66,7 +66,7 @@ open: (defaultProvider?: string, tab?: SettingsTab) =>
 **Step 4: Run tests to verify they pass**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/__tests__/stores/settings.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/__tests__/stores/settings.test.ts
 ```
 
 Expected: All tests PASS (new test + all existing tests).
@@ -135,7 +135,7 @@ function Row({ label, value }: { label: string; value: string }): React.ReactEle
 **Step 2: Verify TypeScript compiles**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no type errors.
@@ -177,7 +177,7 @@ case 'about':
 **Step 2: Verify TypeScript compiles**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no errors.
@@ -223,7 +223,7 @@ Also remove `useCallback` from imports if it's no longer used after this change 
 **Step 2: Verify TypeScript compiles**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no errors.
@@ -231,7 +231,7 @@ Expected: no errors.
 **Step 3: Run the full desktop test suite**
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all tests PASS.

--- a/docs/plans/completed/2026-02-19-ask-user-question-wizard-plan.md
+++ b/docs/plans/completed/2026-02-19-ask-user-question-wizard-plan.md
@@ -38,6 +38,6 @@
 - Test: `packages/desktop/src/renderer/components/chat/AskUserQuestionCard.test.ts`
 - Verify: `packages/desktop/src/renderer/components/chat/AskUserQuestionCard.tsx`
 
-1. Run: `pnpm --filter @mainframe/desktop test -- src/renderer/components/chat/AskUserQuestionCard.test.ts`
-2. Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+1. Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- src/renderer/components/chat/AskUserQuestionCard.test.ts`
+2. Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 3. Confirm tests and typecheck pass.

--- a/docs/plans/completed/2026-02-19-context-picker.md
+++ b/docs/plans/completed/2026-02-19-context-picker.md
@@ -29,7 +29,7 @@ if (q.length < 1) {
 **Step 2: Verify build passes**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: no TypeScript errors.
 
@@ -57,7 +57,7 @@ import { focusComposerInput } from '../../lib/focus';
 import { useSkillsStore, useProjectsStore, useChatsStore } from '../../store';
 import { searchFiles, addMention } from '../../lib/api';
 import { cn } from '../../lib/utils';
-import type { AgentConfig, Skill } from '@mainframe/types';
+import type { AgentConfig, Skill } from '@qlan-ro/mainframe-types';
 
 // ── types ──────────────────────────────────────────────────────────────────
 
@@ -364,7 +364,7 @@ export function ContextPickerMenu({ forceOpen, onClose }: ContextPickerMenuProps
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: no TypeScript errors.
 
@@ -443,7 +443,7 @@ Replace the entire `<button>` block that has `onClick` inserting `@` (lines 102�
 **Step 5: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: no TypeScript errors.
 
@@ -472,7 +472,7 @@ git rm packages/desktop/src/renderer/components/chat/SlashCommandMenu.tsx
 **Step 2: Typecheck to confirm nothing else imports them**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: no TypeScript errors. If there are import errors, find and remove the remaining references.
 

--- a/docs/plans/completed/2026-02-19-remove-project.md
+++ b/docs/plans/completed/2026-02-19-remove-project.md
@@ -93,7 +93,7 @@ describe('ChatManager.removeProject', () => {
 **Step 2: Run the test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test -- chat-manager-remove-project
+pnpm --filter @qlan-ro/mainframe-core test -- chat-manager-remove-project
 ```
 
 Expected: FAIL — `removeProject is not a function`
@@ -135,7 +135,7 @@ const logger = createChildLogger('chat-manager');
 **Step 4: Run the test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test -- chat-manager-remove-project
+pnpm --filter @qlan-ro/mainframe-core test -- chat-manager-remove-project
 ```
 
 Expected: PASS
@@ -143,7 +143,7 @@ Expected: PASS
 **Step 5: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 Expected: no errors
@@ -188,7 +188,7 @@ describe('DELETE /api/projects/:id', () => {
 **Step 2: Run the test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test -- routes/projects
+pnpm --filter @qlan-ro/mainframe-core test -- routes/projects
 ```
 
 Expected: FAIL — `ctx.chats.removeProject` not called
@@ -224,7 +224,7 @@ const logger = createChildLogger('projects-route');
 **Step 4: Run tests**
 
 ```bash
-pnpm --filter @mainframe/core test -- routes/projects
+pnpm --filter @qlan-ro/mainframe-core test -- routes/projects
 ```
 
 Expected: PASS
@@ -232,7 +232,7 @@ Expected: PASS
 **Step 5: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 **Step 6: Commit**
@@ -410,7 +410,7 @@ export function ProjectRail(): React.ReactElement {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no TypeScript errors
@@ -441,8 +441,8 @@ Start the app and verify:
 ### Task 5: Final typecheck and test run
 
 ```bash
-pnpm --filter @mainframe/core build
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core build
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all tests pass, no type errors.

--- a/docs/plans/completed/2026-02-20-comprehensive-testing-design.md
+++ b/docs/plans/completed/2026-02-20-comprehensive-testing-design.md
@@ -109,7 +109,7 @@ Tier 3: Desktop Components (Vitest+RTL + Playwright CT)
 ```json
 // root package.json
 "test": "pnpm -r run test",
-"test:playwright": "pnpm --filter @mainframe/desktop run test:playwright"
+"test:playwright": "pnpm --filter @qlan-ro/mainframe-desktop run test:playwright"
 
 // packages/desktop/package.json
 "test:playwright": "playwright test -c playwright-ct.config.ts"

--- a/docs/plans/completed/2026-02-20-comprehensive-testing.md
+++ b/docs/plans/completed/2026-02-20-comprehensive-testing.md
@@ -87,7 +87,7 @@ rm packages/core/src/__tests__/set-model-integration.test.ts
 
 **Step 2: Verify tests still pass**
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 Expected: all remaining tests pass, no references to deleted file.
 
@@ -117,7 +117,7 @@ import { createHttpServer } from '../server/http.js';
 import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { BaseAdapter } from '../adapters/base.js';
-import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockAdapter extends BaseAdapter {
   id = 'claude'; name = 'Mock';
@@ -254,7 +254,7 @@ describe('send-message flow', () => {
 
 **Step 2: Run the test**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose send-message-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose send-message-flow
 ```
 Expected: 1 test passes.
 
@@ -284,7 +284,7 @@ import { createHttpServer } from '../server/http.js';
 import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { BaseAdapter } from '../adapters/base.js';
-import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent, PermissionRequest } from '@mainframe/types';
+import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent, PermissionRequest } from '@qlan-ro/mainframe-types';
 
 class MockAdapter extends BaseAdapter {
   id = 'claude'; name = 'Mock';
@@ -454,7 +454,7 @@ describe('permission flow', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose permission-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose permission-flow
 ```
 Expected: 4 tests pass.
 
@@ -484,7 +484,7 @@ import { createHttpServer } from '../server/http.js';
 import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { BaseAdapter } from '../adapters/base.js';
-import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockAdapter extends BaseAdapter {
   id = 'claude'; name = 'Mock';
@@ -615,7 +615,7 @@ describe('file-edit flow', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose file-edit-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose file-edit-flow
 ```
 Expected: 1 test passes.
 
@@ -697,7 +697,7 @@ describe('buildFrontmatter', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose frontmatter
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose frontmatter
 ```
 Expected: 7 tests pass.
 
@@ -724,7 +724,7 @@ import {
   extractPlanFilePathFromText,
   extractLatestPlanFileFromMessages,
 } from '../chat/context-tracker.js';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 function makeDb(addMentionReturn = true, addModifiedFileReturn = true) {
   return {
@@ -884,7 +884,7 @@ describe('extractLatestPlanFileFromMessages', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose context-tracker
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose context-tracker
 ```
 Expected: 14 tests pass.
 
@@ -1010,7 +1010,7 @@ describe('AttachmentStore', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose attachment-store
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose attachment-store
 ```
 Expected: 7 tests pass.
 
@@ -1144,7 +1144,7 @@ describe('agents', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose claude-skills
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose claude-skills
 ```
 Expected: 8 tests pass.
 
@@ -1166,7 +1166,7 @@ git commit -m "test(core): add claude-skills FS CRUD unit tests"
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PlanModeHandler, type PlanModeContext } from '../chat/plan-mode-handler.js';
-import type { Chat, DaemonEvent, PermissionResponse } from '@mainframe/types';
+import type { Chat, DaemonEvent, PermissionResponse } from '@qlan-ro/mainframe-types';
 
 function makeChat(overrides: Partial<Chat> = {}): Chat {
   return {
@@ -1311,7 +1311,7 @@ describe('PlanModeHandler', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose plan-mode-handler
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose plan-mode-handler
 ```
 Expected: 6 tests pass.
 
@@ -1488,7 +1488,7 @@ describe('GET /api/projects/:id/files', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose "routes/files"
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose "routes/files"
 ```
 Expected: 6 tests pass.
 
@@ -1619,7 +1619,7 @@ describe('GET /api/projects/:id/diff?source=session (no file)', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose "routes/git"
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose "routes/git"
 ```
 Expected: 5 tests pass.
 
@@ -1656,7 +1656,7 @@ export default defineConfig({
 
 **Step 2: Run with coverage to verify thresholds pass**
 ```bash
-pnpm --filter @mainframe/core test -- --coverage
+pnpm --filter @qlan-ro/mainframe-core test -- --coverage
 ```
 Expected: all thresholds met. If a threshold fails, check which module is dragging it down and either add a focused test or adjust the threshold by 5%.
 
@@ -1678,7 +1678,7 @@ git commit -m "test(core): raise coverage thresholds to 60/50/55"
 
 **Step 1: Install jest-dom**
 ```bash
-pnpm --filter @mainframe/desktop add -D @testing-library/jest-dom @types/testing-library__jest-dom
+pnpm --filter @qlan-ro/mainframe-desktop add -D @testing-library/jest-dom @types/testing-library__jest-dom
 ```
 
 **Step 2: Update vitest.config.ts**
@@ -1710,7 +1710,7 @@ import '@testing-library/jest-dom';
 
 **Step 4: Run existing tests to confirm nothing broke**
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 Expected: all existing tests pass.
 
@@ -1734,7 +1734,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PermissionCard } from '../../renderer/components/chat/PermissionCard.js';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
   return {
@@ -1800,7 +1800,7 @@ describe('PermissionCard', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose PermissionCard
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose PermissionCard
 ```
 Expected: 7 tests pass.
 
@@ -1831,7 +1831,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AskUserQuestionCard } from './AskUserQuestionCard.js';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(questions: unknown[]): PermissionRequest {
   return {
@@ -1951,7 +1951,7 @@ rm packages/desktop/src/renderer/components/chat/AskUserQuestionCard.test.ts
 
 **Step 4: Run**
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose AskUserQuestionCard
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose AskUserQuestionCard
 ```
 Expected: 6+ tests pass.
 
@@ -2017,7 +2017,7 @@ describe('BashCard', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose BashCard
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose BashCard
 ```
 Expected: 5 tests pass.
 
@@ -2102,7 +2102,7 @@ describe('EditFileCard', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose EditFileCard
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose EditFileCard
 ```
 Expected: 4 tests pass.
 
@@ -2159,7 +2159,7 @@ describe('PLAN_PREFIX', () => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose message-parsing
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose message-parsing
 ```
 Expected: 4 tests pass.
 
@@ -2181,8 +2181,8 @@ git commit -m "test(desktop): add message-parsing unit tests"
 
 **Step 1: Install**
 ```bash
-pnpm --filter @mainframe/desktop add -D @playwright/experimental-ct-react
-pnpm --filter @mainframe/desktop exec playwright install chromium
+pnpm --filter @qlan-ro/mainframe-desktop add -D @playwright/experimental-ct-react
+pnpm --filter @qlan-ro/mainframe-desktop exec playwright install chromium
 ```
 
 **Step 2: Create `packages/desktop/playwright-ct.config.ts`**
@@ -2224,7 +2224,7 @@ mkdir -p packages/desktop/src/__tests__/playwright
 
 **Step 5: Verify config is valid**
 ```bash
-pnpm --filter @mainframe/desktop exec playwright test -c playwright-ct.config.ts --list 2>&1 | head -20
+pnpm --filter @qlan-ro/mainframe-desktop exec playwright test -c playwright-ct.config.ts --list 2>&1 | head -20
 ```
 Expected: runs without error (no tests found yet is fine).
 
@@ -2246,7 +2246,7 @@ git commit -m "test(desktop): add Playwright CT configuration"
 ```tsx
 import { test, expect } from '@playwright/experimental-ct-react';
 import { PermissionCard } from '../../renderer/components/chat/PermissionCard.js';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 
 const request: PermissionRequest = {
   requestId: 'req-1',
@@ -2305,7 +2305,7 @@ test('expands details section on click', async ({ mount }) => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test:playwright -- PermissionCard
+pnpm --filter @qlan-ro/mainframe-desktop test:playwright -- PermissionCard
 ```
 Expected: 4 tests pass.
 
@@ -2327,7 +2327,7 @@ git commit -m "test(desktop): add PermissionCard Playwright CT tests"
 ```tsx
 import { test, expect } from '@playwright/experimental-ct-react';
 import { AskUserQuestionCard } from '../../renderer/components/chat/AskUserQuestionCard.js';
-import type { PermissionRequest } from '@mainframe/types';
+import type { PermissionRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(): PermissionRequest {
   return {
@@ -2396,7 +2396,7 @@ test('calls onRespond with selected answer', async ({ mount }) => {
 
 **Step 2: Run**
 ```bash
-pnpm --filter @mainframe/desktop test:playwright -- AskUserQuestionCard
+pnpm --filter @qlan-ro/mainframe-desktop test:playwright -- AskUserQuestionCard
 ```
 Expected: 4 tests pass.
 
@@ -2480,7 +2480,7 @@ test('shows running indicator while processing', async ({ mount }) => {
 
 **Step 3: Run all Playwright tests**
 ```bash
-pnpm --filter @mainframe/desktop test:playwright
+pnpm --filter @qlan-ro/mainframe-desktop test:playwright
 ```
 Expected: all CT tests pass.
 
@@ -2497,20 +2497,20 @@ git commit -m "test(desktop): add BashCard and EditFileCard Playwright CT tests"
 
 **Step 1: Run all core tests**
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 Expected: all pass.
 
 **Step 2: Run all desktop unit/RTL tests**
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 Expected: all pass.
 
 **Step 3: Typecheck both packages**
 ```bash
-pnpm --filter @mainframe/core build
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-core build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: no TypeScript errors.
 
@@ -2530,9 +2530,9 @@ gh pr create \
 
 ## Test plan
 
-- [ ] `pnpm --filter @mainframe/core test` passes
-- [ ] `pnpm --filter @mainframe/desktop test` passes
-- [ ] `pnpm --filter @mainframe/desktop test:playwright` passes (run manually)
+- [ ] `pnpm --filter @qlan-ro/mainframe-core test` passes
+- [ ] `pnpm --filter @qlan-ro/mainframe-desktop test` passes
+- [ ] `pnpm --filter @qlan-ro/mainframe-desktop test:playwright` passes (run manually)
 - [ ] TypeScript compiles without errors
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/plans/completed/2026-02-20-e2e-testing.md
+++ b/docs/plans/completed/2026-02-20-e2e-testing.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Layer 1 tests spawn a real daemon with a random free port and temp SQLite DB, then hit its HTTP API with `fetch`. Layer 2 tests build the Electron app, start a test daemon, and launch Electron with `NODE_ENV=development` (which already skips daemon spawning) plus `MF_DAEMON_PORT` to redirect the renderer to the test daemon.
 
-**Tech Stack:** Vitest (already installed in workspace), tsx (already in `@mainframe/core` devDeps), `@playwright/test`, Node.js `net` module for port allocation.
+**Tech Stack:** Vitest (already installed in workspace), tsx (already in `@qlan-ro/mainframe-core` devDeps), `@playwright/test`, Node.js `net` module for port allocation.
 
 ---
 
@@ -75,7 +75,7 @@ describe('getConfig env var overrides', () => {
 ### Step 2: Run test to verify it fails
 
 ```bash
-pnpm --filter @mainframe/core test -- --run src/__tests__/config.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/config.test.ts
 ```
 
 Expected: FAIL — `getConfig()` ignores env vars.
@@ -133,7 +133,7 @@ export function saveConfig(config: Partial<MainframeConfig>): void {
 ### Step 4: Run test to verify it passes
 
 ```bash
-pnpm --filter @mainframe/core test -- --run src/__tests__/config.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/config.test.ts
 ```
 
 > If module caching prevents the unit tests from passing, delete the unit tests and verify env var behavior is covered by the integration tests in Task 4 (the daemon fixture exercises this end-to-end). Don't fight ESM cache — move on.
@@ -141,7 +141,7 @@ pnpm --filter @mainframe/core test -- --run src/__tests__/config.test.ts
 ### Step 5: Typecheck
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 Expected: no errors.
@@ -916,7 +916,7 @@ const WS_URL = `ws://127.0.0.1:${(window as unknown as { mainframe?: { daemonPor
 ### Step 4: Typecheck
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no errors.
@@ -924,7 +924,7 @@ Expected: no errors.
 ### Step 5: Run desktop tests
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all pass (this change is backward-compatible — if `window.mainframe` is absent, defaults to 31415).

--- a/docs/plans/completed/2026-02-20-flow-gap-testing.md
+++ b/docs/plans/completed/2026-02-20-flow-gap-testing.md
@@ -203,7 +203,7 @@ it('second queued permission is emitted after first is answered', async () => {
 **Step 2: Run the new tests only**
 
 ```bash
-pnpm --filter @mainframe/core test -- --run --reporter=verbose permission-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --run --reporter=verbose permission-flow
 ```
 
 Expected: 6 tests pass (4 existing + 2 new).
@@ -236,7 +236,7 @@ import { createHttpServer } from '../server/http.js';
 import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { BaseAdapter } from '../adapters/base.js';
-import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 // [Paste MockAdapter, createMockDb, createStack, startServer, stopServer, connectWs, sleep helpers here]
 // Same as permission-flow.test.ts but MockAdapter also needs kill and sendMessage
@@ -401,7 +401,7 @@ describe('adapter events flow', () => {
 **Step 2: Run the new file**
 
 ```bash
-pnpm --filter @mainframe/core test -- --run --reporter=verbose adapter-events-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --run --reporter=verbose adapter-events-flow
 ```
 
 Expected: 7 tests pass.
@@ -433,7 +433,7 @@ import { createHttpServer } from '../server/http.js';
 import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { BaseAdapter } from '../adapters/base.js';
-import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterProcess, PermissionResponse, SpawnOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 // [Paste MockAdapter, createMockDb, createStack, startServer, stopServer, connectWs, sleep helpers here]
 
@@ -539,7 +539,7 @@ describe('WS inbound flows', () => {
 **Step 2: Run the new file**
 
 ```bash
-pnpm --filter @mainframe/core test -- --run --reporter=verbose ws-inbound-flow
+pnpm --filter @qlan-ro/mainframe-core test -- --run --reporter=verbose ws-inbound-flow
 ```
 
 Expected: 5 tests pass.
@@ -558,7 +558,7 @@ git commit -m "test(core): add WS inbound flow tests (message.send, interrupt, e
 **Step 1: Run full test suite**
 
 ```bash
-CI=1 pnpm --filter @mainframe/core test --run
+CI=1 pnpm --filter @qlan-ro/mainframe-core test --run
 ```
 
 Expected: All tests pass (no failures in new or existing files). The `title-generation.test.ts` tests are skipped because `CI=1`.
@@ -566,7 +566,7 @@ Expected: All tests pass (no failures in new or existing files). The `title-gene
 **Step 2: Check coverage**
 
 ```bash
-CI=1 pnpm --filter @mainframe/core test --coverage
+CI=1 pnpm --filter @qlan-ro/mainframe-core test --coverage
 ```
 
 Expected coverage (current baseline — new tests should improve `server/` coverage):
@@ -581,7 +581,7 @@ If new tests push branches or lines significantly higher, bump the thresholds in
 **Step 4: Run desktop tests to ensure nothing regressed**
 
 ```bash
-pnpm --filter @mainframe/desktop test --run
+pnpm --filter @qlan-ro/mainframe-desktop test --run
 ```
 
 Expected: 222 tests pass (Playwright CT excluded).

--- a/docs/plans/completed/2026-02-20-logging-design.md
+++ b/docs/plans/completed/2026-02-20-logging-design.md
@@ -17,12 +17,12 @@ Three separate log files, all under `~/.mainframe/logs/`, with daily rotation an
 
 ```
 ~/.mainframe/logs/
-  daemon.2026-02-20.log     ← pino NDJSON, @mainframe/core daemon process
+  daemon.2026-02-20.log     ← pino NDJSON, @qlan-ro/mainframe-core daemon process
   main.2026-02-20.log       ← pino NDJSON, Electron main process
   renderer.2026-02-20.log   ← pino NDJSON, forwarded from renderer via IPC
 ```
 
-### Daemon (`@mainframe/core`)
+### Daemon (`@qlan-ro/mainframe-core`)
 
 Extend the existing `pino` logger in `packages/core/src/logger.ts` with a `pino-roll` file transport. The logger always writes to file (both dev and prod). In dev, also pretty-prints to stdout at `debug` level. In prod, writes NDJSON to stdout + file at `info` level.
 
@@ -45,7 +45,7 @@ New file: `packages/desktop/src/main/logger.ts`
 
 A fresh `pino` instance with its own `pino-roll` transport pointing to `~/.mainframe/logs/main.log`. Same daily rotation, 7-day retention. Replaces all `console.*` calls in `packages/desktop/src/main/index.ts`.
 
-Dependencies added to `@mainframe/desktop`: `pino`, `pino-roll`.
+Dependencies added to `@qlan-ro/mainframe-desktop`: `pino`, `pino-roll`.
 
 ### Renderer (IPC Bridge)
 
@@ -120,6 +120,6 @@ log: (level: string, module: string, message: string, data?: unknown) =>
 ## Constraints
 
 - No tight-loop DEBUG logs (no per-iteration logging without a meaningful timeout between steps).
-- No `console.log` / `console.error` in `@mainframe/core` — use pino child loggers only.
+- No `console.log` / `console.error` in `@qlan-ro/mainframe-core` — use pino child loggers only.
 - `console.warn` with a tag is acceptable in renderer/desktop code where pino is unavailable.
 - `pino-roll` uses worker threads — verify it builds correctly through electron-vite's rollup for the main process. If not, fall back to a simple async `fs.appendFile` writer for the main logger.

--- a/docs/plans/completed/2026-02-20-logging-plan.md
+++ b/docs/plans/completed/2026-02-20-logging-plan.md
@@ -121,7 +121,7 @@ export function createChildLogger(name: string) {
 **Step 2: Run core tests to confirm no regressions**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all tests pass.
@@ -244,7 +244,7 @@ export function logFromRenderer(level: string, module: string, message: string, 
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop exec tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
 ```
 
 Fix any type errors before proceeding.
@@ -347,7 +347,7 @@ log.info('window created');
 **Step 6: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop exec tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
 ```
 
 Fix any errors.
@@ -423,7 +423,7 @@ const api: MainframeAPI = {
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop exec tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
 ```
 
 **Step 4: Commit**
@@ -500,7 +500,7 @@ describe('createLogger', () => {
 **Step 2: Run the test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose renderer/lib/logger
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose renderer/lib/logger
 ```
 
 Expected: FAIL — `cannot find module './logger'`
@@ -556,7 +556,7 @@ export function createLogger(module: string): ModuleLogger {
 **Step 4: Run tests to verify they pass**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- --reporter=verbose renderer/lib/logger
+pnpm --filter @qlan-ro/mainframe-desktop test -- --reporter=verbose renderer/lib/logger
 ```
 
 Expected: all 5 tests pass.
@@ -631,7 +631,7 @@ logger.info({ projectId: param(req, 'id') }, 'project deleted');
 **Step 4: Run core tests**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all pass.
@@ -703,7 +703,7 @@ log.debug({ type: event.type, chatId: 'chatId' in event ? event.chatId : undefin
 **Step 4: Run core tests**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all pass.
@@ -843,7 +843,7 @@ to:
 **Step 5: Run desktop tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all pass.
@@ -862,8 +862,8 @@ git commit -m "feat(desktop): replace console.* with structured renderer logger 
 **Step 1: Typecheck all packages**
 
 ```bash
-pnpm --filter @mainframe/core exec tsc --noEmit
-pnpm --filter @mainframe/desktop exec tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
 ```
 
 Expected: zero errors.
@@ -880,7 +880,7 @@ Expected: all tests pass.
 
 Start the daemon in dev mode:
 ```bash
-pnpm --filter @mainframe/core dev
+pnpm --filter @qlan-ro/mainframe-core dev
 ```
 
 Check that a log file was created:

--- a/docs/plans/completed/2026-02-20-onboarding-tutorial.md
+++ b/docs/plans/completed/2026-02-20-onboarding-tutorial.md
@@ -61,7 +61,7 @@ describe('useTutorialStore', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- tutorial.test
+pnpm --filter @qlan-ro/mainframe-desktop test -- tutorial.test
 ```
 Expected: FAIL — `Cannot find module './tutorial'`
 
@@ -107,7 +107,7 @@ export const useTutorialStore = create<TutorialState>()(
 **Step 4: Run test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- tutorial.test
+pnpm --filter @qlan-ro/mainframe-desktop test -- tutorial.test
 ```
 Expected: PASS (5 tests)
 
@@ -584,7 +584,7 @@ git commit -m "feat(desktop): add auto-advancement logic to TutorialOverlay"
 **Step 1: Run TypeScript compiler**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: No TypeScript errors.
 
@@ -593,7 +593,7 @@ If you see errors about missing store imports (step 5), adjust the import path t
 **Step 2: Run tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- tutorial
+pnpm --filter @qlan-ro/mainframe-desktop test -- tutorial
 ```
 Expected: All tutorial store tests pass.
 

--- a/docs/plans/completed/2026-02-20-production-hardening.md
+++ b/docs/plans/completed/2026-02-20-production-hardening.md
@@ -38,7 +38,7 @@ app.on('second-instance', () => {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: builds with no TypeScript errors.
 
@@ -71,7 +71,7 @@ mainWindow.on('ready-to-show', () => {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: builds with no TypeScript errors.
 
@@ -168,7 +168,7 @@ if (process.env.NODE_ENV !== 'development') {
 **Step 5: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: builds with no TypeScript errors.
 
@@ -185,8 +185,8 @@ git commit -m "feat(desktop): block devtools access in production builds"
 
 After all tasks:
 
-1. **Single instance** — Build and run the app (`pnpm --filter @mainframe/desktop start`). Try launching a second instance from terminal. The second launch should exit and the first window should come to the foreground.
+1. **Single instance** — Build and run the app (`pnpm --filter @qlan-ro/mainframe-desktop start`). Try launching a second instance from terminal. The second launch should exit and the first window should come to the foreground.
 
-2. **No DevTools auto-open** — Run `pnpm --filter @mainframe/desktop dev`. Window should open without DevTools panel visible. Open DevTools manually via ⌥⌘I to confirm they still work in dev.
+2. **No DevTools auto-open** — Run `pnpm --filter @qlan-ro/mainframe-desktop dev`. Window should open without DevTools panel visible. Open DevTools manually via ⌥⌘I to confirm they still work in dev.
 
-3. **Production DevTools blocked** — Run `pnpm --filter @mainframe/desktop start` (preview mode, `NODE_ENV=production`). Open View menu → "Toggle Developer Tools" should be absent. Press ⌥⌘I — DevTools should not open (or open and immediately close).
+3. **Production DevTools blocked** — Run `pnpm --filter @qlan-ro/mainframe-desktop start` (preview mode, `NODE_ENV=production`). Open View menu → "Toggle Developer Tools" should be absent. Press ⌥⌘I — DevTools should not open (or open and immediately close).

--- a/docs/plans/completed/2026-02-20-renderer-action-logging.md
+++ b/docs/plans/completed/2026-02-20-renderer-action-logging.md
@@ -110,7 +110,7 @@ disableWorktree(chatId: string): void {
 **Step 4: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.
@@ -162,7 +162,7 @@ export async function archiveChat(chatId: string): Promise<void> {
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.
@@ -209,7 +209,7 @@ export async function uploadAttachments(
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.
@@ -275,7 +275,7 @@ export async function deleteAgent(adapterId: string, agentId: string, projectPat
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.
@@ -321,7 +321,7 @@ export async function updateGeneralSettings(settings: Partial<GeneralConfig>): P
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.
@@ -340,7 +340,7 @@ git commit -m "feat(desktop): log settings mutations in api layer"
 **Step 1: Run logger unit tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test -- renderer/lib/logger
+pnpm --filter @qlan-ro/mainframe-desktop test -- renderer/lib/logger
 ```
 
 Expected: all 5 tests pass.
@@ -348,7 +348,7 @@ Expected: all 5 tests pass.
 **Step 2: Run full desktop test suite**
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all tests pass, no regressions.

--- a/docs/plans/completed/2026-02-22-claude-adapter-into-plugin.md
+++ b/docs/plans/completed/2026-02-22-claude-adapter-into-plugin.md
@@ -49,7 +49,7 @@ Also fix the upward path to `BaseAdapter`/`BaseSession` — they moved FROM a si
 **Step 3: Verify moved files compile**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: TypeScript errors about missing imports in other files — that's expected, those are fixed in subsequent tasks. The moved files themselves should have no internal errors.
 
@@ -65,7 +65,7 @@ Expected: TypeScript errors about missing imports in other files — that's expe
 Replace the entire file with:
 
 ```typescript
-import type { Adapter, AdapterInfo } from '@mainframe/types';
+import type { Adapter, AdapterInfo } from '@qlan-ro/mainframe-types';
 
 export class AdapterRegistry {
   private adapters = new Map<string, Adapter>();
@@ -114,7 +114,7 @@ export { BaseSession } from './base-session.js';
 **Step 2: Build to confirm**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: Errors in files that imported `ClaudeAdapter` from `adapters/index.js` — fixed in subsequent tasks.
 
@@ -139,7 +139,7 @@ import { ClaudeAdapter } from './adapter.js';
 **Step 2: Build**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: Remaining errors in test files and `core/src/index.ts` — not yet fixed.
 
@@ -159,7 +159,7 @@ The daemon entry point imports `claudeManifest` and `activate` from the plugin. 
 **Step 2: Build**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: Only test-related errors remain.
 
@@ -199,7 +199,7 @@ import { buildToolResultBlocks, convertHistoryEntry } from '../plugins/builtin/c
 **Step 3: Run these two test files**
 
 ```bash
-pnpm --filter @mainframe/core exec vitest run -- "adapter-registry|event-pipeline-parity"
+pnpm --filter @qlan-ro/mainframe-core exec vitest run -- "adapter-registry|event-pipeline-parity"
 ```
 Expected: PASS.
 
@@ -240,7 +240,7 @@ import { parseFrontmatter } from '../plugins/builtin/claude/frontmatter.js';
 **Step 3: Run**
 
 ```bash
-pnpm --filter @mainframe/core exec vitest run -- "claude-events|claude-skills"
+pnpm --filter @qlan-ro/mainframe-core exec vitest run -- "claude-events|claude-skills"
 ```
 Expected: PASS.
 
@@ -293,7 +293,7 @@ import { ClaudeAdapter } from '../plugins/builtin/claude/adapter.js';
 **Step 4: Run**
 
 ```bash
-pnpm --filter @mainframe/core exec vitest run -- "frontmatter|message-loading|control-requests"
+pnpm --filter @qlan-ro/mainframe-core exec vitest run -- "frontmatter|message-loading|control-requests"
 ```
 Expected: PASS.
 
@@ -311,7 +311,7 @@ Expected: PASS — no errors, no warnings.
 **Step 2: Full test run**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 Expected: Same pass rate as before (477/480 — only pre-existing title-generation failures).
 

--- a/docs/plans/completed/2026-02-22-plugin-system-design.md
+++ b/docs/plans/completed/2026-02-22-plugin-system-design.md
@@ -432,7 +432,7 @@ Daemon stop / unload:
 
 ```typescript
 // A hypothetical Gemini CLI adapter plugin
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { GeminiAdapter } from './gemini-adapter.js';
 
 export function activate(ctx: PluginContext): void {
@@ -498,7 +498,7 @@ const PluginPanel = ({ pluginId, entryPoint }: Props) => {
 
 Plugin UI components communicate with the daemon only via `api.fetch()` (scoped to
 `/api/plugins/{id}/`) and `api.onEvent()` (scoped WS events). They cannot import
-from `@mainframe/core` or access the main Zustand store.
+from `@qlan-ro/mainframe-core` or access the main Zustand store.
 
 ### 9.3 Consent Dialog Component (Desktop)
 
@@ -544,12 +544,12 @@ Elevated to required because `ctx.adapters.register(adapter)` depends on `Adapte
 
 ## 11. File Map
 
-### New in `@mainframe/types/src/`
+### New in `@qlan-ro/mainframe-types/src/`
 ```
 plugin.ts     — all plugin types: manifest, capabilities, context, sub-APIs, events
 ```
 
-### New in `@mainframe/core/src/plugins/`
+### New in `@qlan-ro/mainframe-core/src/plugins/`
 ```
 manager.ts                   — PluginManager: discovery, consent flow, lifecycle
 context.ts                   — buildPluginContext() with capability gating
@@ -570,12 +570,12 @@ builtin/
     index.ts
 ```
 
-### New in `@mainframe/core/src/server/routes/`
+### New in `@qlan-ro/mainframe-core/src/server/routes/`
 ```
 plugins.ts     — GET /api/plugins, GET /api/plugins/:id, POST /api/plugins/:id/consent
 ```
 
-### New in `@mainframe/desktop/src/renderer/`
+### New in `@qlan-ro/mainframe-desktop/src/renderer/`
 ```
 components/plugins/
   PluginConsentDialog.tsx   — install-time consent UI

--- a/docs/plans/completed/2026-02-22-plugin-system-plan.md
+++ b/docs/plans/completed/2026-02-22-plugin-system-plan.md
@@ -45,7 +45,7 @@ Do not start Phase 1 until Phase 0 is 100% done and `pnpm build` passes.
 
 ## Phase 1 — Plugin System Types
 
-### Task 1.1: Add plugin types to @mainframe/types
+### Task 1.1: Add plugin types to @qlan-ro/mainframe-types
 
 **Files:**
 - Create: `packages/types/src/plugin.ts`
@@ -247,7 +247,7 @@ export type {
 
 **Step 3: Build types package**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: PASS.
 
 **Step 4: Commit**
@@ -308,7 +308,7 @@ Create `packages/core/src/plugins/security/manifest-validator.ts`:
 
 ```typescript
 import { z } from 'zod';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 
 const VALID_CAPABILITIES = [
   'storage', 'ui:panels', 'ui:notifications', 'daemon:public-events',
@@ -348,7 +348,7 @@ export function validateManifest(raw: unknown): { success: true; manifest: Plugi
 
 **Step 3: Run tests, commit**
 
-Run: `pnpm --filter @mainframe/core test -- manifest-validator`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- manifest-validator`
 Expected: PASS.
 
 ```bash
@@ -410,7 +410,7 @@ Create `packages/core/src/plugins/db-context.ts`:
 import Database from 'better-sqlite3';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
-import type { PluginDatabaseContext, PluginDatabaseStatement } from '@mainframe/types';
+import type { PluginDatabaseContext, PluginDatabaseStatement } from '@qlan-ro/mainframe-types';
 
 export function createPluginDatabaseContext(dbPath: string): PluginDatabaseContext {
   mkdirSync(path.dirname(dbPath), { recursive: true });
@@ -497,7 +497,7 @@ Create `packages/core/src/plugins/event-bus.ts`:
 
 ```typescript
 import { EventEmitter } from 'node:events';
-import type { PluginEventBus, PublicDaemonEventName, PublicDaemonEvent } from '@mainframe/types';
+import type { PluginEventBus, PublicDaemonEventName, PublicDaemonEvent } from '@qlan-ro/mainframe-types';
 
 export const PUBLIC_DAEMON_EVENT_PREFIX = 'plugin:public:';
 
@@ -571,7 +571,7 @@ describe('PluginConfig', () => {
 Create `packages/core/src/plugins/config-context.ts`:
 
 ```typescript
-import type { PluginConfig } from '@mainframe/types';
+import type { PluginConfig } from '@qlan-ro/mainframe-types';
 
 export function createPluginConfig(
   pluginId: string,
@@ -644,8 +644,8 @@ Create `packages/core/src/plugins/ui-context.ts`:
 
 ```typescript
 import path from 'node:path';
-import type { PluginUIContext, PluginPanelSpec } from '@mainframe/types';
-import type { DaemonEvent } from '@mainframe/types';
+import type { PluginUIContext, PluginPanelSpec } from '@qlan-ro/mainframe-types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 
 export function createPluginUIContext(
   pluginId: string,
@@ -734,7 +734,7 @@ Build a `PluginContext` where each capability-gated property is either:
 - A Proxy that throws a `PluginCapabilityError` (if not declared)
 
 ```typescript
-import type { PluginContext, PluginManifest } from '@mainframe/types';
+import type { PluginContext, PluginManifest } from '@qlan-ro/mainframe-types';
 import { createPluginDatabaseContext } from './db-context.js';
 import { createPluginEventBus } from './event-bus.js';
 import { createPluginConfig } from './config-context.js';
@@ -742,7 +742,7 @@ import { createPluginUIContext } from './ui-context.js';
 import type { EventEmitter } from 'node:events';
 import type { Router } from 'express';
 import type { Logger } from 'pino';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 
@@ -869,7 +869,7 @@ import { readdirSync, existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { Router } from 'express';
-import type { PluginContext, PluginModule } from '@mainframe/types';
+import type { PluginContext, PluginModule } from '@qlan-ro/mainframe-types';
 import { validateManifest } from './security/manifest-validator.js';
 import { buildPluginContext } from './context.js';
 import { createChildLogger } from '../logger.js';
@@ -1014,7 +1014,7 @@ process.on('SIGTERM', async () => {
 
 **Step 3: Build and typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS.
 
 **Step 4: Commit**
@@ -1115,7 +1115,7 @@ git commit -m "feat(core): add plugin listing routes and WS event types"
 ```typescript
 // packages/desktop/src/renderer/store/plugins.ts
 import { create } from 'zustand';
-import type { PluginPanelSpec } from '@mainframe/types';
+import type { PluginPanelSpec } from '@qlan-ro/mainframe-types';
 
 interface RegisteredPanel {
   pluginId: string;
@@ -1266,7 +1266,7 @@ const panels = usePluginsStore((s) => s.panels.filter((p) => p.position === 'sid
 
 **Step 5: Build and typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: PASS.
 
 **Step 6: Commit**
@@ -1311,7 +1311,7 @@ activated via a builtin plugin.
 
 ```typescript
 // packages/core/src/plugins/builtin/claude/index.ts
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { ClaudeAdapter } from '../../../adapters/claude.js';
 
 export function activate(ctx: PluginContext): void {
@@ -1404,7 +1404,7 @@ git commit -m "test(plugins): add plugin system integration test"
 | Capability-gated context | `context.ts` | ✅ |
 | Plugin lifecycle manager | `manager.ts` | ✅ |
 | Plugin HTTP routes | `server/routes/plugins.ts` | ✅ |
-| WS event types | `@mainframe/types` | — |
+| WS event types | `@qlan-ro/mainframe-types` | — |
 | Desktop panel store | `store/plugins.ts` | — |
 | Dynamic panel loading | `components/plugins/` | — |
 | Claude builtin plugin | `builtin/claude/` | manual |

--- a/docs/plans/completed/2026-02-22-sdk-session-sink-refactor.md
+++ b/docs/plans/completed/2026-02-22-sdk-session-sink-refactor.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Replace the EventEmitter-based session→core communication with a typed `SessionSink` callback interface, remove `BaseAdapter`/`BaseSession`, rename `Permission*` → `Control*`, and make `@mainframe/types` a publishable SDK.
+**Goal:** Replace the EventEmitter-based session→core communication with a typed `SessionSink` callback interface, remove `BaseAdapter`/`BaseSession`, rename `Permission*` → `Control*`, and make `@qlan-ro/mainframe-types` a publishable SDK.
 
 **Architecture:** `AdapterSession.spawn()` receives a `SessionSink` that the core builds — sessions call `sink.onMessage(...)` etc. instead of `this.emit('message', ...)`. All base classes move to test helpers. The types package becomes the SDK: no private flag, full `PluginContext` typing, no magic event strings.
 
@@ -79,7 +79,7 @@ Expected: PASS — clean build, no errors.
 **Step 7: Run tests**
 
 ```bash
-pnpm --filter @mainframe/core test 2>&1 | tail -20
+pnpm --filter @qlan-ro/mainframe-core test 2>&1 | tail -20
 ```
 
 Expected: 477/480 (same as before — only pre-existing title-generation failures).
@@ -98,7 +98,7 @@ EOF
 
 ---
 
-## Task 2: Add `SessionSink` to `@mainframe/types`, update `AdapterSession` interface
+## Task 2: Add `SessionSink` to `@qlan-ro/mainframe-types`, update `AdapterSession` interface
 
 **Files:**
 - Modify: `packages/types/src/adapter.ts`
@@ -219,13 +219,13 @@ If found, remove the line.
 **Step 6: Verify build (expected failures are OK)**
 
 ```bash
-pnpm --filter @mainframe/types build 2>&1 | tail -10
+pnpm --filter @qlan-ro/mainframe-types build 2>&1 | tail -10
 ```
 
 Expected: PASS for types package.
 
 ```bash
-pnpm --filter @mainframe/core build 2>&1 | grep "error TS" | head -20
+pnpm --filter @qlan-ro/mainframe-core build 2>&1 | grep "error TS" | head -20
 ```
 
 Expected: TypeScript errors in `ClaudeSession` (still extends BaseSession which has `on/off/emit`), `event-handler.ts` (calls `session.on()`), and test files (mock sessions extend BaseSession). These are fixed in subsequent tasks.
@@ -287,7 +287,7 @@ export function handleStdout(line: string, sink: SessionSink): void
 
 Apply same pattern to `handleStderr`, `handleSystemEvent`, `handleAssistantEvent`, `handleUserEvent`, `handleControlRequestEvent` (was `handlePermissionRequestEvent`), `handleResultEvent`.
 
-Import `SessionSink` from `'@mainframe/types'` instead of the old session type.
+Import `SessionSink` from `'@qlan-ro/mainframe-types'` instead of the old session type.
 
 **Step 3: Rewrite `ClaudeSession` in `session.ts`**
 
@@ -338,12 +338,12 @@ Key changes:
    };
    ```
 8. Remove any `this.emit(...)` calls — all event emission now goes through `sink`
-9. Import `SessionSink` from `'@mainframe/types'`
+9. Import `SessionSink` from `'@qlan-ro/mainframe-types'`
 
 **Step 4: Build the plugin to verify**
 
 ```bash
-pnpm --filter @mainframe/core build 2>&1 | grep "builtin/claude" | head -10
+pnpm --filter @qlan-ro/mainframe-core build 2>&1 | grep "builtin/claude" | head -10
 ```
 
 Expected: No errors in the claude plugin files. Remaining errors should be in `event-handler.ts` only (still calls `session.on()`).
@@ -376,7 +376,7 @@ The file has an `EventHandler` class with `attachSession(chatId, session)` and a
 The class keeps all the same constructor dependencies. The method changes from attaching listeners on a session to building and returning a `SessionSink`:
 
 ```typescript
-import type { SessionSink } from '@mainframe/types';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
 
 // BEFORE
 attachSession(chatId: string, session: AdapterSession): void {
@@ -453,7 +453,7 @@ After this change, `event-handler.ts` no longer needs `AdapterSession` (it doesn
 **Step 5: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/core build 2>&1 | grep "error TS" | head -20
+pnpm --filter @qlan-ro/mainframe-core build 2>&1 | grep "error TS" | head -20
 ```
 
 Expected: Errors only in `lifecycle-manager.ts` (calls `eventHandler.attachSession()` which no longer exists). All other source files should be clean.
@@ -525,7 +525,7 @@ Expected: zero matches after your edits.
 **Step 5: Build to verify source files are clean**
 
 ```bash
-pnpm --filter @mainframe/core build 2>&1 | grep "error TS"
+pnpm --filter @qlan-ro/mainframe-core build 2>&1 | grep "error TS"
 ```
 
 Expected: Zero errors in source files. Only test file errors remain (they still import BaseAdapter/BaseSession and call session.emit()).
@@ -563,7 +563,7 @@ import { BaseAdapter } from '../../../adapters/base.js';
 export class ClaudeAdapter extends BaseAdapter { ... }
 
 // AFTER
-import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@mainframe/types';
+import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@qlan-ro/mainframe-types';
 export class ClaudeAdapter implements Adapter { ... }
 ```
 
@@ -581,7 +581,7 @@ export { BaseAdapter } from './base.js';
 export { BaseSession } from './base-session.js';
 ```
 
-Also remove `MessageMetadata` re-export if it was there (it's now in `@mainframe/types`).
+Also remove `MessageMetadata` re-export if it was there (it's now in `@qlan-ro/mainframe-types`).
 
 **Step 3: Delete the base files**
 
@@ -593,7 +593,7 @@ rm packages/core/src/adapters/base-session.ts
 **Step 4: Create `packages/core/src/__tests__/helpers/mock-adapter.ts`**
 
 ```typescript
-import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@mainframe/types';
+import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@qlan-ro/mainframe-types';
 
 export class MockBaseAdapter implements Adapter {
   id = 'mock';
@@ -631,7 +631,7 @@ import type {
   SkillFileEntry,
   ContextFile,
   ChatMessage,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 export class MockBaseSession implements AdapterSession {
   readonly id: string;
@@ -700,7 +700,7 @@ export class MockBaseSession implements AdapterSession {
 **Step 6: Verify source build is still clean**
 
 ```bash
-pnpm --filter @mainframe/core build 2>&1 | grep "error TS"
+pnpm --filter @qlan-ro/mainframe-core build 2>&1 | grep "error TS"
 ```
 
 Expected: Only test file errors (they still import from deleted base files).
@@ -838,7 +838,7 @@ await session.spawn({}, testSink);
 **Step 6: Run each test file individually as you go**
 
 ```bash
-pnpm --filter @mainframe/core exec vitest run src/__tests__/adapter-events-flow.test.ts 2>&1 | tail -15
+pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/adapter-events-flow.test.ts 2>&1 | tail -15
 ```
 
 Fix any failures before moving to the next file.
@@ -846,7 +846,7 @@ Fix any failures before moving to the next file.
 **Step 7: Run all core tests**
 
 ```bash
-pnpm --filter @mainframe/core test 2>&1 | tail -20
+pnpm --filter @qlan-ro/mainframe-core test 2>&1 | tail -20
 ```
 
 Expected: 477/480 (same pre-existing failures only).
@@ -878,7 +878,7 @@ Expected: PASS — zero errors across all packages.
 **Step 2: Full core test run**
 
 ```bash
-pnpm --filter @mainframe/core test 2>&1 | tail -20
+pnpm --filter @qlan-ro/mainframe-core test 2>&1 | tail -20
 ```
 
 Expected: 477/480 (pre-existing title-generation failures only).

--- a/docs/plans/completed/2026-02-23-plugin-ui-zones-plan.md
+++ b/docs/plans/completed/2026-02-23-plugin-ui-zones-plan.md
@@ -112,7 +112,7 @@ grep "UIZone\|plugin" packages/types/src/index.ts
 **Step 6: Verify types compile**
 
 ```bash
-pnpm --filter @mainframe/types build
+pnpm --filter @qlan-ro/mainframe-types build
 ```
 
 Expected: `dist/` rebuilt with no errors.
@@ -138,7 +138,7 @@ git commit -m "feat(types): replace PluginPanelPosition with UIZone, add manifes
 Replace the entire file content:
 
 ```typescript
-import type { PluginUIContext, UIZone, DaemonEvent } from '@mainframe/types';
+import type { PluginUIContext, UIZone, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 export function createPluginUIContext(
   pluginId: string,
@@ -195,7 +195,7 @@ createPluginUIContext(pluginId, emitEvent)
 **Step 3: Build core to verify**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 Expected: no errors.
@@ -203,7 +203,7 @@ Expected: no errors.
 **Step 4: Run core tests**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all pass (ui-context has no tests yet; existing tests should still pass).
@@ -231,7 +231,7 @@ git commit -m "feat(core): update ui-context to use UIZone, drop pluginDir and e
 // packages/desktop/src/renderer/store/plugins.test.ts
 import { describe, it, expect, beforeEach } from 'vitest';
 import { usePluginLayoutStore } from './plugins';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 const makeContrib = (pluginId: string, zone: PluginUIContribution['zone']): PluginUIContribution => ({
   pluginId,
@@ -312,7 +312,7 @@ describe('setActiveLeftPanel / setActiveRightPanel', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/renderer/store/plugins.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/renderer/store/plugins.test.ts
 ```
 
 Expected: FAIL — "Cannot find module './plugins'"
@@ -322,7 +322,7 @@ Expected: FAIL — "Cannot find module './plugins'"
 ```typescript
 // packages/desktop/src/renderer/store/plugins.ts
 import { create } from 'zustand';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 interface PluginLayoutState {
   contributions: PluginUIContribution[];
@@ -390,7 +390,7 @@ Export from `packages/types/src/index.ts` if not already.
 **Step 5: Run test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/desktop test src/renderer/store/plugins.test.ts
+pnpm --filter @qlan-ro/mainframe-desktop test src/renderer/store/plugins.test.ts
 ```
 
 Expected: all 8 tests pass.
@@ -464,7 +464,7 @@ Adjust the import if it lives elsewhere.
 **Step 3: Build desktop to verify no type errors**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 4: Commit**
@@ -597,7 +597,7 @@ export function LeftRail(): React.ReactElement {
 **Step 2: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 3: Commit**
@@ -694,7 +694,7 @@ export function RightRail(): React.ReactElement {
 **Step 2: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 3: Commit**
@@ -908,7 +908,7 @@ export function TitleBar({ panelSizes: _panelSizes, panelCollapsed: _panelCollap
 **Step 2: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 3: Commit**
@@ -1049,7 +1049,7 @@ Remove any remaining import (there should only be one, which was in `Layout.tsx`
 **Step 4: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 5: Commit**
@@ -1128,7 +1128,7 @@ export function LeftPanel(): React.ReactElement {
 **Step 2: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 3: Commit**
@@ -1191,7 +1191,7 @@ For right-tab contributions, append to the existing `<TabsList>` and add matchin
 **Step 2: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 3: Commit**
@@ -1244,7 +1244,7 @@ Import `usePluginLayoutStore` at the top of that file.
 **Step 3: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 4: Commit**
@@ -1263,9 +1263,9 @@ git commit -m "feat(desktop): handle plugin.panel.registered WS events in layout
 **Step 1: Build all packages in order**
 
 ```bash
-pnpm --filter @mainframe/types build
-pnpm --filter @mainframe/core build
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-core build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no errors in any package.
@@ -1273,8 +1273,8 @@ Expected: no errors in any package.
 **Step 2: Run all tests**
 
 ```bash
-pnpm --filter @mainframe/core test
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-core test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all pass. The `title-generation.test.ts` tests may time out (pre-existing issue, unrelated to this work).
@@ -1345,7 +1345,7 @@ ctx.onUnload(() => ctx.ui.removePanel());
 **Step 3: Build core to verify**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 **Step 4: Commit**
@@ -1399,7 +1399,7 @@ The ternary should go straight from the "no active tab" case to `<ChatContainer 
 **Step 4: Build to verify**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -i error | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -i error | head -20
 ```
 
 **Step 5: Commit**
@@ -1420,7 +1420,7 @@ git commit -m "feat(desktop): route todos through PluginView, remove bespoke Tod
 **Step 1: Full build**
 
 ```bash
-pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build && pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build && pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: no errors.
@@ -1428,8 +1428,8 @@ Expected: no errors.
 **Step 2: Run tests**
 
 ```bash
-pnpm --filter @mainframe/core test
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-core test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 **Step 3: Manual smoke test checklist**

--- a/docs/plans/completed/2026-02-23-todo-kanban-plugin-design.md
+++ b/docs/plans/completed/2026-02-23-todo-kanban-plugin-design.md
@@ -109,7 +109,7 @@ CREATE TABLE todo_attachments (
 
 ## 4. Plugin System Changes Required
 
-### 4a. `@mainframe/types/src/plugin.ts`
+### 4a. `@qlan-ro/mainframe-types/src/plugin.ts`
 
 Add `PluginAttachmentContext`:
 

--- a/docs/plans/completed/2026-02-23-todo-kanban-plugin-plan.md
+++ b/docs/plans/completed/2026-02-23-todo-kanban-plugin-plan.md
@@ -15,7 +15,7 @@
 
 ---
 
-## Task 1: Add `PluginAttachmentContext` to `@mainframe/types`
+## Task 1: Add `PluginAttachmentContext` to `@qlan-ro/mainframe-types`
 
 **Files:**
 - Modify: `packages/types/src/plugin.ts`
@@ -55,7 +55,7 @@ In the `PluginContext` interface, after `readonly db: PluginDatabaseContext;` ad
 **Step 2: Typecheck types package**
 
 ```bash
-pnpm --filter @mainframe/types build
+pnpm --filter @qlan-ro/mainframe-types build
 ```
 Expected: No errors.
 
@@ -146,7 +146,7 @@ describe('createPluginAttachmentContext', () => {
 **Step 2: Run test — expect FAIL**
 
 ```bash
-pnpm --filter @mainframe/core test packages/core/src/__tests__/plugins/attachment-context.test.ts
+pnpm --filter @qlan-ro/mainframe-core test packages/core/src/__tests__/plugins/attachment-context.test.ts
 ```
 Expected: FAIL — "attachment-context module not found"
 
@@ -156,7 +156,7 @@ Expected: FAIL — "attachment-context module not found"
 import { mkdir, writeFile, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { nanoid } from 'nanoid';
-import type { PluginAttachmentContext, PluginAttachmentMeta } from '@mainframe/types';
+import type { PluginAttachmentContext, PluginAttachmentMeta } from '@qlan-ro/mainframe-types';
 
 interface AttachmentRecord {
   id: string;
@@ -234,7 +234,7 @@ export function createPluginAttachmentContext(baseDir: string): PluginAttachment
 **Step 4: Run test — expect PASS**
 
 ```bash
-pnpm --filter @mainframe/core test packages/core/src/__tests__/plugins/attachment-context.test.ts
+pnpm --filter @qlan-ro/mainframe-core test packages/core/src/__tests__/plugins/attachment-context.test.ts
 ```
 Expected: All 5 tests pass.
 
@@ -318,7 +318,7 @@ it('provides attachments when storage capability is declared', () => {
 **Step 4: Run context tests**
 
 ```bash
-pnpm --filter @mainframe/core test packages/core/src/__tests__/plugins/context.test.ts
+pnpm --filter @qlan-ro/mainframe-core test packages/core/src/__tests__/plugins/context.test.ts
 ```
 Expected: All tests pass.
 
@@ -341,7 +341,7 @@ git commit -m "feat(core): wire ctx.attachments into PluginContext, add pluginDi
 
 At the top of `chat-service.ts`, change the import to include `DaemonEvent`:
 ```typescript
-import type { ChatServiceAPI, ChatSummary, PluginManifest, DaemonEvent } from '@mainframe/types';
+import type { ChatServiceAPI, ChatSummary, PluginManifest, DaemonEvent } from '@qlan-ro/mainframe-types';
 ```
 
 Change `buildChatService` signature to:
@@ -381,7 +381,7 @@ const chatService = buildChatService(manifest, deps.db, deps.emitEvent);
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: No errors.
 
@@ -428,7 +428,7 @@ import { pino } from 'pino';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 import request from 'supertest';
 import express from 'express';
 
@@ -532,14 +532,14 @@ describe('todos plugin routes', () => {
 **Step 3: Run test — expect FAIL**
 
 ```bash
-pnpm --filter @mainframe/core test packages/core/src/__tests__/plugins/builtin/todos.test.ts
+pnpm --filter @qlan-ro/mainframe-core test packages/core/src/__tests__/plugins/builtin/todos.test.ts
 ```
 Expected: FAIL — module not found.
 
 **Step 4: Create `packages/core/src/plugins/builtin/todos/index.ts`**
 
 ```typescript
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
@@ -718,7 +718,7 @@ export function activate(ctx: PluginContext): void {
 **Step 5: Run test — expect PASS**
 
 ```bash
-pnpm --filter @mainframe/core test packages/core/src/__tests__/plugins/builtin/todos.test.ts
+pnpm --filter @qlan-ro/mainframe-core test packages/core/src/__tests__/plugins/builtin/todos.test.ts
 ```
 Expected: All 5 tests pass.
 
@@ -763,7 +763,7 @@ import { mkdirSync } from 'node:fs';
 **Step 4: Build core**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 Expected: No errors.
 
@@ -821,7 +821,7 @@ const tabs = (raw.tabs ?? []).filter((t) => t.type === 'chat' || t.type === 'tod
 **Step 5: Run desktop tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 Expected: All existing tests pass. (Tabs store tests may need a quick scan — todos tab has a fixed id `'todos'` and is deduped by the existing `openTab` logic.)
 
@@ -867,7 +867,7 @@ import { useTabsStore } from '../store/tabs';
 **Step 4: Typecheck desktop**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: No type errors.
 
@@ -1109,7 +1109,7 @@ export function TodoCard({ todo, onMove, onEdit, onDelete, onStartSession }: Pro
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | head -30
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | head -30
 ```
 Expected: No errors in this file.
 
@@ -1430,7 +1430,7 @@ export function TodosPanel(): React.ReactElement {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | grep -E "error|Error" | head -20
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | grep -E "error|Error" | head -20
 ```
 Expected: No errors.
 
@@ -1474,7 +1474,7 @@ Change to:
 **Step 3: Run typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 Expected: No errors. If there are type issues with the discriminated union, cast `activePrimaryTab` explicitly using the narrowed type check.
 
@@ -1499,14 +1499,14 @@ Expected: All packages build with no type errors.
 **Step 2: Run core tests**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 Expected: All tests pass. Coverage thresholds met.
 
 **Step 3: Run desktop tests**
 
 ```bash
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 Expected: All tests pass.
 
@@ -1515,7 +1515,7 @@ Expected: All tests pass.
 Follow test output. Common issues:
 - Missing `afterEach` import in attachment test — add `import { afterEach } from 'vitest'`
 - CenterPanel type narrowing — use `activePrimaryTab.type === 'chat'` guard
-- `supertest` not installed — run `pnpm --filter @mainframe/core add -D supertest @types/supertest`
+- `supertest` not installed — run `pnpm --filter @qlan-ro/mainframe-core add -D supertest @types/supertest`
 
 **Step 5: Final commit**
 
@@ -1531,7 +1531,7 @@ git commit -m "chore: fix typecheck and test issues for todos plugin"
 **Step 1: Build and start**
 
 ```bash
-pnpm build && pnpm --filter @mainframe/desktop start
+pnpm build && pnpm --filter @qlan-ro/mainframe-desktop start
 ```
 
 **Step 2: Verify the Tasks button**

--- a/docs/plans/completed/2026-02-24-todos-kanban-redesign.md
+++ b/docs/plans/completed/2026-02-24-todos-kanban-redesign.md
@@ -182,7 +182,7 @@ After the rewrite, `PRIORITY_COLORS` is deleted (replaced by `PRIORITY_PILL`). V
 **Step 4: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop tsc --noEmit
+pnpm --filter @qlan-ro/mainframe-desktop tsc --noEmit
 ```
 
 Expected: no errors.

--- a/docs/plans/completed/2026-02-25-directory-browser-plan.md
+++ b/docs/plans/completed/2026-02-25-directory-browser-plan.md
@@ -28,7 +28,7 @@ export const BrowseFilesystemQuery = z.object({
 
 **Step 2: Verify types build**
 
-Run: `pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build`
 Expected: PASS
 
 **Step 3: Commit**
@@ -117,7 +117,7 @@ describe('GET /api/filesystem/browse', () => {
 
 **Step 2: Run tests to verify they fail**
 
-Run: `pnpm --filter @mainframe/core test -- --reporter=verbose packages/core/src/__tests__/routes/files.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose packages/core/src/__tests__/routes/files.test.ts`
 Expected: FAIL — `No handler for GET /api/filesystem/browse`
 
 **Step 3: Write the handler and register route**
@@ -168,7 +168,7 @@ router.get(
 
 **Step 4: Run tests to verify they pass**
 
-Run: `pnpm --filter @mainframe/core test -- --reporter=verbose packages/core/src/__tests__/routes/files.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose packages/core/src/__tests__/routes/files.test.ts`
 Expected: PASS (note: the home-dir validation test may need adjustment since the temp dir may be under `/tmp` not `~/` — mock `homedir` or use a temp dir under `~/`)
 
 **Step 5: Commit**
@@ -208,7 +208,7 @@ Add `browseFilesystem` to the `files-api` export block in `packages/desktop/src/
 
 **Step 3: Verify types build**
 
-Run: `pnpm --filter @mainframe/desktop build` (or just typecheck)
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build` (or just typecheck)
 Expected: PASS
 
 **Step 4: Commit**
@@ -410,7 +410,7 @@ export function DirectoryPickerModal({ open, onSelect, onCancel }: DirectoryPick
 
 **Step 2: Verify types build**
 
-Run: `pnpm --filter @mainframe/desktop build` (or typecheck)
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build` (or typecheck)
 Expected: PASS
 
 **Step 3: Commit**
@@ -479,7 +479,7 @@ Add modal at the end of the returned JSX, before the closing `</div>`:
 
 **Step 2: Verify types build and manual test**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: PASS
 
 Manual test: Open `dev:web` in browser, click project dropdown → "Add project" → modal opens, browse directories, select one → project created.
@@ -523,7 +523,7 @@ Run: `grep -r "openDirectoryDialog" packages/desktop/src/` — should return no 
 
 **Step 5: Verify types build**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: PASS
 
 **Step 6: Commit**
@@ -539,13 +539,13 @@ git commit -m "refactor(desktop): remove Electron openDirectoryDialog IPC"
 
 **Step 1: Run all tests**
 
-Run: `pnpm --filter @mainframe/core test && pnpm --filter @mainframe/desktop test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test && pnpm --filter @qlan-ro/mainframe-desktop test`
 Expected: PASS
 
 **Step 2: Manual test — browser mode**
 
 1. Start daemon: `pnpm dev:core`
-2. Start web: `pnpm --filter @mainframe/desktop run dev:web`
+2. Start web: `pnpm --filter @qlan-ro/mainframe-desktop run dev:web`
 3. Open `http://localhost:5173` in browser
 4. Click project dropdown → "Add project"
 5. Modal opens with home directory contents
@@ -555,7 +555,7 @@ Expected: PASS
 **Step 3: Manual test — Electron mode**
 
 1. Start daemon: `pnpm dev:core`
-2. Start Electron: `pnpm --filter @mainframe/desktop run dev`
+2. Start Electron: `pnpm --filter @qlan-ro/mainframe-desktop run dev`
 3. Same flow as above — modal works identically
 
 **Step 4: Verify path traversal is blocked**

--- a/docs/plans/completed/2026-02-25-sandbox-design.md
+++ b/docs/plans/completed/2026-02-25-sandbox-design.md
@@ -73,7 +73,7 @@ A new **bottom panel** sits below the existing left/center/right panel row and s
 
 ### Daemon — Process Management
 
-New routes under `@mainframe/core`:
+New routes under `@qlan-ro/mainframe-core`:
 
 | Route | Purpose |
 |-------|---------|
@@ -172,13 +172,13 @@ type LaunchProcessStatus = 'stopped' | 'starting' | 'running' | 'failed';
 
 | Package | Path | Purpose |
 |---------|------|---------|
-| `@mainframe/core` | `src/launch/launch-manager.ts` | Spawn, track, stream launch processes |
-| `@mainframe/core` | `src/launch/launch-config.ts` | Read/validate `launch.json` |
-| `@mainframe/core` | `src/server/routes/launch.ts` | Express routes for launch API |
-| `@mainframe/types` | `src/launch.ts` | Shared launch types |
-| `@mainframe/desktop` | `src/main/sandbox.ts` | IPC handlers: inject, screenshot, capture |
-| `@mainframe/desktop` | `src/renderer/components/sandbox/` | BottomPanel, PreviewTab, LogsTab |
-| `@mainframe/desktop` | `src/renderer/store/sandbox.ts` | Capture stack Zustand store |
+| `@qlan-ro/mainframe-core` | `src/launch/launch-manager.ts` | Spawn, track, stream launch processes |
+| `@qlan-ro/mainframe-core` | `src/launch/launch-config.ts` | Read/validate `launch.json` |
+| `@qlan-ro/mainframe-core` | `src/server/routes/launch.ts` | Express routes for launch API |
+| `@qlan-ro/mainframe-types` | `src/launch.ts` | Shared launch types |
+| `@qlan-ro/mainframe-desktop` | `src/main/sandbox.ts` | IPC handlers: inject, screenshot, capture |
+| `@qlan-ro/mainframe-desktop` | `src/renderer/components/sandbox/` | BottomPanel, PreviewTab, LogsTab |
+| `@qlan-ro/mainframe-desktop` | `src/renderer/store/sandbox.ts` | Capture stack Zustand store |
 
 ---
 

--- a/docs/plans/completed/2026-02-25-sandbox-launch-ui-plan.md
+++ b/docs/plans/completed/2026-02-25-sandbox-launch-ui-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the "Preview" toggle button in StatusBar with a split button + popover launcher, and merge log output into the bottom panel as a collapsible strip below the webview.
 
-**Architecture:** UI-only changes in `@mainframe/desktop`. No backend changes needed — process start/stop already works via `startLaunchConfig`/`stopLaunchConfig` in `lib/launch.ts`. Process statuses flow in via WebSocket events into the sandbox Zustand store.
+**Architecture:** UI-only changes in `@qlan-ro/mainframe-desktop`. No backend changes needed — process start/stop already works via `startLaunchConfig`/`stopLaunchConfig` in `lib/launch.ts`. Process statuses flow in via WebSocket events into the sandbox Zustand store.
 
 **Tech Stack:** React 18, TypeScript strict/NodeNext, Zustand, Tailwind CSS
 
@@ -38,7 +38,7 @@ clearLogsForProcess: (name) =>
 
 **Step 4: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors.
 
@@ -62,7 +62,7 @@ git commit -m "feat(desktop): add clearLogsForProcess to sandbox store"
 Create `packages/desktop/src/renderer/hooks/useLaunchConfig.ts`:
 ```typescript
 import { useEffect, useState } from 'react';
-import type { LaunchConfig } from '@mainframe/types';
+import type { LaunchConfig } from '@qlan-ro/mainframe-types';
 import { useProjectsStore } from '../store/projects';
 
 export function useLaunchConfig(): LaunchConfig | null {
@@ -91,7 +91,7 @@ export function useLaunchConfig(): LaunchConfig | null {
 
 **Step 2: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors.
 
@@ -119,7 +119,7 @@ import { useSandboxStore } from '../../store/sandbox';
 import { useProjectsStore } from '../../store/projects';
 import { startLaunchConfig, stopLaunchConfig } from '../../lib/launch';
 import { useLaunchConfig } from '../../hooks/useLaunchConfig';
-import type { LaunchConfiguration } from '@mainframe/types';
+import type { LaunchConfiguration } from '@qlan-ro/mainframe-types';
 
 interface Props {
   onClose: () => void;
@@ -220,7 +220,7 @@ export function LaunchPopover({ onClose }: Props): React.ReactElement {
 
 **Step 2: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors.
 
@@ -336,7 +336,7 @@ Replace with:
 
 **Step 5: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors.
 
@@ -392,7 +392,7 @@ export function BottomPanel(): React.ReactElement | null {
 
 **Step 4: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors and no remaining references to `bottomPanelTab`, `setBottomPanelTab`, or `LogsTab`.
 
@@ -420,7 +420,7 @@ Read `packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx`. Note the
 
 Remove:
 ```typescript
-import type { LaunchConfig } from '@mainframe/types';
+import type { LaunchConfig } from '@qlan-ro/mainframe-types';
 import { useProjectsStore } from '../../store/projects';
 ```
 
@@ -569,7 +569,7 @@ After the closing `</div>` of the webview wrapper, add the log strip:
 
 **Step 6: Typecheck**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -5
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -5
 ```
 Expected: no errors.
 
@@ -585,13 +585,13 @@ git commit -m "feat(desktop): add log strip to PreviewTab"
 
 **Step 1: Full build**
 ```bash
-pnpm --filter @mainframe/desktop build 2>&1 | tail -10
+pnpm --filter @qlan-ro/mainframe-desktop build 2>&1 | tail -10
 ```
 Expected: clean build, no TypeScript errors.
 
 **Step 2: Run desktop tests**
 ```bash
-pnpm --filter @mainframe/desktop test 2>&1 | tail -20
+pnpm --filter @qlan-ro/mainframe-desktop test 2>&1 | tail -20
 ```
 Expected: all tests pass (no desktop component tests exist, but the build itself is the verification).
 

--- a/docs/plans/completed/2026-02-25-sandbox-plan.md
+++ b/docs/plans/completed/2026-02-25-sandbox-plan.md
@@ -84,7 +84,7 @@ export * from './launch.js';
 **Step 4: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/types build
+pnpm --filter @qlan-ro/mainframe-types build
 ```
 
 Expected: clean build, no errors.
@@ -179,7 +179,7 @@ describe('getPreviewUrl', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose launch-config
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose launch-config
 ```
 
 Expected: FAIL with "Cannot find module '../launch/launch-config.js'"
@@ -188,7 +188,7 @@ Expected: FAIL with "Cannot find module '../launch/launch-config.js'"
 
 ```typescript
 import { z } from 'zod';
-import type { LaunchConfig, LaunchConfiguration } from '@mainframe/types';
+import type { LaunchConfig, LaunchConfiguration } from '@qlan-ro/mainframe-types';
 
 // Allowed executables: common package managers + node. No shell operators.
 const SAFE_EXECUTABLE = /^(node|pnpm|npm|yarn|bun|python|python3|[a-zA-Z0-9_\-./]+)$/;
@@ -239,7 +239,7 @@ export function getPreviewUrl(configurations: LaunchConfiguration[]): string | n
 **Step 4: Run test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose launch-config
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose launch-config
 ```
 
 Expected: all 7 tests pass.
@@ -266,7 +266,7 @@ git commit -m "feat(core): add launch-config parser with Zod validation"
 // packages/core/src/__tests__/launch-manager.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LaunchManager } from '../launch/launch-manager.js';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 
 const ECHO_CONFIG = {
   version: '0.0.1',
@@ -358,7 +358,7 @@ describe('LaunchManager', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose launch-manager
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose launch-manager
 ```
 
 Expected: FAIL with "Cannot find module"
@@ -368,7 +368,7 @@ Expected: FAIL with "Cannot find module"
 ```typescript
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import type { DaemonEvent, LaunchConfiguration, LaunchProcessStatus } from '@mainframe/types';
+import type { DaemonEvent, LaunchConfiguration, LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 import { createChildLogger } from '../logger.js';
 
 const log = createChildLogger('launch');
@@ -496,7 +496,7 @@ export { parseLaunchConfig, getPreviewUrl } from './launch-config.js';
 **Step 5: Run test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose launch-manager
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose launch-manager
 ```
 
 Expected: all 5 tests pass.
@@ -613,7 +613,7 @@ describe('launchRoutes', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose routes/launch
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose routes/launch
 ```
 
 Expected: FAIL with "Cannot find module"
@@ -701,7 +701,7 @@ export function launchRoutes(ctx: RouteContext): Router {
 **Step 4: Run test to verify it passes**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose routes/launch
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose routes/launch
 ```
 
 Expected: all 4 tests pass.
@@ -729,7 +729,7 @@ git commit -m "feat(core): add launch API routes for dev server process control"
 A simple registry that creates one `LaunchManager` per project.
 
 ```typescript
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { LaunchManager } from './launch-manager.js';
 
 export class LaunchRegistry {
@@ -847,7 +847,7 @@ launchRegistry.stopAll();
 **Step 7: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-core build
 ```
 
 Expected: clean build.
@@ -890,7 +890,7 @@ webPreferences: {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean build.
@@ -978,7 +978,7 @@ export { useSandboxStore } from './sandbox.js';
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean build.
@@ -1024,7 +1024,7 @@ bottomPanelTab: 'preview',
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean build. Fix any type errors from the changed union.
@@ -1082,7 +1082,7 @@ export async function stopLaunchConfig(projectId: string, name: string): Promise
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 **Step 3: Commit**
@@ -1175,7 +1175,7 @@ const togglePanel = useUIStore((s) => s.togglePanel);
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean build (stub `PreviewTab` and `LogsTab` with placeholder if needed).
@@ -1391,7 +1391,7 @@ export function PreviewTab(): React.ReactElement {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean (the `@ts-expect-error` handles the `<webview>` typing).
@@ -1539,7 +1539,7 @@ export function LogsTab(): React.ReactElement {
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 **Step 3: Commit**
@@ -1581,7 +1581,7 @@ case 'launch.status': {
 **Step 3: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 **Step 4: Commit**
@@ -1679,7 +1679,7 @@ client.sendMessage(chatId, finalContent, allAttachmentIds.length > 0 ? allAttach
 **Step 4: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop build
+pnpm --filter @qlan-ro/mainframe-desktop build
 ```
 
 Expected: clean build.
@@ -1698,7 +1698,7 @@ git commit -m "feat(desktop): integrate capture stack into chat composer"
 **Step 1: Run all core tests**
 
 ```bash
-pnpm --filter @mainframe/core test
+pnpm --filter @qlan-ro/mainframe-core test
 ```
 
 Expected: all pass.

--- a/docs/plans/completed/2026-02-26-launch-env-daemon-endpoint.md
+++ b/docs/plans/completed/2026-02-26-launch-env-daemon-endpoint.md
@@ -44,7 +44,7 @@ it('rejects env with non-uppercase key', () => {
 **Step 2: Run to verify failure**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose src/__tests__/launch-config.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose src/__tests__/launch-config.test.ts
 ```
 Expected: both new tests FAIL (env field unknown to Zod / type error).
 
@@ -98,7 +98,7 @@ env: z
 **Step 2: Run tests**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose src/__tests__/launch-config.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose src/__tests__/launch-config.test.ts
 ```
 Expected: all tests pass.
 
@@ -146,7 +146,7 @@ it('passes env vars to the spawned process', async () => {
 **Step 2: Run to verify failure**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose src/__tests__/launch-manager.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose src/__tests__/launch-manager.test.ts
 ```
 Expected: new test FAIL — output contains "missing", not "hello-from-env".
 
@@ -184,7 +184,7 @@ env: {
 **Step 4: Run tests**
 
 ```bash
-pnpm --filter @mainframe/core test -- --reporter=verbose src/__tests__/launch-manager.test.ts
+pnpm --filter @qlan-ro/mainframe-core test -- --reporter=verbose src/__tests__/launch-manager.test.ts
 ```
 Expected: all pass.
 
@@ -217,7 +217,7 @@ No test needed — this is a pure config change with no runtime logic to verify 
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop exec tsc --noEmit 2>&1 | grep -v TS6305
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit 2>&1 | grep -v TS6305
 ```
 Expected: no new errors.
 
@@ -254,7 +254,7 @@ const WS_URL = `ws://${host}:${wsPort}`;
 **Step 2: Typecheck**
 
 ```bash
-pnpm --filter @mainframe/desktop exec tsc --noEmit 2>&1 | grep -v TS6305
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit 2>&1 | grep -v TS6305
 ```
 Expected: no new errors.
 
@@ -281,7 +281,7 @@ git commit -m "feat(desktop): read daemon WS host/port from VITE_* env vars"
     {
       "name": "Core Daemon",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/core", "run", "dev"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-core", "run", "dev"],
       "port": 31416,
       "url": null,
       "env": {
@@ -291,7 +291,7 @@ git commit -m "feat(desktop): read daemon WS host/port from VITE_* env vars"
     {
       "name": "Desktop App",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/desktop", "run", "dev:web"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-desktop", "run", "dev:web"],
       "port": 5174,
       "url": null,
       "preview": true,
@@ -303,7 +303,7 @@ git commit -m "feat(desktop): read daemon WS host/port from VITE_* env vars"
     {
       "name": "Types Watch",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@mainframe/types", "run", "dev"],
+      "runtimeArgs": ["--filter", "@qlan-ro/mainframe-types", "run", "dev"],
       "port": null,
       "url": null
     }
@@ -332,8 +332,8 @@ git commit -m "feat: configure sandbox isolation via launch.json env vars"
 ### Task 7: Run full test suites
 
 ```bash
-pnpm --filter @mainframe/core test
-pnpm --filter @mainframe/desktop test
+pnpm --filter @qlan-ro/mainframe-core test
+pnpm --filter @qlan-ro/mainframe-desktop test
 ```
 
 Expected: all tests pass, no regressions.

--- a/docs/plans/completed/2026-02-26-logging-panel-redesign.md
+++ b/docs/plans/completed/2026-02-26-logging-panel-redesign.md
@@ -43,7 +43,7 @@ Ensure the store initializes with `panelVisible: false` so panel is hidden by de
 
 **Step 4: Run typecheck to verify no errors**
 
-Run: `pnpm --filter @mainframe/desktop typecheck`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck`
 
 Expected: No TS errors related to `panelVisible`.
 
@@ -97,7 +97,7 @@ const setPanelVisible = useUIStore((s) => s.setPanelVisible);
 
 **Step 3: Run typecheck**
 
-Run: `pnpm --filter @mainframe/desktop typecheck`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck`
 
 Expected: No TS errors.
 
@@ -162,7 +162,7 @@ In PreviewTab header, change the minimize button to:
 
 **Step 4: Run typecheck**
 
-Run: `pnpm --filter @mainframe/desktop typecheck`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck`
 
 Expected: No TS errors.
 
@@ -283,7 +283,7 @@ To:
 
 **Step 3: Run typecheck**
 
-Run: `pnpm --filter @mainframe/desktop typecheck`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck`
 
 Expected: No TS errors.
 
@@ -406,7 +406,7 @@ Around line 244 where the webview renders, add:
 
 **Step 3: Run typecheck**
 
-Run: `pnpm --filter @mainframe/desktop typecheck`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck`
 
 Expected: No TS errors.
 
@@ -430,13 +430,13 @@ git commit -m "feat(desktop): show 'No preview available' for processes without 
 
 **Step 1: Verify UI store changes compile and work**
 
-Run: `pnpm --filter @mainframe/desktop typecheck && pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop typecheck && pnpm --filter @qlan-ro/mainframe-desktop build`
 
 Expected: No errors.
 
 **Step 2: Run existing tests (if any)**
 
-Run: `pnpm --filter @mainframe/desktop test`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test`
 
 Expected: All tests pass.
 

--- a/docs/plans/completed/2026-02-27-custom-commands-design.md
+++ b/docs/plans/completed/2026-02-27-custom-commands-design.md
@@ -136,7 +136,7 @@ interface CustomCommand {
 }
 ```
 
-Added to `@mainframe/types` as the canonical command type.
+Added to `@qlan-ro/mainframe-types` as the canonical command type.
 
 ### 6. Data Flow
 

--- a/docs/plans/completed/2026-02-27-custom-commands-plan.md
+++ b/docs/plans/completed/2026-02-27-custom-commands-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add CustomCommand type to @mainframe/types
+### Task 1: Add CustomCommand type to @qlan-ro/mainframe-types
 
 **Files:**
 - Create: `packages/types/src/command.ts`
@@ -43,7 +43,7 @@ export * from './command.js';
 
 **Step 3: Build types package**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: Clean build, no errors.
 
 **Step 4: Commit**
@@ -94,7 +94,7 @@ In `packages/core/src/plugins/builtin/claude/manifest.json`, add the `commands` 
 
 **Step 3: Build types package**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: Clean build.
 
 **Step 4: Commit**
@@ -134,11 +134,11 @@ listCommands(): CustomCommand[] {
 }
 ```
 
-Import `CustomCommand` from `@mainframe/types` and import `manifest` from `./manifest.json`.
+Import `CustomCommand` from `@qlan-ro/mainframe-types` and import `manifest` from `./manifest.json`.
 
 **Step 3: Build**
 
-Run: `pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build`
 Expected: Clean build.
 
 **Step 4: Commit**
@@ -160,7 +160,7 @@ git commit -m "feat: add Adapter.listCommands() and implement for Claude"
 Create `packages/core/src/commands/registry.ts`:
 
 ```typescript
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 /**
  * Static registry of Mainframe-defined custom commands.
@@ -175,7 +175,7 @@ export function getMainframeCommands(): CustomCommand[] {
 
 **Step 2: Build**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: Clean build.
 
 **Step 3: Commit**
@@ -231,7 +231,7 @@ describe('GET /api/commands', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- src/server/routes/__tests__/commands.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/server/routes/__tests__/commands.test.ts`
 Expected: FAIL — module not found.
 
 **Step 3: Create the route**
@@ -243,7 +243,7 @@ import { Router } from 'express';
 import type { RouteContext } from './types.js';
 import { getMainframeCommands } from '../../commands/registry.js';
 import { asyncHandler } from './async-handler.js';
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 export function commandRoutes(ctx: RouteContext): Router {
   const router = Router();
@@ -291,7 +291,7 @@ app.use(commandRoutes(ctx));
 
 **Step 6: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- src/server/routes/__tests__/commands.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/server/routes/__tests__/commands.test.ts`
 Expected: PASS.
 
 **Step 7: Commit**
@@ -354,7 +354,7 @@ Note: The exact test setup depends on how ChatManager is constructed. Look at ex
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- src/chat/__tests__/command-routing.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/chat/__tests__/command-routing.test.ts`
 Expected: FAIL.
 
 **Step 3: Extend MessageSend schema**
@@ -445,12 +445,12 @@ function wrapMainframeCommand(name: string, _content: string, args?: string): st
 
 **Step 6: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- src/chat/__tests__/command-routing.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/chat/__tests__/command-routing.test.ts`
 Expected: PASS.
 
 **Step 7: Build**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: Clean build.
 
 **Step 8: Commit**
@@ -497,7 +497,7 @@ describe('stripMainframeCommandTags', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- src/messages/__tests__/message-parsing.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/messages/__tests__/message-parsing.test.ts`
 Expected: FAIL — function not exported.
 
 **Step 3: Implement**
@@ -521,7 +521,7 @@ export function stripMainframeCommandTags(text: string): string {
 
 **Step 4: Run test**
 
-Run: `pnpm --filter @mainframe/core test -- src/messages/__tests__/message-parsing.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/messages/__tests__/message-parsing.test.ts`
 Expected: PASS.
 
 **Step 5: Commit**
@@ -545,7 +545,7 @@ git commit -m "feat(core): add stripMainframeCommandTags for response extraction
 
 ```typescript
 import { fetchJson, API_BASE } from './http';
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 export async function getCommands(): Promise<CustomCommand[]> {
   const json = await fetchJson<{ success: boolean; data: CustomCommand[] }>(
@@ -575,7 +575,7 @@ Add a `fetchCommands` action that calls `getCommands()` and sets `commands`. Cal
 
 **Step 4: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Clean build.
 
 **Step 5: Commit**
@@ -608,7 +608,7 @@ type PickerItem =
   | { type: 'command'; command: CustomCommand };
 ```
 
-Import `CustomCommand` from `@mainframe/types`.
+Import `CustomCommand` from `@qlan-ro/mainframe-types`.
 
 **Step 2: Pull commands from store**
 
@@ -664,7 +664,7 @@ Import `Wrench` from `lucide-react`.
 
 **Step 6: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Clean build.
 
 **Step 7: Commit**
@@ -744,7 +744,7 @@ Pull `commands` from `useSkillsStore()` in the provider component.
 
 **Step 4: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Clean build.
 
 **Step 5: Commit**
@@ -809,7 +809,7 @@ Import `Wrench` from `lucide-react`. Pass `commands` from the skills store to `p
 
 **Step 3: Build**
 
-Run: `pnpm --filter @mainframe/core build && pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build && pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Clean build.
 
 **Step 4: Commit**
@@ -842,7 +842,7 @@ useEffect(() => {
 
 **Step 2: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Clean build.
 
 **Step 3: Commit**
@@ -868,8 +868,8 @@ Expected: All tests pass (new tests + existing).
 
 **Step 3: Manual smoke test**
 
-1. Start the daemon: `pnpm --filter @mainframe/core dev`
-2. Start the desktop: `pnpm --filter @mainframe/desktop dev`
+1. Start the daemon: `pnpm --filter @qlan-ro/mainframe-core dev`
+2. Start the desktop: `pnpm --filter @qlan-ro/mainframe-desktop dev`
 3. Open a project, start a chat.
 4. Type `/` in the composer — verify `/clear` and `/compact` appear with wrench icons alongside skills.
 5. Select `/compact` — verify it sends and the CLI processes it (context compacted).

--- a/docs/plans/completed/2026-02-28-display-message-pipeline-design.md
+++ b/docs/plans/completed/2026-02-28-display-message-pipeline-design.md
@@ -21,7 +21,7 @@ Message transformations are scattered across daemon and desktop:
 
 Raw `MessageCache` stays unchanged. A `prepareMessagesForClient()` pipeline transforms raw messages into `DisplayMessage[]` on demand when serving via REST or WS. This avoids a second cache and keeps the raw cache as the single source of truth.
 
-## 1. New Types (`@mainframe/types`)
+## 1. New Types (`@qlan-ro/mainframe-types`)
 
 ```typescript
 // Display-ready content blocks — superset of raw MessageContent

--- a/docs/plans/completed/2026-02-28-display-message-pipeline-plan.md
+++ b/docs/plans/completed/2026-02-28-display-message-pipeline-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Move all message transformations from the desktop to the daemon so clients receive display-ready messages.
 
-**Architecture:** A `prepareMessagesForClient()` pipeline in `@mainframe/core/messages` transforms raw `ChatMessage[]` into `DisplayMessage[]`. The daemon runs this pipeline when serving messages via REST and when emitting WS events. The desktop becomes a thin mapper from `DisplayMessage` to the UI framework's `ThreadMessageLike`.
+**Architecture:** A `prepareMessagesForClient()` pipeline in `@qlan-ro/mainframe-core/messages` transforms raw `ChatMessage[]` into `DisplayMessage[]`. The daemon runs this pipeline when serving messages via REST and when emitting WS events. The desktop becomes a thin mapper from `DisplayMessage` to the UI framework's `ThreadMessageLike`.
 
 **Tech Stack:** TypeScript, Node.js, Vitest, React, assistant-ui, pnpm workspaces
 
@@ -29,7 +29,7 @@ Expected: clean working tree on `feat/display-message-pipeline`
 
 ---
 
-### Task 2: Add DisplayMessage types to `@mainframe/types`
+### Task 2: Add DisplayMessage types to `@qlan-ro/mainframe-types`
 
 **Files:**
 - Create: `packages/types/src/display.ts`
@@ -83,7 +83,7 @@ describe('DisplayMessage types', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/types test -- --run display-types`
+Run: `pnpm --filter @qlan-ro/mainframe-types test -- --run display-types`
 Expected: FAIL — module `../display.js` not found
 
 **Step 3: Create the types file**
@@ -134,12 +134,12 @@ Modify: `packages/types/src/index.ts` — add `export * from './display.js';`
 
 **Step 5: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/types test -- --run display-types`
+Run: `pnpm --filter @qlan-ro/mainframe-types test -- --run display-types`
 Expected: PASS
 
 **Step 6: Typecheck**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: no errors
 
 **Step 7: Commit**
@@ -164,7 +164,7 @@ In `packages/types/src/adapter.ts`, add to the `Adapter` interface (after line 1
   getToolCategories?(): import('./tool-categorization.js').ToolCategories;
 ```
 
-Wait — `ToolCategories` is defined in `@mainframe/core`, not `@mainframe/types`. We need to either:
+Wait — `ToolCategories` is defined in `@qlan-ro/mainframe-core`, not `@qlan-ro/mainframe-types`. We need to either:
 - Move `ToolCategories` to types, OR
 - Define a simpler version in types
 
@@ -188,7 +188,7 @@ export interface ToolCategories {
 Modify: `packages/core/src/messages/tool-categorization.ts` — change to import and re-export from types:
 
 ```typescript
-export type { ToolCategories } from '@mainframe/types';
+export type { ToolCategories } from '@qlan-ro/mainframe-types';
 // keep predicate functions as-is
 ```
 
@@ -202,7 +202,7 @@ In `packages/types/src/adapter.ts`, add to the `Adapter` interface after `killAl
 
 **Step 2: Typecheck**
 
-Run: `pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build`
 Expected: no errors (ClaudeAdapter already has `getToolCategories()` — it now satisfies the interface)
 
 **Step 3: Commit**
@@ -231,7 +231,7 @@ Add to the `DaemonEvent` union in `packages/types/src/events.ts`:
 
 **Step 2: Typecheck**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: no errors
 
 **Step 3: Commit**
@@ -278,7 +278,7 @@ Test helper structure:
 ```typescript
 import { describe, it, expect, beforeEach } from 'vitest';
 import { prepareMessagesForClient } from '../../messages/display-pipeline.js';
-import type { ChatMessage, MessageContent, ToolCategories } from '@mainframe/types';
+import type { ChatMessage, MessageContent, ToolCategories } from '@qlan-ro/mainframe-types';
 
 let idCounter = 0;
 function resetIds() { idCounter = 0; }
@@ -309,7 +309,7 @@ const CATEGORIES: ToolCategories = {
 
 **Step 2: Run tests to verify they fail**
 
-Run: `pnpm --filter @mainframe/core test -- --run display-pipeline`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run display-pipeline`
 Expected: FAIL — module not found
 
 **Step 3: Implement `prepareMessagesForClient()`**
@@ -343,7 +343,7 @@ If `categories` is not provided, all tools get `category: 'default'` and no grou
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- --run display-pipeline`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run display-pipeline`
 Expected: PASS
 
 **Step 5: Export from index**
@@ -356,7 +356,7 @@ export { prepareMessagesForClient } from './display-pipeline.js';
 
 **Step 6: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 7: Commit**
 
@@ -402,8 +402,8 @@ const messages = await ctx.chats.getDisplayMessages(param(req, 'id'));
 
 **Step 4: Run tests and typecheck**
 
-Run: `pnpm --filter @mainframe/core test -- --run` (relevant tests)
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run` (relevant tests)
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 **Step 5: Commit**
 
@@ -473,7 +473,7 @@ git commit -m "feat(core): emit display.message events from event handler"
 In `packages/desktop/src/renderer/store/chats.ts`:
 - Change `messages: Map<string, ChatMessage[]>` to `messages: Map<string, DisplayMessage[]>`
 - Update `addMessage` and `setMessages` signatures
-- Import `DisplayMessage` from `@mainframe/types`
+- Import `DisplayMessage` from `@qlan-ro/mainframe-types`
 - Remove `ChatMessage` import if no longer needed
 
 **Step 2: Update WS event router**
@@ -505,7 +505,7 @@ updateMessage: (chatId, message) =>
 
 **Step 3: Typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 
@@ -532,7 +532,7 @@ The hook should work with `DisplayMessage[]` now. The types flow from the store.
 
 **Step 3: Typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 
@@ -555,7 +555,7 @@ This is where the desktop sheds most of its message transformation logic.
 Remove:
 - `CLAUDE_CATEGORIES` constant (lines 14-28)
 - `getToolCategoriesForAdapter` function (lines 31-34)
-- Imports of `groupMessages`, `GroupedMessage`, `ToolGroupItem`, `TaskProgressItem`, `PartEntry`, `ToolCategories`, `groupToolCallParts`, `groupTaskChildren` from `@mainframe/core/messages`
+- Imports of `groupMessages`, `GroupedMessage`, `ToolGroupItem`, `TaskProgressItem`, `PartEntry`, `ToolCategories`, `groupToolCallParts`, `groupTaskChildren` from `@qlan-ro/mainframe-core/messages`
 - Re-exports on line 40
 
 **Step 2: Rewrite convertMessage for DisplayMessage**
@@ -564,7 +564,7 @@ The function now maps `DisplayMessage` → `ThreadMessageLike`. It's much simple
 
 ```typescript
 import type { ThreadMessageLike } from '@assistant-ui/react';
-import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 export const ERROR_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_ERROR__' });
 export const PERMISSION_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_PERMISSION__' });
@@ -688,7 +688,7 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
 
 **Step 3: Typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 
@@ -717,7 +717,7 @@ Components that call `getExternalStoreMessages<ChatMessage>` should use `getExte
 
 **Step 3: Typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 
@@ -759,7 +759,7 @@ Replace `parsed` references with `command`, replace `parsedFileTags` with `attac
 
 **Step 4: Typecheck**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 5: Commit**
 
@@ -804,7 +804,7 @@ Modify `packages/core/src/__tests__/message-loading.test.ts`:
 
 **Step 3: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- --run message-loading`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run message-loading`
 
 **Step 4: Commit**
 
@@ -839,7 +839,7 @@ Keep: `PLAN_PREFIX`, `highlightMentions`, `renderHighlights`, `formatTurnDuratio
 
 **Step 3: Typecheck both packages**
 
-Run: `pnpm --filter @mainframe/core build && pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build && pnpm --filter @qlan-ro/mainframe-desktop build`
 
 **Step 4: Commit**
 

--- a/docs/plans/completed/2026-03-01-desktop-ux-improvements-design.md
+++ b/docs/plans/completed/2026-03-01-desktop-ux-improvements-design.md
@@ -7,7 +7,7 @@ Four small, self-contained UX improvements to the desktop app.
 The Claude adapter spawns `'claude'` via PATH lookup. Users with non-standard installations need to specify the full path.
 
 **Changes:**
-- Add `executablePath?: string` to `ProviderConfig` in `@mainframe/types`
+- Add `executablePath?: string` to `ProviderConfig` in `@qlan-ro/mainframe-types`
 - Add "Executable Path" text input in Provider settings section
 - Adapter uses `config.executablePath || 'claude'` for spawn and `isInstalled()` calls
 

--- a/docs/plans/completed/2026-03-01-e2e-composer-status-tests-plan.md
+++ b/docs/plans/completed/2026-03-01-e2e-composer-status-tests-plan.md
@@ -53,7 +53,7 @@ Apply these edits to `ChatSessionBar.tsx`:
 
 **Step 2: Verify build**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Build succeeds.
 
 **Step 3: Commit**
@@ -431,7 +431,7 @@ Expected: All 13 tests pass (3 + 6 + 4).
 
 **Step 2: Typecheck the desktop package**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: Build succeeds.
 
 **Step 3: Create PR**

--- a/docs/plans/completed/2026-03-03-sandbox-tunneling-plan.md
+++ b/docs/plans/completed/2026-03-03-sandbox-tunneling-plan.md
@@ -25,7 +25,7 @@ In `packages/types/src/events.ts`, add after the `launch.status` line (line 32):
 
 **Step 2: Build types package**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: Clean build, no errors
 
 **Step 3: Commit**
@@ -70,7 +70,7 @@ if (process.env['TUNNEL_URL']) {
 
 **Step 3: Build core**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: Clean build
 
 **Step 4: Commit**
@@ -133,7 +133,7 @@ describe('TunnelManager', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core test -- src/__tests__/tunnel/tunnel-manager.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/__tests__/tunnel/tunnel-manager.test.ts`
 Expected: FAIL — module not found
 
 **Step 3: Implement TunnelManager**
@@ -256,7 +256,7 @@ export { TunnelManager } from './tunnel-manager.js';
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core test -- src/__tests__/tunnel/tunnel-manager.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/__tests__/tunnel/tunnel-manager.test.ts`
 Expected: PASS
 
 **Step 5: Commit**
@@ -333,7 +333,7 @@ Add `tunnelUrl?: string | null` to `RouteContext` in `packages/core/src/server/r
 
 **Step 3: Build and verify**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: Clean build
 
 **Step 4: Commit**
@@ -442,8 +442,8 @@ const launchRegistry = new LaunchRegistry((event) => broadcastEvent(event), tunn
 
 **Step 7: Run tests, build, commit**
 
-Run: `pnpm --filter @mainframe/core test -- src/__tests__/launch/`
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- src/__tests__/launch/`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 
 ```bash
 git add packages/core/src/launch/ packages/core/src/index.ts packages/core/src/__tests__/launch/
@@ -637,7 +637,7 @@ Or if preferred, add to a separate barrel in `packages/core/src/tunnel/index.ts`
 **Step 2: Final build and typecheck**
 
 Run: `pnpm build`
-Run: `pnpm --filter @mainframe/core test`
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
 Expected: All pass
 
 **Step 3: Commit**

--- a/docs/plans/completed/2026-03-04-mobile-context-picker-plan.md
+++ b/docs/plans/completed/2026-03-04-mobile-context-picker-plan.md
@@ -19,7 +19,7 @@
 
 ```typescript
 // After existing imports, add:
-import type { CustomCommand, Skill, AgentConfig } from '@mainframe/types';
+import type { CustomCommand, Skill, AgentConfig } from '@qlan-ro/mainframe-types';
 
 // After existing exports, add:
 
@@ -136,7 +136,7 @@ git commit -m "feat(mobile): forward command metadata through sendMessage chain"
 ```typescript
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { getCommands, getSkills, getAgents, searchFiles } from '../lib/api';
-import type { CustomCommand, Skill, AgentConfig } from '@mainframe/types';
+import type { CustomCommand, Skill, AgentConfig } from '@qlan-ro/mainframe-types';
 
 export type PickerItem =
   | { type: 'skill'; name: string; displayName: string; invocationName: string; description: string; scope: string; source: string }

--- a/docs/plans/completed/2026-03-04-permission-sync-plan.md
+++ b/docs/plans/completed/2026-03-04-permission-sync-plan.md
@@ -25,7 +25,7 @@ In `packages/types/src/events.ts`, add after the `permission.requested` line (li
 
 **Step 2: Build types package**
 
-Run: `pnpm --filter @mainframe/types build`
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
 Expected: clean build
 
 **Step 3: Commit**
@@ -169,7 +169,7 @@ it('rejects stale permission response with mismatched requestId', async () => {
 
 **Step 5: Run tests**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/permission-flow.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/permission-flow.test.ts`
 Expected: all tests pass
 
 **Step 6: Commit**
@@ -206,7 +206,7 @@ case 'permission.resolved': {
 
 **Step 2: Build desktop**
 
-Run: `pnpm --filter @mainframe/desktop build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
 Expected: clean build
 
 **Step 3: Commit**
@@ -258,7 +258,7 @@ Replace the `respondToPermission` callback in `packages/mobile/hooks/useChatSess
 const respondToPermission = useCallback(
   (
     behavior: 'allow' | 'deny',
-    alwaysAllow?: import('@mainframe/types').ControlUpdate[],
+    alwaysAllow?: import('@qlan-ro/mainframe-types').ControlUpdate[],
     overrideInput?: Record<string, unknown>,
     message?: string,
     executionMode?: string,
@@ -291,7 +291,7 @@ const respondToPermission = useCallback(
 The hook return type changes. Update the `ControlResponse` import to also import `ControlUpdate`:
 
 ```typescript
-import type { ControlResponse, ControlUpdate, DisplayMessage } from '@mainframe/types';
+import type { ControlResponse, ControlUpdate, DisplayMessage } from '@qlan-ro/mainframe-types';
 ```
 
 Remove `ControlResponse` from the import if it's no longer used directly (the callback now takes individual params instead of a full `ControlResponse` object).
@@ -318,7 +318,7 @@ import { useState } from 'react';
 import { View, Text, TouchableOpacity, Pressable } from 'react-native';
 import { ShieldAlert, ChevronDown, ChevronUp } from 'lucide-react-native';
 import * as Haptics from 'expo-haptics';
-import type { ControlRequest, ControlUpdate } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 
 interface PermissionCardProps {
   request: ControlRequest;
@@ -435,7 +435,7 @@ import { useState, useCallback } from 'react';
 import { View, Text, TouchableOpacity, TextInput, ScrollView, Pressable } from 'react-native';
 import { HelpCircle, Check } from 'lucide-react-native';
 import * as Haptics from 'expo-haptics';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 
 interface Question {
   question: string;
@@ -663,7 +663,7 @@ import { useState, useCallback } from 'react';
 import { View, Text, TouchableOpacity, TextInput, ScrollView } from 'react-native';
 import { ClipboardList } from 'lucide-react-native';
 import * as Haptics from 'expo-haptics';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 import { MarkdownText } from './MarkdownText';
 
 interface AllowedPrompt {
@@ -840,7 +840,7 @@ interface MessageListProps {
   pendingPermission: ControlRequest | null;
   onRespondToPermission: (
     behavior: 'allow' | 'deny',
-    alwaysAllow?: import('@mainframe/types').ControlUpdate[],
+    alwaysAllow?: import('@qlan-ro/mainframe-types').ControlUpdate[],
     overrideInput?: Record<string, unknown>,
     message?: string,
     executionMode?: string,
@@ -913,7 +913,7 @@ Expected: clean build
 
 **Step 2: Run core tests**
 
-Run: `pnpm --filter @mainframe/core test -- --run src/__tests__/permission-flow.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- --run src/__tests__/permission-flow.test.ts`
 Expected: all pass including new guard + resolved tests
 
 **Step 3: Commit all together if any fixes needed**

--- a/docs/plans/completed/2026-03-04-sandbox-multi-launch-plan.md
+++ b/docs/plans/completed/2026-03-04-sandbox-multi-launch-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** `react-native-pager-view` provides native horizontal swipe between pages. Each page is a self-contained component (`PreviewPage` or `ConsolePage`) that manages its own content. The header updates dynamically based on the active page index.
 
-**Tech Stack:** React Native, Expo, react-native-pager-view, zustand, @mainframe/types
+**Tech Stack:** React Native, Expo, react-native-pager-view, zustand, @qlan-ro/mainframe-types
 
 ---
 

--- a/docs/plans/completed/2026-03-05-daemon-distribution-plan.md
+++ b/docs/plans/completed/2026-03-05-daemon-distribution-plan.md
@@ -68,7 +68,7 @@ Import `ensureAuthSecret` from `'./config.js'`.
 
 **Step 4: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: compiles with no errors
 
 **Step 5: Commit**
@@ -142,7 +142,7 @@ describe('DevicesRepository', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core vitest run src/db/__tests__/devices.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core vitest run src/db/__tests__/devices.test.ts`
 Expected: FAIL — `DevicesRepository` does not exist
 
 **Step 3: Write `DevicesRepository`**
@@ -195,7 +195,7 @@ export class DevicesRepository {
 
 **Step 4: Run test to verify it passes**
 
-Run: `pnpm --filter @mainframe/core vitest run src/db/__tests__/devices.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core vitest run src/db/__tests__/devices.test.ts`
 Expected: PASS (4 tests)
 
 **Step 5: Add table to schema**
@@ -221,7 +221,7 @@ In `packages/core/src/db/index.ts`:
 
 **Step 7: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: compiles with no errors
 
 **Step 8: Commit**
@@ -292,7 +292,7 @@ describe('device endpoints', () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `pnpm --filter @mainframe/core vitest run src/server/routes/__tests__/auth.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core vitest run src/server/routes/__tests__/auth.test.ts`
 Expected: FAIL — `devicesRepo` option not accepted, endpoints don't exist
 
 **Step 3: Update auth routes**
@@ -333,7 +333,7 @@ router.delete('/api/auth/devices/:deviceId', (req, res) => {
 
 **Step 4: Run tests**
 
-Run: `pnpm --filter @mainframe/core vitest run src/server/routes/__tests__/auth.test.ts`
+Run: `pnpm --filter @qlan-ro/mainframe-core vitest run src/server/routes/__tests__/auth.test.ts`
 Expected: ALL PASS
 
 **Step 5: Wire `devicesRepo` in `http.ts`**
@@ -346,7 +346,7 @@ app.use(authRoutes({ pushService, devicesRepo: db.devices }));
 
 **Step 6: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: compiles with no errors
 
 **Step 7: Commit**
@@ -366,8 +366,8 @@ feat(core): persist paired devices in SQLite, add list/revoke endpoints
 
 **Step 1: Install `qrcode-terminal`**
 
-Run: `pnpm --filter @mainframe/core add qrcode-terminal`
-Run: `pnpm --filter @mainframe/core add -D @types/qrcode-terminal` (if types exist; otherwise add a `declare module` in a `.d.ts`)
+Run: `pnpm --filter @qlan-ro/mainframe-core add qrcode-terminal`
+Run: `pnpm --filter @qlan-ro/mainframe-core add -D @types/qrcode-terminal` (if types exist; otherwise add a `declare module` in a `.d.ts`)
 
 **Step 2: Create `cli/pair.ts`**
 
@@ -530,13 +530,13 @@ if (subcommand === 'pair') {
 
 **Step 5: Typecheck**
 
-Run: `pnpm --filter @mainframe/core build`
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
 Expected: compiles with no errors
 
 **Step 6: Manual smoke test**
 
 Run: `pnpm dev:core` in one terminal.
-Run: `pnpm --filter @mainframe/core exec tsx src/index.ts status` in another terminal.
+Run: `pnpm --filter @qlan-ro/mainframe-core exec tsx src/index.ts status` in another terminal.
 Expected: prints daemon status with port 31415.
 
 **Step 7: Commit**
@@ -586,7 +586,7 @@ RUN pnpm install --frozen-lockfile
 COPY packages/types/ packages/types/
 COPY packages/core/ packages/core/
 COPY packages/desktop/scripts/bundle-daemon.mjs packages/desktop/scripts/
-RUN pnpm --filter @mainframe/types build && pnpm --filter @mainframe/core build
+RUN pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build
 RUN node packages/desktop/scripts/bundle-daemon.mjs
 
 # Stage 2: Runtime
@@ -811,8 +811,8 @@ rm -rf "$DIST_DIR"
 mkdir -p "${DIST_DIR}/bin" "${DIST_DIR}/lib"
 
 # 1. Bundle daemon
-pnpm --filter @mainframe/types build
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-core build
 node packages/desktop/scripts/bundle-daemon.mjs
 cp packages/desktop/resources/daemon.cjs "${DIST_DIR}/lib/"
 
@@ -941,7 +941,7 @@ ci: add standalone binary build and release workflow
 
 ---
 
-### Task 9: Unprivate `@mainframe/core` for npm publish (optional)
+### Task 9: Unprivate `@qlan-ro/mainframe-core` for npm publish (optional)
 
 **Files:**
 - Modify: `packages/core/package.json`
@@ -990,7 +990,7 @@ This keeps the existing behavior for the desktop build while allowing the standa
 
 **Step 2: Typecheck desktop build still works**
 
-Run: `pnpm --filter @mainframe/desktop run build`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop run build`
 Expected: daemon.cjs is created in `packages/desktop/resources/`
 
 **Step 3: Commit**

--- a/docs/plans/completed/2026-03-05-file-viewing-improvements-plan.md
+++ b/docs/plans/completed/2026-03-05-file-viewing-improvements-plan.md
@@ -154,7 +154,7 @@ In `packages/desktop/src/renderer/components/panels/ContextTab.tsx`, remove `cha
 
 ### Step 5: Typecheck
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 
 ### Step 6: Commit
 
@@ -293,7 +293,7 @@ Key changes:
 
 ### Step 2: Typecheck
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 
 ### Step 3: Commit
 
@@ -385,7 +385,7 @@ Export it from `packages/desktop/src/renderer/lib/api/index.ts` if not auto-expo
 
 ### Step 3: Typecheck
 
-Run: `pnpm --filter @mainframe/core exec tsc --noEmit && pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit && pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 
 ### Step 4: Commit
 
@@ -822,7 +822,7 @@ export function FileViewContent(): React.ReactElement | null {
 
 ### Step 2: Typecheck
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit && pnpm --filter @mainframe/core exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit && pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit`
 
 ### Step 3: Commit
 
@@ -844,6 +844,6 @@ Run: `pnpm build`
 
 ### Step 2: Verify no broken imports
 
-Run: `pnpm --filter @mainframe/desktop exec tsc --noEmit`
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
 
 ### Step 3: Commit any fixups if needed

--- a/package.json
+++ b/package.json
@@ -13,20 +13,20 @@
     "url": "https://github.com/qlan-ro/mainframe/issues"
   },
   "scripts": {
-    "dev": "pnpm --filter @mainframe/core run dev & sleep 2 && pnpm --filter @mainframe/desktop run dev",
-    "dev:core": "pnpm --filter @mainframe/core run dev",
-    "dev:desktop": "pnpm --filter @mainframe/desktop run dev",
+    "dev": "pnpm --filter @qlan-ro/mainframe-core run dev & sleep 2 && pnpm --filter @qlan-ro/mainframe-desktop run dev",
+    "dev:core": "pnpm --filter @qlan-ro/mainframe-core run dev",
+    "dev:desktop": "pnpm --filter @qlan-ro/mainframe-desktop run dev",
     "build": "pnpm -r run build",
-    "build:types": "pnpm --filter @mainframe/types run build",
-    "build:core": "pnpm --filter @mainframe/core run build",
-    "build:desktop": "pnpm --filter @mainframe/desktop run build",
+    "build:types": "pnpm --filter @qlan-ro/mainframe-types run build",
+    "build:core": "pnpm --filter @qlan-ro/mainframe-core run build",
+    "build:desktop": "pnpm --filter @qlan-ro/mainframe-desktop run build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "pnpm -r run lint",
-    "test": "pnpm -r --filter=!@mainframe/e2e run test",
-    "test:e2e": "pnpm --filter @mainframe/e2e test",
+    "test": "pnpm -r --filter=!@qlan-ro/mainframe-e2e run test",
+    "test:e2e": "pnpm --filter @qlan-ro/mainframe-e2e test",
     "clean": "pnpm -r run clean",
-    "package": "pnpm build && pnpm --filter @mainframe/desktop run package",
+    "package": "pnpm build && pnpm --filter @qlan-ro/mainframe-desktop run package",
     "version": "pnpm -r version --no-git-tag-version $npm_new_version && git add -A",
     "prepare": "husky"
   },
@@ -47,7 +47,8 @@
       "esbuild"
     ],
     "overrides": {
-      "tar": ">=7.5.7"
+      "tar": ">=7.5.7",
+      "@qlan-ro/mainframe-types": "workspace:*"
     }
   },
   "lint-staged": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mainframe/core",
+  "name": "@qlan-ro/mainframe-core",
   "version": "0.2.0",
   "description": "Mainframe daemon — session lifecycle, agent process management, and metadata storage",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "status": "node dist/index.js status"
   },
   "dependencies": {
-    "@mainframe/types": "workspace:*",
+    "@qlan-ro/mainframe-types": "workspace:*",
     "better-sqlite3": "^12.6.2",
     "express": "^5.0.0",
     "nanoid": "^5.0.4",

--- a/packages/core/src/__tests__/adapter-events-flow.test.ts
+++ b/packages/core/src/__tests__/adapter-events-flow.test.ts
@@ -7,7 +7,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
   constructor(private adapter: MockAdapter) {

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Adapter, AdapterModel } from '@mainframe/types';
+import type { Adapter, AdapterModel } from '@qlan-ro/mainframe-types';
 import { AdapterRegistry } from '../adapters/index.js';
 import { ClaudeAdapter } from '../plugins/builtin/claude/adapter.js';
 

--- a/packages/core/src/__tests__/chat-resume.test.ts
+++ b/packages/core/src/__tests__/chat-resume.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { createServer, type Server } from 'node:http';
 import { WebSocket } from 'ws';
 import { WebSocketManager } from '../server/websocket.js';
-import type { Chat } from '@mainframe/types';
+import type { Chat } from '@qlan-ro/mainframe-types';
 import { EventEmitter } from 'node:events';
 
 // ── Mock ChatManager ────────────────────────────────────────────────

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { handleStdout, handleStderr } from '../plugins/builtin/claude/events.js';
 import { ClaudeSession } from '../plugins/builtin/claude/session.js';
-import type { SessionSink } from '@mainframe/types';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
 
 function createSession() {
   return new ClaudeSession({ projectPath: '/tmp', chatId: '' });

--- a/packages/core/src/__tests__/context-tracker.test.ts
+++ b/packages/core/src/__tests__/context-tracker.test.ts
@@ -5,7 +5,7 @@ import {
   extractPlanFilePathFromText,
   extractLatestPlanFileFromMessages,
 } from '../chat/context-tracker.js';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 function makeDb(addMentionReturn = true, addModifiedFileReturn = true) {
   return {

--- a/packages/core/src/__tests__/control-requests.test.ts
+++ b/packages/core/src/__tests__/control-requests.test.ts
@@ -12,7 +12,7 @@ import type {
   SessionOptions,
   SessionSpawnOptions,
   ChatMessage,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 // ── Helpers: capture stdin writes from ClaudeSession ────────────────
 

--- a/packages/core/src/__tests__/daemon-restart-messages.test.ts
+++ b/packages/core/src/__tests__/daemon-restart-messages.test.ts
@@ -7,7 +7,13 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { ChatMessage, MessageContent, AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type {
+  ChatMessage,
+  MessageContent,
+  AdapterSession,
+  SessionOptions,
+  DaemonEvent,
+} from '@qlan-ro/mainframe-types';
 
 // ── Mock Session ─────────────────────────────────────────────────────
 

--- a/packages/core/src/__tests__/event-handler-display.test.ts
+++ b/packages/core/src/__tests__/event-handler-display.test.ts
@@ -3,7 +3,7 @@ import { EventHandler } from '../chat/event-handler.js';
 import { MessageCache } from '../chat/message-cache.js';
 import { PermissionManager } from '../chat/permission-manager.js';
 import { AdapterRegistry } from '../adapters/index.js';
-import type { DaemonEvent, SessionSink } from '@mainframe/types';
+import type { DaemonEvent, SessionSink } from '@qlan-ro/mainframe-types';
 
 function createRespondToPermission() {
   return vi.fn().mockResolvedValue(undefined);

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -3,7 +3,7 @@ import { EventHandler } from '../chat/event-handler.js';
 import { MessageCache } from '../chat/message-cache.js';
 import { PermissionManager } from '../chat/permission-manager.js';
 import { AdapterRegistry } from '../adapters/index.js';
-import type { SessionSink } from '@mainframe/types';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
 
 function createRespondToPermission() {
   return vi.fn().mockResolvedValue(undefined);

--- a/packages/core/src/__tests__/event-pipeline-parity.test.ts
+++ b/packages/core/src/__tests__/event-pipeline-parity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildToolResultBlocks, convertHistoryEntry } from '../plugins/builtin/claude/history.js';
-import type { ToolResultMessageContent } from '@mainframe/types';
+import type { ToolResultMessageContent } from '@qlan-ro/mainframe-types';
 
 /**
  * Ensures that tool_result blocks produced by history loading and live stream

--- a/packages/core/src/__tests__/external-session-service.test.ts
+++ b/packages/core/src/__tests__/external-session-service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { initializeSchema } from '../db/schema.js';
 import { ExternalSessionService } from '../chat/external-session-service.js';
-import type { Adapter, ExternalSession, DaemonEvent } from '@mainframe/types';
+import type { Adapter, ExternalSession, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { AdapterRegistry } from '../adapters/index.js';
 import { ChatsRepository } from '../db/chats.js';
 import { ProjectsRepository } from '../db/projects.js';

--- a/packages/core/src/__tests__/file-edit-flow.test.ts
+++ b/packages/core/src/__tests__/file-edit-flow.test.ts
@@ -7,7 +7,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
   constructor(private adapter: MockAdapter) {

--- a/packages/core/src/__tests__/helpers/mock-adapter.ts
+++ b/packages/core/src/__tests__/helpers/mock-adapter.ts
@@ -1,4 +1,4 @@
-import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@mainframe/types';
+import type { Adapter, AdapterSession, AdapterModel, SessionOptions } from '@qlan-ro/mainframe-types';
 import { MockBaseSession } from './mock-session.js';
 
 export class MockBaseAdapter implements Adapter {

--- a/packages/core/src/__tests__/helpers/mock-session.ts
+++ b/packages/core/src/__tests__/helpers/mock-session.ts
@@ -11,7 +11,7 @@ import type {
   MessageMetadata,
   ControlRequest,
   SessionResult,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 export class MockBaseSession implements AdapterSession {
   readonly id: string;

--- a/packages/core/src/__tests__/launch-manager.test.ts
+++ b/packages/core/src/__tests__/launch-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LaunchManager } from '../launch/launch-manager.js';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 
 const ECHO_CONFIG = {
   version: '0.0.1',

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { prepareMessagesForClient } from '../../messages/display-pipeline.js';
-import type { ChatMessage, MessageContent, ToolCategories } from '@mainframe/types';
+import type { ChatMessage, MessageContent, ToolCategories } from '@qlan-ro/mainframe-types';
 
 /* ── helpers ─────────────────────────────────────────────────────── */
 

--- a/packages/core/src/__tests__/messages/message-grouping.test.ts
+++ b/packages/core/src/__tests__/messages/message-grouping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { groupMessages, type GroupedMessage } from '../../messages/message-grouping.js';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 /* ── helpers ─────────────────────────────────────────────────────── */
 

--- a/packages/core/src/__tests__/permission-flow.test.ts
+++ b/packages/core/src/__tests__/permission-flow.test.ts
@@ -7,7 +7,13 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent, ControlRequest } from '@mainframe/types';
+import type {
+  ControlResponse,
+  AdapterSession,
+  SessionOptions,
+  DaemonEvent,
+  ControlRequest,
+} from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
   constructor(private adapter: MockAdapter) {

--- a/packages/core/src/__tests__/permission-manager.test.ts
+++ b/packages/core/src/__tests__/permission-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PermissionManager } from '../chat/permission-manager.js';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(overrides: Partial<ControlRequest> = {}): ControlRequest {
   return {

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PlanModeHandler, type PlanModeContext } from '../chat/plan-mode-handler.js';
-import type { Chat, ControlResponse } from '@mainframe/types';
+import type { Chat, ControlResponse } from '@qlan-ro/mainframe-types';
 import type { ActiveChat } from '../chat/types.js';
 
 function makeChat(overrides: Partial<Chat> = {}): Chat {

--- a/packages/core/src/__tests__/plugins/builtin/todos.test.ts
+++ b/packages/core/src/__tests__/plugins/builtin/todos.test.ts
@@ -7,7 +7,7 @@ import { pino } from 'pino';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 import request from 'supertest';
 import express from 'express';
 

--- a/packages/core/src/__tests__/plugins/context.test.ts
+++ b/packages/core/src/__tests__/plugins/context.test.ts
@@ -3,7 +3,7 @@ import { buildPluginContext, type PluginContextDeps } from '../../plugins/contex
 import { EventEmitter } from 'node:events';
 import { Router } from 'express';
 import { pino } from 'pino';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 
 const baseManifest: PluginManifest = {
   id: 'test-plugin',

--- a/packages/core/src/__tests__/restore-permission.test.ts
+++ b/packages/core/src/__tests__/restore-permission.test.ts
@@ -11,7 +11,7 @@ import type {
   SessionOptions,
   SessionSpawnOptions,
   AdapterProcess,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 // ── Minimal mock session & adapter ──────────────────────────────────
 

--- a/packages/core/src/__tests__/send-message-flow.test.ts
+++ b/packages/core/src/__tests__/send-message-flow.test.ts
@@ -7,7 +7,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type { AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
   constructor(private adapter: MockAdapter) {

--- a/packages/core/src/__tests__/title-generation.test.ts
+++ b/packages/core/src/__tests__/title-generation.test.ts
@@ -3,7 +3,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { ChatMessage, AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type { ChatMessage, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 // ── Mock adapter & DB (infrastructure, not what we're testing) ──────
 

--- a/packages/core/src/__tests__/ws-inbound-flow.test.ts
+++ b/packages/core/src/__tests__/ws-inbound-flow.test.ts
@@ -7,7 +7,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
-import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@mainframe/types';
+import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
   constructor(private adapter: MockAdapter) {

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -1,4 +1,4 @@
-import type { Adapter, AdapterInfo } from '@mainframe/types';
+import type { Adapter, AdapterInfo } from '@qlan-ro/mainframe-types';
 
 export class AdapterRegistry {
   private adapters = new Map<string, Adapter>();

--- a/packages/core/src/chat/__tests__/command-routing.test.ts
+++ b/packages/core/src/chat/__tests__/command-routing.test.ts
@@ -3,7 +3,7 @@ import { ChatManager } from '../index.js';
 import { wrapMainframeCommand } from '../../commands/wrap.js';
 import { MockBaseSession } from '../../__tests__/helpers/mock-session.js';
 import { MockBaseAdapter } from '../../__tests__/helpers/mock-adapter.js';
-import type { AdapterSession, SessionOptions } from '@mainframe/types';
+import type { AdapterSession, SessionOptions } from '@qlan-ro/mainframe-types';
 
 // ── wrapMainframeCommand unit tests ──────────────────────────────────────────
 

--- a/packages/core/src/chat/attachment-processor.ts
+++ b/packages/core/src/chat/attachment-processor.ts
@@ -1,4 +1,4 @@
-import type { MessageContent } from '@mainframe/types';
+import type { MessageContent } from '@qlan-ro/mainframe-types';
 import type { AttachmentStore } from '../attachment/index.js';
 import { buildAttachedFilePathTag } from '../attachment/index.js';
 

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -7,7 +7,7 @@ import type {
   DisplayMessage,
   SessionMention,
   SessionContext,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -1,5 +1,5 @@
-import type { Chat, DaemonEvent } from '@mainframe/types';
-import { GENERAL_DEFAULTS } from '@mainframe/types';
+import type { Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { DatabaseManager } from '../db/index.js';
 import { createWorktree, removeWorktree } from '../workspace/index.js';

--- a/packages/core/src/chat/context-tracker.ts
+++ b/packages/core/src/chat/context-tracker.ts
@@ -1,6 +1,12 @@
 import { nanoid } from 'nanoid';
 import { relative, isAbsolute } from 'node:path';
-import type { MessageContent, SessionMention, SessionContext, ChatMessage, AdapterSession } from '@mainframe/types';
+import type {
+  MessageContent,
+  SessionMention,
+  SessionContext,
+  ChatMessage,
+  AdapterSession,
+} from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';

--- a/packages/core/src/chat/display-emitter.ts
+++ b/packages/core/src/chat/display-emitter.ts
@@ -1,4 +1,4 @@
-import type { DaemonEvent, DisplayMessage, ToolCategories } from '@mainframe/types';
+import type { DaemonEvent, DisplayMessage, ToolCategories } from '@qlan-ro/mainframe-types';
 import type { MessageCache } from './message-cache.js';
 import { prepareMessagesForClient } from '../messages/display-pipeline.js';
 

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -7,7 +7,7 @@ import type {
   SkillFileEntry,
   MessageMetadata,
   ToolCategories,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -1,4 +1,4 @@
-import type { Chat, DaemonEvent, ExternalSession } from '@mainframe/types';
+import type { Chat, DaemonEvent, ExternalSession } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import { createChildLogger } from '../logger.js';

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -1,4 +1,4 @@
-import type { Chat, DaemonEvent, SessionSink, ControlResponse } from '@mainframe/types';
+import type { Chat, DaemonEvent, SessionSink, ControlResponse } from '@qlan-ro/mainframe-types';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
 import type { DatabaseManager } from '../db/index.js';

--- a/packages/core/src/chat/message-cache.ts
+++ b/packages/core/src/chat/message-cache.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 const MAX_MESSAGES_PER_CHAT = 2000;
 const MAX_CHATS = 50;

--- a/packages/core/src/chat/permission-handler.ts
+++ b/packages/core/src/chat/permission-handler.ts
@@ -1,4 +1,4 @@
-import type { Chat, ChatMessage, ControlRequest, ControlResponse, DaemonEvent } from '@mainframe/types';
+import type { Chat, ChatMessage, ControlRequest, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { PlanModeHandler } from './plan-mode-handler.js';

--- a/packages/core/src/chat/permission-manager.ts
+++ b/packages/core/src/chat/permission-manager.ts
@@ -1,4 +1,4 @@
-import type { Chat, ChatMessage, ControlRequest, DaemonEvent, AdapterProcess } from '@mainframe/types';
+import type { Chat, ChatMessage, ControlRequest, DaemonEvent, AdapterProcess } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 

--- a/packages/core/src/chat/plan-mode-handler.ts
+++ b/packages/core/src/chat/plan-mode-handler.ts
@@ -1,4 +1,4 @@
-import type { Chat, ControlResponse, DaemonEvent } from '@mainframe/types';
+import type { Chat, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { MessageCache } from './message-cache.js';

--- a/packages/core/src/chat/types.ts
+++ b/packages/core/src/chat/types.ts
@@ -1,4 +1,4 @@
-import type { Chat, AdapterSession } from '@mainframe/types';
+import type { Chat, AdapterSession } from '@qlan-ro/mainframe-types';
 
 export interface ActiveChat {
   chat: Chat;

--- a/packages/core/src/commands/registry.ts
+++ b/packages/core/src/commands/registry.ts
@@ -1,4 +1,4 @@
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 const LAUNCH_CONFIG_PROMPT = `\
 Analyze this project and generate a .mainframe/launch.json file that defines how to run its development processes.

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import type { Chat, SessionMention, SkillFileEntry } from '@mainframe/types';
+import type { Chat, SessionMention, SkillFileEntry } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 
 function parseJsonColumn<T>(value: string | null | undefined, fallback: T): T {

--- a/packages/core/src/db/devices.ts
+++ b/packages/core/src/db/devices.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import type { Device } from '@mainframe/types';
+import type { Device } from '@qlan-ro/mainframe-types';
 
 export class DevicesRepository {
   constructor(private db: Database.Database) {}

--- a/packages/core/src/db/projects.ts
+++ b/packages/core/src/db/projects.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import type { Project } from '@mainframe/types';
+import type { Project } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 import { basename } from 'node:path';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ import { activate as activateClaude } from './plugins/builtin/claude/index.js';
 import todosManifest from './plugins/builtin/todos/manifest.json' with { type: 'json' };
 import { activate as activateTodos } from './plugins/builtin/todos/index.js';
 import { logger } from './logger.js';
-import type { DaemonEvent, PluginManifest } from '@mainframe/types';
+import type { DaemonEvent, PluginManifest } from '@qlan-ro/mainframe-types';
 
 async function main(): Promise<void> {
   const config = getConfig();

--- a/packages/core/src/launch/launch-config.ts
+++ b/packages/core/src/launch/launch-config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { LaunchConfig, LaunchConfiguration } from '@mainframe/types';
+import type { LaunchConfig, LaunchConfiguration } from '@qlan-ro/mainframe-types';
 
 // Allowed executables: common package managers + node. No shell operators.
 const SAFE_EXECUTABLE = /^(node|pnpm|npm|yarn|bun|python|python3|[a-zA-Z0-9_\-./]+)$/;

--- a/packages/core/src/launch/launch-manager.ts
+++ b/packages/core/src/launch/launch-manager.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { homedir } from 'node:os';
-import type { DaemonEvent, LaunchConfiguration, LaunchProcessStatus } from '@mainframe/types';
+import type { DaemonEvent, LaunchConfiguration, LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 import { createChildLogger } from '../logger.js';
 import type { TunnelManager } from '../tunnel/tunnel-manager.js';
 

--- a/packages/core/src/launch/launch-registry.ts
+++ b/packages/core/src/launch/launch-registry.ts
@@ -1,4 +1,4 @@
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { TunnelManager } from '../tunnel/index.js';
 import { LaunchManager } from './launch-manager.js';
 

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -1,4 +1,4 @@
-import type { MessageContent, ToolCategories, DisplayContent, ToolCallResult } from '@mainframe/types';
+import type { MessageContent, ToolCategories, DisplayContent, ToolCallResult } from '@qlan-ro/mainframe-types';
 import { stripMainframeCommandTags, parseCommandMessage, parseAttachedFilePathTags } from './message-parsing.js';
 import type { GroupedMessage } from './message-grouping.js';
 import type { PartEntry } from './tool-grouping.js';

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ToolCategories, DisplayMessage } from '@mainframe/types';
+import type { ChatMessage, ToolCategories, DisplayMessage } from '@qlan-ro/mainframe-types';
 import { groupMessages } from './message-grouping.js';
 import {
   isInternalUserMessage,

--- a/packages/core/src/messages/message-grouping.ts
+++ b/packages/core/src/messages/message-grouping.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, MessageContent } from '@mainframe/types';
+import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 
 export interface GroupedMessage extends ChatMessage {
   _toolResults?: Map<string, MessageContent & { type: 'tool_result' }>;

--- a/packages/core/src/messages/message-parsing.ts
+++ b/packages/core/src/messages/message-parsing.ts
@@ -1,4 +1,4 @@
-import type { Skill } from '@mainframe/types';
+import type { Skill } from '@qlan-ro/mainframe-types';
 
 // TODO: Big, the parsing in this class is mostly related to a specific implementation (Claude), I feel like all Claude related classes should live under adapters/claude/
 export const COMMAND_NAME_RE = /<command-name>\/?([^<]*)<\/command-name>/;

--- a/packages/core/src/messages/tool-categorization.ts
+++ b/packages/core/src/messages/tool-categorization.ts
@@ -1,7 +1,7 @@
 /* ── Adapter-declared tool categorization ──────────────────────── */
 
-import type { ToolCategories } from '@mainframe/types';
-export type { ToolCategories } from '@mainframe/types';
+import type { ToolCategories } from '@qlan-ro/mainframe-types';
+export type { ToolCategories } from '@qlan-ro/mainframe-types';
 
 export function isExploreTool(name: string, categories: ToolCategories): boolean {
   return categories.explore.has(name);

--- a/packages/core/src/plugins/attachment-context.ts
+++ b/packages/core/src/plugins/attachment-context.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { join, basename } from 'node:path';
 import { nanoid } from 'nanoid';
-import type { PluginAttachmentContext, PluginAttachmentMeta } from '@mainframe/types';
+import type { PluginAttachmentContext, PluginAttachmentMeta } from '@qlan-ro/mainframe-types';
 
 interface AttachmentRecord {
   id: string;

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -10,7 +10,7 @@ import type {
   AgentConfig,
   CreateSkillInput,
   CreateAgentInput,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 import { ClaudeSession } from './session.js';
 import * as skills from './skills.js';
 import { listExternalSessions } from './external-sessions.js';

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { ControlRequest, ControlUpdate, MessageContent, SessionSink } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate, MessageContent, SessionSink } from '@qlan-ro/mainframe-types';
 import type { ClaudeSession } from './session.js';
 import { buildToolResultBlocks } from './history.js';
 import { createChildLogger } from '../../../logger.js';

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -4,7 +4,7 @@ import { createInterface } from 'node:readline';
 import path from 'node:path';
 import { homedir } from 'node:os';
 import { createChildLogger } from '../../../logger.js';
-import type { ExternalSession } from '@mainframe/types';
+import type { ExternalSession } from '@qlan-ro/mainframe-types';
 
 const logger = createChildLogger('claude:external-sessions');
 

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -4,7 +4,7 @@ import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
-import type { ChatMessage, MessageContent, DiffHunk, SkillFileEntry } from '@mainframe/types';
+import type { ChatMessage, MessageContent, DiffHunk, SkillFileEntry } from '@qlan-ro/mainframe-types';
 
 export function deriveModifiedFile(
   tur: Record<string, unknown> | undefined,

--- a/packages/core/src/plugins/builtin/claude/index.ts
+++ b/packages/core/src/plugins/builtin/claude/index.ts
@@ -1,4 +1,4 @@
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { ClaudeAdapter } from './adapter.js';
 
 export function activate(ctx: PluginContext): void {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -14,7 +14,7 @@ import type {
   ChatMessage,
   ContextFile,
   SkillFileEntry,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 import { handleStdout, handleStderr } from './events.js';
 import { createChildLogger } from '../../../logger.js';
 import {

--- a/packages/core/src/plugins/builtin/claude/skills.ts
+++ b/packages/core/src/plugins/builtin/claude/skills.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, writeFile, mkdir, rm, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput } from '@mainframe/types';
+import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput } from '@qlan-ro/mainframe-types';
 import { parseFrontmatter, buildFrontmatter } from './frontmatter.js';
 
 // TODO rename as claude-tools.ts

--- a/packages/core/src/plugins/builtin/todos/index.ts
+++ b/packages/core/src/plugins/builtin/todos/index.ts
@@ -1,4 +1,4 @@
-import type { PluginContext } from '@mainframe/types';
+import type { PluginContext } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 

--- a/packages/core/src/plugins/config-context.ts
+++ b/packages/core/src/plugins/config-context.ts
@@ -1,4 +1,4 @@
-import type { PluginConfig } from '@mainframe/types';
+import type { PluginConfig } from '@qlan-ro/mainframe-types';
 
 export function createPluginConfig(
   pluginId: string,

--- a/packages/core/src/plugins/context.ts
+++ b/packages/core/src/plugins/context.ts
@@ -1,4 +1,4 @@
-import type { PluginContext, PluginManifest, DaemonEvent } from '@mainframe/types';
+import type { PluginContext, PluginManifest, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { createPluginDatabaseContext } from './db-context.js';
 import { createPluginAttachmentContext } from './attachment-context.js';
 import { createPluginEventBus } from './event-bus.js';

--- a/packages/core/src/plugins/db-context.ts
+++ b/packages/core/src/plugins/db-context.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
-import type { PluginDatabaseContext, PluginDatabaseStatement } from '@mainframe/types';
+import type { PluginDatabaseContext, PluginDatabaseStatement } from '@qlan-ro/mainframe-types';
 
 export function createPluginDatabaseContext(dbPath: string): PluginDatabaseContext {
   mkdirSync(path.dirname(dbPath), { recursive: true });

--- a/packages/core/src/plugins/event-bus.ts
+++ b/packages/core/src/plugins/event-bus.ts
@@ -5,7 +5,7 @@ import type {
   PublicDaemonEvent,
   ChatEventName,
   ChatEvent,
-} from '@mainframe/types';
+} from '@qlan-ro/mainframe-types';
 
 export const PUBLIC_DAEMON_EVENT_PREFIX = 'plugin:public:';
 

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { Router } from 'express';
 import type { EventEmitter } from 'node:events';
-import type { PluginContext, PluginManifest, PluginModule, DaemonEvent } from '@mainframe/types';
+import type { PluginContext, PluginManifest, PluginModule, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { validateManifest } from './security/manifest-validator.js';
 import { buildPluginContext } from './context.js';
 import type { DatabaseManager } from '../db/index.js';

--- a/packages/core/src/plugins/security/manifest-validator.ts
+++ b/packages/core/src/plugins/security/manifest-validator.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { PluginManifest } from '@mainframe/types';
+import type { PluginManifest } from '@qlan-ro/mainframe-types';
 
 const VALID_CAPABILITIES = [
   'storage',

--- a/packages/core/src/plugins/services/chat-service.ts
+++ b/packages/core/src/plugins/services/chat-service.ts
@@ -1,4 +1,4 @@
-import type { ChatServiceAPI, ChatSummary, PluginManifest, DaemonEvent } from '@mainframe/types';
+import type { ChatServiceAPI, ChatSummary, PluginManifest, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../../db/index.js';
 
 export function buildChatService(

--- a/packages/core/src/plugins/services/project-service.ts
+++ b/packages/core/src/plugins/services/project-service.ts
@@ -1,4 +1,4 @@
-import type { ProjectServiceAPI, ProjectSummary } from '@mainframe/types';
+import type { ProjectServiceAPI, ProjectSummary } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../../db/index.js';
 
 export function buildProjectService(db: DatabaseManager): ProjectServiceAPI {

--- a/packages/core/src/plugins/ui-context.ts
+++ b/packages/core/src/plugins/ui-context.ts
@@ -1,4 +1,4 @@
-import type { PluginUIContext, UIZone, DaemonEvent } from '@mainframe/types';
+import type { PluginUIContext, UIZone, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 export function createPluginUIContext(pluginId: string, emitEvent: (event: DaemonEvent) => void): PluginUIContext {
   return {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -8,7 +8,7 @@ import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
 import type { PluginManager } from '../plugins/manager.js';
 import type { LaunchRegistry } from '../launch/index.js';
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { createChildLogger } from '../logger.js';
 
 const log = createChildLogger('server');

--- a/packages/core/src/server/routes/commands.ts
+++ b/packages/core/src/server/routes/commands.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import type { RouteContext } from './types.js';
 import { getMainframeCommands } from '../../commands/registry.js';
 import { asyncHandler } from './async-handler.js';
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 export function commandRoutes(ctx: RouteContext): Router {
   const router = Router();

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { homedir } from 'node:os';
-import { GENERAL_DEFAULTS } from '@mainframe/types';
+import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 import type { RouteContext } from './types.js';
 import { validate, UpdateProviderSettingsBody, UpdateGeneralSettingsBody } from './schemas.js';
 import { asyncHandler } from './async-handler.js';

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -1,7 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import type { Server } from 'node:http';
 import type { ChatManager } from '../chat/index.js';
-import type { ClientEvent, DaemonEvent } from '@mainframe/types';
+import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { ClientEventSchema } from './ws-schemas.js';
 import { createChildLogger } from '../logger.js';
 import { validateToken } from '../auth/token.js';

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mainframe/desktop",
+  "name": "@qlan-ro/mainframe-desktop",
   "version": "0.2.0",
   "description": "Mainframe desktop app — Electron/React frontend for orchestrating AI agents",
   "license": "MIT",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@assistant-ui/react": "^0.12.11",
     "@assistant-ui/react-markdown": "^0.12.4",
-    "@mainframe/core": "workspace:*",
-    "@mainframe/types": "workspace:*",
+    "@qlan-ro/mainframe-core": "workspace:*",
+    "@qlan-ro/mainframe-types": "workspace:*",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/desktop/src/__tests__/components/PermissionCard.test.tsx
+++ b/packages/desktop/src/__tests__/components/PermissionCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 import { PermissionCard } from '../../renderer/components/chat/PermissionCard.js';
 
 function createRequest(overrides?: Partial<ControlRequest>): ControlRequest {

--- a/packages/desktop/src/__tests__/playwright/AskUserQuestionCard.ct.test.tsx
+++ b/packages/desktop/src/__tests__/playwright/AskUserQuestionCard.ct.test.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import React from 'react';
 import { AskUserQuestionCard } from '../../renderer/components/chat/AskUserQuestionCard.js';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 
 function makeRequest(): ControlRequest {
   return {

--- a/packages/desktop/src/__tests__/playwright/PermissionCard.ct.test.tsx
+++ b/packages/desktop/src/__tests__/playwright/PermissionCard.ct.test.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import React from 'react';
 import { PermissionCard } from '../../renderer/components/chat/PermissionCard.js';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 
 const request: ControlRequest = {
   requestId: 'req-1',

--- a/packages/desktop/src/__tests__/stores/chats.test.ts
+++ b/packages/desktop/src/__tests__/stores/chats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { Chat, ChatMessage, ControlRequest, AdapterProcess } from '@mainframe/types';
+import type { Chat, ChatMessage, ControlRequest, AdapterProcess } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../renderer/store/chats.js';
 
 function makeChat(overrides: Partial<Chat> = {}): Chat {

--- a/packages/desktop/src/__tests__/stores/projects.test.ts
+++ b/packages/desktop/src/__tests__/stores/projects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { Project } from '@mainframe/types';
+import type { Project } from '@qlan-ro/mainframe-types';
 import { useProjectsStore } from '../../renderer/store/projects.js';
 
 function makeProject(overrides: Partial<Project> = {}): Project {

--- a/packages/desktop/src/__tests__/stores/settings.test.ts
+++ b/packages/desktop/src/__tests__/stores/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { ProviderConfig } from '@mainframe/types';
-import { GENERAL_DEFAULTS } from '@mainframe/types';
+import type { ProviderConfig } from '@qlan-ro/mainframe-types';
+import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 import { useSettingsStore } from '../../renderer/store/settings.js';
 import type { SettingsTab } from '../../renderer/store/settings.js';
 

--- a/packages/desktop/src/__tests__/stores/skills.test.ts
+++ b/packages/desktop/src/__tests__/stores/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { Skill, AgentConfig } from '@mainframe/types';
+import type { Skill, AgentConfig } from '@qlan-ro/mainframe-types';
 
 vi.mock('../../renderer/lib/api/index.js', () => ({
   getSkills: vi.fn(),

--- a/packages/desktop/src/renderer/components/chat/AskUserQuestionCard.test.tsx
+++ b/packages/desktop/src/renderer/components/chat/AskUserQuestionCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import type { ControlRequest } from '@mainframe/types';
+import type { ControlRequest } from '@qlan-ro/mainframe-types';
 import { AskUserQuestionCard } from './AskUserQuestionCard.js';
 
 function createSingleRequest(): ControlRequest {

--- a/packages/desktop/src/renderer/components/chat/AskUserQuestionCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/AskUserQuestionCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Check } from 'lucide-react';
-import type { ControlRequest, ControlUpdate } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 

--- a/packages/desktop/src/renderer/components/chat/ContextPickerMenu.tsx
+++ b/packages/desktop/src/renderer/components/chat/ContextPickerMenu.tsx
@@ -8,7 +8,7 @@ import { focusComposerInput } from '../../lib/focus';
 import { useSkillsStore, useProjectsStore, useChatsStore } from '../../store';
 import { searchFiles, addMention } from '../../lib/api';
 import { cn } from '../../lib/utils';
-import type { Skill, CustomCommand } from '@mainframe/types';
+import type { Skill, CustomCommand } from '@qlan-ro/mainframe-types';
 
 type FilterMode = 'all' | 'agents-files' | 'skills';
 

--- a/packages/desktop/src/renderer/components/chat/PermissionCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/PermissionCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ShieldAlert, Terminal, ChevronRight } from 'lucide-react';
-import type { ControlRequest, ControlUpdate } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
 

--- a/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { ClipboardList, ShieldOff, FileEdit, Shield, ChevronDown } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { ControlRequest, ControlUpdate } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { Button } from '../ui/button';
 import { useChatsStore } from '../../store/chats';
 import { useMainframeRuntime } from './assistant-ui/MainframeRuntimeProvider';

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
@@ -14,7 +14,7 @@ import { archiveChat } from '../../../lib/api';
 import { useChatsStore } from '../../../store/chats';
 import { useProjectsStore } from '../../../store/projects';
 import { useTabsStore } from '../../../store/tabs';
-import type { ControlRequest, ControlUpdate } from '@mainframe/types';
+import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { AllToolUIs } from './parts/tool-ui-registry';
 import { useSkillsStore } from '../../../store/skills';
 import { useSandboxStore } from '../../../store/sandbox';

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { convertMessage, ERROR_PLACEHOLDER, PERMISSION_PLACEHOLDER } from './convert-message';
-import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 /* ── helpers ─────────────────────────────────────────────────────── */
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -1,11 +1,11 @@
 import type { ThreadMessageLike } from '@assistant-ui/react';
-import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 // Mutable version of the content array element type (ThreadMessageLike['content'] is readonly)
 type ContentPart = Exclude<ThreadMessageLike['content'], string>[number];
 
 // Re-export for consumers that import from this module
-export type { ToolGroupItem, TaskProgressItem, PartEntry } from '@mainframe/core/messages';
+export type { ToolGroupItem, TaskProgressItem, PartEntry } from '@qlan-ro/mainframe-core/messages';
 
 // Sentinel placeholders — null-byte prefix prevents collision with user content
 export const ERROR_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_ERROR__' });

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/message-parsing.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/message-parsing.tsx
@@ -11,7 +11,7 @@ export {
   decodeXmlAttr,
   parseAttachedFilePathTags,
   formatTurnDuration,
-} from '@mainframe/core/messages';
+} from '@qlan-ro/mainframe-core/messages';
 
 export const MENTION_RE = /(?:^|\s)(@[\w.\/\-]+)/g;
 export const PLAN_PREFIX = 'Implement the following plan:\n\n';

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
-import type { DisplayMessage } from '@mainframe/types';
+import type { DisplayMessage } from '@qlan-ro/mainframe-types';
 import { formatTurnDuration } from '../message-parsing';
 
 export function TurnFooter() {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm';
 import { markdownComponents } from '../parts/markdown-text';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
 import { useSkillsStore } from '../../../../store/skills';
-import type { DisplayMessage, DisplayContent } from '@mainframe/types';
+import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 import { PLAN_PREFIX, highlightMentions, resolveSkillName, parseRawCommand } from '../message-parsing';
 import { ImageThumbs, FileAttachmentThumbs } from './ImageThumbs';
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { TextMessagePartComponent } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { useMessage } from '@assistant-ui/react';
-import type { DisplayMessage } from '@mainframe/types';
+import type { DisplayMessage } from '@qlan-ro/mainframe-types';
 import { ERROR_PLACEHOLDER, PERMISSION_PLACEHOLDER } from '../convert-message';
 import { ErrorPart } from './ErrorPart';
 import { MarkdownText } from './markdown-text';

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { structuredPatch } from 'diff';
-import type { DiffHunk } from '@mainframe/types';
+import type { DiffHunk } from '@qlan-ro/mainframe-types';
 export function stripErrorXml(text: string): string {
   return text.replace(/<\/?(?:tool_use_error|error)>/g, '').trim();
 }

--- a/packages/desktop/src/renderer/components/panels/AgentsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/AgentsPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useState } from 'react';
 import { Bot, MoreHorizontal, Pencil, Trash2, Globe, FolderOpen } from 'lucide-react';
 import { useSkillsStore, useProjectsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
-import type { AgentConfig } from '@mainframe/types';
+import type { AgentConfig } from '@qlan-ro/mainframe-types';
 
 const SCOPE_ICON: Record<string, React.ReactNode> = {
   project: <FolderOpen size={12} />,

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -12,7 +12,7 @@ import { archiveChat, getExternalSessions, importExternalSession } from '../../l
 import { cn } from '../../lib/utils';
 import { getAdapterLabel } from '../../lib/adapters';
 import { useAdaptersStore } from '../../store/adapters';
-import type { ExternalSession } from '@mainframe/types';
+import type { ExternalSession } from '@qlan-ro/mainframe-types';
 
 function SessionStatusDot({ status }: { status: SessionStatus }) {
   const isWorking = status === 'working' || status === 'waiting';

--- a/packages/desktop/src/renderer/components/panels/ContextTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/ContextTab.tsx
@@ -6,7 +6,7 @@ const log = createLogger('renderer:panels');
 import { useChatsStore } from '../../store';
 import { daemonClient } from '../../lib/client';
 import { getSessionContext } from '../../lib/api';
-import type { SessionContext } from '@mainframe/types';
+import type { SessionContext } from '@qlan-ro/mainframe-types';
 import { ContextSection } from './ContextSection';
 import { ContextFileItem } from './ContextFileItem';
 import { SessionAttachmentsGrid } from './SessionAttachmentsGrid';

--- a/packages/desktop/src/renderer/components/panels/SessionAttachmentsGrid.tsx
+++ b/packages/desktop/src/renderer/components/panels/SessionAttachmentsGrid.tsx
@@ -3,7 +3,7 @@ import { FileText } from 'lucide-react';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:panels');
-import type { SessionAttachment } from '@mainframe/types';
+import type { SessionAttachment } from '@qlan-ro/mainframe-types';
 import { getAttachment } from '../../lib/api';
 import { ImageLightbox } from '../chat/ImageLightbox';
 

--- a/packages/desktop/src/renderer/components/panels/SkillsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/SkillsPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { Zap, MoreHorizontal, Pencil, Trash2, Globe, FolderOpen, Puzzle } from 'lucide-react';
 import { useSkillsStore, useProjectsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
-import type { Skill } from '@mainframe/types';
+import type { Skill } from '@qlan-ro/mainframe-types';
 
 const SCOPE_ICON: Record<string, React.ReactNode> = {
   project: <FolderOpen size={12} />,

--- a/packages/desktop/src/renderer/components/sandbox/LaunchPopover.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/LaunchPopover.tsx
@@ -7,7 +7,7 @@ import { useUIStore } from '../../store/ui';
 import { startLaunchConfig, stopLaunchConfig } from '../../lib/launch';
 import { useLaunchConfig } from '../../hooks/useLaunchConfig';
 import { daemonClient } from '../../lib/client';
-import type { LaunchConfiguration } from '@mainframe/types';
+import type { LaunchConfiguration } from '@qlan-ro/mainframe-types';
 import { cn } from '../../lib/utils';
 
 interface Props {

--- a/packages/desktop/src/renderer/components/settings/GeneralSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/GeneralSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { GENERAL_DEFAULTS } from '@mainframe/types';
+import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:settings');

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -7,7 +7,7 @@ import { useSettingsStore } from '../../store/settings';
 import { useAdaptersStore } from '../../store/adapters';
 import { getConfigConflicts, updateProviderSettings } from '../../lib/api';
 import { getModelOptions } from '../../lib/adapters';
-import type { ProviderConfig } from '@mainframe/types';
+import type { ProviderConfig } from '@qlan-ro/mainframe-types';
 import { ModelDropdown } from './ModelDropdown';
 import { MODE_OPTIONS, EXECUTION_MODE_OPTIONS } from './constants';
 

--- a/packages/desktop/src/renderer/components/settings/constants.ts
+++ b/packages/desktop/src/renderer/components/settings/constants.ts
@@ -1,5 +1,5 @@
 import type { SettingsTab } from '../../store/settings';
-import type { ProviderConfig } from '@mainframe/types';
+import type { ProviderConfig } from '@qlan-ro/mainframe-types';
 import { SlidersHorizontal, Keyboard, Info, Cpu } from 'lucide-react';
 import type React from 'react';
 

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -12,7 +12,7 @@ import { routeEvent } from '../lib/ws-event-router';
 import { createLogger } from '../lib/logger';
 import { fetchLaunchStatuses } from '../lib/launch';
 import { useSandboxStore } from '../store/sandbox';
-import type { LaunchProcessStatus } from '@mainframe/types';
+import type { LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 
 export { useChatSession } from './useChatSession.js';
 

--- a/packages/desktop/src/renderer/hooks/useChatSession.ts
+++ b/packages/desktop/src/renderer/hooks/useChatSession.ts
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef } from 'react';
 import { daemonClient } from '../lib/client';
 import { getChatMessages, getPendingPermission, uploadAttachments } from '../lib/api';
 import { useChatsStore } from '../store/chats';
-import type { ControlUpdate } from '@mainframe/types';
+import type { ControlUpdate } from '@qlan-ro/mainframe-types';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('renderer:chat-session');

--- a/packages/desktop/src/renderer/hooks/useLaunchConfig.ts
+++ b/packages/desktop/src/renderer/hooks/useLaunchConfig.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { LaunchConfig } from '@mainframe/types';
+import type { LaunchConfig } from '@qlan-ro/mainframe-types';
 import { useProjectsStore } from '../store/projects';
 
 export function useLaunchConfig(): LaunchConfig | null {

--- a/packages/desktop/src/renderer/lib/adapters.test.ts
+++ b/packages/desktop/src/renderer/lib/adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { AdapterInfo } from '@mainframe/types';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
 import { getAdapterLabel, getAdapterOptions, getModelContextWindow, getModelLabel, getModelOptions } from './adapters';
 
 describe('adapters model metadata', () => {

--- a/packages/desktop/src/renderer/lib/adapters.ts
+++ b/packages/desktop/src/renderer/lib/adapters.ts
@@ -1,4 +1,4 @@
-import type { AdapterInfo } from '@mainframe/types';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
 
 const ADAPTER_LABEL_FALLBACK: Record<string, string> = {
   claude: 'Claude',

--- a/packages/desktop/src/renderer/lib/api/commands-api.ts
+++ b/packages/desktop/src/renderer/lib/api/commands-api.ts
@@ -1,5 +1,5 @@
 import { fetchJson, API_BASE } from './http';
-import type { CustomCommand } from '@mainframe/types';
+import type { CustomCommand } from '@qlan-ro/mainframe-types';
 
 export async function getCommands(): Promise<CustomCommand[]> {
   const json = await fetchJson<{ success: boolean; data: CustomCommand[] }>(`${API_BASE}/api/commands`);

--- a/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
+++ b/packages/desktop/src/renderer/lib/api/external-sessions-api.ts
@@ -1,4 +1,4 @@
-import type { Chat, ExternalSession } from '@mainframe/types';
+import type { Chat, ExternalSession } from '@qlan-ro/mainframe-types';
 import { API_BASE, postJson } from './http';
 
 export async function getExternalSessions(projectId: string): Promise<ExternalSession[]> {

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -1,4 +1,4 @@
-import type { ControlRequest, SessionContext } from '@mainframe/types';
+import type { ControlRequest, SessionContext } from '@qlan-ro/mainframe-types';
 import { fetchJson, postJson, API_BASE } from './http';
 
 export async function getFileTree(

--- a/packages/desktop/src/renderer/lib/api/plugins-api.ts
+++ b/packages/desktop/src/renderer/lib/api/plugins-api.ts
@@ -1,4 +1,4 @@
-import type { UIZone } from '@mainframe/types';
+import type { UIZone } from '@qlan-ro/mainframe-types';
 import { API_BASE, fetchJson } from './http';
 
 interface PluginPanel {

--- a/packages/desktop/src/renderer/lib/api/projects-api.ts
+++ b/packages/desktop/src/renderer/lib/api/projects-api.ts
@@ -1,4 +1,4 @@
-import type { Project, Chat, DisplayMessage, AdapterInfo } from '@mainframe/types';
+import type { Project, Chat, DisplayMessage, AdapterInfo } from '@qlan-ro/mainframe-types';
 import { postJson, deleteRequest, API_BASE } from './http';
 import { createLogger } from '../logger';
 

--- a/packages/desktop/src/renderer/lib/api/settings-api.ts
+++ b/packages/desktop/src/renderer/lib/api/settings-api.ts
@@ -1,4 +1,4 @@
-import type { ProviderConfig, GeneralConfig } from '@mainframe/types';
+import type { ProviderConfig, GeneralConfig } from '@qlan-ro/mainframe-types';
 import { fetchJson, putJson, API_BASE } from './http';
 import { createLogger } from '../logger';
 

--- a/packages/desktop/src/renderer/lib/api/skills-api.ts
+++ b/packages/desktop/src/renderer/lib/api/skills-api.ts
@@ -1,4 +1,4 @@
-import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput } from '@mainframe/types';
+import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput } from '@qlan-ro/mainframe-types';
 import { fetchJson, postJson, putJson, deleteRequest, API_BASE } from './http';
 import { createLogger } from '../logger';
 

--- a/packages/desktop/src/renderer/lib/client.ts
+++ b/packages/desktop/src/renderer/lib/client.ts
@@ -1,4 +1,4 @@
-import type { ClientEvent, DaemonEvent, ControlResponse } from '@mainframe/types';
+import type { ClientEvent, DaemonEvent, ControlResponse } from '@qlan-ro/mainframe-types';
 import { createLogger } from './logger';
 
 const env = (import.meta as { env?: Record<string, string> }).env ?? {};

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -1,4 +1,4 @@
-import type { DaemonEvent } from '@mainframe/types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../store/chats';
 import { useTabsStore } from '../store/tabs';
 import { useProjectsStore } from '../store/projects';

--- a/packages/desktop/src/renderer/store/adapters.ts
+++ b/packages/desktop/src/renderer/store/adapters.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { AdapterInfo } from '@mainframe/types';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
 
 interface AdaptersState {
   adapters: AdapterInfo[];

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Chat, DisplayMessage, ControlRequest, AdapterProcess } from '@mainframe/types';
+import type { Chat, DisplayMessage, ControlRequest, AdapterProcess } from '@qlan-ro/mainframe-types';
 
 export type SessionStatus = 'idle' | 'working' | 'waiting';
 

--- a/packages/desktop/src/renderer/store/plugins.test.ts
+++ b/packages/desktop/src/renderer/store/plugins.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { usePluginLayoutStore } from './plugins';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 const makeContrib = (pluginId: string, zone: PluginUIContribution['zone']): PluginUIContribution => ({
   pluginId,

--- a/packages/desktop/src/renderer/store/plugins.ts
+++ b/packages/desktop/src/renderer/store/plugins.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { PluginUIContribution } from '@mainframe/types';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 interface PluginLayoutState {
   contributions: PluginUIContribution[];

--- a/packages/desktop/src/renderer/store/projects.ts
+++ b/packages/desktop/src/renderer/store/projects.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Project } from '@mainframe/types';
+import type { Project } from '@qlan-ro/mainframe-types';
 
 interface ProjectsState {
   projects: Project[];

--- a/packages/desktop/src/renderer/store/sandbox.ts
+++ b/packages/desktop/src/renderer/store/sandbox.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { nanoid } from 'nanoid';
-import type { LaunchProcessStatus } from '@mainframe/types';
+import type { LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 
 export interface Capture {
   id: string;

--- a/packages/desktop/src/renderer/store/settings.ts
+++ b/packages/desktop/src/renderer/store/settings.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import type { ProviderConfig, GeneralConfig } from '@mainframe/types';
-import { GENERAL_DEFAULTS } from '@mainframe/types';
+import type { ProviderConfig, GeneralConfig } from '@qlan-ro/mainframe-types';
+import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 
 export type SettingsTab = 'providers' | 'general' | 'keybindings' | 'about';
 

--- a/packages/desktop/src/renderer/store/skills.ts
+++ b/packages/desktop/src/renderer/store/skills.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput, CustomCommand } from '@mainframe/types';
+import type { Skill, AgentConfig, CreateSkillInput, CreateAgentInput, CustomCommand } from '@qlan-ro/mainframe-types';
 import { createLogger } from '../lib/logger';
 
 const log = createLogger('renderer:store');

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mainframe/e2e",
+  "name": "@qlan-ro/mainframe-e2e",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mainframe/types",
+  "name": "@qlan-ro/mainframe-types",
   "version": "0.2.0",
   "description": "Shared TypeScript types for Mainframe",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "dist"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "scripts": {
     "build": "tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   tar: '>=7.5.7'
+  '@qlan-ro/mainframe-types': workspace:*
 
 importers:
 
@@ -38,7 +39,7 @@ importers:
 
   packages/core:
     dependencies:
-      '@mainframe/types':
+      '@qlan-ro/mainframe-types':
         specifier: workspace:*
         version: link:../types
       better-sqlite3:
@@ -108,15 +109,15 @@ importers:
       '@assistant-ui/react-markdown':
         specifier: ^0.12.4
         version: 0.12.4(@assistant-ui/react@0.12.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mainframe/core':
-        specifier: workspace:*
-        version: link:../core
-      '@mainframe/types':
-        specifier: workspace:*
-        version: link:../types
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@qlan-ro/mainframe-core':
+        specifier: workspace:*
+        version: link:../core
+      '@qlan-ro/mainframe-types':
+        specifier: workspace:*
+        version: link:../types
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -247,7 +248,7 @@ importers:
 
   packages/mobile:
     dependencies:
-      '@mainframe/types':
+      '@qlan-ro/mainframe-types':
         specifier: workspace:*
         version: link:../types
       '@react-native-async-storage/async-storage':
@@ -313,9 +314,6 @@ importers:
       react-native-safe-area-context:
         specifier: ^5.7.0
         version: 5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      react-native-screens:
-        specifier: ~4.23.0
-        version: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-svg:
         specifier: ^15.15.3
         version: 15.15.3(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -17,8 +17,8 @@ rm -rf "$DIST_DIR"
 mkdir -p "${DIST_DIR}/bin" "${DIST_DIR}/lib"
 
 # 1. Bundle daemon
-pnpm --filter @mainframe/types build
-pnpm --filter @mainframe/core build
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-core build
 node packages/desktop/scripts/bundle-daemon.mjs "${DIST_DIR}/lib/daemon.cjs"
 
 # 2. Copy better-sqlite3 prebuild for target platform


### PR DESCRIPTION
## Summary
- Rename all packages from `@mainframe/*` to `@qlan-ro/mainframe-*` to use the existing `@qlan-ro` npm org
- Switch publish workflow from GitHub Packages to npm registry (no auth needed for reads)
- Add pnpm override so mobile's versioned dep (`^0.2.0`) resolves to workspace locally
- Update all imports, pnpm filters, workflows, and docs across the monorepo

## Packages renamed
| Before | After |
|--------|-------|
| `@mainframe/types` | `@qlan-ro/mainframe-types` |
| `@mainframe/core` | `@qlan-ro/mainframe-core` |
| `@mainframe/desktop` | `@qlan-ro/mainframe-desktop` |
| `@mainframe/mobile` | `@qlan-ro/mainframe-mobile` |
| `@mainframe/e2e` | `@qlan-ro/mainframe-e2e` |

## After merge
1. Delete the old `types-v0.2.0` tag: `git push origin :refs/tags/types-v0.2.0`
2. `npm login` and add `NPM_TOKEN` as a GitHub Actions secret
3. Tag `types-v0.2.0` on the new main to trigger publish
4. Retrigger EAS build

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `pnpm build` (types + core) compiles without errors
- [x] 634/637 tests pass (3 flaky title-generation integration tests, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)