### PR TITLE
fix(release): draft releases and deduplicate changelog

### DIFF
--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -57,4 +57,5 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*.tar.gz
-          generate_release_notes: true
+          draft: true
+          append_body: true

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -112,7 +112,7 @@
       "provider": "github",
       "owner": "qlan-ro",
       "repo": "mainframe",
-      "releaseType": "release"
+      "releaseType": "draft"
     },
     "mac": {
       "category": "public.app-category.developer-tools",


### PR DESCRIPTION
## Summary
- Changed electron-builder `releaseType` from `"release"` to `"draft"` so desktop releases are created as drafts
- Added `draft: true` to the daemon release workflow
- Replaced `generate_release_notes` with `append_body` in the daemon workflow to prevent duplicate changelog entries when both workflows update the same GitHub release

## Test plan
- [x] Push a test tag and verify the GitHub release is created as draft
- [x] Verify changelog entries are not duplicated across the two workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)