### PR TITLE
fix(desktop): prevent chat message text overflow

### DIFF
--- a/.changeset/fix-chat-text-overflow.md
+++ b/.changeset/fix-chat-text-overflow.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Fix chat message text overflow by adding word-break rules to markdown container

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -210,6 +210,8 @@ code {
   font-size: 15px;
   line-height: 24px;
   color: var(--mf-text-primary);
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 /* Code */


### PR DESCRIPTION
## Summary
- Add `overflow-wrap: break-word` and `word-break: break-word` to `.aui-md` container
- Fixes long unbroken strings (URLs, package names, file paths) overflowing the chat window

## Test plan
- [x] Open a chat with assistant messages containing long URLs or file paths
- [x] Verify text wraps within the message container instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)