### PR TITLE
fix(ci): repair all release pipelines

### DIFF
--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Daemon
 
 on:
   push:
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -15,7 +15,7 @@ jobs:
           - os: macos-14
             target_os: darwin
             target_arch: arm64
-          - os: macos-13
+          - os: macos-latest
             target_os: darwin
             target_arch: x64
           - os: ubuntu-latest

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -10,14 +10,12 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-14
             target_os: darwin
             target_arch: arm64
-          - os: macos-latest
-            target_os: darwin
-            target_arch: x64
           - os: ubuntu-latest
             target_os: linux
             target_arch: x64

--- a/packages/desktop/.npmignore
+++ b/packages/desktop/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+src
+.env*
+*.ts
+*.map

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -75,7 +75,13 @@
     "productName": "Mainframe",
     "icon": "resources/icon",
     "files": [
-      "out/**/*",
+      {
+        "from": "out",
+        "to": "out",
+        "filter": [
+          "**/*"
+        ]
+      },
       "resources/icon*",
       "resources/favicon.png",
       "package.json"

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -21,14 +21,21 @@ pnpm --filter @qlan-ro/mainframe-types build
 pnpm --filter @qlan-ro/mainframe-core build
 node packages/desktop/scripts/bundle-daemon.mjs "${DIST_DIR}/lib/daemon.cjs"
 
-# 2. Copy better-sqlite3 prebuild for target platform
-PREBUILD_DIR="node_modules/better-sqlite3/prebuilds/${OS}-${ARCH}"
-if [ ! -d "$PREBUILD_DIR" ]; then
-  echo "No prebuild found at ${PREBUILD_DIR}" >&2
+# 2. Copy better-sqlite3 native binary for target platform
+SQLITE_PKG="$(node -e "console.log(require('path').dirname(require.resolve('better-sqlite3/package.json')))")"
+PREBUILD_DIR="${SQLITE_PKG}/prebuilds/${OS}-${ARCH}"
+BUILD_DIR="${SQLITE_PKG}/build/Release"
+
+if [ -d "$PREBUILD_DIR" ]; then
+  mkdir -p "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}"
+  cp -r "${PREBUILD_DIR}/." "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}/"
+elif [ -f "${BUILD_DIR}/better_sqlite3.node" ]; then
+  mkdir -p "${DIST_DIR}/lib/build/Release"
+  cp "${BUILD_DIR}/better_sqlite3.node" "${DIST_DIR}/lib/build/Release/"
+else
+  echo "No better-sqlite3 binary found at ${PREBUILD_DIR} or ${BUILD_DIR}" >&2
   exit 1
 fi
-mkdir -p "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}"
-cp -r "${PREBUILD_DIR}/." "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}/"
 
 # 3. Download Node.js binary for target platform
 NODE_ARCH="$ARCH"

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -41,8 +41,9 @@ fi
 NODE_ARCH="$ARCH"
 
 NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${OS}-${NODE_ARCH}.tar.gz"
+NODE_PREFIX="node-v${NODE_VERSION}-${OS}-${NODE_ARCH}"
 echo "Downloading Node.js ${NODE_VERSION} for ${OS}-${NODE_ARCH}..."
-curl -fsSL "$NODE_URL" | tar -xz --strip-components=1 -C "${DIST_DIR}" "*/bin/node"
+curl -fsSL "$NODE_URL" | tar -xz -C "${DIST_DIR}/bin/" --strip-components=2 "${NODE_PREFIX}/bin/node"
 
 # 4. Download cloudflared for target platform
 if [ "$OS" = "darwin" ]; then


### PR DESCRIPTION
## Summary
- **Release (desktop):** Fix `out/main/index.js` missing from asar — root `.gitignore` excluded `out/`, added `.npmignore` and explicit `from/to/filter` in electron-builder files config
- **Release Daemon:** Add missing pnpm version, fix tar glob for Linux, resolve better-sqlite3 path for pnpm, drop unavailable `macos-13` (darwin-x64) runner
- Add `fail-fast: false` to daemon matrix so one failure doesn't cancel all builds

## Verified
All pipelines passed on `v0.2.0-rc5`:
- Release (desktop): macOS, Windows, Ubuntu
- Release Daemon: darwin-arm64, linux-x64, linux-arm64
- Docker: multi-platform

## After merge
Delete old `v0.2.0` tag and re-tag on main for the real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)