### PR TITLE
chore: add pino-pretty config for dev scripts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "dev": "tsx watch src/index.ts | pino-pretty",
+    "dev": "tsx watch src/index.ts | pino-pretty --config ../../pino-pretty.config.cjs",
     "start": "node dist/index.js",
     "lint": "eslint .",
     "test": "vitest run",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "main": "./out/main/index.js",
   "scripts": {
-    "dev": "electron-vite dev | pino-pretty",
+    "dev": "electron-vite dev | pino-pretty --config ../../pino-pretty.config.cjs",
     "dev:web": "vite --config vite.web.config.ts",
     "build": "electron-vite build && node scripts/bundle-daemon.mjs",
     "clean": "rm -rf out dist",

--- a/pino-pretty.config.cjs
+++ b/pino-pretty.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  singleLine: true,
+  customPrettifiers: {
+    level: (level) => level.padEnd(5),
+  },
+};


### PR DESCRIPTION
## Summary
- Add shared `pino-pretty.config.cjs` with single-line output and padded log levels
- Pass `--config ../../pino-pretty.config.cjs` to pino-pretty in both core and desktop dev scripts

## Test plan
- [x] Run `pnpm --filter @qlan-ro/mainframe-core dev` and verify log output uses single-line format with padded levels
- [x] Run `pnpm --filter @qlan-ro/mainframe-desktop dev` and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)