### PR TITLE
fix(core, desktop): launch env isolation, imported sessions, macOS permissions

### DIFF
--- a/.mainframe/launch.json
+++ b/.mainframe/launch.json
@@ -8,7 +8,7 @@
       "port": 31416,
       "url": null,
       "env": {
-        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev",
+        "MAINFRAME_DATA_DIR": "~/.mainframe_dev",
         "DAEMON_PORT": 31416
       }
     },
@@ -20,7 +20,7 @@
       "url": null,
       "preview": true,
       "env": {
-        "MAINFRAME_DATA_DIR": "/Users/doruchiulan/.mainframe_dev",
+        "MAINFRAME_DATA_DIR": "~/.mainframe_dev",
         "VITE_DAEMON_HTTP_PORT": "31416",
         "VITE_DAEMON_WS_PORT": "31416",
         "VITE_PORT": 5174

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -5,6 +5,8 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
   readdir: vi.fn(),
   stat: vi.fn(),
+  access: vi.fn(),
+  constants: { R_OK: 4 },
 }));
 
 vi.mock('node:fs', () => ({
@@ -15,13 +17,14 @@ vi.mock('node:readline', () => ({
   createInterface: vi.fn(),
 }));
 
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat, access } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 
 const mockReadFile = vi.mocked(readFile);
 const mockReaddir = vi.mocked(readdir);
 const mockStat = vi.mocked(stat);
+const mockAccess = vi.mocked(access);
 const mockCreateReadStream = vi.mocked(createReadStream);
 const mockCreateInterface = vi.mocked(createInterface);
 
@@ -43,6 +46,8 @@ describe('listExternalSessions', () => {
     // Default: no index, no JSONL files
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
     mockReaddir.mockRejectedValue(new Error('ENOENT'));
+    // Default: JSONL files exist on disk (for sessions-index tests)
+    mockAccess.mockResolvedValue(undefined);
   });
 
   describe('from sessions-index.json', () => {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -334,11 +334,13 @@ export class ChatManager {
         chatId: chat.claudeSessionId,
       });
       const history = await session.loadHistory();
-      if (history.length > 0) {
-        this.messages.set(chatId, history);
-        this.permissions.restorePendingPermission(chatId, history);
+      // loadHistory embeds the Claude sessionId as chatId — remap to Mainframe chatId
+      const remapped = history.map((msg) => ({ ...msg, chatId }));
+      if (remapped.length > 0) {
+        this.messages.set(chatId, remapped);
+        this.permissions.restorePendingPermission(chatId, remapped);
       }
-      return history;
+      return remapped;
     } catch {
       /* best-effort: return empty if history loading fails */
       return [];

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -4,7 +4,7 @@ import type { AttachmentStore } from '../attachment/index.js';
 import type { DatabaseManager } from '../db/index.js';
 import { removeWorktree } from '../workspace/index.js';
 import { createChildLogger } from '../logger.js';
-import { deriveTitleFromMessage, generateTitle } from './title-generator.js';
+import { generateTitle } from './title-generator.js';
 import { extractMentionsFromText } from './context-tracker.js';
 import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';
@@ -217,9 +217,11 @@ export class ChatLifecycleManager {
 
       try {
         const history = await session.loadHistory();
-        if (history.length > 0) {
-          this.deps.messages.set(chatId, history);
-          this.deps.permissions.restorePendingPermission(chatId, history);
+        // loadHistory embeds the Claude sessionId as chatId — remap to Mainframe chatId
+        const remapped = history.map((msg) => ({ ...msg, chatId }));
+        if (remapped.length > 0) {
+          this.deps.messages.set(chatId, remapped);
+          this.deps.permissions.restorePendingPermission(chatId, remapped);
         }
       } catch {
         // Best-effort
@@ -230,7 +232,11 @@ export class ChatLifecycleManager {
         for (const msg of cached) {
           if (msg.type !== 'user') continue;
           for (const block of msg.content) {
-            if (block.type === 'text') extractMentionsFromText(chatId, block.text, this.deps.db);
+            if (block.type !== 'text') continue;
+            const text = (block as { text: string }).text;
+            // Skip command/skill injections — they contain example @-patterns
+            if (/<mainframe-command|<command-name>/.test(text)) continue;
+            extractMentionsFromText(chatId, text, this.deps.db);
           }
         }
       }

--- a/packages/core/src/launch/launch-manager.ts
+++ b/packages/core/src/launch/launch-manager.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { DaemonEvent, LaunchConfiguration, LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 import { createChildLogger } from '../logger.js';
@@ -102,7 +103,14 @@ export class LaunchManager {
 
     this.emit({ type: 'launch.status', projectId: this.projectId, name: config.name, status: 'starting' });
 
-    const child = spawn(config.runtimeExecutable, config.runtimeArgs, {
+    // Resolve relative executables (./gradlew, ../bin/foo) against the project directory.
+    // Node's spawn only searches PATH, not cwd, for the executable.
+    const executable =
+      config.runtimeExecutable.startsWith('./') || config.runtimeExecutable.startsWith('../')
+        ? resolve(this.projectPath, config.runtimeExecutable)
+        : config.runtimeExecutable;
+
+    const child = spawn(executable, config.runtimeArgs, {
       cwd: this.projectPath,
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,

--- a/packages/core/src/launch/launch-manager.ts
+++ b/packages/core/src/launch/launch-manager.ts
@@ -25,6 +25,7 @@ function expandEnvValues(env: Record<string, string>): Record<string, string> {
  * Users can add arbitrary vars via the launch config `env` block.
  */
 const ENV_ALLOWLIST_EXACT = new Set([
+  // OS / user identity
   'PATH',
   'HOME',
   'USER',
@@ -42,6 +43,23 @@ const ENV_ALLOWLIST_EXACT = new Set([
   'COLORTERM',
   'EDITOR',
   'VISUAL',
+  // Developer toolchains
+  'JAVA_HOME',
+  'ANDROID_HOME',
+  'ANDROID_SDK_ROOT',
+  'GOPATH',
+  'GOROOT',
+  'CARGO_HOME',
+  'RUSTUP_HOME',
+  'PYENV_ROOT',
+  'NVM_DIR',
+  'VOLTA_HOME',
+  'BUN_INSTALL',
+  'DENO_DIR',
+  'DOTNET_ROOT',
+  'GRADLE_HOME',
+  'MAVEN_HOME',
+  'M2_HOME',
 ]);
 
 const ENV_ALLOWLIST_PREFIXES = ['LANG', 'LC_'];

--- a/packages/core/src/launch/launch-manager.ts
+++ b/packages/core/src/launch/launch-manager.ts
@@ -19,13 +19,44 @@ function expandEnvValues(env: Record<string, string>): Record<string, string> {
   return result;
 }
 
-/** Strip pnpm/npm vars leaked from the daemon's own pnpm run context. */
+/**
+ * Allowlisted env var names and prefixes passed to launched processes.
+ * Everything else from the daemon (Electron, pnpm, internal Node vars) is dropped.
+ * Users can add arbitrary vars via the launch config `env` block.
+ */
+const ENV_ALLOWLIST_EXACT = new Set([
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TERM',
+  'TERM_PROGRAM',
+  'TMPDIR',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_RUNTIME_DIR',
+  'DISPLAY',
+  'SSH_AUTH_SOCK',
+  'COLORTERM',
+  'EDITOR',
+  'VISUAL',
+]);
+
+const ENV_ALLOWLIST_PREFIXES = ['LANG', 'LC_'];
+
+function isAllowedEnvVar(key: string): boolean {
+  if (ENV_ALLOWLIST_EXACT.has(key)) return true;
+  return ENV_ALLOWLIST_PREFIXES.some((p) => key.startsWith(p));
+}
+
+/** Build a minimal env for launched processes — only essential OS/user vars. */
 function cleanEnv(): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [k, v] of Object.entries(process.env)) {
     if (v == null) continue;
-    if (k.startsWith('npm_') || k === 'PNPM_SCRIPT_SRC_DIR') continue;
-    result[k] = v;
+    if (isAllowedEnvVar(k)) result[k] = v;
   }
   return result;
 }

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { access, constants, readFile, readdir, stat } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
@@ -73,22 +73,31 @@ async function listFromIndex(
     return null;
   }
 
-  return index.entries
-    .filter((e) => e.sessionId && !excludeSet.has(e.sessionId) && !e.isSidechain)
-    .map(
-      (entry): ExternalSession => ({
-        sessionId: entry.sessionId,
-        adapterId: 'claude',
-        projectPath,
-        firstPrompt: entry.firstPrompt,
-        summary: entry.summary,
-        messageCount: entry.messageCount,
-        createdAt: entry.created ?? new Date().toISOString(),
-        modifiedAt: entry.modified ?? entry.created ?? new Date().toISOString(),
-        gitBranch: entry.gitBranch || undefined,
-      }),
-    )
-    .sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
+  const candidates = index.entries.filter((e) => e.sessionId && !excludeSet.has(e.sessionId) && !e.isSidechain);
+
+  // Verify JSONL files exist on disk — the index can reference deleted sessions
+  const verified: ExternalSession[] = [];
+  for (const entry of candidates) {
+    const jsonlPath = entry.fullPath ?? path.join(projectDir, entry.sessionId + '.jsonl');
+    try {
+      await access(jsonlPath, constants.R_OK);
+    } catch {
+      continue; // JSONL deleted — skip ghost entry
+    }
+    verified.push({
+      sessionId: entry.sessionId,
+      adapterId: 'claude',
+      projectPath,
+      firstPrompt: entry.firstPrompt,
+      summary: entry.summary,
+      messageCount: entry.messageCount,
+      createdAt: entry.created ?? new Date().toISOString(),
+      modifiedAt: entry.modified ?? entry.created ?? new Date().toISOString(),
+      gitBranch: entry.gitBranch || undefined,
+    });
+  }
+
+  return verified.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
 }
 
 /** Scan *.jsonl files, reading the first user message from each for metadata. */

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -274,7 +274,7 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
 }
 
 export async function extractPlanFilePaths(sessionId: string, projectPath: string): Promise<string[]> {
-  const { jsonlPath } = getSessionJsonlPath(sessionId, projectPath);
+  const { jsonlPath, projectDir } = getSessionJsonlPath(sessionId, projectPath);
 
   try {
     await access(jsonlPath, constants.R_OK);
@@ -293,7 +293,9 @@ export async function extractPlanFilePaths(sessionId: string, projectPath: strin
         if (entry.type !== 'user') continue;
         const tur = entry.toolUseResult as Record<string, unknown> | undefined;
         if (typeof tur?.plan === 'string' && typeof tur?.filePath === 'string') {
-          planFiles.push(tur.filePath as string);
+          // CLI stores relative paths (e.g. ../../../.claude/plans/foo.md) — resolve
+          // against the JSONL's directory so downstream consumers get absolute paths.
+          planFiles.push(path.resolve(projectDir, tur.filePath as string));
         }
       } catch {
         /* skip malformed */

--- a/packages/core/src/server/routes/files.ts
+++ b/packages/core/src/server/routes/files.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { homedir } from 'node:os';
 import type { RouteContext } from './types.js';
 import { getEffectivePath, param } from './types.js';
-import { resolveAndValidatePath } from './path-utils.js';
+import { resolveAndValidatePath, resolveClaudeConfigPath } from './path-utils.js';
 import { asyncHandler } from './async-handler.js';
 import { createChildLogger } from '../../logger.js';
 import { BrowseFilesystemQuery, validate } from './schemas.js';
@@ -194,7 +194,7 @@ async function handleFileContent(ctx: RouteContext, req: Request, res: Response)
   const encoding = req.query.encoding as string | undefined;
 
   try {
-    const fullPath = resolveAndValidatePath(basePath, filePath);
+    const fullPath = resolveAndValidatePath(basePath, filePath) ?? resolveClaudeConfigPath(basePath, filePath);
     if (!fullPath) {
       res.status(403).json({ error: 'Path outside project' });
       return;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -119,7 +119,15 @@
       "target": [
         "dmg",
         "zip"
-      ]
+      ],
+      "extendInfo": {
+        "NSAppleMusicUsageDescription": null,
+        "NSAudioCaptureUsageDescription": null,
+        "NSBluetoothAlwaysUsageDescription": null,
+        "NSBluetoothPeripheralUsageDescription": null,
+        "NSCameraUsageDescription": null,
+        "NSMicrophoneUsageDescription": null
+      }
     },
     "win": {
       "target": [

--- a/packages/desktop/src/__tests__/hooks/useProject.test.ts
+++ b/packages/desktop/src/__tests__/hooks/useProject.test.ts
@@ -56,8 +56,8 @@ describe('useProject', () => {
   it('syncs launch statuses into useSandboxStore on mount', async () => {
     const { fetchLaunchStatuses } = await import('../../renderer/lib/launch.js');
     vi.mocked(fetchLaunchStatuses).mockResolvedValue({
-      'Desktop App': 'running',
-      api: 'stopped',
+      statuses: { 'Desktop App': 'running', api: 'stopped' },
+      tunnelUrls: {},
     });
 
     renderHook(() => useProject('proj-1'));

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, ipcMain, utilityProcess, Menu } from 'electron';
+import { app, BrowserWindow, session, shell, ipcMain, utilityProcess, Menu } from 'electron';
 import type { UtilityProcess } from 'electron';
 import { join, resolve, sep } from 'path';
 import { execFileSync } from 'child_process';
@@ -177,6 +177,15 @@ function createWindow(): void {
 
 app.whenReady().then(() => {
   log.info({ version: app.getVersion() }, 'app ready');
+
+  // Deny media/sensor permissions — the app doesn't need camera, mic, etc.
+  // Prevents macOS from prompting for Apple Music, microphone, or camera access
+  // when user projects loaded in the preview webview request these APIs.
+  const ALLOWED_PERMISSIONS = new Set(['clipboard-read', 'clipboard-sanitized-write', 'notifications']);
+  session.defaultSession.setPermissionRequestHandler((_wc, permission, callback) => {
+    callback(ALLOWED_PERMISSIONS.has(permission));
+  });
+
   setupIPC();
   startDaemon();
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -31,27 +31,32 @@ app.on('second-instance', () => {
 let mainWindow: BrowserWindow | null = null;
 let daemon: UtilityProcess | null = null;
 
-// Electron apps launch with a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
-// Resolve the user's full login-shell PATH so the daemon can find CLI tools
-// installed via nvm, fnm, homebrew, etc.
-function resolveShellPath(): string {
-  const fallback = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+// Electron apps launch with a minimal environment (/usr/bin:/bin:/usr/sbin:/sbin PATH,
+// no JAVA_HOME, etc.). Resolve the user's full login-shell environment so the daemon
+// can find CLI tools installed via nvm, sdkman, homebrew, etc.
+function resolveShellEnv(): Record<string, string> {
   try {
     const userShell = process.env.SHELL || '/bin/zsh';
-    const result = execFileSync(userShell, ['-lic', 'echo "$PATH"'], {
+    const result = execFileSync(userShell, ['-lic', 'env'], {
       encoding: 'utf-8',
       timeout: 5_000,
     });
-    const shellPath = result.trim();
-    if (shellPath) return shellPath;
+    const env: Record<string, string> = {};
+    for (const line of result.split('\n')) {
+      const eqIdx = line.indexOf('=');
+      if (eqIdx <= 0) continue;
+      env[line.slice(0, eqIdx)] = line.slice(eqIdx + 1);
+    }
+    if (env['PATH']) return env;
   } catch (err) {
-    log.warn({ err }, 'failed to resolve shell PATH, using fallback');
+    log.warn({ err }, 'failed to resolve shell env, using fallback');
   }
-  // Fallback: at least add common user-level locations
+  // Fallback: at least add common user-level PATH locations
+  const fallback = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
   const extra = [`${homedir()}/.local/bin`, '/usr/local/bin', '/opt/homebrew/bin', '/opt/homebrew/sbin'];
   const seen = new Set(fallback.split(':'));
   const additions = extra.filter((p) => !seen.has(p));
-  return additions.length ? `${additions.join(':')}:${fallback}` : fallback;
+  return { PATH: additions.length ? `${additions.join(':')}:${fallback}` : fallback };
 }
 
 function startDaemon(): void {
@@ -66,7 +71,7 @@ function startDaemon(): void {
   log.info({ path: daemonPath }, 'daemon starting');
   daemon = utilityProcess.fork(daemonPath, [], {
     stdio: 'inherit',
-    env: { ...process.env, NODE_ENV: 'production', PATH: resolveShellPath() },
+    env: { ...process.env, NODE_ENV: 'production', ...resolveShellEnv() },
   });
 
   daemon.on('exit', (code) => {

--- a/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
@@ -439,7 +439,6 @@ export function PreviewTab(): React.ReactElement {
               style={hasPreview ? undefined : { position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
             >
               {isElectron ? (
-                // @ts-expect-error — webview is an Electron-specific HTML element not present in React's type definitions
                 // Electron webviews render in a separate GPU process and paint OVER regular DOM,
                 // so visibility:hidden doesn't help. Use zero dimensions to truly hide until ready.
                 <webview
@@ -503,7 +502,7 @@ export function PreviewTab(): React.ReactElement {
                 ref={logRef}
                 data-testid="preview-console-output"
                 className={[
-                  'overflow-y-auto px-2 pb-2 font-mono text-xs text-mf-text-secondary',
+                  'overflow-y-auto px-2 pb-2 font-mono text-xs text-mf-text-secondary whitespace-pre-wrap select-text',
                   hasPreview ? '' : 'flex-1',
                 ].join(' ')}
                 style={hasPreview ? { height: 150 } : undefined}

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -117,7 +117,7 @@ export function useProject(projectId: string | null) {
 
     const syncLaunchStatuses = async () => {
       try {
-        const statuses = await fetchLaunchStatuses(projectId);
+        const { statuses } = await fetchLaunchStatuses(projectId);
         const { setProcessStatus } = useSandboxStore.getState();
         for (const [name, status] of Object.entries(statuses)) {
           setProcessStatus(projectId, name, status as LaunchProcessStatus);

--- a/packages/desktop/src/renderer/lib/launch.ts
+++ b/packages/desktop/src/renderer/lib/launch.ts
@@ -1,10 +1,17 @@
 import { API_BASE } from './api/http';
 
-export async function fetchLaunchStatuses(projectId: string): Promise<Record<string, string>> {
+interface LaunchStatusResponse {
+  success: boolean;
+  data: { statuses: Record<string, string>; tunnelUrls: Record<string, string> };
+}
+
+export async function fetchLaunchStatuses(
+  projectId: string,
+): Promise<{ statuses: Record<string, string>; tunnelUrls: Record<string, string> }> {
   const res = await fetch(`${API_BASE}/api/projects/${projectId}/launch/status`);
-  if (!res.ok) return {};
-  const json = (await res.json()) as { success: boolean; data: Record<string, string> };
-  return json.success ? json.data : {};
+  if (!res.ok) return { statuses: {}, tunnelUrls: {} };
+  const json = (await res.json()) as LaunchStatusResponse;
+  return json.success ? json.data : { statuses: {}, tunnelUrls: {} };
 }
 
 export async function startLaunchConfig(projectId: string, name: string): Promise<void> {


### PR DESCRIPTION
## Summary
- **Launch env isolation**: Allowlist-based env for child processes — prevents Electron/daemon internals (`NODE_ENV`, pnpm vars) from leaking into launched dev servers (fixes `_jsxDEV is not a function` in Vite projects)
- **Developer toolchains**: Add `JAVA_HOME`, `ANDROID_HOME`, `GOPATH`, and other toolchain vars to the launch env allowlist
- **Login-shell env**: Resolve full login-shell environment (not just PATH) at daemon startup so CLI tools installed via sdkman/nvm/homebrew are found
- **Relative executable resolution**: Resolve `./gradlew`, `../bin/foo` against project directory since Node's `spawn` only searches PATH
- **Launch state persistence**: Fix `fetchLaunchStatuses` response parsing so running state survives CMD+R reload
- **Imported sessions**: Add `access()` check to skip ghost entries in `sessions-index.json` where JSONL was deleted; remap chatId in loaded history
- **Plan file paths**: Resolve relative plan file paths from CLI to absolute using projectDir
- **Ghost mentions**: Filter `@`-mention extraction from `<mainframe-command>` injected messages
- **macOS permissions**: Null out electron-builder media plist keys and add `setPermissionRequestHandler` to deny camera/mic/Apple Music prompts
- **Console UX**: Enable text selection in sandbox console output
- **Dev launch config**: Use `~` instead of absolute home path in `.mainframe/launch.json`

## Test plan
- [ ] Launch a Vite project — no `_jsxDEV` error, `NODE_ENV` not leaked
- [ ] Launch `./gradlew` or `./mvnw` project — executable resolves correctly
- [ ] Java/Gradle project finds `JAVA_HOME` from shell profile
- [ ] CMD+R preserves launch running state
- [ ] Import a session with deleted JSONL — no crash, ghost entries skipped
- [ ] Plan files open correctly (absolute paths)
- [ ] No ghost `@` mentions from command injections
- [ ] macOS build doesn't prompt for Apple Music/camera/mic
- [ ] Console output is selectable/copyable

🤖 Generated with [Claude Code](https://claude.com/claude-code)