### PR TITLE
fix: show skill name instead of full path in session context

### DIFF
--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -65,6 +65,49 @@ describe('handleStdout', () => {
     expect(sink.onInit).not.toHaveBeenCalled();
     expect(sink.onMessage).not.toHaveBeenCalled();
   });
+
+  it('extracts skill name (not full path) from user text blocks', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Base directory for this skill: /home/user/.claude/skills/brainstorming\n\n# Skill Content',
+          },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: '/home/user/.claude/skills/brainstorming/SKILL.md',
+      displayName: 'brainstorming',
+    });
+  });
+
+  it('extracts skill name from rawContent string (non-array content)', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: 'Base directory for this skill: /home/user/.claude/skills/my-skill\n\nSkill body here.',
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: '/home/user/.claude/skills/my-skill/SKILL.md',
+      displayName: 'my-skill',
+    });
+  });
 });
 
 describe('handleStderr', () => {

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -102,8 +102,10 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       const text = (block.text as string) || '';
       const skillMatch = text.match(/^Base directory for this skill: (.+)/m);
       if (skillMatch?.[1]) {
-        const skillPath = path.join(skillMatch[1].trim(), 'SKILL.md');
-        sink.onSkillFile({ path: skillPath, displayName: skillMatch[1].trim() });
+        const basePath = skillMatch[1].trim();
+        const skillPath = path.join(basePath, 'SKILL.md');
+        const skillName = basePath.split('/').pop() ?? basePath;
+        sink.onSkillFile({ path: skillPath, displayName: skillName });
       }
     }
   }
@@ -111,8 +113,10 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   if (typeof rawContent === 'string') {
     const skillMatch = rawContent.match(/^Base directory for this skill: (.+)/m);
     if (skillMatch?.[1]) {
-      const skillPath = path.join(skillMatch[1].trim(), 'SKILL.md');
-      sink.onSkillFile({ path: skillPath, displayName: skillMatch[1].trim() });
+      const basePath = skillMatch[1].trim();
+      const skillPath = path.join(basePath, 'SKILL.md');
+      const skillName = basePath.split('/').pop() ?? basePath;
+      sink.onSkillFile({ path: skillPath, displayName: skillName });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extract last path segment from skill base directory for `displayName` in live event handler, matching existing behavior in `history.ts` and `chats.ts`
- Fixes both array-content and string-content code paths in `events.ts`
- Adds 2 tests verifying skill name extraction

## Test plan
- [x] Core package builds cleanly
- [x] All 669 tests pass (2 new tests for skill name extraction)
- [ ] Manual: start a session that invokes a skill, verify the Context tab shows the skill name (e.g. `brainstorming`) not the full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)