### PR TITLE
fix(core, desktop): validate cwd before spawn, dynamic CSP

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,14 +27,23 @@ function enrichPath(): void {
       encoding: 'utf-8',
       timeout: 5_000,
     }).trim();
-    if (result) process.env['PATH'] = result;
-  } catch {
-    const current = process.env['PATH'] ?? '/usr/bin:/bin:/usr/sbin:/sbin';
-    const extra = [`${homedir()}/.local/bin`, '/usr/local/bin', '/opt/homebrew/bin'];
-    const seen = new Set(current.split(':'));
-    const additions = extra.filter((p) => !seen.has(p));
-    if (additions.length) process.env['PATH'] = `${additions.join(':')}:${current}`;
+    if (result) {
+      process.env['PATH'] = result;
+      logger.debug({ shell, pathLength: result.split(':').length }, 'enrichPath: resolved from login shell');
+      return;
+    }
+  } catch (err) {
+    logger.warn({ err }, 'enrichPath: login shell failed, using fallback');
   }
+  const current = process.env['PATH'] ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+  const extra = [`${homedir()}/.local/bin`, '/usr/local/bin', '/opt/homebrew/bin'];
+  const seen = new Set(current.split(':'));
+  const additions = extra.filter((p) => !seen.has(p));
+  if (additions.length) process.env['PATH'] = `${additions.join(':')}:${current}`;
+  logger.debug(
+    { additions, totalPaths: (process.env['PATH'] ?? '').split(':').length },
+    'enrichPath: fallback applied',
+  );
 }
 
 async function main(): Promise<void> {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, accessSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
@@ -136,6 +136,11 @@ export class ClaudeSession implements AdapterSession {
     }
 
     const executable = options.executablePath || 'claude';
+    try {
+      accessSync(this.projectPath);
+    } catch {
+      throw new Error(`Project directory does not exist or is not accessible: ${this.projectPath}`);
+    }
     const child = spawn(executable, args, {
       cwd: this.projectPath,
       shell: process.platform === 'win32',

--- a/packages/core/src/server/routes/exec-git.ts
+++ b/packages/core/src/server/routes/exec-git.ts
@@ -1,9 +1,13 @@
 import { execFile } from 'node:child_process';
+import { access } from 'node:fs/promises';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
 export async function execGit(args: string[], cwd: string): Promise<string> {
+  await access(cwd).catch(() => {
+    throw Object.assign(new Error(`Directory not accessible: ${cwd}`), { code: 128 });
+  });
   const { stdout } = await execFileAsync('git', args, { cwd, encoding: 'utf-8', timeout: 30_000 });
   return stdout;
 }

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -2,6 +2,23 @@ import { defineConfig } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
+import type { Plugin } from 'vite';
+
+const daemonHost = process.env['VITE_DAEMON_HOST'] ?? '127.0.0.1';
+const daemonPort = process.env['VITE_DAEMON_HTTP_PORT'] ?? '31415';
+
+/** Rewrite the CSP meta tag so the renderer can reach the daemon at the configured port. */
+function dynamicCspPlugin(): Plugin {
+  return {
+    name: 'dynamic-csp',
+    transformIndexHtml(html) {
+      return html.replace(
+        /connect-src\s+'self'[^"']*/,
+        `connect-src 'self' http://${daemonHost}:${daemonPort} ws://${daemonHost}:${daemonPort}`,
+      );
+    },
+  };
+}
 
 export default defineConfig({
   main: {
@@ -36,6 +53,6 @@ export default defineConfig({
       },
     },
     resolve: {},
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), dynamicCspPlugin()],
   },
 });


### PR DESCRIPTION
## Summary
- Validate project directory exists before spawning claude sessions and git commands — iCloud Drive evicted directories caused misleading `spawn claude ENOENT` errors (the missing path was the cwd, not the binary)
- Add `dynamicCspPlugin` to `electron.vite.config.ts` so the renderer CSP respects `VITE_DAEMON_HTTP_PORT` (was only applied in `vite.web.config.ts` for sandbox builds)
- Add debug/warn logging to `enrichPath()` for PATH resolution diagnostics

## Test plan
- [x] Open a project whose directory is in iCloud and evicted — should get a clear "directory not accessible" error instead of "spawn claude ENOENT"
- [x] Verify git branch polling stops spamming ENOENT for inaccessible project directories
- [x] Run daemon with `VITE_DAEMON_HTTP_PORT=31416` and confirm Electron renderer can connect without CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)