### PR TITLE
fix: preserve agent label in task groups and stable session list order

### DIFF
--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -179,6 +179,7 @@ function convertGroupedPartsToDisplay(
       result.push({
         type: 'task_group',
         agentId,
+        taskArgs: taskArgs ?? {},
         calls: children.map((child) => {
           if (child.type !== 'tool-call') return { type: 'text' as const, text: child.text };
           return {

--- a/packages/core/src/messages/tool-grouping.ts
+++ b/packages/core/src/messages/tool-grouping.ts
@@ -152,6 +152,12 @@ export function groupTaskChildren(parts: PartEntry[], categories: ToolCategories
       let j = i + 1;
       while (j < parts.length) {
         const next = parts[j]!;
+        // Sentinel text entries (\0ng:N) are non-groupable placeholders (thinking,
+        // images) — skip over them without breaking or adding as children.
+        if (next.type === 'text' && next.text.startsWith('\0ng:')) {
+          j++;
+          continue;
+        }
         if (next.type === 'text') break;
         if (next.type === 'tool-call' && isSubagentTool(next.toolName, categories)) break;
         children.push(next);

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -208,6 +208,44 @@ export function filterSkillExpansions(messages: ChatMessage[]): ChatMessage[] {
   });
 }
 
+function collectAgentProgressTools(entry: Record<string, unknown>, agentTools: Map<string, MessageContent[]>): void {
+  const parentId = entry.parentToolUseID as string | undefined;
+  if (!parentId) return;
+  const data = entry.data as Record<string, unknown>;
+  const msg = data.message as Record<string, unknown> | undefined;
+  const inner = msg?.message as Record<string, unknown> | undefined;
+  if (!inner || inner.role !== 'assistant') return;
+  const content = inner.content as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(content)) return;
+
+  for (const block of content) {
+    if (block.type !== 'tool_use') continue;
+    const existing = agentTools.get(parentId) ?? [];
+    existing.push({
+      type: 'tool_use',
+      id: (block.id as string) || nanoid(),
+      name: block.name as string,
+      input: (block.input as Record<string, unknown>) ?? {},
+    });
+    agentTools.set(parentId, existing);
+  }
+}
+
+function injectAgentChildren(messages: ChatMessage[], agentTools: Map<string, MessageContent[]>): void {
+  for (const msg of messages) {
+    if (msg.type !== 'assistant') continue;
+    const newContent: MessageContent[] = [];
+    for (const block of msg.content) {
+      newContent.push(block);
+      if (block.type === 'tool_use' && (block.name === 'Agent' || block.name === 'Task')) {
+        const children = agentTools.get(block.id);
+        if (children) newContent.push(...children);
+      }
+    }
+    msg.content = newContent;
+  }
+}
+
 function getSessionJsonlPath(sessionId: string, projectPath: string): { jsonlPath: string; projectDir: string } {
   const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
   const projectDir = path.join(homedir(), '.claude', 'projects', encodedPath);
@@ -249,6 +287,8 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
   }
 
   const messages: ChatMessage[] = [];
+  const agentTools = new Map<string, MessageContent[]>();
+
   for (const file of jsonlFiles) {
     const stream = createReadStream(file);
     try {
@@ -259,6 +299,13 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           const entry = JSON.parse(line);
           if (entry.isMeta === true) continue;
           if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) continue;
+
+          // Collect tool_use blocks from agent_progress events
+          if (entry.type === 'progress' && entry.data?.type === 'agent_progress') {
+            collectAgentProgressTools(entry, agentTools);
+            continue;
+          }
+
           const msg = convertHistoryEntry(entry, sessionId);
           if (msg) messages.push(msg);
         } catch {
@@ -268,6 +315,11 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
     } finally {
       stream.destroy();
     }
+  }
+
+  // Inject collected subagent tool calls after their parent Agent tool_use blocks
+  if (agentTools.size > 0) {
+    injectAgentChildren(messages, agentTools);
   }
 
   return filterSkillExpansions(messages);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -104,13 +104,12 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
             const calls = block.calls.filter(
               (c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call',
             );
-            const firstCall = calls[0];
             parts.push({
               type: 'tool-call',
               toolCallId: block.agentId,
               toolName: '_TaskGroup',
               args: {
-                taskArgs: firstCall?.input ?? {},
+                taskArgs: block.taskArgs,
                 children: calls.map((c) => ({
                   toolCallId: c.id,
                   toolName: c.name,
@@ -119,7 +118,7 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
                   isError: c.result?.isError,
                 })),
               } as import('assistant-stream/utils').ReadonlyJSONObject,
-              result: firstCall?.result,
+              result: calls[0]?.result,
             });
             break;
           }

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -39,9 +39,19 @@ export const useChatsStore = create<ChatsState>((set) => ({
   setActiveChat: (id) => set({ activeChatId: id }),
   addChat: (chat) => set((state) => ({ chats: [chat, ...state.chats] })),
   updateChat: (chat) =>
-    set((state) => ({
-      chats: [chat, ...state.chats.filter((c) => c.id !== chat.id)],
-    })),
+    set((state) => {
+      const idx = state.chats.findIndex((c) => c.id === chat.id);
+      if (idx === -1) return { chats: [chat, ...state.chats] };
+      const prev = state.chats[idx]!;
+      // Only move to top when updatedAt actually changed (real content update)
+      if (chat.updatedAt !== prev.updatedAt) {
+        return { chats: [chat, ...state.chats.filter((c) => c.id !== chat.id)] };
+      }
+      // Otherwise update in-place to preserve list order
+      const updated = [...state.chats];
+      updated[idx] = chat;
+      return { chats: updated };
+    }),
   removeChat: (id) =>
     set((state) => ({
       chats: state.chats.filter((c) => c.id !== id),

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -28,7 +28,7 @@ export type DisplayContent =
       result?: ToolCallResult;
     }
   | { type: 'tool_group'; calls: DisplayContent[] }
-  | { type: 'task_group'; agentId: string; calls: DisplayContent[] }
+  | { type: 'task_group'; agentId: string; taskArgs: Record<string, unknown>; calls: DisplayContent[] }
   | { type: 'permission_request'; request: unknown }
   | { type: 'error'; message: string };
 


### PR DESCRIPTION
## Summary
- **Preserve agent taskArgs through task_group display round-trip**: The `task_group` DisplayContent type was missing the parent Agent's input (`subagent_type`, `model`, `description`). `convertGroupedPartsToDisplay` dropped `taskArgs`, and `convertMessage` reconstructed it from the first child's input — losing the agent label ("Explore" → "Task"). Now `taskArgs` is carried through both layers.
- **Stable session list order on metadata updates**: `updateChat` was moving every updated session to the top of the list, even for metadata-only changes (status, tokens). Now it only reorders when `updatedAt` changes (real content update), otherwise updates in-place.

## Test plan
- [x] Dispatch an Explore agent → verify label stays "Explore" (not "Task") after children are grouped
- [x] Reload chat from history → verify TaskGroupCard shows correct agent type
- [x] Send messages in a chat → verify session moves to top of list
- [x] Observe status/token updates → verify session stays in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)