### PR TITLE
fix(desktop): recover missed responses after tab/project switch

### DIFF
--- a/packages/desktop/src/renderer/hooks/useChatSession.ts
+++ b/packages/desktop/src/renderer/hooks/useChatSession.ts
@@ -20,17 +20,15 @@ export function useChatSession(chatId: string | null) {
     // If the process is already running, startChat returns early — this is a safe no-op.
     daemonClient.resumeChat(chatId);
 
-    // Load cached messages from daemon (survives desktop reloads)
-    const existing = useChatsStore.getState().messages.get(chatId);
-    if (!existing || existing.length === 0) {
-      getChatMessages(chatId)
-        .then((msgs) => {
-          if (msgs.length > 0) {
-            useChatsStore.getState().setMessages(chatId, msgs);
-          }
-        })
-        .catch((err) => log.warn('message fetch failed', { err: String(err) }));
-    }
+    // Always load messages from daemon — the store may have stale data from before
+    // the WS subscription was dropped (e.g. user switched tabs/projects).
+    getChatMessages(chatId)
+      .then((msgs) => {
+        if (msgs.length > 0) {
+          useChatsStore.getState().setMessages(chatId, msgs);
+        }
+      })
+      .catch((err) => log.warn('message fetch failed', { err: String(err) }));
 
     // Restore pending permission from daemon (survives desktop reloads)
     if (!useChatsStore.getState().pendingPermissions.has(chatId)) {

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -22,14 +22,18 @@ export function routeEvent(event: DaemonEvent): void {
         tabs.openChatTab(event.chat.id, event.chat.title);
       }
       break;
-    case 'chat.updated':
-      if (event.chat.projectId !== activeProjectId) break;
+    case 'chat.updated': {
+      // Allow updates for chats already in the store (e.g. processState changes while
+      // browsing another project). Only block chats we haven't loaded.
+      const knownChat = chats.chats.some((c) => c.id === event.chat.id);
+      if (!knownChat && event.chat.projectId !== activeProjectId) break;
       log.debug('event:chat.updated', { chatId: event.chat.id });
       chats.updateChat(event.chat);
       if (event.chat.title) {
         tabs.updateTabLabel(`chat:${event.chat.id}`, event.chat.title);
       }
       break;
+    }
     case 'chat.ended':
       log.info('event:chat.ended', { chatId: event.chatId });
       chats.removeChat(event.chatId);


### PR DESCRIPTION
## Summary

- **Root cause**: When navigating away from a chat, `useChatSession` cleanup unsubscribes from WS events. The daemon continues processing but drops display events for the unsubscribed chat. On return, the REST fetch that would recover missed messages was skipped because stale messages still existed in the Zustand store — so responses that arrived while browsing elsewhere were permanently invisible.
- **Fix 1** (`useChatSession.ts`): Always fetch messages from the daemon when a chat becomes active, removing the stale-data guard that skipped the fetch.
- **Fix 2** (`ws-event-router.ts`): Allow `chat.updated` events through for chats already in the Zustand store, even from other projects, so `processState` and status changes aren't silently dropped during cross-project browsing.

Closes #8

## Test plan

- [x] Open a chat, send a message, switch to another chat tab while the response is streaming
- [x] Switch back — verify the full response is visible (not truncated at the point you left)
- [x] Switch to a different project while a chat is working, then switch back — verify response and process status are correct
- [x] Verify no duplicate messages appear when switching back to an active chat
- [x] Verify messages still load correctly on first open of a chat (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)