### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mainframe",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "AI-native development environment for orchestrating agents",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Mainframe daemon — session lifecycle, agent process management, and metadata storage",
   "license": "MIT",
   "repository": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Mainframe desktop app — Electron/React frontend for orchestrating AI agents",
   "license": "MIT",
   "repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlan-ro/mainframe-types",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Shared TypeScript types for Mainframe",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump version from 0.2.2 to 0.2.3 across all packages (root, types, core, desktop)

## Test plan
- [ ] CI passes
- [ ] Release build triggered by `v0.2.3-rc1` tag succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)