### PR TITLE
feat: move file view collapse button to pane header with expand strip

### DIFF
--- a/docs/superpowers/specs/2026-03-16-file-view-collapse-button-design.md
+++ b/docs/superpowers/specs/2026-03-16-file-view-collapse-button-design.md
@@ -1,0 +1,56 @@
+# Move File View Collapse/Expand Button
+
+## Problem
+
+The collapse/expand button for the file view pane sits in the sidebar's tab bar header (`Context | Files | Changes | ... | ◀`). It feels disconnected from the file view it controls.
+
+## Design
+
+Two-state approach: the button lives on the file view pane itself, and a thin edge strip appears when collapsed.
+
+### Expanded state — collapse button in FileViewHeader
+
+Add a `PanelLeftClose` icon button to the right edge of `FileViewHeader`, after the diff stats. Import `toggleFileViewCollapsed` from `useTabsStore`.
+
+```
+┌──────────────────────────────────────────────────┐
+│ 📄 index.ts  src/renderer/   ←spacer→  +3 -1  ◀ │
+├──────────────────────────────────────────────────┤
+│                file content                      │
+└──────────────────────────────────────────────────┘
+```
+
+### Collapsed state — thin expand strip
+
+Instead of hiding the file view to `w-0`, render a `w-7 shrink-0` vertical strip with a centered `PanelLeftOpen` icon. Clicking it calls `toggleFileViewCollapsed()`.
+
+```
+┌──┐┊┌──────────────────┐
+│  │┊│ Context Files ... │
+│ ▶│┊│  sidebar content  │
+└──┘┊└──────────────────┘
+```
+
+Strip styling: `w-7 shrink-0 flex items-center justify-center border-r border-mf-divider cursor-pointer`, icon has standard hover state.
+
+The sidebar div next to the strip uses `flex-1 min-w-0` (not `width: 100%`) so it shares space correctly with the strip.
+
+### Removed
+
+- The toggle button in `RightPanel.tsx` `TabsList` (lines 125–137) is deleted.
+- The `toggleMode` variable (lines 29–30) becomes dead code and is deleted.
+- The `PanelLeftOpen`/`PanelLeftClose` imports move out of `RightPanel.tsx`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `FileViewHeader.tsx` | Add `toggleFileViewCollapsed` store selector; add collapse button at right edge |
+| `RightPanel.tsx` | Remove toggle button + `toggleMode` from TabsList; replace `w-0` hidden state with expand strip; sidebar uses `flex-1` when collapsed instead of `width: 100%` |
+| `Layout.tsx` | Change `hasFileView` to `fileView != null` (remove `&& !fileViewCollapsed`) so the right panel stays wide when collapsed with the strip visible |
+
+## Edge Cases
+
+- **No file view open**: No strip or button rendered (unchanged behavior).
+- **Plugin right panel active**: `RightPanel` early-returns with `PluginView` — no strip rendered (unchanged).
+- **Resize handle**: Hidden when collapsed (existing behavior), strip takes its place visually.

--- a/packages/desktop/src/renderer/components/SearchPalette.tsx
+++ b/packages/desktop/src/renderer/components/SearchPalette.tsx
@@ -43,10 +43,11 @@ export function SearchPalette(): React.ReactElement | null {
     }
   }, [isOpen]);
 
