### PR TITLE
fix: resolve multiple Changes tab bugs

### DIFF
--- a/packages/core/src/__tests__/claude-history-extract.test.ts
+++ b/packages/core/src/__tests__/claude-history-extract.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { extractModifiedFiles } from '../plugins/builtin/claude/history.js';
+
+const PROJECT_PATH = '/Users/test/project';
+
+function encodedProjectDir(): string {
+  return PROJECT_PATH.replace(/[^a-zA-Z0-9-]/g, '-');
+}
+
+describe('extractModifiedFiles', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let origHome: string;
+
+  beforeEach(async () => {
+    tmpDir = path.join(tmpdir(), `mf-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    projectDir = path.join(tmpDir, '.claude', 'projects', encodedProjectDir());
+    await mkdir(projectDir, { recursive: true });
+    origHome = process.env.HOME ?? '';
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = origHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeJsonl(sessionId: string, entries: Record<string, unknown>[]): Promise<void> {
+    const content = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    return writeFile(path.join(projectDir, `${sessionId}.jsonl`), content);
+  }
+
+  it('extracts Write and Edit file paths from assistant events', async () => {
+    await writeJsonl('session-1', [
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: `${PROJECT_PATH}/src/main.ts` } },
+          ],
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tu-2', name: 'Edit', input: { file_path: `${PROJECT_PATH}/lib/utils.ts` } },
+          ],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-1', PROJECT_PATH);
+    expect(files).toContain('src/main.ts');
+    expect(files).toContain('lib/utils.ts');
+    expect(files).toHaveLength(2);
+  });
+
+  it('deduplicates files', async () => {
+    await writeJsonl('session-2', [
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: `${PROJECT_PATH}/src/main.ts` } },
+          ],
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'tu-2', name: 'Edit', input: { file_path: `${PROJECT_PATH}/src/main.ts` } },
+          ],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-2', PROJECT_PATH);
+    expect(files).toEqual(['src/main.ts']);
+  });
+
+  it('ignores non-Write/Edit tools', async () => {
+    await writeJsonl('session-3', [
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } }],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-3', PROJECT_PATH);
+    expect(files).toEqual([]);
+  });
+
+  it('ignores user events', async () => {
+    await writeJsonl('session-4', [
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok' }],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-4', PROJECT_PATH);
+    expect(files).toEqual([]);
+  });
+
+  it('skips paths outside project', async () => {
+    await writeJsonl('session-5', [
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: '/etc/passwd' } }],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-5', PROJECT_PATH);
+    expect(files).toEqual([]);
+  });
+
+  it('returns empty for nonexistent JSONL', async () => {
+    const files = await extractModifiedFiles('nonexistent', PROJECT_PATH);
+    expect(files).toEqual([]);
+  });
+
+  it('handles relative paths directly', async () => {
+    await writeJsonl('session-6', [
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: 'src/relative.ts' } }],
+        },
+      },
+    ]);
+
+    const files = await extractModifiedFiles('session-6', PROJECT_PATH);
+    expect(files).toEqual(['src/relative.ts']);
+  });
+});

--- a/packages/core/src/__tests__/helpers/mock-session.ts
+++ b/packages/core/src/__tests__/helpers/mock-session.ts
@@ -82,6 +82,10 @@ export class MockBaseSession implements AdapterSession {
     return [];
   }
 
+  async extractModifiedFiles(): Promise<string[]> {
+    return [];
+  }
+
   // ── Test simulation helpers ───────────────────────────────────────────────
 
   simulateInit(sessionId: string): void {

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -224,9 +224,14 @@ export class ChatLifecycleManager {
       }
 
       try {
-        const [planPaths, skillPaths] = await Promise.all([session.extractPlanFiles(), session.extractSkillFiles()]);
+        const [planPaths, skillPaths, modifiedFiles] = await Promise.all([
+          session.extractPlanFiles(),
+          session.extractSkillFiles(),
+          session.extractModifiedFiles(),
+        ]);
         for (const p of planPaths) this.deps.db.chats.addPlanFile(chatId, p);
         for (const p of skillPaths) this.deps.db.chats.addSkillFile(chatId, p);
+        for (const f of modifiedFiles) this.deps.db.chats.addModifiedFile(chatId, f);
       } catch {
         /* best-effort */
       }

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -273,6 +273,48 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
   return filterSkillExpansions(messages);
 }
 
+export async function extractModifiedFiles(sessionId: string, projectPath: string): Promise<string[]> {
+  const { jsonlPath } = getSessionJsonlPath(sessionId, projectPath);
+
+  try {
+    await access(jsonlPath, constants.R_OK);
+  } catch {
+    return [];
+  }
+
+  const files = new Set<string>();
+  const stream = createReadStream(jsonlPath);
+  try {
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type !== 'assistant') continue;
+        const content = entry.message?.content;
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+          if (block.type !== 'tool_use') continue;
+          if (block.name !== 'Write' && block.name !== 'Edit') continue;
+          let filePath = block.input?.file_path as string | undefined;
+          if (!filePath) continue;
+          if (path.isAbsolute(filePath)) {
+            filePath = path.relative(projectPath, filePath);
+          }
+          if (filePath.startsWith('..')) continue;
+          files.add(filePath);
+        }
+      } catch {
+        /* skip malformed */
+      }
+    }
+  } finally {
+    stream.destroy();
+  }
+
+  return [...files];
+}
+
 export async function extractPlanFilePaths(sessionId: string, projectPath: string): Promise<string[]> {
   const { jsonlPath, projectDir } = getSessionJsonlPath(sessionId, projectPath);
 

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -21,6 +21,7 @@ import {
   loadHistory as loadHistoryFromDisk,
   extractPlanFilePaths as extractPlans,
   extractSkillFilePaths as extractSkills,
+  extractModifiedFiles as extractModified,
 } from './history.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 
@@ -355,5 +356,10 @@ export class ClaudeSession implements AdapterSession {
   async extractSkillFiles(): Promise<SkillFileEntry[]> {
     if (!this.resumeSessionId) return [];
     return extractSkills(this.resumeSessionId, this.projectPath);
+  }
+
+  async extractModifiedFiles(): Promise<string[]> {
+    if (!this.resumeSessionId) return [];
+    return extractModified(this.resumeSessionId, this.projectPath);
   }
 }

--- a/packages/core/src/server/routes/git.ts
+++ b/packages/core/src/server/routes/git.ts
@@ -32,7 +32,8 @@ async function handleGitStatus(ctx: RouteContext, req: Request, res: Response): 
           }
         }
         return { status: code, path: rest };
-      });
+      })
+      .filter((f) => !f.path.endsWith('/'));
     res.json({ files });
   } catch (err) {
     if ((err as { code?: unknown }).code !== 128) {
@@ -94,7 +95,11 @@ async function handleDiff(ctx: RouteContext, req: Request, res: Response): Promi
           res.status(403).json({ error: 'Path outside project' });
           return;
         }
-        modified = await readFile(resolvedFile, 'utf-8');
+        try {
+          modified = await readFile(resolvedFile, 'utf-8');
+        } catch {
+          /* deleted file */
+        }
       }
       res.json({ diff, original, modified, source: 'git' });
     } catch (err) {
@@ -109,25 +114,25 @@ async function handleDiff(ctx: RouteContext, req: Request, res: Response): Promi
       res.json({ files: modifiedFiles, source: 'session' });
       return;
     }
-    try {
-      const resolvedFile = resolveAndValidatePath(basePath, file);
-      if (!resolvedFile) {
-        res.status(403).json({ error: 'Path outside project' });
-        return;
-      }
-      let original = '';
-      const headPath = oldPath || file;
-      try {
-        original = await execGit(['show', `HEAD:${headPath}`], basePath);
-      } catch {
-        /* new file */
-      }
-      const modified = await readFile(resolvedFile, 'utf-8');
-      res.json({ original, modified, source: 'session', file });
-    } catch (err) {
-      logger.warn({ err, file }, 'Failed to read session diff file');
-      res.status(404).json({ error: 'File not found' });
+    const resolvedFile = resolveAndValidatePath(basePath, file);
+    if (!resolvedFile) {
+      res.status(403).json({ error: 'Path outside project' });
+      return;
     }
+    let original = '';
+    const headPath = oldPath || file;
+    try {
+      original = await execGit(['show', `HEAD:${headPath}`], basePath);
+    } catch {
+      /* new file */
+    }
+    let modified = '';
+    try {
+      modified = await readFile(resolvedFile, 'utf-8');
+    } catch {
+      /* deleted file */
+    }
+    res.json({ original, modified, source: 'session', file });
   } else {
     res.status(400).json({ error: 'Invalid source. Use "git" or "session".' });
   }

--- a/packages/desktop/src/renderer/components/panels/ChangesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChangesTab.tsx
@@ -21,7 +21,7 @@ const statusLabels: Record<string, { label: string; color: string }> = {
   M: { label: 'Modified', color: 'text-mf-warning' },
   A: { label: 'Added', color: 'text-mf-success' },
   D: { label: 'Deleted', color: 'text-mf-destructive' },
-  '?': { label: 'Untracked', color: 'text-mf-text-secondary' },
+  '??': { label: 'Untracked', color: 'text-mf-text-secondary' },
   R: { label: 'Renamed', color: 'text-mf-info' },
 };
 
@@ -72,6 +72,7 @@ export function ChangesTab(): React.ReactElement {
   }, [activeProjectId]);
   useEffect(() => {
     if (mode === 'session') refreshSession();
+    else refreshBranch();
   }, [activeChatId, mode]);
 
   useEffect(() => {
@@ -159,7 +160,7 @@ export function ChangesTab(): React.ReactElement {
               return (
                 <button
                   key={file.path}
-                  onClick={() => openDiffTab(file.path, 'git', undefined, file.oldPath)}
+                  onClick={() => openDiffTab(file.path, 'git', activeChatId ?? undefined, file.oldPath)}
                   className={cn(
                     'w-full flex items-center gap-2 px-2 py-1 rounded-mf-input text-left',
                     isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -127,6 +127,7 @@ export interface AdapterSession {
   loadHistory(): Promise<import('./chat.js').ChatMessage[]>;
   extractPlanFiles(): Promise<string[]>;
   extractSkillFiles(): Promise<import('./context.js').SkillFileEntry[]>;
+  extractModifiedFiles(): Promise<string[]>;
 }
 
 export interface AdapterInfo {


### PR DESCRIPTION
## Summary
- **`??` status label**: `git status --porcelain` outputs `??` for untracked files but the frontend mapped single `?` — showed raw `??` instead of "Untracked"
- **Directories in file list**: Untracked directories (`?? dirname/`) appeared as files — now filtered out
- **Stale branch data**: Switching to Branch mode didn't refresh — showed data from initial load only
- **Deleted file diffs crash**: Both git and session diff sources threw on deleted files — now gracefully show empty modified content
- **Session changes empty**: Imported/resumed sessions had no modified files — now extracts Write/Edit tool paths from JSONL history on session start via `extractModifiedFiles()`
- **Worktree diffs broken in branch mode**: `openDiffTab` passed `undefined` for chatId — diffs used main project path instead of worktree

## Test plan
- [x] `extractModifiedFiles` unit tests (7 cases: Write/Edit extraction, dedup, ignore non-Write tools, ignore user events, skip paths outside project, nonexistent JSONL, relative paths)
- [x] Existing git route tests pass (5 cases)
- [x] Existing context-tracker tests pass (12 cases)
- [x] Existing event-handler tests pass (12 cases)
- [x] Types build (`@qlan-ro/mainframe-types`)
- [x] Core builds (`@qlan-ro/mainframe-core`)
- [ ] Manual: verify Branch mode shows "Untracked" label (not `??`)
- [ ] Manual: verify no directories appear in Branch mode file list
- [ ] Manual: verify switching Session ↔ Branch refreshes data
- [ ] Manual: verify clicking a changed file in a worktree chat opens correct diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)