### PR TITLE
fix: simplify permission mode management

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -677,7 +677,6 @@ Content-Type: application/json
 |-------|------|-------------|
 | `defaultModel` | string | Default model for new chats |
 | `defaultMode` | `'default' \| 'acceptEdits' \| 'plan' \| 'yolo'` | Default permission mode |
-| `planExecutionMode` | `'default' \| 'acceptEdits' \| 'yolo'` | Execution mode after ExitPlanMode approval |
 | `executablePath` | string | Path to the adapter CLI binary |
 
 **Response**: `ApiResponse<void>`

--- a/docs/plans/2026-03-14-permission-mode-simplification-plan.md
+++ b/docs/plans/2026-03-14-permission-mode-simplification-plan.md
@@ -1,0 +1,393 @@
+# Permission Mode Simplification Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Simplify permission mode management by always passing `--permission-mode` and `--allow-dangerously-skip-permissions` at spawn, removing daemon-side yolo auto-approval, and eliminating `planExecutionMode` tracking.
+
+**Architecture:** The CLI handles permission enforcement natively. The daemon always tells the CLI which mode to use at spawn via `--permission-mode <mode> --allow-dangerously-skip-permissions`. Mode transitions use `set_permission_mode` control_requests. The ExitPlanMode dialog is the only place that picks the post-plan mode — no defaults or fallback chains needed.
+
+**Tech Stack:** TypeScript, Node.js, Vitest
+
+---
+
+## Chunk 1: Spawn logic and yolo removal
+
+### Task 1: Simplify spawn args in `session.ts`
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts:130-136`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/core/src/__tests__/claude-session-spawn.test.ts` (or the existing spawn test file), add tests that verify:
+1. `--permission-mode default --allow-dangerously-skip-permissions` for `permissionMode: 'default'`
+2. `--permission-mode plan --allow-dangerously-skip-permissions` for `permissionMode: 'plan'`
+3. `--permission-mode acceptEdits --allow-dangerously-skip-permissions` for `permissionMode: 'acceptEdits'`
+4. `--permission-mode bypassPermissions --allow-dangerously-skip-permissions` for `permissionMode: 'yolo'`
+5. No `--dangerously-skip-permissions` flag in any case
+
+Note: `spawn` calls `child_process.spawn` — tests should mock it and inspect the args array. Check existing test patterns for how `spawn` is tested in this codebase. If no spawn arg tests exist, create `packages/core/src/__tests__/session-spawn-args.test.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/core/src/__tests__/session-spawn-args.test.ts`
+Expected: FAIL — current code doesn't pass `--permission-mode` for `default`, passes `--dangerously-skip-permissions` for yolo
+
+- [ ] **Step 3: Replace spawn arg logic**
+
+In `packages/core/src/plugins/builtin/claude/session.ts`, replace lines 130-136:
+
+```typescript
+// Before:
+if (options.permissionMode === 'plan') {
+  args.push('--permission-mode', 'plan');
+} else if (options.permissionMode === 'acceptEdits') {
+  args.push('--permission-mode', 'acceptEdits');
+} else if (options.permissionMode === 'yolo') {
+  args.push('--dangerously-skip-permissions');
+}
+
+// After:
+const cliMode = options.permissionMode === 'yolo' ? 'bypassPermissions' : (options.permissionMode ?? 'default');
+args.push('--permission-mode', cliMode, '--allow-dangerously-skip-permissions');
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run packages/core/src/__tests__/session-spawn-args.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+feat: always pass --permission-mode and --allow-dangerously-skip-permissions at spawn
+```
+
+### Task 2: Remove `setPermissionMode` yolo-to-bypassPermissions mapping
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts:209-219`
+- Modify: `packages/core/src/__tests__/control-requests.test.ts`
+
+The `setPermissionMode` method maps `'yolo'` → `'bypassPermissions'`. This mapping should stay — our internal type uses `'yolo'` but the CLI expects `'bypassPermissions'`. No change needed here.
+
+(This task is a no-op — keep the existing mapping. Noted for completeness.)
+
+### Task 3: Remove daemon-side yolo auto-approval
+
+**Files:**
+- Modify: `packages/core/src/chat/event-handler.ts:134-148`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/core/src/__tests__/event-handler.test.ts`, add a test:
+```typescript
+it('does not auto-approve permissions in yolo mode (CLI handles it)', () => {
+  // Set up active chat with permissionMode: 'yolo'
+  // Build sink, call sink.onPermission(request) with a non-interactive tool
+  // Verify respondToPermission was NOT called (no daemon-side auto-approve)
+  // Verify the permission was enqueued normally
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/core/src/__tests__/event-handler.test.ts`
+Expected: FAIL — current code auto-approves in yolo mode
+
+- [ ] **Step 3: Remove yolo auto-approval block**
+
+In `packages/core/src/chat/event-handler.ts`, delete lines 136-148 (the `if (mode === 'yolo' && !requiresUserInput)` block). The `onPermission` handler should unconditionally enqueue all requests:
+
+```typescript
+onPermission(request: any) {
+  const isFirst = permissions.enqueue(chatId, request);
+  if (isFirst) {
+    log.info(
+      { chatId, requestId: request.requestId, toolName: request.toolName },
+      'permission.requested emitted to clients',
+    );
+    emitEvent({ type: 'permission.requested', chatId, request });
+    // ... push notification code stays
+  } else {
+    // ... queue log stays
+  }
+},
+```
+
+- [ ] **Step 4: Also remove the yolo guard in `getPending`**
+
+In `packages/core/src/chat/permission-manager.ts:15-18`, remove the yolo check:
+
+```typescript
+// Before:
+getPending(chatId: string): ControlRequest | null {
+  const chat = this.db.chats.get(chatId);
+  if (chat?.permissionMode === 'yolo') return null;
+  return this.pendingPermissions.get(chatId)?.[0] ?? null;
+}
+
+// After:
+getPending(chatId: string): ControlRequest | null {
+  return this.pendingPermissions.get(chatId)?.[0] ?? null;
+}
+```
+
+This also removes the `DatabaseManager` and `AdapterRegistry` constructor dependencies from `PermissionManager` if they're only used for the yolo check. Check if `db` or `adapters` are used elsewhere in the class — if not, remove them from the constructor.
+
+- [ ] **Step 5: Run tests to verify**
+
+Run: `npx vitest run packages/core/src/__tests__/event-handler.test.ts packages/core/src/__tests__/permission-flow.test.ts`
+Expected: PASS (may need to update permission-flow tests that tested yolo auto-approval behavior)
+
+- [ ] **Step 6: Commit**
+
+```
+refactor: remove daemon-side yolo auto-approval, let CLI handle it
+```
+
+---
+
+## Chunk 2: Remove `planExecutionMode` tracking
+
+### Task 4: Simplify `PlanModeHandler` — remove `planExecutionMode` usage
+
+**Files:**
+- Modify: `packages/core/src/chat/plan-mode-handler.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/core/src/__tests__/plan-mode-handler.test.ts`, add/update tests:
+```typescript
+it('handleEscalation uses response.executionMode, falls back to default', () => {
+  // Verify: response.executionMode = 'acceptEdits' → mode becomes 'acceptEdits'
+  // Verify: response.executionMode = undefined → mode becomes 'default'
+  // Verify: permissions.getPlanExecutionMode is NOT called
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run packages/core/src/__tests__/plan-mode-handler.test.ts`
+
+- [ ] **Step 3: Simplify all three methods**
+
+Replace the `targetMode` logic in all three methods (`handleNoProcess`, `handleClearContext`, `handleEscalation`):
+
+```typescript
+// Before (in each method):
+const targetMode = (response.executionMode ?? this.ctx.permissions.getPlanExecutionMode(chatId)) as ...;
+this.ctx.permissions.deletePlanExecutionMode(chatId);
+const newMode = targetMode || 'default';
+
+// After (in each method):
+const newMode = (response.executionMode ?? 'default') as Chat['permissionMode'];
+```
+
+Remove the `permissions` field from `PlanModeContext` interface (if no longer needed).
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run packages/core/src/__tests__/plan-mode-handler.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+refactor: simplify PlanModeHandler — use response.executionMode directly
+```
+
+### Task 5: Remove `planExecutionMode` from `PermissionManager`
+
+**Files:**
+- Modify: `packages/core/src/chat/permission-manager.ts`
+
+- [ ] **Step 1: Remove the `planExecutionModes` map and its methods**
+
+Delete:
+- Line 7: `private planExecutionModes = new Map<string, Chat['permissionMode']>()`
+- Line 33: `this.planExecutionModes.delete(chatId)` from `clear()`
+- Lines 54-64: `setPlanExecutionMode`, `getPlanExecutionMode`, `deletePlanExecutionMode` methods
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npx vitest run packages/core/src/__tests__/`
+Expected: Compilation errors in files that call these methods — fix in next tasks
+
+- [ ] **Step 3: Commit**
+
+```
+refactor: remove planExecutionMode from PermissionManager
+```
+
+### Task 6: Remove `planExecutionMode` from `LifecycleManager` and `ChatManager`
+
+**Files:**
+- Modify: `packages/core/src/chat/lifecycle-manager.ts:42-86`
+- Modify: `packages/core/src/chat/chat-manager.ts:122-139`
+
+- [ ] **Step 1: Simplify `createChat`**
+
+```typescript
+// Before:
+async createChat(projectId, adapterId, model?, permissionMode?, planExecutionMode?): Promise<Chat> {
+  const chat = this.deps.db.chats.create(projectId, adapterId, model, permissionMode);
+  ...
+  if (planExecutionMode && permissionMode === 'plan') {
+    this.deps.permissions.setPlanExecutionMode(chat.id, planExecutionMode as Chat['permissionMode']);
+  }
+  ...
+}
+
+// After:
+async createChat(projectId, adapterId, model?, permissionMode?): Promise<Chat> {
+  const chat = this.deps.db.chats.create(projectId, adapterId, model, permissionMode);
+  ...
+  // No planExecutionMode handling
+  ...
+}
+```
+
+- [ ] **Step 2: Simplify `createChatWithDefaults`**
+
+```typescript
+// Before:
+async createChatWithDefaults(...) {
+  let planExecutionMode: string | undefined;
+  ...
+  if (defaultMode === 'plan') {
+    effectiveMode = 'plan';
+    const storedExec = this.deps.db.settings.get('provider', `${adapterId}.planExecutionMode`);
+    if (storedExec) planExecutionMode = storedExec;
+  }
+  return this.createChat(..., planExecutionMode);
+}
+
+// After:
+async createChatWithDefaults(...) {
+  ...
+  // Just read defaultMode, no planExecutionMode lookup
+  if (!effectiveMode && defaultMode) {
+    effectiveMode = defaultMode;
+  }
+  return this.createChat(projectId, adapterId, effectiveModel, effectiveMode);
+}
+```
+
+- [ ] **Step 3: Update `ChatManager.createChat` wrapper** to remove `planExecutionMode` param
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run packages/core/src/__tests__/`
+
+- [ ] **Step 5: Commit**
+
+```
+refactor: remove planExecutionMode from lifecycle and chat managers
+```
+
+### Task 7: Remove `planExecutionMode` from settings API and schema
+
+**Files:**
+- Modify: `packages/core/src/server/routes/schemas.ts:35`
+- Modify: `packages/core/src/server/routes/settings.ts:67-81`
+- Modify: `packages/core/src/__tests__/routes/settings.test.ts`
+
+- [ ] **Step 1: Remove from Zod schema**
+
+In `schemas.ts`, remove `planExecutionMode: z.string().optional()` from `UpdateProviderSettingsBody`.
+
+- [ ] **Step 2: Remove from settings route handler**
+
+In `settings.ts`, remove the `planExecutionMode` destructuring and the DB set/delete block (lines 78-80).
+
+- [ ] **Step 3: Update or remove the settings test**
+
+In `settings.test.ts`, remove/update the `'sets planExecutionMode'` test.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run packages/core/src/__tests__/routes/settings.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```
+refactor: remove planExecutionMode from settings API
+```
+
+### Task 8: Remove `planExecutionMode` from types and UI
+
+**Files:**
+- Modify: `packages/types/src/settings.ts:6`
+- Modify: `packages/desktop/src/renderer/components/settings/constants.ts:23-35`
+- Modify: `packages/desktop/src/renderer/components/settings/ProviderSection.tsx:102-129`
+- Modify: `packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx:43`
+
+- [ ] **Step 1: Remove from `ProviderConfig` type**
+
+In `packages/types/src/settings.ts`, remove line 6: `planExecutionMode?: 'default' | 'acceptEdits' | 'yolo'`
+
+- [ ] **Step 2: Remove `EXECUTION_MODE_OPTIONS` from constants**
+
+In `packages/desktop/src/renderer/components/settings/constants.ts`, delete the entire `EXECUTION_MODE_OPTIONS` array (lines 23-35) and the type import if unused.
+
+- [ ] **Step 3: Remove "After Plan Approval" section from ProviderSection**
+
+In `ProviderSection.tsx`, delete the entire conditional block at lines 102-129 that renders the plan execution mode radio buttons.
+
+- [ ] **Step 4: Simplify PlanApprovalCard default**
+
+In `PlanApprovalCard.tsx:43`, change:
+```typescript
+// Before:
+const settingsDefault: ExecutionMode = providerConfig?.planExecutionMode ?? 'default';
+
+// After:
+const settingsDefault: ExecutionMode = 'default';
+```
+
+Also remove the `useSettingsStore` import and `providerConfig` lookup if no longer needed.
+
+- [ ] **Step 5: Build types package, then run desktop typecheck**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```
+refactor: remove planExecutionMode from types and UI
+```
+
+---
+
+## Chunk 3: Update docs
+
+### Task 9: Update API reference
+
+**Files:**
+- Modify: `docs/API-REFERENCE.md:680`
+
+- [ ] **Step 1: Remove `planExecutionMode` from the API docs**
+
+Find the table entry at line 680 and remove it.
+
+- [ ] **Step 2: Commit**
+
+```
+docs: remove planExecutionMode from API reference
+```
+
+---
+
+## Summary of changes
+
+| Area | Before | After |
+|------|--------|-------|
+| Spawn | Conditional `--permission-mode` for plan/acceptEdits, `--dangerously-skip-permissions` for yolo, nothing for default | Always `--permission-mode <mode> --allow-dangerously-skip-permissions` |
+| Yolo handling | Daemon auto-approves `control_request`s | CLI handles it natively via `bypassPermissions` mode |
+| `planExecutionMode` | Per-chat + per-adapter-setting + fallback chain | Gone — ExitPlanMode dialog picks the mode, falls back to `'default'` |
+| Mode transitions | Mix of spawn flags and `set_permission_mode` | `set_permission_mode` for all in-flight transitions |
+| Settings UI | "After Plan Approval" radio group in provider settings | Removed |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mainframe",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "AI-native development environment for orchestrating agents",
   "license": "MIT",

--- a/packages/core/src/__tests__/event-handler-display.test.ts
+++ b/packages/core/src/__tests__/event-handler-display.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventHandler } from '../chat/event-handler.js';
 import { MessageCache } from '../chat/message-cache.js';
 import { PermissionManager } from '../chat/permission-manager.js';
-import { AdapterRegistry } from '../adapters/index.js';
 import type { DaemonEvent, SessionSink } from '@qlan-ro/mainframe-types';
 
 function createRespondToPermission() {
@@ -11,7 +10,6 @@ function createRespondToPermission() {
 
 describe('EventHandler display event emission', () => {
   let db: any;
-  let adapters: AdapterRegistry;
   let messages: MessageCache;
   let permissions: PermissionManager;
   let emitEvent: ReturnType<typeof vi.fn<(event: DaemonEvent) => void>>;
@@ -25,9 +23,8 @@ describe('EventHandler display event emission', () => {
       projects: { get: vi.fn() },
       settings: { get: vi.fn() },
     };
-    adapters = new AdapterRegistry();
     messages = new MessageCache();
-    permissions = new PermissionManager(db, adapters);
+    permissions = new PermissionManager();
     emitEvent = vi.fn();
     activeChats = new Map();
     activeChats.set(chatId, {

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventHandler } from '../chat/event-handler.js';
 import { MessageCache } from '../chat/message-cache.js';
 import { PermissionManager } from '../chat/permission-manager.js';
-import { AdapterRegistry } from '../adapters/index.js';
 import type { SessionSink } from '@qlan-ro/mainframe-types';
 
 function createRespondToPermission() {
@@ -11,7 +10,6 @@ function createRespondToPermission() {
 
 describe('EventHandler token accumulation', () => {
   let db: any;
-  let adapters: AdapterRegistry;
   let messages: MessageCache;
   let permissions: PermissionManager;
   let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
@@ -25,9 +23,8 @@ describe('EventHandler token accumulation', () => {
       projects: { get: vi.fn() },
       settings: { get: vi.fn() },
     };
-    adapters = new AdapterRegistry();
     messages = new MessageCache();
-    permissions = new PermissionManager(db, adapters);
+    permissions = new PermissionManager();
     emitEvent = vi.fn();
     activeChats = new Map();
   });
@@ -70,7 +67,6 @@ describe('EventHandler token accumulation', () => {
 
 describe('EventHandler adapterId stamping', () => {
   let db: any;
-  let adapters: AdapterRegistry;
   let messages: MessageCache;
   let permissions: PermissionManager;
   let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
@@ -84,9 +80,8 @@ describe('EventHandler adapterId stamping', () => {
       projects: { get: vi.fn() },
       settings: { get: vi.fn() },
     };
-    adapters = new AdapterRegistry();
     messages = new MessageCache();
-    permissions = new PermissionManager(db, adapters);
+    permissions = new PermissionManager();
     emitEvent = vi.fn();
     activeChats = new Map();
   });
@@ -117,7 +112,6 @@ describe('EventHandler adapterId stamping', () => {
 
 describe('EventHandler skill_file announcement', () => {
   let db: any;
-  let adapters: AdapterRegistry;
   let msgCache: MessageCache;
   let permissions: PermissionManager;
   let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
@@ -131,9 +125,8 @@ describe('EventHandler skill_file announcement', () => {
       projects: { get: vi.fn() },
       settings: { get: vi.fn() },
     };
-    adapters = new AdapterRegistry();
     msgCache = new MessageCache();
-    permissions = new PermissionManager(db, adapters);
+    permissions = new PermissionManager();
     emitEvent = vi.fn();
     activeChats = new Map();
     activeChats.set(chatId, {
@@ -192,5 +185,76 @@ describe('EventHandler skill_file announcement', () => {
 
     expect(systemEvents).toHaveLength(1);
     expect(systemEvents[0][0].message.content[0]).toMatchObject({ text: 'Using skill: my-skill' });
+  });
+});
+
+describe('EventHandler onPermission — yolo no longer auto-approves', () => {
+  let db: any;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+  let respondToPermission: ReturnType<typeof createRespondToPermission>;
+
+  const chatId = 'chat-yolo';
+
+  beforeEach(() => {
+    db = {
+      chats: {
+        update: vi.fn(),
+        get: vi.fn(),
+        addPlanFile: vi.fn().mockReturnValue(false),
+        addSkillFile: vi.fn().mockReturnValue(false),
+      },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    messages = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    respondToPermission = createRespondToPermission();
+    activeChats = new Map();
+    activeChats.set(chatId, {
+      chat: {
+        id: chatId,
+        permissionMode: 'yolo',
+        totalCost: 0,
+        totalTokensInput: 0,
+        totalTokensOutput: 0,
+        processState: 'working',
+      },
+      session: { id: 'session-1', adapterId: 'claude' },
+    });
+  });
+
+  it('enqueues permissions normally in yolo mode without calling respondToPermission', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, respondToPermission);
+
+    sink.onPermission({ requestId: 'req-1', toolName: 'Bash', toolUseId: 'tu-1', input: {}, suggestions: [] });
+
+    expect(respondToPermission).not.toHaveBeenCalled();
+    expect(permissions.hasPending(chatId)).toBe(true);
+    expect(permissions.getPending(chatId)?.requestId).toBe('req-1');
+
+    const permissionEvent = emitEvent.mock.calls.find(([e]: [any]) => e.type === 'permission.requested');
+    expect(permissionEvent).toBeDefined();
+    expect(permissionEvent![0].request.toolName).toBe('Bash');
+  });
+
+  it('enqueues AskUserQuestion in yolo mode without auto-approving', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, respondToPermission);
+
+    sink.onPermission({
+      requestId: 'req-ask',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tu-ask',
+      input: { questions: [] },
+      suggestions: [],
+    });
+
+    expect(respondToPermission).not.toHaveBeenCalled();
+    expect(permissions.hasPending(chatId)).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/permission-flow.test.ts
+++ b/packages/core/src/__tests__/permission-flow.test.ts
@@ -175,18 +175,19 @@ describe('permission flow', () => {
     expect((events[0] as any).request.toolName).toBe('AskUserQuestion');
   }, 10_000);
 
-  it('auto-approves bash tool in yolo mode (no permission.requested emitted)', async () => {
+  it('enqueues and emits permission.requested in yolo mode (no daemon-side auto-approve)', async () => {
     const adapter = new MockAdapter();
     const events = await setupAndResume(adapter, 'yolo');
 
     adapter.currentSession!.simulatePermission(makePermissionRequest('Bash'));
     await sleep(50);
 
-    expect(events).toHaveLength(0);
-    expect(adapter.respondToPermissionSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'allow' }));
+    expect(events).toHaveLength(1);
+    expect((events[0] as any).request.toolName).toBe('Bash');
+    expect(adapter.respondToPermissionSpy).not.toHaveBeenCalled();
   }, 10_000);
 
-  it('does NOT auto-approve AskUserQuestion in yolo mode', async () => {
+  it('enqueues AskUserQuestion in yolo mode like any other tool', async () => {
     const adapter = new MockAdapter();
     const events = await setupAndResume(adapter, 'yolo');
 
@@ -201,7 +202,7 @@ describe('permission flow', () => {
     expect(adapter.respondToPermissionSpy).not.toHaveBeenCalled();
   }, 10_000);
 
-  it('does NOT auto-approve ExitPlanMode in yolo mode', async () => {
+  it('enqueues ExitPlanMode in yolo mode like any other tool', async () => {
     const adapter = new MockAdapter();
     const events = await setupAndResume(adapter, 'yolo');
 

--- a/packages/core/src/__tests__/permission-manager.test.ts
+++ b/packages/core/src/__tests__/permission-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { PermissionManager } from '../chat/permission-manager.js';
 import type { ControlRequest } from '@qlan-ro/mainframe-types';
 
@@ -15,15 +15,9 @@ function makeRequest(overrides: Partial<ControlRequest> = {}): ControlRequest {
 
 describe('PermissionManager', () => {
   let pm: PermissionManager;
-  let db: any;
 
   beforeEach(() => {
-    db = {
-      chats: { get: vi.fn() },
-      settings: { get: vi.fn() },
-    };
-    const adapters = { get: vi.fn() } as any;
-    pm = new PermissionManager(db, adapters);
+    pm = new PermissionManager();
   });
 
   describe('enqueue/shift FIFO', () => {
@@ -63,10 +57,9 @@ describe('PermissionManager', () => {
       expect(pm.getPending('c1')?.requestId).toBe('r1');
     });
 
-    it('returns null in yolo mode', () => {
-      db.chats.get.mockReturnValue({ permissionMode: 'yolo' });
+    it('returns enqueued request regardless of permission mode', () => {
       pm.enqueue('c1', makeRequest());
-      expect(pm.getPending('c1')).toBeNull();
+      expect(pm.getPending('c1')?.requestId).toBe('req-1');
     });
   });
 

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -43,8 +43,6 @@ function makeContext(hasActiveSession = true): PlanModeContext & {
 
   return {
     permissions: {
-      getPlanExecutionMode: vi.fn().mockReturnValue(undefined),
-      deletePlanExecutionMode: vi.fn(),
       shift: vi.fn(),
       enqueue: vi.fn(),
       hasPending: vi.fn(),
@@ -87,6 +85,19 @@ describe('PlanModeHandler', () => {
 
       expect(ctx.db.chats.update).toHaveBeenCalledWith('chat-1', expect.objectContaining({ permissionMode: 'yolo' }));
       expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
+    });
+
+    it('falls back to "default" when executionMode is not provided', async () => {
+      const ctx = makeContext();
+      const handler = new PlanModeHandler(ctx);
+      const active = ctx.getActiveChat('chat-1')!;
+
+      await handler.handleNoProcess('chat-1', active, makeResponse());
+
+      expect(ctx.db.chats.update).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ permissionMode: 'default' }),
+      );
     });
 
     it('does not emit chat.updated when mode is unchanged', async () => {
@@ -157,6 +168,19 @@ describe('PlanModeHandler', () => {
       expect(ctx.db.chats.update).toHaveBeenCalledWith('chat-1', expect.objectContaining({ permissionMode: 'yolo' }));
       expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
       expect(ctx.session!.setPermissionMode).toHaveBeenCalledWith('yolo');
+    });
+
+    it('falls back to "default" when executionMode is not provided', async () => {
+      const ctx = makeContext(true);
+      const handler = new PlanModeHandler(ctx);
+      const active = ctx.getActiveChat('chat-1')!;
+
+      await handler.handleEscalation('chat-1', active, makeResponse());
+
+      expect(ctx.db.chats.update).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ permissionMode: 'default' }),
+      );
     });
   });
 });

--- a/packages/core/src/__tests__/routes/settings.test.ts
+++ b/packages/core/src/__tests__/routes/settings.test.ts
@@ -145,16 +145,6 @@ describe('settingRoutes', () => {
       expect(ctx.db.settings.delete).toHaveBeenCalledWith('provider', 'claude.skipPermissions');
     });
 
-    it('sets planExecutionMode', () => {
-      const router = settingRoutes(ctx);
-      const handler = extractHandler(router, 'put', '/api/settings/providers/:adapterId');
-      const res = mockRes();
-
-      handler({ params: { adapterId: 'gemini' }, query: {}, body: { planExecutionMode: 'auto' } }, res, vi.fn());
-
-      expect(ctx.db.settings.set).toHaveBeenCalledWith('provider', 'gemini.planExecutionMode', 'auto');
-    });
-
     it('sets executablePath', () => {
       const router = settingRoutes(ctx);
       const handler = extractHandler(router, 'put', '/api/settings/providers/:adapterId');

--- a/packages/core/src/__tests__/session-spawn-args.test.ts
+++ b/packages/core/src/__tests__/session-spawn-args.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Writable, Readable } from 'node:stream';
+
+// Must be called before any import that uses child_process.spawn.
+// vi.mock is hoisted to the top of the file by vitest.
+const spawnMock = vi.fn();
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, accessSync: vi.fn() };
+});
+
+function makeMockChild() {
+  const stdin = new Writable({
+    write(_c, _e, cb) {
+      cb();
+    },
+  });
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  return Object.assign(new EventEmitter(), { stdin, stdout, stderr, pid: 99999, kill: vi.fn() });
+}
+
+describe('ClaudeSession spawn args', () => {
+  beforeEach(() => {
+    spawnMock.mockReturnValue(makeMockChild());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function spawnWithMode(permissionMode: string | undefined): Promise<string[]> {
+    const { ClaudeSession } = await import('../plugins/builtin/claude/session.js');
+    const session = new ClaudeSession({ projectPath: '/tmp', chatId: undefined });
+    await session.spawn({ permissionMode } as any).catch(() => {});
+    return spawnMock.mock.calls[0]?.[1] as string[];
+  }
+
+  it('default mode passes --permission-mode default --allow-dangerously-skip-permissions', async () => {
+    const args = await spawnWithMode('default');
+    const modeIdx = args.indexOf('--permission-mode');
+    expect(modeIdx).toBeGreaterThan(-1);
+    expect(args[modeIdx + 1]).toBe('default');
+    expect(args).toContain('--allow-dangerously-skip-permissions');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('plan mode passes --permission-mode plan --allow-dangerously-skip-permissions', async () => {
+    const args = await spawnWithMode('plan');
+    const modeIdx = args.indexOf('--permission-mode');
+    expect(args[modeIdx + 1]).toBe('plan');
+    expect(args).toContain('--allow-dangerously-skip-permissions');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('acceptEdits mode passes --permission-mode acceptEdits --allow-dangerously-skip-permissions', async () => {
+    const args = await spawnWithMode('acceptEdits');
+    const modeIdx = args.indexOf('--permission-mode');
+    expect(args[modeIdx + 1]).toBe('acceptEdits');
+    expect(args).toContain('--allow-dangerously-skip-permissions');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('yolo mode passes --permission-mode bypassPermissions --allow-dangerously-skip-permissions', async () => {
+    const args = await spawnWithMode('yolo');
+    const modeIdx = args.indexOf('--permission-mode');
+    expect(args[modeIdx + 1]).toBe('bypassPermissions');
+    expect(args).toContain('--allow-dangerously-skip-permissions');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('undefined permissionMode defaults to --permission-mode default', async () => {
+    const args = await spawnWithMode(undefined);
+    const modeIdx = args.indexOf('--permission-mode');
+    expect(args[modeIdx + 1]).toBe('default');
+    expect(args).toContain('--allow-dangerously-skip-permissions');
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -47,7 +47,7 @@ export class ChatManager {
     private attachmentStore?: AttachmentStore,
     private onEvent: (event: DaemonEvent) => void = () => {},
   ) {
-    this.permissions = new PermissionManager(db, adapters);
+    this.permissions = new PermissionManager();
     this.eventHandler = new EventHandler(
       this.db,
       this.messages,
@@ -119,14 +119,8 @@ export class ChatManager {
     this.externalSessions.stopAutoScan(projectId);
   }
 
-  async createChat(
-    projectId: string,
-    adapterId: string,
-    model?: string,
-    permissionMode?: string,
-    planExecutionMode?: string,
-  ): Promise<Chat> {
-    return this.lifecycle.createChat(projectId, adapterId, model, permissionMode, planExecutionMode);
+  async createChat(projectId: string, adapterId: string, model?: string, permissionMode?: string): Promise<Chat> {
+    return this.lifecycle.createChat(projectId, adapterId, model, permissionMode);
   }
 
   async createChatWithDefaults(

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -71,7 +71,7 @@ function buildSessionSink(
   permissions: PermissionManager,
   getActiveChat: (chatId: string) => ActiveChat | undefined,
   emitEvent: (event: DaemonEvent) => void,
-  respondToPermission: (response: ControlResponse) => Promise<void>,
+  _respondToPermission: (response: ControlResponse) => Promise<void>,
   displayCache: Map<string, DisplayMessage[]>,
   getToolCategories: (chatId: string) => ToolCategories | undefined,
   pushService?: PushService,
@@ -132,21 +132,6 @@ function buildSessionSink(
     },
 
     onPermission(request: any) {
-      const active = getActiveChat(chatId);
-      const mode = active?.chat.permissionMode;
-
-      // Interactive tools require real user input even in yolo mode.
-      const requiresUserInput = request.toolName === 'AskUserQuestion' || request.toolName === 'ExitPlanMode';
-      if (mode === 'yolo' && !requiresUserInput) {
-        respondToPermission({
-          requestId: request.requestId,
-          toolUseId: request.toolUseId,
-          behavior: 'allow',
-          updatedInput: request.input,
-        }).catch((err) => log.warn({ err, chatId }, 'yolo auto-approve failed'));
-        return;
-      }
-
       const isFirst = permissions.enqueue(chatId, request);
       if (isFirst) {
         log.info(

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -39,19 +39,10 @@ export class ChatLifecycleManager {
     return this.loadingChats;
   }
 
-  async createChat(
-    projectId: string,
-    adapterId: string,
-    model?: string,
-    permissionMode?: string,
-    planExecutionMode?: string,
-  ): Promise<Chat> {
+  async createChat(projectId: string, adapterId: string, model?: string, permissionMode?: string): Promise<Chat> {
     const chat = this.deps.db.chats.create(projectId, adapterId, model, permissionMode);
     log.info({ chatId: chat.id, projectId, adapterId }, 'chat created');
     this.deps.activeChats.set(chat.id, { chat, session: null });
-    if (planExecutionMode && permissionMode === 'plan') {
-      this.deps.permissions.setPlanExecutionMode(chat.id, planExecutionMode as Chat['permissionMode']);
-    }
     this.deps.emitEvent({ type: 'chat.created', chat });
     return chat;
   }
@@ -64,25 +55,16 @@ export class ChatLifecycleManager {
   ): Promise<Chat> {
     let effectiveModel = model;
     let effectiveMode = permissionMode;
-    let planExecutionMode: string | undefined;
 
     if (!effectiveModel || !effectiveMode) {
       const defaultModel = this.deps.db.settings.get('provider', `${adapterId}.defaultModel`);
       const defaultMode = this.deps.db.settings.get('provider', `${adapterId}.defaultMode`);
 
       if (!effectiveModel && defaultModel) effectiveModel = defaultModel;
-      if (!effectiveMode) {
-        if (defaultMode === 'plan') {
-          effectiveMode = 'plan';
-          const storedExec = this.deps.db.settings.get('provider', `${adapterId}.planExecutionMode`);
-          if (storedExec) planExecutionMode = storedExec;
-        } else if (defaultMode) {
-          effectiveMode = defaultMode;
-        }
-      }
+      if (!effectiveMode && defaultMode) effectiveMode = defaultMode;
     }
 
-    return this.createChat(projectId, adapterId, effectiveModel, effectiveMode, planExecutionMode);
+    return this.createChat(projectId, adapterId, effectiveModel, effectiveMode);
   }
 
   async resumeChat(chatId: string): Promise<void> {

--- a/packages/core/src/chat/permission-manager.ts
+++ b/packages/core/src/chat/permission-manager.ts
@@ -1,20 +1,10 @@
-import type { Chat, ChatMessage, ControlRequest, DaemonEvent, AdapterProcess } from '@qlan-ro/mainframe-types';
-import type { DatabaseManager } from '../db/index.js';
-import type { AdapterRegistry } from '../adapters/index.js';
+import type { ChatMessage, ControlRequest } from '@qlan-ro/mainframe-types';
 
 export class PermissionManager {
   private pendingPermissions = new Map<string, ControlRequest[]>();
-  private planExecutionModes = new Map<string, Chat['permissionMode']>();
   private interruptedChats = new Set<string>();
 
-  constructor(
-    private db: DatabaseManager,
-    private adapters: AdapterRegistry,
-  ) {}
-
   getPending(chatId: string): ControlRequest | null {
-    const chat = this.db.chats.get(chatId);
-    if (chat?.permissionMode === 'yolo') return null;
     return this.pendingPermissions.get(chatId)?.[0] ?? null;
   }
 
@@ -30,7 +20,6 @@ export class PermissionManager {
 
   clear(chatId: string): void {
     this.pendingPermissions.delete(chatId);
-    this.planExecutionModes.delete(chatId);
     this.interruptedChats.delete(chatId);
   }
 
@@ -49,18 +38,6 @@ export class PermissionManager {
       return undefined;
     }
     return queue[0];
-  }
-
-  setPlanExecutionMode(chatId: string, mode: Chat['permissionMode']): void {
-    this.planExecutionModes.set(chatId, mode);
-  }
-
-  getPlanExecutionMode(chatId: string): Chat['permissionMode'] | undefined {
-    return this.planExecutionModes.get(chatId);
-  }
-
-  deletePlanExecutionMode(chatId: string): void {
-    this.planExecutionModes.delete(chatId);
   }
 
   markInterrupted(chatId: string): void {

--- a/packages/core/src/chat/plan-mode-handler.ts
+++ b/packages/core/src/chat/plan-mode-handler.ts
@@ -6,9 +6,9 @@ import type { ActiveChat } from './types.js';
 import { extractLatestPlanFileFromMessages } from './context-tracker.js';
 
 export interface PlanModeContext {
-  permissions: PermissionManager;
   messages: MessageCache;
   db: DatabaseManager;
+  permissions: PermissionManager;
   getActiveChat(chatId: string): ActiveChat | undefined;
   emitEvent(event: DaemonEvent): void;
   clearDisplayCache(chatId: string): void;
@@ -20,11 +20,7 @@ export class PlanModeHandler {
   constructor(private ctx: PlanModeContext) {}
 
   async handleNoProcess(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
-    const targetMode = (response.executionMode ?? this.ctx.permissions.getPlanExecutionMode(chatId)) as
-      | Chat['permissionMode']
-      | undefined;
-    this.ctx.permissions.deletePlanExecutionMode(chatId);
-    const newMode = targetMode || 'default';
+    const newMode = (response.executionMode ?? 'default') as Chat['permissionMode'];
     if (newMode !== active.chat.permissionMode) {
       active.chat.permissionMode = newMode;
       this.ctx.db.chats.update(chatId, { permissionMode: newMode });
@@ -38,11 +34,7 @@ export class PlanModeHandler {
     if (recoveredPlanPath && this.ctx.db.chats.addPlanFile(chatId, recoveredPlanPath)) {
       this.ctx.emitEvent({ type: 'context.updated', chatId });
     }
-    const targetMode = (response.executionMode ?? this.ctx.permissions.getPlanExecutionMode(chatId)) as
-      | Chat['permissionMode']
-      | undefined;
-    this.ctx.permissions.deletePlanExecutionMode(chatId);
-    const newMode = targetMode || 'default';
+    const newMode = (response.executionMode ?? 'default') as Chat['permissionMode'];
 
     if (!active.session?.isSpawned) {
       this.ctx.permissions.shift(chatId);
@@ -76,11 +68,7 @@ export class PlanModeHandler {
   }
 
   async handleEscalation(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
-    const targetMode = (response.executionMode ?? this.ctx.permissions.getPlanExecutionMode(chatId)) as
-      | Chat['permissionMode']
-      | undefined;
-    this.ctx.permissions.deletePlanExecutionMode(chatId);
-    const newMode = targetMode || 'default';
+    const newMode = (response.executionMode ?? 'default') as NonNullable<Chat['permissionMode']>;
     if (newMode !== active.chat.permissionMode) {
       active.chat.permissionMode = newMode;
       this.ctx.db.chats.update(chatId, { permissionMode: newMode });

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -127,13 +127,8 @@ export class ClaudeSession implements AdapterSession {
 
     if (this.resumeSessionId) args.push('--resume', this.resumeSessionId);
     if (options.model) args.push('--model', options.model);
-    if (options.permissionMode === 'plan') {
-      args.push('--permission-mode', 'plan');
-    } else if (options.permissionMode === 'acceptEdits') {
-      args.push('--permission-mode', 'acceptEdits');
-    } else if (options.permissionMode === 'yolo') {
-      args.push('--dangerously-skip-permissions');
-    }
+    const cliMode = options.permissionMode === 'yolo' ? 'bypassPermissions' : (options.permissionMode ?? 'default');
+    args.push('--permission-mode', cliMode, '--allow-dangerously-skip-permissions');
 
     const executable = options.executablePath || 'claude';
     try {

--- a/packages/core/src/server/routes/schemas.ts
+++ b/packages/core/src/server/routes/schemas.ts
@@ -32,7 +32,6 @@ export const AddMentionBody = z.object({
 export const UpdateProviderSettingsBody = z.object({
   defaultModel: z.string().optional(),
   defaultMode: z.string().optional(),
-  planExecutionMode: z.string().optional(),
   executablePath: z.string().optional(),
 });
 

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -64,7 +64,7 @@ export function settingRoutes(ctx: RouteContext): Router {
       res.status(400).json({ success: false, error: parsed.error });
       return;
     }
-    const { defaultModel, defaultMode, planExecutionMode, executablePath } = parsed.data;
+    const { defaultModel, defaultMode, executablePath } = parsed.data;
 
     if (defaultModel !== undefined) {
       if (defaultModel) ctx.db.settings.set('provider', `${adapterId}.defaultModel`, defaultModel);
@@ -74,10 +74,6 @@ export function settingRoutes(ctx: RouteContext): Router {
       if (defaultMode) ctx.db.settings.set('provider', `${adapterId}.defaultMode`, defaultMode);
       else ctx.db.settings.delete('provider', `${adapterId}.defaultMode`);
       ctx.db.settings.delete('provider', `${adapterId}.skipPermissions`);
-    }
-    if (planExecutionMode !== undefined) {
-      if (planExecutionMode) ctx.db.settings.set('provider', `${adapterId}.planExecutionMode`, planExecutionMode);
-      else ctx.db.settings.delete('provider', `${adapterId}.planExecutionMode`);
     }
     if (executablePath !== undefined) {
       if (executablePath) ctx.db.settings.set('provider', `${adapterId}.executablePath`, executablePath);

--- a/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
@@ -4,9 +4,6 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { Button } from '../ui/button';
-import { useChatsStore } from '../../store/chats';
-import { useMainframeRuntime } from './assistant-ui/MainframeRuntimeProvider';
-import { useSettingsStore } from '../../store/settings';
 
 interface PlanApprovalCardProps {
   request: ControlRequest;
@@ -37,10 +34,7 @@ export function PlanApprovalCard({ request, onRespond }: PlanApprovalCardProps):
   const [revising, setRevising] = useState(false);
   const [feedback, setFeedback] = useState('');
 
-  const { chatId } = useMainframeRuntime();
-  const chat = useChatsStore((s) => s.chats.find((c) => c.id === chatId));
-  const providerConfig = useSettingsStore((s) => s.providers[chat?.adapterId ?? '']);
-  const settingsDefault: ExecutionMode = providerConfig?.planExecutionMode ?? 'default';
+  const settingsDefault: ExecutionMode = 'default';
 
   const [execMode, setExecMode] = useState<ExecutionMode>(settingsDefault);
   const [execModeTouched, setExecModeTouched] = useState(false);

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -9,7 +9,7 @@ import { getConfigConflicts, updateProviderSettings } from '../../lib/api';
 import { getModelOptions } from '../../lib/adapters';
 import type { ProviderConfig } from '@qlan-ro/mainframe-types';
 import { ModelDropdown } from './ModelDropdown';
-import { MODE_OPTIONS, EXECUTION_MODE_OPTIONS } from './constants';
+import { MODE_OPTIONS } from './constants';
 
 const EMPTY_CONFIG: ProviderConfig = {};
 
@@ -98,37 +98,6 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
           ))}
         </div>
       </div>
-
-      {/* Plan execution mode (shown when Plan Mode is active) */}
-      {(config.defaultMode ?? 'default') === 'plan' && (
-        <div className="space-y-1.5">
-          <label className="text-mf-small text-mf-text-secondary">After Plan Approval</label>
-          <div className="space-y-1">
-            {EXECUTION_MODE_OPTIONS.map((mode) => (
-              <label
-                key={mode.id}
-                className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors"
-              >
-                <input
-                  type="radio"
-                  name={`${adapterId}-exec-mode`}
-                  checked={(config.planExecutionMode ?? 'default') === mode.id}
-                  onChange={() => update({ planExecutionMode: mode.id })}
-                  className={`mt-0.5 ${mode.id === 'yolo' ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
-                />
-                <div>
-                  <span
-                    className={`text-mf-small ${mode.id === 'yolo' ? 'text-mf-destructive' : 'text-mf-text-primary'}`}
-                  >
-                    {mode.label}
-                  </span>
-                  <p className="text-mf-status text-mf-text-secondary">{mode.description}</p>
-                </div>
-              </label>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/settings/constants.ts
+++ b/packages/desktop/src/renderer/components/settings/constants.ts
@@ -20,20 +20,6 @@ export const MODE_OPTIONS: {
   { id: 'plan', label: 'Plan Mode', description: 'Research only until plan is approved' },
 ];
 
-export const EXECUTION_MODE_OPTIONS: {
-  id: NonNullable<ProviderConfig['planExecutionMode']>;
-  label: string;
-  description: string;
-}[] = [
-  { id: 'default', label: 'Interactive', description: 'Prompts for everything after plan approval' },
-  { id: 'acceptEdits', label: 'Auto-Accept Edits', description: 'Auto-approves file edits, prompts for bash' },
-  {
-    id: 'yolo',
-    label: 'Skip All Permissions',
-    description: 'Auto-approves everything — use in isolated environments only',
-  },
-];
-
 export const SIDEBAR_TABS: { id: SettingsTab; label: string; icon: React.ElementType }[] = [
   { id: 'general', label: 'General', icon: SlidersHorizontal },
   { id: 'providers', label: 'Providers', icon: Cpu },

--- a/packages/e2e/tests/07-plan-approval.spec.ts
+++ b/packages/e2e/tests/07-plan-approval.spec.ts
@@ -42,6 +42,20 @@ test.describe('§7 Plan approval', () => {
     await waitForAIIdle(fixture.page, 60_000);
   });
 
+  test('session exits plan mode after approval — next message does not re-enter plan mode', async () => {
+    // This is the same chat from the previous test — plan was approved, execution completed.
+    // Sending a new message should NOT trigger another plan card.
+    await sendMessage(fixture.page, 'What is 2 + 2? Answer with just the number.');
+    const planCard = fixture.page.locator('[data-testid="plan-approval-card"]');
+    // Wait for AI to either show a plan card (bug) or finish (correct).
+    // Use a race: if the plan card appears within 15s, that's a regression.
+    const raced = await Promise.race([
+      planCard.waitFor({ timeout: 15_000 }).then(() => 'plan-card' as const),
+      waitForAIIdle(fixture.page, 30_000).then(() => 'idle' as const),
+    ]);
+    expect(raced).toBe('idle');
+  });
+
   test('plan revision feedback is sent back to AI', async () => {
     await createTestChat(fixture.page, project.projectId, 'plan');
     await sendMessage(

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -3,7 +3,6 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'yolo';
 export interface ProviderConfig {
   defaultModel?: string;
   defaultMode?: 'default' | 'acceptEdits' | 'yolo' | 'plan';
-  planExecutionMode?: 'default' | 'acceptEdits' | 'yolo';
   executablePath?: string;
 }
 


### PR DESCRIPTION
## Summary
- Always pass `--permission-mode <mode> --allow-dangerously-skip-permissions` at CLI spawn instead of conditional flag logic
- Remove daemon-side yolo auto-approval — CLI handles `bypassPermissions` mode natively
- Eliminate `planExecutionMode` tracking (per-chat, per-adapter-setting, fallback chain) — ExitPlanMode dialog picks the target mode directly, falls back to `default`
- Fixes #20: resumed sessions no longer get stuck in plan mode after a plan was already executed

## Test plan
- [x] All 598 core unit tests pass
- [x] 3 e2e plan approval tests pass (including new regression test)
- [x] New `session-spawn-args.test.ts` verifies correct CLI flags for all permission modes
- [x] Updated `permission-flow.test.ts` reflects new yolo behavior (no daemon auto-approval)
- [x] New e2e test: after plan approval, next message does NOT re-enter plan mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)