### PR TITLE
fix(desktop): auto-refresh editor when agent edits the open file

### DIFF
--- a/.changeset/editor-auto-refresh.md
+++ b/.changeset/editor-auto-refresh.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Auto-refresh editor tab when agent edits the open file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ AI-native development environment for orchestrating agents.
 - For Claude CLI behavior, refer to [CLAUDE-JSONL-SCHEMA.md](docs/adapters/claude/CLAUDE-JSONL-SCHEMA.md), [PROTOCOL_REVERSED.md](docs/adapters/claude/PROTOCOL_REVERSED.md), and examples in `~/.claude/projects/**` and [CLAUDE-JSONL-SAMPLES](docs/adapters/claude/CLAUDE-JSONL-SAMPLES.md)
 - Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance
-- **Changesets required.** Every PR must include a changeset file. Run `pnpm changeset` before committing, pick the affected packages and bump type (patch/minor/major). For PRs that don't need a changelog entry (CI, docs typos), run `pnpm changeset --empty`. The pre-push hook and CI will reject without one.
+- For git workflow and commit practices, see [Git](#git)
 
 ## Tech Stack
 
@@ -80,6 +80,15 @@ Invoke the listed skill **before** taking the described action. No exceptions.
 | Writing docs, commits, PRs, error messages, or UI copy | `writing-clearly-and-concisely` |
 | Creating READMEs, changelogs, ADRs, or structured docs | `documentation-templates` |
 
+## Git
+
+Git workflow and commit practices.
+
+- **Never commit to `main`.** Always work on a feature or fix branch. Run `git branch --show-current` before any commit or reset to confirm you are not on `main`.
+- **Check branch before destructive git ops.** Before `reset`, `rebase`, or `push --force`, verify the current branch with `git status` or `git branch`.
+- **Never discard unstaged changes you didn't create.** They may be in-progress work from another session. When committing, stage only your own files by name. Do not `git checkout --`, `git restore`, or `git stash` other people's changes.
+- **Changesets required.** Every PR must include a changeset file. Run `pnpm changeset` before committing, pick the affected packages and bump type (patch/minor/major). For PRs that don't need a changelog entry (CI, docs typos), run `pnpm changeset --empty`. The pre-push hook and CI will reject without one.
+
 ## Code Style
 
 - **Comments**: Omit notes about removed or missing features. Focus on *why*, not *what*.
@@ -123,10 +132,6 @@ These rules exist because every one was violated before and required cleanup. Fo
 ### Performance
 - **Lazy-load heavy components.** Large editors and visualizations must use `React.lazy()` with `Suspense`.
 - **Cascade deletes.** When deleting parent entities (projects, chats), delete child records in a transaction.
-
-### Git
-- **Never commit to `main`.** Always work on a feature or fix branch. Run `git branch --show-current` before any commit or reset to confirm you are not on `main`.
-- **Check branch before destructive git ops.** Before `reset`, `rebase`, or `push --force`, verify the current branch with `git status` or `git branch`.
 
 ### Hygiene
 - **No `@ts-ignore`.** Use `@ts-expect-error` with a reason comment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ AI-native development environment for orchestrating agents.
 - For Claude CLI behavior, refer to [CLAUDE-JSONL-SCHEMA.md](docs/adapters/claude/CLAUDE-JSONL-SCHEMA.md), [PROTOCOL_REVERSED.md](docs/adapters/claude/PROTOCOL_REVERSED.md), and examples in `~/.claude/projects/**` and [CLAUDE-JSONL-SAMPLES](docs/adapters/claude/CLAUDE-JSONL-SAMPLES.md)
 - Be sure to typecheck when you're done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance
-- **Changesets required.** Every PR must include a changeset file. Run `pnpm changeset` before committing, pick the affected packages and bump type (patch/minor/major). For PRs that don't need a changelog entry (CI, docs typos), run `pnpm changeset --empty`. The pre-push hook and CI will reject without one.
+- For git workflow and commit practices, see [Git](#git)
 
 ## Tech Stack
 
@@ -80,6 +80,15 @@ Invoke the listed skill **before** taking the described action. No exceptions.
 | Writing docs, commits, PRs, error messages, or UI copy | `writing-clearly-and-concisely` |
 | Creating READMEs, changelogs, ADRs, or structured docs | `documentation-templates` |
 
+## Git
+
+Git workflow and commit practices.
+
+- **Never commit to `main`.** Always work on a feature or fix branch. Run `git branch --show-current` before any commit or reset to confirm you are not on `main`.
+- **Check branch before destructive git ops.** Before `reset`, `rebase`, or `push --force`, verify the current branch with `git status` or `git branch`.
+- **Never discard unstaged changes you didn't create.** They may be in-progress work from another session. When committing, stage only your own files by name. Do not `git checkout --`, `git restore`, or `git stash` other people's changes.
+- **Changesets required.** Every PR must include a changeset file. Run `pnpm changeset` before committing, pick the affected packages and bump type (patch/minor/major). For PRs that don't need a changelog entry (CI, docs typos), run `pnpm changeset --empty`. The pre-push hook and CI will reject without one.
+
 ## Code Style
 
 - **Comments**: Omit notes about removed or missing features. Focus on *why*, not *what*.
@@ -123,10 +132,6 @@ These rules exist because every one was violated before and required cleanup. Fo
 ### Performance
 - **Lazy-load heavy components.** Large editors and visualizations must use `React.lazy()` with `Suspense`.
 - **Cascade deletes.** When deleting parent entities (projects, chats), delete child records in a transaction.
-
-### Git
-- **Never commit to `main`.** Always work on a feature or fix branch. Run `git branch --show-current` before any commit or reset to confirm you are not on `main`.
-- **Check branch before destructive git ops.** Before `reset`, `rebase`, or `push --force`, verify the current branch with `git status` or `git branch`.
 
 ### Hygiene
 - **No `@ts-ignore`.** Use `@ts-expect-error` with a reason comment.

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -98,7 +98,7 @@ function buildSessionSink(
           const fp = (block.input as Record<string, unknown>)?.file_path as string | undefined;
           if (fp && !seenEditFiles.has(fp)) {
             seenEditFiles.add(fp);
-            emitEvent({ type: 'context.updated', chatId });
+            emitEvent({ type: 'context.updated', chatId, filePaths: [fp] });
           }
         }
       }

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -80,8 +80,6 @@ function buildSessionSink(
     emitDisplayDelta(chatId, messages, displayCache, categories, emitEvent);
   }
 
-  const seenEditFiles = new Set<string>();
-
   return {
     onInit(sessionId: string) {
       const active = getActiveChat(chatId);
@@ -93,14 +91,15 @@ function buildSessionSink(
 
     onMessage(content: any[], metadata?: MessageMetadata) {
       log.debug({ chatId, blockCount: content.length }, 'assistant message received');
+      const editedPaths: string[] = [];
       for (const block of content) {
         if (block.type === 'tool_use' && (block.name === 'Write' || block.name === 'Edit')) {
           const fp = (block.input as Record<string, unknown>)?.file_path as string | undefined;
-          if (fp && !seenEditFiles.has(fp)) {
-            seenEditFiles.add(fp);
-            emitEvent({ type: 'context.updated', chatId, filePaths: [fp] });
-          }
+          if (fp) editedPaths.push(fp);
         }
+      }
+      if (editedPaths.length > 0) {
+        emitEvent({ type: 'context.updated', chatId, filePaths: editedPaths });
       }
       const hasEnterPlanMode = content.some((b: any) => b.type === 'tool_use' && b.name === 'EnterPlanMode');
       if (hasEnterPlanMode) {

--- a/packages/desktop/src/renderer/components/center/EditorTab.tsx
+++ b/packages/desktop/src/renderer/components/center/EditorTab.tsx
@@ -3,6 +3,7 @@ import { Save } from 'lucide-react';
 import { useProjectsStore } from '../../store';
 import { useChatsStore } from '../../store/chats';
 import { getFileContent, saveFileContent } from '../../lib/api';
+import { daemonClient } from '../../lib/client';
 import { sendCommentMessage } from '../../lib/send-comment-message';
 import { MonacoEditor } from '../editor/MonacoEditor';
 
@@ -98,6 +99,24 @@ export function EditorTab({
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, []);
+
+  // Re-fetch file content when agent edits a file in this session
+  useEffect(() => {
+    if (!activeChatId || !activeProjectId || providedContent !== undefined) return;
+    return daemonClient.onEvent((event) => {
+      if (event.type === 'context.updated' && event.chatId === activeChatId) {
+        if (dirtyRef.current) return; // don't overwrite unsaved user changes
+        getFileContent(activeProjectId, filePath, activeChatId)
+          .then((result) => {
+            setSavedContent(result.content);
+            setCurrentContent(result.content);
+          })
+          .catch(() => {
+            /* file may have been deleted; keep current content */
+          });
+      }
+    });
+  }, [activeChatId, activeProjectId, filePath, providedContent]);
 
   const handleChange = useCallback((value: string | undefined) => {
     if (value !== undefined) setCurrentContent(value);

--- a/packages/desktop/src/renderer/components/center/EditorTab.tsx
+++ b/packages/desktop/src/renderer/components/center/EditorTab.tsx
@@ -100,21 +100,22 @@ export function EditorTab({
     return () => document.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  // Re-fetch file content when agent edits a file in this session
+  // Re-fetch file content when any agent edits this file
   useEffect(() => {
-    if (!activeChatId || !activeProjectId || providedContent !== undefined) return;
+    if (!activeProjectId || providedContent !== undefined) return;
     return daemonClient.onEvent((event) => {
-      if (event.type === 'context.updated' && event.chatId === activeChatId) {
-        if (dirtyRef.current) return; // don't overwrite unsaved user changes
-        getFileContent(activeProjectId, filePath, activeChatId)
-          .then((result) => {
-            setSavedContent(result.content);
-            setCurrentContent(result.content);
-          })
-          .catch(() => {
-            /* file may have been deleted; keep current content */
-          });
-      }
+      if (event.type !== 'context.updated' || !event.filePaths) return;
+      const match = event.filePaths.some((fp) => filePath.endsWith(fp) || fp.endsWith(filePath));
+      if (!match) return;
+      if (dirtyRef.current) return; // don't overwrite unsaved user changes
+      getFileContent(activeProjectId, filePath, activeChatId ?? undefined)
+        .then((result) => {
+          setSavedContent(result.content);
+          setCurrentContent(result.content);
+        })
+        .catch(() => {
+          /* file may have been deleted; keep current content */
+        });
     });
   }, [activeChatId, activeProjectId, filePath, providedContent]);
 

--- a/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
@@ -62,6 +62,18 @@ export function MonacoEditor({
     setTimeout(() => editor.focus(), 50);
   }, [line, column]);
 
+  // Sync external value changes into the Monaco model (e.g. agent edits).
+  // The `path` prop makes @monaco-editor/react ignore `value` after initial mount.
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const model = editor.getModel();
+    if (!model) return;
+    if (model.getValue() !== value) {
+      model.setValue(value);
+    }
+  }, [value]);
+
   const lineRef = useRef(line);
   lineRef.current = line;
   const columnRef = useRef(column);

--- a/packages/desktop/src/renderer/components/panels/ContextFileItem.tsx
+++ b/packages/desktop/src/renderer/components/panels/ContextFileItem.tsx
@@ -4,16 +4,15 @@ import { useTabsStore } from '../../store/tabs';
 interface ContextFileItemProps {
   path: string;
   displayName?: string;
-  content?: string;
   badge?: string;
 }
 
-export function ContextFileItem({ path, displayName, content, badge }: ContextFileItemProps) {
+export function ContextFileItem({ path, displayName, badge }: ContextFileItemProps) {
   const fileName = displayName ?? path.split('/').pop() ?? path;
   const openEditorTab = useTabsStore((s) => s.openEditorTab);
 
   const handleClick = () => {
-    openEditorTab(path, content);
+    openEditorTab(path);
   };
 
   return (

--- a/packages/desktop/src/renderer/components/panels/ContextTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/ContextTab.tsx
@@ -75,13 +75,13 @@ export function ContextTab(): React.ReactElement {
     <div className="space-y-2">
       <ContextSection icon={Globe} title="Global" count={globalFiles.length} defaultOpen>
         {globalFiles.map((f) => (
-          <ContextFileItem key={f.path} path={f.path} content={f.content} />
+          <ContextFileItem key={f.path} path={f.path} />
         ))}
       </ContextSection>
 
       <ContextSection icon={FolderOpen} title="Project" count={projectFiles.length} defaultOpen>
         {projectFiles.map((f) => (
-          <ContextFileItem key={f.path} path={f.path} content={f.content} />
+          <ContextFileItem key={f.path} path={f.path} />
         ))}
       </ContextSection>
 

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -18,7 +18,7 @@ export type DaemonEvent =
   | { type: 'messages.cleared'; chatId: string }
   | { type: 'permission.requested'; chatId: string; request: ControlRequest }
   | { type: 'permission.resolved'; chatId: string; requestId: string }
-  | { type: 'context.updated'; chatId: string }
+  | { type: 'context.updated'; chatId: string; filePaths?: string[] }
   | { type: 'error'; chatId?: string; error: string }
   | {
       type: 'plugin.panel.registered';


### PR DESCRIPTION
## Summary
- Add `filePaths` to `context.updated` WS event so the editor can match edited files by path
- `EditorTab` listens to `context.updated` from **any** session, refreshing when the open file was edited
- Context tab no longer passes pre-loaded content to `openEditorTab`, enabling the refresh listener
- Remove `seenEditFiles` dedup — emit `context.updated` on every Write/Edit, not just the first per file
- Fix Monaco not updating: `value` prop is ignored when `path` is set, so sync via `model.setValue()` directly
- Skip refresh when the editor has unsaved user changes

## Test plan
- [x] Open CLAUDE.md from the **Context tab**, have a session edit it — editor refreshes
- [x] Open a file from the **file tree**, have a session edit it — editor refreshes
- [x] Open a file, make unsaved edits, then have an agent edit it — editor should NOT overwrite
- [x] Verify file tree and changes tab still refresh as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)