### PR TITLE
feat(desktop): mobile view toggle for sandbox preview

### DIFF
--- a/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
@@ -10,6 +10,7 @@ import {
   Minus,
   ChevronDown,
   ChevronUp,
+  Smartphone,
 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger } from '../ui/tabs';
 import { startLaunchConfig, stopLaunchConfig } from '../../lib/launch';
@@ -105,6 +106,7 @@ interface ElementPickResult {
 export function PreviewTab(): React.ReactElement {
   const webviewRef = useRef<HTMLElement>(null);
   const [inspecting, setInspecting] = useState(false);
+  const [mobileView, setMobileView] = useState(false);
   const addCapture = useSandboxStore((s) => s.addCapture);
   const logsOutput = useSandboxStore((s) => s.logsOutput);
   const clearLogsForName = useSandboxStore((s) => s.clearLogsForName);
@@ -191,7 +193,9 @@ export function PreviewTab(): React.ReactElement {
       }
       wv.loadURL(previewUrl)
         .then(() => {
-          if (!cancelled) setWebviewReady(true);
+          if (cancelled) return;
+          setWebviewReady(true);
+          wv.insertCSS('::-webkit-scrollbar { display: none; }').catch(() => {});
         })
         .catch(() => {});
     };
@@ -409,6 +413,18 @@ export function PreviewTab(): React.ReactElement {
               >
                 <Camera size={14} />
               </button>
+              <button
+                onClick={() => setMobileView((v) => !v)}
+                className={[
+                  'p-1.5 rounded transition-colors',
+                  mobileView
+                    ? 'bg-mf-hover text-mf-accent'
+                    : 'hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary',
+                ].join(' ')}
+                title="Mobile view (390×844)"
+              >
+                <Smartphone size={14} />
+              </button>
               <div className="w-px h-3.5 bg-mf-border mx-0.5" />
             </>
           )}
@@ -435,7 +451,9 @@ export function PreviewTab(): React.ReactElement {
                when display:none, breaking loadURL and did-finish-load events. */}
           {previewConfig ? (
             <div
-              className={hasPreview ? 'flex-1 overflow-hidden min-h-0 relative mx-2 my-2' : ''}
+              className={
+                hasPreview ? 'flex-1 overflow-hidden min-h-0 relative mx-2 my-2 flex items-start justify-center' : ''
+              }
               style={hasPreview ? undefined : { position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
             >
               {isElectron ? (
@@ -444,8 +462,16 @@ export function PreviewTab(): React.ReactElement {
                 <webview
                   ref={webviewRef}
                   src="about:blank"
-                  className={webviewReady ? 'w-full h-full' : ''}
-                  style={webviewReady ? undefined : { position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
+                  className={
+                    webviewReady ? (mobileView ? 'h-full rounded border border-mf-border' : 'w-full h-full') : ''
+                  }
+                  style={
+                    webviewReady
+                      ? mobileView
+                        ? { width: 390, maxHeight: 844 }
+                        : undefined
+                      : { position: 'absolute', width: 0, height: 0, overflow: 'hidden' }
+                  }
                 />
               ) : (
                 <div className="flex items-center justify-center h-full text-mf-text-secondary text-sm">

--- a/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
@@ -195,7 +195,6 @@ export function PreviewTab(): React.ReactElement {
         .then(() => {
           if (cancelled) return;
           setWebviewReady(true);
-          wv.insertCSS('::-webkit-scrollbar { display: none; }').catch(() => {});
         })
         .catch(() => {});
     };

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src blob:; connect-src 'self' http://127.0.0.1:31415 ws://127.0.0.1:31415" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src blob:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*" />
     <title>Mainframe</title>
     <link rel="icon" type="image/png" href="/favicon.png">
   </head>

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src blob:; connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src blob:; connect-src 'self' http://127.0.0.1:31415 ws://127.0.0.1:31415" />
     <title>Mainframe</title>
     <link rel="icon" type="image/png" href="/favicon.png">
   </head>


### PR DESCRIPTION
## Summary
- Add mobile view toggle (390×844) to the sandbox preview toolbar — renders the webview at iPhone dimensions with a bordered frame
- Center the webview in the preview area when mobile view is active

## Test plan
- [ ] Click the phone icon in the preview toolbar — webview should resize to 390×844 centered in the panel
- [ ] Click again to toggle back to full-width view
- [ ] Verify the toggle state is visually indicated (accent color when active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)