### PR TITLE
feat: handle deleted worktrees gracefully

### DIFF
--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -11,6 +11,7 @@ import type {
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
+import { existsSync } from 'node:fs';
 import { createChildLogger } from '../logger.js';
 import { MessageCache } from './message-cache.js';
 import { PermissionManager } from './permission-manager.js';
@@ -171,6 +172,20 @@ export class ChatManager {
     attachmentIds?: string[],
     metadata?: { command?: { name: string; source: string; args?: string } },
   ): Promise<void> {
+    const chat = this.getChat(chatId);
+    if (chat?.worktreeMissing) {
+      const errorMsg = this.messages.createTransientMessage(chatId, 'error', [
+        {
+          type: 'error',
+          message: `Worktree directory no longer exists: ${chat.worktreePath}. Archive this session or recreate the worktree.`,
+        },
+      ]);
+      this.messages.append(chatId, errorMsg);
+      this.emitEvent({ type: 'message.added', chatId, message: errorMsg });
+      this.eventHandler.emitDisplay(chatId);
+      return;
+    }
+
     const active = this.activeChats.get(chatId);
     if (!active?.session?.isSpawned) {
       await this.lifecycle.startChat(chatId);
@@ -288,8 +303,11 @@ export class ChatManager {
 
   getChat(chatId: string): Chat | null {
     const active = this.activeChats.get(chatId);
-    if (active) return active.chat;
-    return this.db.chats.get(chatId);
+    const chat = active ? active.chat : this.db.chats.get(chatId);
+    if (chat?.worktreePath) {
+      chat.worktreeMissing = !existsSync(chat.worktreePath);
+    }
+    return chat;
   }
 
   getEffectivePath(chatId: string): string | null {
@@ -392,6 +410,7 @@ export class ChatManager {
       const hasPending = this.permissions.hasPending(chat.id);
       chat.displayStatus = hasPending ? 'waiting' : chat.processState === 'working' ? 'working' : 'idle';
       chat.isRunning = chat.processState === 'working' && !hasPending;
+      chat.worktreeMissing = chat.worktreePath ? !existsSync(chat.worktreePath) : false;
     }
     this.onEvent(event);
   }

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -3,6 +3,7 @@ import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
 import type { DatabaseManager } from '../db/index.js';
 import { removeWorktree } from '../workspace/index.js';
+import { existsSync } from 'node:fs';
 import { createChildLogger } from '../logger.js';
 import { generateTitle } from './title-generator.js';
 import { extractMentionsFromText } from './context-tracker.js';
@@ -192,6 +193,10 @@ export class ChatLifecycleManager {
 
     const effectivePath = chat.worktreePath ?? project.path;
 
+    if (chat.worktreePath && !existsSync(chat.worktreePath)) {
+      return;
+    }
+
     if (chat.claudeSessionId) {
       const session = adapter.createSession({ projectPath: effectivePath, chatId: chat.claudeSessionId });
       const active = this.deps.activeChats.get(chatId)!;
@@ -250,6 +255,11 @@ export class ChatLifecycleManager {
     }
 
     const { chat } = active;
+
+    if (chat.worktreePath && !existsSync(chat.worktreePath)) {
+      throw new Error(`Worktree directory does not exist: ${chat.worktreePath}`);
+    }
+
     const adapter = this.deps.adapters.get(chat.adapterId);
     if (!adapter) throw new Error(`Adapter ${chat.adapterId} not found`);
 

--- a/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
+++ b/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
@@ -32,6 +32,15 @@ function StatusIndicator({ chatId }: { chatId: string }) {
 
   if (!chat) return null;
 
+  if (chat.worktreeMissing) {
+    return (
+      <div className="flex items-center gap-1.5 text-mf-destructive">
+        <AlertTriangle size={12} className="shrink-0" />
+        <span>Worktree Missing</span>
+      </div>
+    );
+  }
+
   if (hasPendingPermission) {
     return (
       <div className="flex items-center gap-1.5 text-mf-text-secondary">

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
-import { ArrowUp, Square, Paperclip, Shield, GitBranch, X } from 'lucide-react';
+import { ArrowUp, Square, Paperclip, Shield, GitBranch, X, AlertTriangle } from 'lucide-react';
 import { createLogger } from '../../../../lib/logger';
 
 const log = createLogger('renderer:composer');
@@ -98,9 +98,17 @@ function StopButton() {
   );
 }
 
-function SendButton({ composerRuntime, hasCaptures }: { composerRuntime: ComposerRuntime; hasCaptures: boolean }) {
+function SendButton({
+  composerRuntime,
+  hasCaptures,
+  disabled: externalDisabled,
+}: {
+  composerRuntime: ComposerRuntime;
+  hasCaptures: boolean;
+  disabled?: boolean;
+}) {
   const composerEmpty = useComposerEmpty(composerRuntime);
-  const disabled = composerEmpty && !hasCaptures;
+  const disabled = externalDisabled || (composerEmpty && !hasCaptures);
   return (
     <button
       type="button"
@@ -263,6 +271,15 @@ export function ComposerCard() {
           </button>
         </div>
       )}
+      {chat?.worktreeMissing && (
+        <div className="mx-3 mt-2 rounded-md bg-mf-destructive/15 px-3 py-2 text-mf-small text-mf-destructive flex items-center gap-2">
+          <AlertTriangle size={14} className="shrink-0" />
+          <span>
+            The worktree for this session was deleted. Archive this session or recreate the worktree at{' '}
+            <code className="font-mono text-mf-status">{chat.worktreePath}</code>.
+          </span>
+        </div>
+      )}
 
       <div className="relative">
         <ComposerHighlight />
@@ -271,6 +288,7 @@ export function ComposerCard() {
           rows={2}
           autoFocus
           spellCheck={false}
+          disabled={chat?.worktreeMissing}
           placeholder="Type @ to search files, / for skills… (Enter to send)"
           className="w-full bg-transparent border-none px-3 py-2 font-sans text-mf-chat text-transparent caret-mf-text-primary selection:text-mf-text-primary resize-none placeholder:text-mf-text-secondary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
         />
@@ -322,7 +340,11 @@ export function ComposerCard() {
         </div>
         <div className="flex items-center gap-1">
           <StopButton />
-          <SendButton composerRuntime={composerRuntime} hasCaptures={captures.length > 0} />
+          <SendButton
+            composerRuntime={composerRuntime}
+            hasCaptures={captures.length > 0}
+            disabled={chat?.worktreeMissing}
+          />
         </div>
       </div>
     </ComposerPrimitive.Root>

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -22,7 +22,10 @@ interface ContextMenuState {
   items: ContextMenuItem[];
 }
 
-function SessionStatusDot({ status }: { status: SessionStatus }) {
+function SessionStatusDot({ status, worktreeMissing }: { status: SessionStatus; worktreeMissing?: boolean }) {
+  if (worktreeMissing) {
+    return <div data-testid="chat-status-missing" className="w-2 h-2 rounded-full shrink-0 bg-mf-destructive" />;
+  }
   const isWorking = status === 'working' || status === 'waiting';
   return (
     <div
@@ -236,7 +239,7 @@ export function ChatsPanel(): React.ReactElement {
                   className="flex-1 min-w-0 px-3 py-2 text-left rounded-mf-input"
                 >
                   <div className="flex items-center gap-2">
-                    <SessionStatusDot status={chat.displayStatus ?? 'idle'} />
+                    <SessionStatusDot status={chat.displayStatus ?? 'idle'} worktreeMissing={chat.worktreeMissing} />
                     <div className="flex-1 min-w-0">
                       <div
                         className={cn(

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -23,6 +23,7 @@ export interface Chat {
   processState?: 'working' | 'idle' | null;
   displayStatus?: 'idle' | 'working' | 'waiting';
   isRunning?: boolean;
+  worktreeMissing?: boolean;
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary
- Detect when a session's worktree directory has been deleted externally and surface clear feedback instead of silently failing
- Add computed `worktreeMissing` flag to `Chat` (set via `existsSync` in `emitEvent`/`getChat`)
- Reject `sendMessage` early with an inline error message, guard `doLoadChat`/`doStartChat` against missing paths
- Show "Worktree Missing" status in session bar, red dot in chat list, and disabled composer with explanatory banner

Closes #21

## Test plan
- [ ] Create a session with worktree enabled, send a message so CLI starts
- [ ] Delete the worktree directory manually (`rm -rf`)
- [ ] Verify session bar shows "Worktree Missing" with alert icon
- [ ] Verify composer shows banner and input is disabled
- [ ] Verify chat list shows red status dot
- [ ] Verify archiving the session still works
- [ ] Verify sessions without worktrees are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)