### PR TITLE
feat: side panel minimize button and rail toggle

### DIFF
--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -37,13 +37,25 @@ export function LeftRail(): React.ReactElement {
   const setPanelVisible = useUIStore((s) => s.setPanelVisible);
   const togglePanel = useUIStore((s) => s.togglePanel);
 
+  const panelCollapsed = useUIStore((s) => s.panelCollapsed);
+
   const handleSessionsClick = (): void => {
+    if (activeLeftPanelId === null && !panelCollapsed.left) {
+      togglePanel('left');
+      return;
+    }
     usePluginLayoutStore.getState().setActiveLeftPanel(null);
+    if (panelCollapsed.left) togglePanel('left');
   };
 
   const handlePluginClick = (pluginId: string): void => {
     const { activeLeftPanelId: current, setActiveLeftPanel } = usePluginLayoutStore.getState();
-    setActiveLeftPanel(current === pluginId ? null : pluginId);
+    if (current === pluginId && !panelCollapsed.left) {
+      togglePanel('left');
+      return;
+    }
+    setActiveLeftPanel(pluginId);
+    if (panelCollapsed.left) togglePanel('left');
   };
 
   const handleFullviewClick = (pluginId: string): void => {
@@ -56,7 +68,7 @@ export function LeftRail(): React.ReactElement {
       <div className="flex-1 flex flex-col gap-2 overflow-y-auto">
         {/* Default: Sessions / AI workspace */}
         <RailButton
-          active={activeLeftPanelId === null && !activeFullviewId}
+          active={activeLeftPanelId === null && !activeFullviewId && !panelCollapsed.left}
           onClick={handleSessionsClick}
           title="Sessions"
         >
@@ -67,7 +79,7 @@ export function LeftRail(): React.ReactElement {
         {contributions.map((c) => (
           <RailButton
             key={c.pluginId}
-            active={activeLeftPanelId === c.pluginId}
+            active={activeLeftPanelId === c.pluginId && !panelCollapsed.left}
             onClick={() => handlePluginClick(c.pluginId)}
             title={c.label}
           >

--- a/packages/desktop/src/renderer/components/RightRail.tsx
+++ b/packages/desktop/src/renderer/components/RightRail.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PanelRight } from 'lucide-react';
 import { cn } from '../lib/utils';
-import { usePluginLayoutStore } from '../store';
+import { usePluginLayoutStore, useUIStore } from '../store';
 import { PluginIcon } from './plugins/PluginIcon';
 
 interface RailButtonProps {
@@ -32,14 +32,26 @@ export function RightRail(): React.ReactElement {
   const contributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'right-panel');
   const activeRightPanelId = usePluginLayoutStore((s) => s.activeRightPanelId);
   const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
+  const panelCollapsed = useUIStore((s) => s.panelCollapsed);
+  const togglePanel = useUIStore((s) => s.togglePanel);
 
   const handleContextClick = (): void => {
+    if (activeRightPanelId === null && !panelCollapsed.right) {
+      togglePanel('right');
+      return;
+    }
     usePluginLayoutStore.getState().setActiveRightPanel(null);
+    if (panelCollapsed.right) togglePanel('right');
   };
 
   const handlePluginClick = (pluginId: string): void => {
     const { activeRightPanelId: current, setActiveRightPanel } = usePluginLayoutStore.getState();
-    setActiveRightPanel(current === pluginId ? null : pluginId);
+    if (current === pluginId && !panelCollapsed.right) {
+      togglePanel('right');
+      return;
+    }
+    setActiveRightPanel(pluginId);
+    if (panelCollapsed.right) togglePanel('right');
   };
 
   return (
@@ -48,7 +60,7 @@ export function RightRail(): React.ReactElement {
       <div className="flex-1 flex flex-col gap-2 overflow-y-auto">
         {/* Default: Context panel */}
         <RailButton
-          active={activeRightPanelId === null && !activeFullviewId}
+          active={activeRightPanelId === null && !activeFullviewId && !panelCollapsed.right}
           onClick={handleContextClick}
           title="Context"
         >
@@ -59,7 +71,7 @@ export function RightRail(): React.ReactElement {
         {contributions.map((c) => (
           <RailButton
             key={c.pluginId}
-            active={activeRightPanelId === c.pluginId}
+            active={activeRightPanelId === c.pluginId && !panelCollapsed.right}
             onClick={() => handlePluginClick(c.pluginId)}
             title={c.label}
           >

--- a/packages/desktop/src/renderer/components/panels/LeftPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/LeftPanel.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import { Minus } from 'lucide-react';
 import { ChatsPanel } from './ChatsPanel';
 import { AgentsPanel } from './AgentsPanel';
 import { SkillsPanel } from './SkillsPanel';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
-import { usePluginLayoutStore } from '../../store';
+import { usePluginLayoutStore, useUIStore } from '../../store';
 import { PluginView } from '../plugins/PluginView';
 
 export function LeftPanel(): React.ReactElement {
   const activeLeftPanelId = usePluginLayoutStore((s) => s.activeLeftPanelId);
   const leftTabContributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'left-tab');
+  const togglePanel = useUIStore((s) => s.togglePanel);
 
   // Full-panel plugin mode — return early
   if (activeLeftPanelId) {
@@ -34,6 +36,14 @@ export function LeftPanel(): React.ReactElement {
               {c.label}
             </TabsTrigger>
           ))}
+          <button
+            onClick={() => togglePanel('left')}
+            className="ml-auto flex items-center justify-center w-6 h-6 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors cursor-pointer"
+            title="Collapse left panel"
+            aria-label="Collapse left panel"
+          >
+            <Minus size={14} />
+          </button>
         </TabsList>
         <TabsContent value="sessions" className="flex-1 overflow-hidden mt-0">
           <ChatsPanel />

--- a/packages/desktop/src/renderer/components/panels/RightPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/RightPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
-import { PanelLeftOpen } from 'lucide-react';
+import { Minus, PanelLeftOpen } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
 import { ContextTab } from './ContextTab';
 import { FilesTab } from './FilesTab';
@@ -7,7 +7,7 @@ import { ChangesTab } from './ChangesTab';
 import { FileViewHeader } from './FileViewHeader';
 import { FileViewContent } from './FileViewContent';
 import { useTabsStore } from '../../store/tabs';
-import { usePluginLayoutStore } from '../../store';
+import { usePluginLayoutStore, useUIStore } from '../../store';
 import { PluginView } from '../plugins/PluginView';
 
 type SidebarTab = 'context' | 'files' | 'changes';
@@ -19,6 +19,7 @@ export function RightPanel(): React.ReactElement {
   const activeRightPanelId = usePluginLayoutStore((s) => s.activeRightPanelId);
   const rightTabContributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'right-tab');
 
+  const togglePanel = useUIStore((s) => s.togglePanel);
   const fileView = useTabsStore((s) => s.fileView);
   const fileViewCollapsed = useTabsStore((s) => s.fileViewCollapsed);
   const toggleFileViewCollapsed = useTabsStore((s) => s.toggleFileViewCollapsed);
@@ -125,6 +126,14 @@ export function RightPanel(): React.ReactElement {
                 {c.label}
               </TabsTrigger>
             ))}
+            <button
+              onClick={() => togglePanel('right')}
+              className="ml-auto flex items-center justify-center w-6 h-6 rounded text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors cursor-pointer"
+              title="Collapse right panel"
+              aria-label="Collapse right panel"
+            >
+              <Minus size={14} />
+            </button>
           </TabsList>
 
           <TabsContent value="context" className="flex-1 overflow-y-auto px-[10px] mt-0">


### PR DESCRIPTION
## Summary
- Add a Minus (`_`) icon button to the left and right panel tab headers for collapsing, matching the bottom panel's minimize pattern
- Rail icons now act as toggles: clicking an active (highlighted) icon collapses its panel; clicking when collapsed reopens it
- Rail icons deselect (unhighlight) when their panel is collapsed

## Test plan
- [x] Click the `_` button in the left panel header — panel collapses, Sessions icon deselects
- [x] Click the `_` button in the right panel header — panel collapses, Context icon deselects
- [x] Click the Sessions icon when highlighted — panel collapses, icon deselects
- [x] Click the Sessions icon when unhighlighted — panel reopens, icon highlights
- [x] Same toggle behavior for Context icon on the right rail
- [x] Same toggle behavior for plugin icons on both rails

🤖 Generated with [Claude Code](https://claude.com/claude-code)