### PR TITLE
fix: allow Enter to send messages while response is in progress

### DIFF
--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -291,6 +291,16 @@ export function ComposerCard() {
           disabled={chat?.worktreeMissing}
           placeholder="Type @ to search files, / for skills… (Enter to send)"
           className="w-full bg-transparent border-none px-3 py-2 font-sans text-mf-chat text-transparent caret-mf-text-primary selection:text-mf-text-primary resize-none placeholder:text-mf-text-secondary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey && chat?.isRunning) {
+              e.preventDefault();
+              try {
+                composerRuntime.send();
+              } catch (err) {
+                log.warn('failed to send from composer', { err: String(err) });
+              }
+            }
+          }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Fixes #22: pressing Enter while the agent is responding now sends the message (queues it), matching the existing Send button behavior
- Adds `onKeyDown` handler to `ComposerPrimitive.Input` that intercepts Enter (without Shift) when `chat.isRunning` is true and calls `composerRuntime.send()` directly, bypassing assistant-ui's built-in submission block

## Test plan
- [x] Start a chat and send a message that triggers a long response
- [x] While the response is in progress, type a follow-up and press Enter — message should be queued and sent
- [x] Verify Shift+Enter still inserts a newline during active responses
- [x] Verify Enter works normally when no response is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)