### PR TITLE
docs: add WIP disclaimer and Cloudflare Tunnel guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install the standalone daemon if you want to run it headless or build your own i
 curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/install.sh | bash
 ```
 
-#### Cloudflare Tunnel (remote access)
+#### Remote Access (e.g. Mobile App)
 
 The mobile companion app and any remote access require a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — a secure outbound connection from your machine to Cloudflare's edge, so you don't need to open ports or configure a firewall. The daemon can manage the tunnel process for you, or you can run `cloudflared` independently.
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,12 @@ Install the standalone daemon if you want to run it headless or build your own i
 curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/install.sh | bash
 ```
 
-#### Remote Access (e.g. Mobile App)
+### Remote Access (e.g. Mobile App)
 
-The mobile companion app and any remote access require a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — a secure outbound connection from your machine to Cloudflare's edge, so you don't need to open ports or configure a firewall. The daemon can manage the tunnel process for you, or you can run `cloudflared` independently.
+The mobile companion app and any remote access require a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — a secure outbound connection from your machine to Cloudflare's edge, so you don't need to open ports or configure a firewall.
 
-Quick start (anonymous URL, changes on each restart):
-
-```bash
-TUNNEL=true mainframe-daemon
-```
+- **Desktop app:** Enable the tunnel from **Settings → Tunnel**.
+- **Standalone daemon:** Set `TUNNEL=true` when starting the daemon, or configure it in `~/.mainframe/config.json`.
 
 See the [Cloudflare Tunnel guide](docs/guides/cloudflare-tunnel.md) for named tunnels with a persistent URL, self-managed setups, and troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Mainframe is an open-source desktop app that brings all your AI coding agents in
 
 AI CLI tools are powerful, but they live in the terminal. Mainframe adds the layer terminals can't: visual file editing, live sandbox previews, task management, cross-project session history, and a mobile companion for working on the go.
 
+> **Work in progress.** Mainframe is under active development — some features are incomplete and the mobile companion app is not yet published. Expect rough edges.
+
 ## Features
 
 - **Unified provider interface** — One app for Claude, Gemini, and other AI coding agents — switch providers without changing your workflow
@@ -60,18 +62,15 @@ curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/inst
 
 #### Cloudflare Tunnel (remote access)
 
-To access the daemon from the mobile app or another network, enable the built-in [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) by setting `TUNNEL=true`. This requires `cloudflared` to be installed on the host.
+The mobile companion app and any remote access require a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) — a secure outbound connection from your machine to Cloudflare's edge, so you don't need to open ports or configure a firewall. The daemon can manage the tunnel process for you, or you can run `cloudflared` independently.
+
+Quick start (anonymous URL, changes on each restart):
 
 ```bash
 TUNNEL=true mainframe-daemon
 ```
 
-For a **persistent URL** with your own domain (so the URL never changes between restarts), create a named tunnel via the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) → Networks → Tunnels → Create, add a public hostname pointing to `http://localhost:31415`, then run:
-
-```bash
-cloudflared tunnel run --token <TOKEN> &                  # run named tunnel
-TUNNEL_URL=https://mainframe.example.com mainframe-daemon # start daemon
-```
+See the [Cloudflare Tunnel guide](docs/guides/cloudflare-tunnel.md) for named tunnels with a persistent URL, self-managed setups, and troubleshooting.
 
 ### Mobile Companion App
 

--- a/docs/guides/cloudflare-tunnel.md
+++ b/docs/guides/cloudflare-tunnel.md
@@ -1,0 +1,84 @@
+# Cloudflare Tunnel Setup
+
+Mainframe uses a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) to expose the daemon over the internet — required for the mobile companion app and any remote access. The tunnel creates a secure outbound connection from your machine to Cloudflare's edge, so you don't need to open ports or configure a firewall.
+
+## Prerequisites
+
+Install `cloudflared` on the machine running the daemon:
+
+- **macOS:** `brew install cloudflared`
+- **Linux:** see [Cloudflare downloads](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)
+- **Windows:** download from the same page
+
+## Option 1: Let the daemon manage the tunnel
+
+The simplest approach. The daemon spawns `cloudflared` as a child process and tears it down on exit.
+
+### Quick tunnel (anonymous)
+
+No Cloudflare account needed. The URL changes on every restart.
+
+```bash
+TUNNEL=true mainframe-daemon
+```
+
+Or in the desktop app: **Settings → Tunnel → Enable**.
+
+The daemon starts a [quick tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/) and prints the assigned `*.trycloudflare.com` URL to the log.
+
+### Named tunnel (persistent URL)
+
+Requires a Cloudflare account and a domain managed by Cloudflare.
+
+1. Go to [Cloudflare Zero Trust](https://one.dash.cloudflare.com/) → Networks → Tunnels → **Create a tunnel**
+2. Choose **Cloudflared** connector, give the tunnel a name
+3. Copy the tunnel **token** (shown in the install command)
+4. Add a **public hostname** (e.g. `mainframe.example.com`) pointing to `http://localhost:31415`
+5. Start the daemon with the token and URL:
+
+```bash
+TUNNEL=true TUNNEL_TOKEN=<TOKEN> TUNNEL_URL=https://mainframe.example.com mainframe-daemon
+```
+
+Or configure once and forget:
+
+```json
+// ~/.mainframe/config.json
+{
+  "tunnel": true,
+  "tunnelToken": "<TOKEN>",
+  "tunnelUrl": "https://mainframe.example.com"
+}
+```
+
+The URL stays the same across restarts.
+
+## Option 2: Run `cloudflared` yourself
+
+If you prefer to manage the tunnel process independently — for example, running it as a systemd service or in a separate terminal — skip the `TUNNEL=true` flag and just tell the daemon where the tunnel points:
+
+```bash
+# Terminal 1: run the named tunnel yourself
+cloudflared tunnel run --token <TOKEN>
+
+# Terminal 2: start the daemon with the known URL
+TUNNEL_URL=https://mainframe.example.com mainframe-daemon
+```
+
+In this mode the daemon does not spawn or stop `cloudflared`. It uses the URL for mobile pairing and push notifications.
+
+## Runtime API
+
+You can also start and stop the tunnel at runtime via the daemon's HTTP API:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/tunnel/status` | Current state: running, URL, health |
+| `POST /api/tunnel/start` | Start tunnel (optionally with `{ token, url }` for named mode) |
+| `POST /api/tunnel/stop` | Stop tunnel (optionally `{ clearConfig: true }` to wipe saved credentials) |
+
+## Troubleshooting
+
+- **`cloudflared` not found:** Make sure the binary is on your `PATH`. Run `cloudflared version` to verify.
+- **Tunnel starts but mobile can't connect:** DNS propagation can take a few seconds. The daemon waits up to 15 seconds for DNS to resolve. Check the logs for warnings.
+- **Named tunnel URL not reachable:** Verify the public hostname in the Cloudflare dashboard points to `http://localhost:31415` (or your configured `DAEMON_PORT`).


### PR DESCRIPTION
## Summary
- Add a work-in-progress disclaimer just above the Features section in the README
- Replace the inline Cloudflare Tunnel instructions with a short overview and link to a new dedicated guide at `docs/guides/cloudflare-tunnel.md`
- The guide covers daemon-managed tunnels (quick + named), self-managed `cloudflared`, the runtime API, and troubleshooting

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify guide links resolve from the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)