### PR TITLE
feat: move fullview plugin buttons to left rail

### DIFF
--- a/packages/desktop/src/renderer/components/Layout.tsx
+++ b/packages/desktop/src/renderer/components/Layout.tsx
@@ -94,7 +94,7 @@ export function Layout({ leftPanel, centerPanel, rightPanel }: LayoutProps): Rea
             )}
           </div>
 
-          <BottomPanel />
+          {!activeFullviewId && <BottomPanel />}
         </div>
 
         <RightRail />

--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -55,7 +55,11 @@ export function LeftRail(): React.ReactElement {
       {/* Activity icons */}
       <div className="flex-1 flex flex-col gap-2 overflow-y-auto">
         {/* Default: Sessions / AI workspace */}
-        <RailButton active={activeLeftPanelId === null} onClick={handleSessionsClick} title="Sessions">
+        <RailButton
+          active={activeLeftPanelId === null && !activeFullviewId}
+          onClick={handleSessionsClick}
+          title="Sessions"
+        >
           <MessageSquare size={16} />
         </RailButton>
 
@@ -80,8 +84,16 @@ export function LeftRail(): React.ReactElement {
       <div className="flex flex-col gap-2 pt-2">
         {/* Logs toggle button */}
         <RailButton
-          active={panelVisible}
+          active={panelVisible && !activeFullviewId}
           onClick={() => {
+            if (activeFullviewId) {
+              usePluginLayoutStore.getState().activateFullview(activeFullviewId);
+              setPanelVisible(true);
+              if (useUIStore.getState().panelCollapsed.bottom) {
+                togglePanel('bottom');
+              }
+              return;
+            }
             const next = !panelVisible;
             setPanelVisible(next);
             if (next && useUIStore.getState().panelCollapsed.bottom) {

--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -31,6 +31,8 @@ function RailButton({ active, onClick, title, children }: RailButtonProps): Reac
 export function LeftRail(): React.ReactElement {
   const contributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'left-panel');
   const activeLeftPanelId = usePluginLayoutStore((s) => s.activeLeftPanelId);
+  const fullviewContributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'fullview');
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
   const panelVisible = useUIStore((s) => s.panelVisible);
   const setPanelVisible = useUIStore((s) => s.setPanelVisible);
   const togglePanel = useUIStore((s) => s.togglePanel);
@@ -42,6 +44,10 @@ export function LeftRail(): React.ReactElement {
   const handlePluginClick = (pluginId: string): void => {
     const { activeLeftPanelId: current, setActiveLeftPanel } = usePluginLayoutStore.getState();
     setActiveLeftPanel(current === pluginId ? null : pluginId);
+  };
+
+  const handleFullviewClick = (pluginId: string): void => {
+    usePluginLayoutStore.getState().activateFullview(pluginId);
   };
 
   return (
@@ -90,6 +96,22 @@ export function LeftRail(): React.ReactElement {
         </RailButton>
 
         <div className="w-5 h-px bg-mf-divider mx-auto" />
+
+        {/* Fullview plugin icons */}
+        {fullviewContributions.map((c) => (
+          <RailButton
+            key={c.pluginId}
+            active={activeFullviewId === c.pluginId}
+            onClick={() => handleFullviewClick(c.pluginId)}
+            title={c.label}
+          >
+            {c.icon ? (
+              <PluginIcon name={c.icon} size={16} />
+            ) : (
+              <span className="text-mf-text-secondary">{c.label.charAt(0)}</span>
+            )}
+          </RailButton>
+        ))}
 
         <RailButton onClick={() => useSettingsStore.getState().open()} title="Settings">
           <Settings size={16} />

--- a/packages/desktop/src/renderer/components/RightRail.tsx
+++ b/packages/desktop/src/renderer/components/RightRail.tsx
@@ -31,6 +31,7 @@ function RailButton({ active, onClick, title, children }: RailButtonProps): Reac
 export function RightRail(): React.ReactElement {
   const contributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'right-panel');
   const activeRightPanelId = usePluginLayoutStore((s) => s.activeRightPanelId);
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
 
   const handleContextClick = (): void => {
     usePluginLayoutStore.getState().setActiveRightPanel(null);
@@ -46,7 +47,11 @@ export function RightRail(): React.ReactElement {
       {/* Activity icons */}
       <div className="flex-1 flex flex-col gap-2 overflow-y-auto">
         {/* Default: Context panel */}
-        <RailButton active={activeRightPanelId === null} onClick={handleContextClick} title="Context">
+        <RailButton
+          active={activeRightPanelId === null && !activeFullviewId}
+          onClick={handleContextClick}
+          title="Context"
+        >
           <PanelRight size={16} />
         </RailButton>
 

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -4,13 +4,12 @@ import { createLogger } from '../lib/logger';
 
 const log = createLogger('renderer:titlebar');
 import type { Layout } from 'react-resizable-panels';
-import { useProjectsStore, useChatsStore, useSearchStore, usePluginLayoutStore } from '../store';
+import { useProjectsStore, useChatsStore, useSearchStore } from '../store';
 import { useTabsStore } from '../store/tabs';
 import { useUIStore } from '../store/ui';
 import { useSandboxStore } from '../store/sandbox';
 import { createProject, removeProject } from '../lib/api';
 import { cn } from '../lib/utils';
-import { PluginIcon } from './plugins/PluginIcon';
 import { DirectoryPickerModal } from './DirectoryPickerModal';
 import { LaunchPopover } from './sandbox/LaunchPopover';
 import { StopPopover } from './sandbox/StopPopover';
@@ -157,14 +156,6 @@ export function TitleBar({
   const handleCloseLaunchPopover = useCallback(() => setLaunchPopoverOpen(false), []);
   const handleCloseStopPopover = useCallback(() => setStopPopoverOpen(false), []);
 
-  // Fullview plugin icons (right side of title bar)
-  const fullviewContributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'fullview');
-  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
-
-  const handleFullviewClick = (pluginId: string): void => {
-    usePluginLayoutStore.getState().activateFullview(pluginId);
-  };
-
   return (
     <div className="h-11 bg-mf-app-bg flex items-center app-drag relative">
       {/* Traffic lights + project picker dropdown */}
@@ -307,7 +298,7 @@ export function TitleBar({
       </div>
 
       {/* Right side — Preview + plugin icons */}
-      <div className="absolute right-4 flex items-center gap-1 app-no-drag z-10">
+      <div className="absolute right-11 flex items-center gap-1 app-no-drag z-10">
         {/* Preview / Launch button */}
         <div className="relative flex items-center" data-launch-popover>
           <button
@@ -362,31 +353,6 @@ export function TitleBar({
             {stopPopoverOpen && <StopPopover onClose={handleCloseStopPopover} />}
           </div>
         )}
-
-        {/* Separator */}
-        {fullviewContributions.length > 0 && <div className="h-4 w-px bg-mf-divider mx-1" />}
-
-        {/* Fullview plugin icons */}
-        {fullviewContributions.map((c) => (
-          <button
-            key={c.pluginId}
-            data-testid={`${c.pluginId}-panel-icon`}
-            onClick={() => handleFullviewClick(c.pluginId)}
-            title={c.label}
-            className={cn(
-              'w-7 h-7 flex items-center justify-center rounded-mf-card transition-colors',
-              activeFullviewId === c.pluginId
-                ? 'bg-mf-accent text-white'
-                : 'text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-panel-bg',
-            )}
-          >
-            {c.icon ? (
-              <PluginIcon name={c.icon} size={15} />
-            ) : (
-              <span className="text-mf-small font-semibold">{c.label.charAt(0)}</span>
-            )}
-          </button>
-        ))}
       </div>
       <DirectoryPickerModal
         open={dirPickerOpen}


### PR DESCRIPTION
## Summary
- Moved fullview plugin buttons (e.g. Tasks) from the title bar to the left rail, positioned above Settings and About with a divider separator
- Aligned title bar right-side content (`right-11`) with the right rail width
- Cleaned up unused imports (`PluginIcon`, `usePluginLayoutStore`) from TitleBar

## Test plan
- [x] Verify fullview plugin icons (Tasks) appear in the left rail above Settings/About
- [x] Verify clicking the icon toggles the fullview as before
- [x] Verify the title bar right-side controls (launch configs) align with the right panel edge
- [x] Verify no visual regressions in the title bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)