### PR TITLE
fix(core): coerce numeric env values in launch config

### DIFF
--- a/packages/core/src/launch/launch-config.ts
+++ b/packages/core/src/launch/launch-config.ts
@@ -17,7 +17,10 @@ const LaunchConfigurationSchema = z.object({
   url: z.string().url().nullable().optional().default(null),
   preview: z.boolean().optional(),
   env: z
-    .record(z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'env key must be letters, digits, or underscores'), z.string())
+    .record(
+      z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'env key must be letters, digits, or underscores'),
+      z.coerce.string(),
+    )
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
- Launch configurations with numeric env values (e.g. `"VITE_PORT": 5174`) caused a 400 Bad Request because the Zod schema required `z.string()` for env values
- Changed to `z.coerce.string()` which accepts numbers/booleans and converts them to strings — correct since env vars are always strings at the OS level

## Test plan
- [x] Start a launch configuration that has a numeric env value in `launch.json`
- [x] Verify no 400 error, process starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)