### PR TITLE
chore: dev data dir, env vars, editor save, bottom panel fixes

### DIFF
--- a/.mainframe/launch.json
+++ b/.mainframe/launch.json
@@ -8,7 +8,7 @@
       "port": 31416,
       "url": null,
       "env": {
-        "MAINFRAME_DATA_DIR": "~/.mainframe_dev"
+        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev"
       }
     },
     {
@@ -19,7 +19,7 @@
       "url": null,
       "preview": true,
       "env": {
-        "MAINFRAME_DATA_DIR": "~/.mainframe_dev",
+        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev",
         "VITE_DAEMON_HTTP_PORT": "31416",
         "VITE_DAEMON_WS_PORT": "31416"
       }

--- a/.mainframe/launch.json
+++ b/.mainframe/launch.json
@@ -8,7 +8,7 @@
       "port": 31416,
       "url": null,
       "env": {
-        "MAINFRAME_DATA_DIR": "~/.mainframe-sandbox"
+        "MAINFRAME_DATA_DIR": "~/.mainframe_dev"
       }
     },
     {
@@ -19,7 +19,7 @@
       "url": null,
       "preview": true,
       "env": {
-        "MAINFRAME_DATA_DIR": "~/.mainframe-sandbox",
+        "MAINFRAME_DATA_DIR": "~/.mainframe_dev",
         "VITE_DAEMON_HTTP_PORT": "31416",
         "VITE_DAEMON_WS_PORT": "31416"
       }

--- a/.mainframe/launch.json
+++ b/.mainframe/launch.json
@@ -8,7 +8,8 @@
       "port": 31416,
       "url": null,
       "env": {
-        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev"
+        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev",
+        "DAEMON_PORT": 31416
       }
     },
     {
@@ -21,7 +22,8 @@
       "env": {
         "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev",
         "VITE_DAEMON_HTTP_PORT": "31416",
-        "VITE_DAEMON_WS_PORT": "31416"
+        "VITE_DAEMON_WS_PORT": "31416",
+        "VITE_PORT": 5174
       }
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,5 +135,7 @@ These rules exist because every one was violated before and required cleanup. Fo
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PORT` | Daemon HTTP server port | 31415 |
+| `DAEMON_PORT` | Daemon HTTP + WebSocket port | 31415 |
+| `VITE_PORT` | Vite dev server port | 5173 |
+| `MAINFRAME_DATA_DIR` | Data directory | `~/.mainframe` |
 | `LOG_LEVEL` | Logging verbosity | info |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ cd mainframe
 pnpm install && pnpm build && pnpm dev
 ```
 
+### Configuration
+
+Env vars override `~/.mainframe/config.json`, which overrides defaults.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAEMON_PORT` | 31415 | Daemon HTTP + WebSocket port |
+| `VITE_PORT` | 5173 | Vite dev server port |
+| `MAINFRAME_DATA_DIR` | `~/.mainframe` | Data directory (DB, config, plugins, logs) |
+| `LOG_LEVEL` | info | Logging verbosity |
+| `AUTH_TOKEN_SECRET` | auto-generated | JWT signing secret for mobile pairing |
+| `TUNNEL` | — | Set `true` to enable Cloudflare tunnel |
+| `TUNNEL_URL` | — | Named tunnel URL |
+| `TUNNEL_TOKEN` | — | Cloudflare tunnel token |
+| `VITE_DAEMON_HOST` | `127.0.0.1` | Daemon host for desktop renderer |
+| `VITE_DAEMON_HTTP_PORT` | 31415 | Daemon HTTP port for desktop renderer |
+| `VITE_DAEMON_WS_PORT` | 31415 | Daemon WebSocket port for desktop renderer |
+
+See the [Developer Guide](docs/DEVELOPER-GUIDE.md#environment-variables) for details on IntelliJ run configurations and precedence.
+
 | Document | Description |
 |----------|-------------|
 | [Architecture](docs/ARCHITECTURE.md) | System design, data flow, package breakdown |

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -185,6 +185,24 @@ Tests live in `packages/e2e/tests/` and cover the full desktop app (daemon + Ele
 | `pnpm clean` | Clean build artifacts |
 | `pnpm package` | Build + package Electron app |
 
+## Releasing
+
+Bump the version across all workspace packages and create a git tag:
+
+```bash
+npm version patch   # 0.2.1 → 0.2.2
+npm version minor   # 0.2.2 → 0.3.0
+npm version major   # 0.3.0 → 1.0.0
+```
+
+This runs `pnpm -r version --no-git-tag-version <version>` to update all `package.json` files, stages them, creates a commit, and tags it (`v<version>`). Push the tag to trigger the release workflow:
+
+```bash
+git push origin <branch> --follow-tags
+```
+
+Do **not** manually edit version strings in `package.json` files — `npm version` keeps all packages in sync.
+
 ## Development Workflow
 
 ### Adding a New REST Endpoint

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -240,11 +240,33 @@ The `@assistant-ui/react` library provides headless chat primitives that work wi
 
 ## Environment Variables
 
+Configuration precedence: **env vars > `~/.mainframe/config.json` > defaults**.
+
+### Daemon (`@qlan-ro/mainframe-core`)
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | 31415 | Daemon HTTP + WebSocket server port |
-| `LOG_LEVEL` | info | Logging verbosity |
-| `NODE_ENV` | — | `development` enables dev tools, assumes daemon running separately |
+| `DAEMON_PORT` | 31415 | Daemon HTTP + WebSocket server port |
+| `MAINFRAME_DATA_DIR` | `~/.mainframe` | Data directory (SQLite DB, config, plugins, logs) |
+| `LOG_LEVEL` | info | Logging verbosity (`trace`, `debug`, `info`, `warn`, `error`) |
+| `AUTH_TOKEN_SECRET` | auto-generated | JWT signing secret for mobile pairing (min 32 chars) |
+| `TUNNEL` | — | Set to `true` to enable Cloudflare tunnel on startup |
+| `TUNNEL_URL` | — | Named tunnel URL (e.g. `https://mainframe.example.com`) |
+| `TUNNEL_TOKEN` | — | Cloudflare tunnel token for named tunnels |
+| `NODE_ENV` | — | `development` skips embedded daemon startup in Electron |
+
+### Desktop (`@qlan-ro/mainframe-desktop`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VITE_PORT` | 5173 | Vite dev server port |
+| `VITE_DAEMON_HOST` | `127.0.0.1` | Daemon host for CSP and API connections |
+| `VITE_DAEMON_HTTP_PORT` | 31415 | Daemon HTTP port the renderer connects to |
+| `VITE_DAEMON_WS_PORT` | 31415 | Daemon WebSocket port the renderer connects to |
+
+### IntelliJ Run Configurations
+
+The `.run/` directory contains pre-configured IntelliJ run configs. For development with isolated data, these set `DAEMON_PORT=31416`, `VITE_PORT=5174`, and `MAINFRAME_DATA_DIR=~/.mainframe_dev` to avoid colliding with a production instance.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mainframe",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "AI-native development environment for orchestrating agents",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Mainframe daemon — session lifecycle, agent process management, and metadata storage",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,15 +12,32 @@ export interface MainframeConfig {
   authSecret?: string;
 }
 
-const rawPort = process.env['PORT'];
-const parsedPort = rawPort !== undefined ? Number(rawPort) : NaN;
 const DEFAULT_CONFIG: MainframeConfig = {
-  port: Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : 31415,
-  dataDir: process.env['MAINFRAME_DATA_DIR'] ?? join(homedir(), '.mainframe'),
+  port: 31415,
+  dataDir: join(homedir(), '.mainframe'),
 };
 
+/** Env vars always override config.json values. */
+function envOverrides(): Partial<MainframeConfig> {
+  const overrides: Partial<MainframeConfig> = {};
+
+  const rawPort = process.env['DAEMON_PORT'];
+  if (rawPort !== undefined) {
+    const parsed = Number(rawPort);
+    if (Number.isFinite(parsed) && parsed > 0) overrides.port = parsed;
+  }
+  if (process.env['MAINFRAME_DATA_DIR']) {
+    overrides.dataDir = process.env['MAINFRAME_DATA_DIR'];
+  }
+  if (process.env['TUNNEL'] === 'true') overrides.tunnel = true;
+  if (process.env['TUNNEL_URL']) overrides.tunnelUrl = process.env['TUNNEL_URL'];
+  if (process.env['TUNNEL_TOKEN']) overrides.tunnelToken = process.env['TUNNEL_TOKEN'];
+
+  return overrides;
+}
+
 export function getDataDir(): string {
-  const dir = DEFAULT_CONFIG.dataDir;
+  const dir = process.env['MAINFRAME_DATA_DIR'] ?? DEFAULT_CONFIG.dataDir;
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -30,27 +47,17 @@ export function getDataDir(): string {
 export function getConfig(): MainframeConfig {
   const configPath = join(getDataDir(), 'config.json');
 
-  let merged = DEFAULT_CONFIG;
+  let fileConfig: Partial<MainframeConfig> = {};
   if (existsSync(configPath)) {
     try {
       const content = readFileSync(configPath, 'utf-8');
-      merged = { ...DEFAULT_CONFIG, ...JSON.parse(content) };
+      fileConfig = JSON.parse(content);
     } catch {
       // fall through with defaults
     }
   }
 
-  if (process.env['TUNNEL'] === 'true') {
-    merged.tunnel = true;
-  }
-  if (process.env['TUNNEL_URL']) {
-    merged.tunnelUrl = process.env['TUNNEL_URL'];
-  }
-  if (process.env['TUNNEL_TOKEN']) {
-    merged.tunnelToken = process.env['TUNNEL_TOKEN'];
-  }
-
-  return merged;
+  return { ...DEFAULT_CONFIG, ...fileConfig, ...envOverrides() };
 }
 
 export function saveConfig(config: Partial<MainframeConfig>): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { ensureAuthSecret, getConfig, getDataDir } from './config.js';
 import { DatabaseManager } from './db/index.js';
@@ -19,7 +20,25 @@ import { activate as activateTodos } from './plugins/builtin/todos/index.js';
 import { logger } from './logger.js';
 import type { DaemonEvent, PluginManifest } from '@qlan-ro/mainframe-types';
 
+function enrichPath(): void {
+  try {
+    const shell = process.env['SHELL'] || '/bin/zsh';
+    const result = execFileSync(shell, ['-lc', 'echo "$PATH"'], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    }).trim();
+    if (result) process.env['PATH'] = result;
+  } catch {
+    const current = process.env['PATH'] ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+    const extra = [`${homedir()}/.local/bin`, '/usr/local/bin', '/opt/homebrew/bin'];
+    const seen = new Set(current.split(':'));
+    const additions = extra.filter((p) => !seen.has(p));
+    if (additions.length) process.env['PATH'] = `${additions.join(':')}:${current}`;
+  }
+}
+
 async function main(): Promise<void> {
+  enrichPath();
   const config = getConfig();
   const authSecret = ensureAuthSecret();
   process.env['AUTH_TOKEN_SECRET'] = authSecret;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ import type { DaemonEvent, PluginManifest } from '@qlan-ro/mainframe-types';
 function enrichPath(): void {
   try {
     const shell = process.env['SHELL'] || '/bin/zsh';
-    const result = execFileSync(shell, ['-lc', 'echo "$PATH"'], {
+    const result = execFileSync(shell, ['-lic', 'echo "$PATH"'], {
       encoding: 'utf-8',
       timeout: 5_000,
     }).trim();

--- a/packages/core/src/server/routes/files.ts
+++ b/packages/core/src/server/routes/files.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { readdir, stat, readFile, realpath } from 'node:fs/promises';
+import { readdir, stat, readFile, writeFile, realpath } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import path from 'node:path';
 import { homedir } from 'node:os';
@@ -220,6 +220,36 @@ async function handleFileContent(ctx: RouteContext, req: Request, res: Response)
   }
 }
 
+/** PUT /api/projects/:id/files — write file content */
+async function handleWriteFile(ctx: RouteContext, req: Request, res: Response): Promise<void> {
+  const basePath = getEffectivePath(ctx, param(req, 'id'), req.body?.chatId as string | undefined);
+  if (!basePath) {
+    res.status(404).json({ error: 'Project not found' });
+    return;
+  }
+
+  const filePath = req.body?.path as string;
+  const content = req.body?.content as string;
+  if (!filePath || content == null) {
+    res.status(400).json({ error: 'path and content required' });
+    return;
+  }
+
+  try {
+    const fullPath = resolveAndValidatePath(basePath, filePath);
+    if (!fullPath) {
+      res.status(403).json({ error: 'Path outside project' });
+      return;
+    }
+
+    await writeFile(fullPath, content, 'utf-8');
+    res.json({ path: filePath, success: true });
+  } catch (err) {
+    logger.warn({ err, path: filePath }, 'Failed to write file');
+    res.status(500).json({ error: 'Failed to write file' });
+  }
+}
+
 /** GET /api/filesystem/browse?path=~ */
 async function handleBrowseFilesystem(_ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(BrowseFilesystemQuery, req.query);
@@ -288,6 +318,10 @@ export function fileRoutes(ctx: RouteContext): Router {
   router.get(
     '/api/projects/:id/files',
     asyncHandler((req, res) => handleFileContent(ctx, req, res)),
+  );
+  router.put(
+    '/api/projects/:id/files',
+    asyncHandler((req, res) => handleWriteFile(ctx, req, res)),
   );
 
   return router;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Mainframe desktop app — Electron/React frontend for orchestrating AI agents",
   "license": "MIT",
   "repository": {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -38,7 +38,7 @@ function resolveShellPath(): string {
   const fallback = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
   try {
     const userShell = process.env.SHELL || '/bin/zsh';
-    const result = execFileSync(userShell, ['-lc', 'echo "$PATH"'], {
+    const result = execFileSync(userShell, ['-lic', 'echo "$PATH"'], {
       encoding: 'utf-8',
       timeout: 5_000,
     });

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, shell, ipcMain, utilityProcess, Menu } from 'electron';
 import type { UtilityProcess } from 'electron';
 import { join, resolve, sep } from 'path';
+import { execFileSync } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { createMainLogger, logFromRenderer } from './logger.js';
@@ -31,14 +32,26 @@ let mainWindow: BrowserWindow | null = null;
 let daemon: UtilityProcess | null = null;
 
 // Electron apps launch with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
-// Prepend common user-level locations so the daemon can find CLI tools like `claude`
-// that are installed outside the system PATH (e.g. ~/.local/bin from the Claude CLI installer).
-function buildDaemonPath(): string {
-  const base = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+// Resolve the user's full login-shell PATH so the daemon can find CLI tools
+// installed via nvm, fnm, homebrew, etc.
+function resolveShellPath(): string {
+  const fallback = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+  try {
+    const userShell = process.env.SHELL || '/bin/zsh';
+    const result = execFileSync(userShell, ['-lc', 'echo "$PATH"'], {
+      encoding: 'utf-8',
+      timeout: 5_000,
+    });
+    const shellPath = result.trim();
+    if (shellPath) return shellPath;
+  } catch (err) {
+    log.warn({ err }, 'failed to resolve shell PATH, using fallback');
+  }
+  // Fallback: at least add common user-level locations
   const extra = [`${homedir()}/.local/bin`, '/usr/local/bin', '/opt/homebrew/bin', '/opt/homebrew/sbin'];
-  const seen = new Set(base.split(':'));
+  const seen = new Set(fallback.split(':'));
   const additions = extra.filter((p) => !seen.has(p));
-  return additions.length ? `${additions.join(':')}:${base}` : base;
+  return additions.length ? `${additions.join(':')}:${fallback}` : fallback;
 }
 
 function startDaemon(): void {
@@ -53,7 +66,7 @@ function startDaemon(): void {
   log.info({ path: daemonPath }, 'daemon starting');
   daemon = utilityProcess.fork(daemonPath, [], {
     stdio: 'inherit',
-    env: { ...process.env, NODE_ENV: 'production', PATH: buildDaemonPath() },
+    env: { ...process.env, NODE_ENV: 'production', PATH: resolveShellPath() },
   });
 
   daemon.on('exit', (code) => {

--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -33,6 +33,7 @@ export function LeftRail(): React.ReactElement {
   const activeLeftPanelId = usePluginLayoutStore((s) => s.activeLeftPanelId);
   const panelVisible = useUIStore((s) => s.panelVisible);
   const setPanelVisible = useUIStore((s) => s.setPanelVisible);
+  const togglePanel = useUIStore((s) => s.togglePanel);
 
   const handleSessionsClick = (): void => {
     usePluginLayoutStore.getState().setActiveLeftPanel(null);
@@ -72,7 +73,17 @@ export function LeftRail(): React.ReactElement {
       {/* Bottom actions */}
       <div className="flex flex-col gap-2 pt-2">
         {/* Logs toggle button */}
-        <RailButton active={panelVisible} onClick={() => setPanelVisible(!panelVisible)} title="Toggle logs panel">
+        <RailButton
+          active={panelVisible}
+          onClick={() => {
+            const next = !panelVisible;
+            setPanelVisible(next);
+            if (next && useUIStore.getState().panelCollapsed.bottom) {
+              togglePanel('bottom');
+            }
+          }}
+          title="Toggle logs panel"
+        >
           <span data-testid="toggle-logs-panel">
             <Play size={16} />
           </span>

--- a/packages/desktop/src/renderer/components/center/EditorTab.tsx
+++ b/packages/desktop/src/renderer/components/center/EditorTab.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Save } from 'lucide-react';
 import { useProjectsStore } from '../../store';
 import { useChatsStore } from '../../store/chats';
-import { getFileContent } from '../../lib/api';
+import { getFileContent, saveFileContent } from '../../lib/api';
 import { sendCommentMessage } from '../../lib/send-comment-message';
 import { MonacoEditor } from '../editor/MonacoEditor';
 
@@ -41,21 +42,62 @@ export function EditorTab({
 }): React.ReactElement {
   const { activeProjectId } = useProjectsStore();
   const activeChatId = useChatsStore((s) => s.activeChatId);
-  const [content, setContent] = useState<string | null>(providedContent ?? null);
+  const [savedContent, setSavedContent] = useState<string | null>(providedContent ?? null);
+  const [currentContent, setCurrentContent] = useState<string | null>(providedContent ?? null);
   const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const dirty = savedContent !== null && currentContent !== null && savedContent !== currentContent;
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
 
   useEffect(() => {
     if (providedContent !== undefined) {
-      setContent(providedContent);
+      setSavedContent(providedContent);
+      setCurrentContent(providedContent);
       return;
     }
     if (!activeProjectId) return;
-    setContent(null);
+    setSavedContent(null);
+    setCurrentContent(null);
     setError(null);
     getFileContent(activeProjectId, filePath, activeChatId ?? undefined)
-      .then((result) => setContent(result.content))
+      .then((result) => {
+        setSavedContent(result.content);
+        setCurrentContent(result.content);
+      })
       .catch(() => setError('Failed to load file'));
   }, [activeProjectId, filePath, activeChatId, providedContent]);
+
+  const handleSave = useCallback(async () => {
+    if (!activeProjectId || currentContent == null) return;
+    setSaving(true);
+    try {
+      await saveFileContent(activeProjectId, filePath, currentContent, activeChatId ?? undefined);
+      setSavedContent(currentContent);
+    } catch {
+      console.warn('[EditorTab] save failed');
+    } finally {
+      setSaving(false);
+    }
+  }, [activeProjectId, filePath, currentContent, activeChatId]);
+
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        if (dirtyRef.current) handleSaveRef.current();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const handleChange = useCallback((value: string | undefined) => {
+    if (value !== undefined) setCurrentContent(value);
+  }, []);
 
   const handleLineComment = useCallback(
     (line: number, lineContent: string, comment: string) => {
@@ -71,19 +113,36 @@ export function EditorTab({
     return <div className="h-full flex items-center justify-center text-mf-text-secondary text-mf-body">{error}</div>;
   }
 
-  if (content === null) {
+  if (currentContent === null) {
     return (
       <div className="h-full flex items-center justify-center text-mf-text-secondary text-mf-body">Loading...</div>
     );
   }
 
   return (
-    <MonacoEditor
-      value={content}
-      language={inferLanguage(filePath)}
-      filePath={filePath}
-      readOnly={false}
-      onLineComment={handleLineComment}
-    />
+    <div className="h-full flex flex-col">
+      {dirty && (
+        <div className="flex items-center justify-end px-3 py-1 shrink-0">
+          <button
+            className="flex items-center gap-1 px-2 py-1 text-mf-small rounded hover:bg-mf-input text-mf-text-secondary hover:text-mf-text-primary disabled:opacity-40"
+            disabled={saving}
+            onClick={handleSave}
+          >
+            <Save size={13} />
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      )}
+      <div className="flex-1 min-h-0">
+        <MonacoEditor
+          value={currentContent}
+          language={inferLanguage(filePath)}
+          filePath={filePath}
+          readOnly={false}
+          onChange={handleChange}
+          onLineComment={handleLineComment}
+        />
+      </div>
+    </div>
   );
 }

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -1,5 +1,5 @@
 import type { ControlRequest, SessionContext } from '@qlan-ro/mainframe-types';
-import { fetchJson, postJson, API_BASE } from './http';
+import { fetchJson, postJson, putJson, API_BASE } from './http';
 
 export async function getFileTree(
   projectId: string,
@@ -35,6 +35,15 @@ export async function getFileContent(
   const params = new URLSearchParams({ path: filePath });
   if (chatId) params.set('chatId', chatId);
   return fetchJson(`${API_BASE}/api/projects/${projectId}/files?${params}`);
+}
+
+export async function saveFileContent(
+  projectId: string,
+  filePath: string,
+  content: string,
+  chatId?: string,
+): Promise<void> {
+  await putJson(`${API_BASE}/api/projects/${projectId}/files`, { path: filePath, content, chatId });
 }
 
 export async function getFileBinary(

--- a/packages/desktop/src/renderer/lib/api/index.ts
+++ b/packages/desktop/src/renderer/lib/api/index.ts
@@ -25,6 +25,7 @@ export {
   getSessionFile,
   addMention,
   browseFilesystem,
+  saveFileContent,
 } from './files-api';
 
 export {

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -10,9 +10,11 @@ const log = createLogger('renderer:ws');
 export function routeEvent(event: DaemonEvent): void {
   const chats = useChatsStore.getState();
   const tabs = useTabsStore.getState();
+  const activeProjectId = useProjectsStore.getState().activeProjectId;
 
   switch (event.type) {
     case 'chat.created':
+      if (event.chat.projectId !== activeProjectId) break;
       log.info('event:chat.created', { chatId: event.chat.id, title: event.chat.title, source: event.source });
       chats.addChat(event.chat);
       if (event.source !== 'import') {
@@ -21,6 +23,7 @@ export function routeEvent(event: DaemonEvent): void {
       }
       break;
     case 'chat.updated':
+      if (event.chat.projectId !== activeProjectId) break;
       log.debug('event:chat.updated', { chatId: event.chat.id });
       chats.updateChat(event.chat);
       if (event.chat.title) {
@@ -96,6 +99,7 @@ export function routeEvent(event: DaemonEvent): void {
       log.warn('event:launch.port.timeout', { projectId: event.projectId, name: event.name, port: event.port });
       break;
     case 'sessions.external.count':
+      if (event.projectId !== activeProjectId) break;
       log.debug('event:sessions.external.count', { projectId: event.projectId, count: event.count });
       chats.setExternalSessionCount(event.count);
       break;

--- a/packages/desktop/vite.web.config.ts
+++ b/packages/desktop/vite.web.config.ts
@@ -24,6 +24,6 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), dynamicCspPlugin()],
   server: {
     host: '127.0.0.1',
-    port: process.env['PORT'] ? parseInt(process.env['PORT'], 10) : 5173,
+    port: process.env['VITE_PORT'] ? parseInt(process.env['VITE_PORT'], 10) : 5173,
   },
 });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared TypeScript types for Mainframe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Use `~/.mainframe_dev` data directory for development to isolate from production
- Use `DAEMON_PORT` and `VITE_PORT` env vars with config.json overrides
- Resolve user's login-shell PATH for launch configs and daemon startup
- Filter WS events by active project to prevent cross-project leaks
- Add file save support to Monaco editor (CMD+S + save button)
- Fix bottom panel not opening from LeftRail play button
- Bump version to 0.2.1 with version bumping docs

## Test plan
- [x] Verify dev mode uses `~/.mainframe_dev` directory
- [x] Confirm launch configs find CLI tools (node, pnpm, etc.)
- [ ] Test editor CMD+S saves files correctly
- [x] Verify bottom panel opens from left rail play button
- [x] Check WS events don't leak across projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)