-  // Global ⌘F / Ctrl+F
+  // Global ⌘F / Ctrl+F and ⌘O / Ctrl+O
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
+      const key = e.key.toLowerCase();
+      if ((e.metaKey || e.ctrlKey) && (key === 'f' || key === 'o')) {
         e.preventDefault();
         if (isOpen) {
           close();

--- a/packages/desktop/src/renderer/components/panels/FileViewHeader.tsx
+++ b/packages/desktop/src/renderer/components/panels/FileViewHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { FileText, GitBranch } from 'lucide-react';
+import { FileText, GitBranch, PanelLeftClose } from 'lucide-react';
 import { useTabsStore, type FileView } from '../../store/tabs';
 
 function computeInlineDiffStats(original?: string, modified?: string): { added: number; removed: number } | null {
@@ -41,6 +41,7 @@ function FileIcon({ fileView }: { fileView: FileView }): React.ReactElement {
 
 export function FileViewHeader(): React.ReactElement | null {
   const fileView = useTabsStore((s) => s.fileView);
+  const toggleFileViewCollapsed = useTabsStore((s) => s.toggleFileViewCollapsed);
 
   const diffStats = useMemo(() => {
     if (!fileView || fileView.type !== 'diff' || fileView.source !== 'inline') return null;
@@ -72,6 +73,15 @@ export function FileViewHeader(): React.ReactElement | null {
           <span className="text-mf-destructive">-{diffStats.removed}</span>
         </div>
       )}
+
+      <button
+        onClick={toggleFileViewCollapsed}
+        className="p-1.5 rounded hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
+        title="Collapse file view"
+        aria-label="Collapse file view"
+      >
+        <PanelLeftClose size={14} />
+      </button>
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/panels/RightPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/RightPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
-import { PanelLeftOpen, PanelLeftClose } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
 import { ContextTab } from './ContextTab';
 import { FilesTab } from './FilesTab';
@@ -26,8 +26,6 @@ export function RightPanel(): React.ReactElement {
 
   const hasFileView = fileView != null;
   const showFileView = fileView != null && !fileViewCollapsed;
-  const toggleMode: 'expand' | 'collapse' | undefined =
-    fileView == null ? undefined : fileViewCollapsed ? 'expand' : 'collapse';
 
   const sidebarWidth = useTabsStore((s) => s.sidebarWidth);
   const setSidebarWidth = useTabsStore((s) => s.setSidebarWidth);
@@ -75,36 +73,41 @@ export function RightPanel(): React.ReactElement {
       {/* File view — conditionally rendered, sidebar stays mounted */}
       {hasFileView && (
         <>
-          <div
-            className={
-              showFileView
-                ? 'flex-1 flex flex-col min-w-0 overflow-hidden'
-                : 'w-0 min-w-0 overflow-hidden opacity-0 pointer-events-none'
-            }
-          >
-            <FileViewHeader />
-            <div className="flex-1 overflow-hidden">
-              <FileViewContent />
-            </div>
-          </div>
-          <div
-            className={showFileView ? 'relative w-[5px] shrink-0 cursor-col-resize group' : 'w-0 shrink-0'}
-            onPointerDown={showFileView ? onPointerDown : undefined}
-            onPointerMove={showFileView ? onPointerMove : undefined}
-            onPointerUp={showFileView ? onPointerUp : undefined}
-          >
-            {showFileView && (
-              <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-mf-divider group-hover:w-[3px] group-active:bg-mf-divider transition-all" />
-            )}
-          </div>
+          {showFileView ? (
+            <>
+              <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+                <FileViewHeader />
+                <div className="flex-1 overflow-hidden">
+                  <FileViewContent />
+                </div>
+              </div>
+              <div
+                className="relative w-[5px] shrink-0 cursor-col-resize group"
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+              >
+                <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-mf-divider group-hover:w-[3px] group-active:bg-mf-divider transition-all" />
+              </div>
+            </>
+          ) : (
+            <button
+              onClick={toggleFileViewCollapsed}
+              className="w-7 shrink-0 flex items-center justify-center border-r border-mf-divider text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors cursor-pointer"
+              title="Expand file view"
+              aria-label="Expand file view"
+            >
+              <PanelLeftOpen size={14} />
+            </button>
+          )}
         </>
       )}
 
       {/* Sidebar — always mounted */}
       <div
         data-testid="right-panel"
-        className="flex flex-col min-w-0 shrink-0"
-        style={showFileView ? { width: `${sidebarWidth}px` } : { width: '100%' }}
+        className={showFileView ? 'flex flex-col min-w-0 shrink-0' : 'flex flex-col min-w-0 flex-1'}
+        style={showFileView ? { width: `${sidebarWidth}px` } : undefined}
       >
         <Tabs value={sidebarTab} onValueChange={(v) => setSidebarTab(v as SidebarTab)} className="h-full flex flex-col">
           <TabsList className="h-11 px-[10px] bg-transparent justify-start gap-1 shrink-0 rounded-none">
@@ -122,19 +125,6 @@ export function RightPanel(): React.ReactElement {
                 {c.label}
               </TabsTrigger>
             ))}
-            {toggleMode && (
-              <>
-                <div className="flex-1" />
-                <button
-                  onClick={toggleFileViewCollapsed}
-                  className="p-1.5 rounded hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
-                  title={toggleMode === 'expand' ? 'Expand file view' : 'Collapse file view'}
-                  aria-label={toggleMode === 'expand' ? 'Expand file view' : 'Collapse file view'}
-                >
-                  {toggleMode === 'expand' ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
-                </button>
-              </>
-            )}
           </TabsList>
 
           <TabsContent value="context" className="flex-1 overflow-y-auto px-[10px] mt-0">


### PR DESCRIPTION
## Summary
- Moved the collapse/expand toggle from the sidebar tab bar (`Context | Files | Changes`) to the file view pane itself — collapse button in the `FileViewHeader`, thin vertical expand strip when collapsed
- Added `Cmd+O` as a second shortcut to open the search palette (alongside existing `Cmd+F`)

## Test plan
- [x] Open a file to trigger the file view pane
- [x] Verify the collapse button appears at the right edge of the file view header
- [x] Click collapse — pane hides, thin strip with expand icon appears
- [x] Click the strip — file view expands back
- [x] Verify the sidebar tab bar no longer has the old toggle button
- [x] Verify `Cmd+O` opens the search palette
- [x] Verify `Cmd+F` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)