### PR TITLE
feat: auto-refresh file tree on agent writes, window focus, and manual trigger

### DIFF
--- a/docs/superpowers/plans/2026-03-15-file-tree-refresh.md
+++ b/docs/superpowers/plans/2026-03-15-file-tree-refresh.md
@@ -1,0 +1,229 @@
+# File Tree Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-refresh the file tree when an agent session modifies files, using debounced `context.updated` WebSocket events.
+
+**Architecture:** Add a `refreshKey` counter to `FilesTab` that increments on debounced `context.updated` events. Pass it to `FileTreeNode` children. Expanded nodes re-fetch; collapsed nodes with stale caches clear their children. Mirrors the proven ContextTab debounce pattern exactly.
+
+**Tech Stack:** React, TypeScript, WebSocket (existing `daemonClient`)
+
+**Spec:** `docs/superpowers/specs/2026-03-15-file-tree-refresh-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/desktop/src/renderer/components/panels/FilesTab.tsx` | Modify | Add event subscription, debounce, refreshKey propagation |
+
+Single file change. No new files, no new types, no daemon changes.
+
+---
+
+## Chunk 1: Implementation
+
+### Task 1: Add debounced `context.updated` subscription to `FilesTab`
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/panels/FilesTab.tsx`
+
+- [ ] **Step 1: Add imports and refreshKey state**
+
+Add `useRef` to the React import. Import `daemonClient`. Add `refreshKey` state and `debounceRef`.
+
+In `FilesTab`, after the existing state declarations (line 108):
+
+```typescript
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+```
+
+```typescript
+import { daemonClient } from '../../lib/client';
+```
+
+Inside `FilesTab()`, after `const [contextMenu, setContextMenu] = ...`:
+
+```typescript
+const [refreshKey, setRefreshKey] = useState(0);
+const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+```
+
+- [ ] **Step 2: Add the event subscription useEffect**
+
+Add a new `useEffect` after the existing root-fetch effect (after line 115). This mirrors `ContextTab.tsx:30-41` exactly:
+
+```typescript
+useEffect(() => {
+  if (!activeChatId) return;
+  const unsub = daemonClient.onEvent((event) => {
+    if (event.type === 'context.updated' && event.chatId === activeChatId) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        setRefreshKey((k) => k + 1);
+      }, 500);
+    }
+  });
+  return () => {
+    unsub();
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  };
+}, [activeChatId]);
+```
+
+- [ ] **Step 3: Add `refreshKey` to root fetch dependency array**
+
+Change the existing root-fetch `useEffect` (line 110-115) to include `refreshKey`:
+
+Before:
+```typescript
+}, [activeProjectId, activeChatId]);
+```
+
+After:
+```typescript
+}, [activeProjectId, activeChatId, refreshKey]);
+```
+
+- [ ] **Step 4: Pass `refreshKey` to `FileTreeNode`**
+
+Update the `FileTreeNode` render call (around line 168) to pass the prop:
+
+```tsx
+<FileTreeNode
+  key={entry.path}
+  entry={entry}
+  depth={1}
+  projectPath={activeProject.path}
+  onContextMenu={handleContextMenu}
+  refreshKey={refreshKey}
+/>
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/panels/FilesTab.tsx
+git commit -m "feat(files-tab): add debounced context.updated subscription with refreshKey"
+```
+
+---
+
+### Task 2: Handle `refreshKey` in `FileTreeNode`
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/panels/FilesTab.tsx`
+
+- [ ] **Step 1: Add `refreshKey` to `FileTreeNode` props**
+
+Update the props type and destructuring (around line 27-36):
+
+```typescript
+function FileTreeNode({
+  entry,
+  depth,
+  projectPath,
+  onContextMenu,
+  refreshKey,
+}: {
+  entry: FileEntry;
+  depth: number;
+  projectPath: string;
+  onContextMenu: (e: React.MouseEvent, entryPath: string) => void;
+  refreshKey: number;
+}): React.ReactElement {
+```
+
+- [ ] **Step 2: Add refs to avoid stale closures, then add the refresh useEffect**
+
+The `refreshKey` effect needs current values of `expanded` and `children` without adding them as dependencies (which would cause re-runs on every expand/collapse). Use refs:
+
+After the existing state declarations in `FileTreeNode`, add refs:
+
+```typescript
+const expandedRef = useRef(expanded);
+expandedRef.current = expanded;
+const childrenRef = useRef(children);
+childrenRef.current = children;
+```
+
+Then add the refresh effect:
+
+```typescript
+useEffect(() => {
+  if (refreshKey === 0) return;
+  if (entry.type !== 'directory') return;
+  if (expandedRef.current && activeProjectId) {
+    getFileTree(activeProjectId, entry.path, activeChatId ?? undefined)
+      .then(setChildren)
+      .catch((err) => log.warn('refresh file tree failed', { err: String(err) }));
+  } else if (childrenRef.current.length > 0) {
+    setChildren([]);
+  }
+}, [refreshKey, activeProjectId, activeChatId, entry.path, entry.type]);
+```
+
+Note: `expandedRef`/`childrenRef` read current values without triggering re-runs. The remaining deps (`activeProjectId`, `activeChatId`, `entry.path`, `entry.type`) are stable or change only on tree restructure.
+
+- [ ] **Step 3: Pass `refreshKey` to child `FileTreeNode` recursively**
+
+Update the recursive render (around line 90):
+
+```tsx
+<FileTreeNode
+  key={child.path}
+  entry={child}
+  depth={depth + 1}
+  projectPath={projectPath}
+  onContextMenu={onContextMenu}
+  refreshKey={refreshKey}
+/>
+```
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/panels/FilesTab.tsx
+git commit -m "feat(files-tab): handle refreshKey in FileTreeNode for auto-refresh"
+```
+
+---
+
+### Task 3: Manual testing
+
+- [ ] **Step 1: Build and run the app**
+
+```bash
+pnpm build && pnpm --filter @qlan-ro/mainframe-desktop dev
+```
+
+- [ ] **Step 2: Test the refresh behavior**
+
+1. Open a project in the app
+2. Navigate to the Files tab in the right panel
+3. Expand a few directories
+4. Start a chat session and ask the agent to create a new file in an expanded directory
+5. Verify: the new file appears in the tree within ~1 second (500ms debounce + fetch time)
+6. Ask the agent to create a file in a collapsed directory
+7. Expand that directory — verify the new file is visible (fresh fetch, not stale cache)
+8. Ask the agent to delete a file visible in an expanded directory
+9. Verify: the file disappears from the tree
+
+- [ ] **Step 3: Test edge cases**
+
+1. Switch to the Context tab while the agent is writing files — switch back to Files tab — verify no errors in console
+2. Switch the active chat — verify no stale refreshes from the old chat
+3. Rapid file writes (ask agent to scaffold multiple files) — verify the tree settles once, not flickering
+
+- [ ] **Step 4: Final commit if any adjustments were needed**
+
+```bash
+git add -u
+git commit -m "fix(files-tab): adjustments from manual testing"
+```

--- a/docs/superpowers/specs/2026-03-15-file-tree-refresh-design.md
+++ b/docs/superpowers/specs/2026-03-15-file-tree-refresh-design.md
@@ -1,0 +1,72 @@
+# File Tree Refresh on Agent Changes
+
+## Problem
+
+When an agent session writes, deletes, or renames files, the Files tab in the right panel does not update. Users must switch projects/chats or re-expand directories to see changes. This breaks the feedback loop during active agent sessions.
+
+## Solution
+
+Subscribe FilesTab to the existing `context.updated` WebSocket event (already emitted by the daemon when session file changes are detected). Debounce rapid events and re-fetch all currently expanded directories.
+
+## Scope
+
+- **In scope:** Agent-driven refresh via `context.updated`, debouncing, preserving expand/collapse state.
+- **Out of scope:** OS-level file watching (external editor changes), auto-reveal of new files, persistent expand state across tab switches.
+
+## Design
+
+### Mechanism
+
+A `refreshKey` counter in `FilesTab` increments on debounced `context.updated` events. Both the root fetch and each expanded `FileTreeNode` include `refreshKey` in their `useEffect` dependency arrays, triggering re-fetches.
+
+### Data flow
+
+```
+Agent writes file
+  -> Daemon emits context.updated (existing behavior)
+  -> FilesTab receives event, starts 500ms debounce timer
+  -> Additional writes reset the timer
+  -> Timer fires -> refreshKey++
+  -> Root useEffect fires -> re-fetches root entries
+  -> Each expanded FileTreeNode useEffect fires -> re-fetches its children
+  -> Tree UI updates
+```
+
+### Changes
+
+**File: `packages/desktop/src/renderer/components/panels/FilesTab.tsx`**
+
+This is the only file modified.
+
+1. Import `daemonClient` from `../../lib/client`.
+2. Add `refreshKey` state (number, starts at 0).
+3. Add a `useRef` for the debounce timer (matches ContextTab pattern).
+4. Add `useEffect` subscribing to `context.updated` events, with 500ms trailing debounce. The handler must guard `event.chatId === activeChatId` before triggering. Dependencies: `[activeChatId]`.
+5. Add `refreshKey` to the root entries fetch `useEffect` dependency array.
+6. Pass `refreshKey` as a prop to each `FileTreeNode`.
+7. In `FileTreeNode`: add `useEffect` on `refreshKey` that (a) re-fetches children if the node is currently expanded, and (b) clears cached children if the node is collapsed but was previously loaded. This ensures re-expanding a collapsed directory after a refresh always fetches fresh data.
+
+### Debounce behavior
+
+- 500ms trailing debounce groups rapid file writes into a single refresh.
+- The debounce timer is cleaned up in the `useEffect` cleanup function, preventing stale refreshes on chat/project switches or unmount.
+
+### Edge cases
+
+- **Tab not visible:** FilesTab unmounts when another right panel tab is active. No event listener, no wasted fetches.
+- **No active chat:** The subscription effect guards on `activeChatId`. No listener when no session is active.
+- **Collapsed directories with cached children:** On `refreshKey` change, cached children are cleared. The next expand triggers a fresh fetch rather than showing stale data.
+- **Collapsed directories never expanded:** Unaffected. They fetch fresh data on first expand as they do today.
+- **Rapid project/chat switches:** Debounce timer cleaned up in effect cleanup.
+
+### What doesn't change
+
+- No new WebSocket events, daemon changes, or type additions.
+- No global state or new Zustand store.
+- Context menu, file opening, expand/collapse behavior unchanged.
+
+## Future extensions
+
+- **OS-level file watching:** Add `chokidar` or `fs.watch` in the daemon, emit a new `files.changed` event. FilesTab would subscribe to both events.
+- **Auto-reveal new files:** Parse file paths from tool results, walk the tree to auto-expand parent directories and highlight new entries.
+- **Change indicators:** Show a dot badge on collapsed directories that contain unseen changes.

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -44,24 +44,34 @@ function FileTreeNode({
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const { openEditorTab } = useTabsStore();
 
-  const expandedRef = useRef(expanded);
-  expandedRef.current = expanded;
-  const childrenRef = useRef(children);
-  childrenRef.current = children;
   const isActive = useTabsStore(
     (s) => entry.type === 'file' && s.fileView?.type === 'editor' && s.fileView.filePath === entry.path,
   );
 
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+  const childrenRef = useRef(children);
+  childrenRef.current = children;
+
   useEffect(() => {
     if (refreshKey === 0) return;
     if (entry.type !== 'directory') return;
+    let cancelled = false;
     if (expandedRef.current && activeProjectId) {
       getFileTree(activeProjectId, entry.path, activeChatId ?? undefined)
-        .then(setChildren)
-        .catch((err) => log.warn('refresh file tree failed', { err: String(err) }));
+        .then((entries) => {
+          if (!cancelled) setChildren(entries);
+        })
+        .catch((err) => {
+          if (!cancelled) log.warn('refresh file tree failed', { err: String(err) });
+        });
     } else if (childrenRef.current.length > 0) {
+      // Clear stale cache so next expand fetches fresh data
       setChildren([]);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [refreshKey, activeProjectId, activeChatId, entry.path, entry.type]);
 
   const handleClick = async (): Promise<void> => {

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -207,7 +207,7 @@ export function FilesTab(): React.ReactElement {
     <>
       <ScrollArea className="h-full">
         <div className="py-1">
-          <div className="flex items-center">
+          <div className="@container flex items-center">
             <button
               onClick={() => setExpanded(!expanded)}
               onContextMenu={(e) => handleContextMenu(e, '.')}
@@ -221,7 +221,7 @@ export function FilesTab(): React.ReactElement {
             </button>
             <button
               onClick={() => setRefreshKey((k) => k + 1)}
-              className="p-1.5 rounded hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
+              className="hidden @min-[160px]:block p-1.5 rounded hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
               title="Refresh file tree"
               aria-label="Refresh file tree"
             >

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Folder, FileText, ChevronRight, ChevronDown } from 'lucide-react';
+import { daemonClient } from '../../lib/client';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:panels');
@@ -106,13 +107,31 @@ export function FilesTab(): React.ReactElement {
   const [rootEntries, setRootEntries] = useState<FileEntry[]>([]);
   const [expanded, setExpanded] = useState(true);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!activeProjectId) return;
     getFileTree(activeProjectId, '.', activeChatId ?? undefined)
       .then(setRootEntries)
       .catch((err) => log.warn('load file tree failed', { err: String(err) }));
-  }, [activeProjectId, activeChatId]);
+  }, [activeProjectId, activeChatId, refreshKey]);
+
+  useEffect(() => {
+    if (!activeChatId) return;
+    const unsub = daemonClient.onEvent((event) => {
+      if (event.type === 'context.updated' && event.chatId === activeChatId) {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+          setRefreshKey((k) => k + 1);
+        }, 500);
+      }
+    });
+    return () => {
+      unsub();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [activeChatId]);
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, entryPath: string) => {

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -30,20 +30,39 @@ function FileTreeNode({
   depth,
   projectPath,
   onContextMenu,
+  refreshKey,
 }: {
   entry: FileEntry;
   depth: number;
   projectPath: string;
   onContextMenu: (e: React.MouseEvent, entryPath: string) => void;
+  refreshKey: number;
 }): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
   const [children, setChildren] = useState<FileEntry[]>([]);
   const { activeProjectId } = useProjectsStore();
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const { openEditorTab } = useTabsStore();
+
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+  const childrenRef = useRef(children);
+  childrenRef.current = children;
   const isActive = useTabsStore(
     (s) => entry.type === 'file' && s.fileView?.type === 'editor' && s.fileView.filePath === entry.path,
   );
+
+  useEffect(() => {
+    if (refreshKey === 0) return;
+    if (entry.type !== 'directory') return;
+    if (expandedRef.current && activeProjectId) {
+      getFileTree(activeProjectId, entry.path, activeChatId ?? undefined)
+        .then(setChildren)
+        .catch((err) => log.warn('refresh file tree failed', { err: String(err) }));
+    } else if (childrenRef.current.length > 0) {
+      setChildren([]);
+    }
+  }, [refreshKey, activeProjectId, activeChatId, entry.path, entry.type]);
 
   const handleClick = async (): Promise<void> => {
     if (entry.type === 'directory') {
@@ -94,6 +113,7 @@ function FileTreeNode({
             depth={depth + 1}
             projectPath={projectPath}
             onContextMenu={onContextMenu}
+            refreshKey={refreshKey}
           />
         ))}
     </>
@@ -190,6 +210,7 @@ export function FilesTab(): React.ReactElement {
                 depth={1}
                 projectPath={activeProject.path}
                 onContextMenu={handleContextMenu}
+                refreshKey={refreshKey}
               />
             ))}
         </div>

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Folder, FileText, ChevronRight, ChevronDown } from 'lucide-react';
+import { Folder, FileText, ChevronRight, ChevronDown, RefreshCw } from 'lucide-react';
 import { daemonClient } from '../../lib/client';
 import { createLogger } from '../../lib/logger';
 
@@ -163,6 +163,12 @@ export function FilesTab(): React.ReactElement {
     };
   }, [activeChatId]);
 
+  useEffect(() => {
+    const onFocus = (): void => setRefreshKey((k) => k + 1);
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
+
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, entryPath: string) => {
       e.preventDefault();
@@ -201,17 +207,27 @@ export function FilesTab(): React.ReactElement {
     <>
       <ScrollArea className="h-full">
         <div className="py-1">
-          <button
-            onClick={() => setExpanded(!expanded)}
-            onContextMenu={(e) => handleContextMenu(e, '.')}
-            className="w-full flex items-center gap-1 py-1 px-2 text-mf-small hover:bg-mf-hover/50 rounded-mf-input text-left font-semibold text-mf-text-primary"
-          >
-            {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-            <Folder size={14} className="text-mf-accent shrink-0" />
-            <span className="truncate" title={activeProject.path}>
-              {activeProject.path}
-            </span>
-          </button>
+          <div className="flex items-center">
+            <button
+              onClick={() => setExpanded(!expanded)}
+              onContextMenu={(e) => handleContextMenu(e, '.')}
+              className="flex-1 flex items-center gap-1 py-1 px-2 text-mf-small hover:bg-mf-hover/50 rounded-mf-input text-left font-semibold text-mf-text-primary min-w-0"
+            >
+              {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <Folder size={14} className="text-mf-accent shrink-0" />
+              <span className="truncate" title={activeProject.path}>
+                {activeProject.path}
+              </span>
+            </button>
+            <button
+              onClick={() => setRefreshKey((k) => k + 1)}
+              className="p-1.5 rounded hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
+              title="Refresh file tree"
+              aria-label="Refresh file tree"
+            >
+              <RefreshCw size={14} />
+            </button>
+          </div>
           {expanded &&
             rootEntries.map((entry) => (
               <FileTreeNode


### PR DESCRIPTION
## Summary

- Subscribe to `context.updated` WebSocket events in FilesTab with 500ms debounce — tree auto-refreshes when an agent session writes files
- Re-fetch expanded directories on refresh; clear cached children for collapsed ones so next expand gets fresh data
- Add window `focus` listener to refresh tree when switching back to the app
- Add manual refresh button (RefreshCw icon) next to the project root header

## Test plan

- [x] Start a chat, expand some directories in Files tab, ask agent to create a file in an expanded directory — verify it appears within ~1s
- [x] Ask agent to create a file in a collapsed directory — expand it — verify new file is there
- [x] Ask agent to delete a file — verify it disappears from the tree
- [x] Rapid writes (scaffold multiple files) — verify tree settles once, no flickering
- [x] Alt-tab away, make external file changes, alt-tab back — verify tree updates on window focus
- [x] Click the refresh button — verify tree updates
- [x] Switch chats — verify no stale refreshes from old chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)