### PR TITLE
fix(ci): electron-builder publish to non-draft release

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -111,7 +111,8 @@
     "publish": {
       "provider": "github",
       "owner": "qlan-ro",
-      "repo": "mainframe"
+      "repo": "mainframe",
+      "releaseType": "release"
     },
     "mac": {
       "category": "public.app-category.developer-tools",


### PR DESCRIPTION
## Summary
- Adds `"releaseType": "release"` to electron-builder's publish config
- Fixes desktop assets (dmg, exe, AppImage) not being uploaded to GitHub releases

**Root cause:** electron-builder defaults to creating draft releases, but the Release Daemon workflow (`softprops/action-gh-release@v2`) creates a non-draft release first. electron-builder then skips uploading with: `"existing type not compatible with publishing type"`.

## Test plan
- [x] Delete and re-create the v0.2.0 tag after merging to verify desktop assets appear on the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)