### PR TITLE
fix(core): deduplicate display messages by id

### DIFF
--- a/.changeset/dedup-display-message-ids.md
+++ b/.changeset/dedup-display-message-ids.md
@@ -1,0 +1,10 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+fix(core): deduplicate display messages by id to prevent assistant-ui crash
+
+The Claude CLI can reuse UUIDs for compact_boundary entries, producing duplicate
+message ids in the display pipeline. assistant-ui's MessageRepository throws when
+it encounters the same id twice. Now `prepareMessagesForClient` skips messages
+whose id was already emitted.

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -149,6 +149,22 @@ describe('prepareMessagesForClient', () => {
     expect(result[0]!.content).toEqual([{ type: 'text', text: '[compact_boundary]' }]);
   });
 
+  it('deduplicates messages with the same id (keeps first occurrence)', () => {
+    const messages = [
+      rawMsg('user', [txt('hello')]),
+      rawMsg('assistant', [txt('hi')]),
+      rawMsg('system', [txt('Context compacted')], { id: 'dup-id' }),
+      rawMsg('user', [txt('more')]),
+      rawMsg('system', [txt('Context compacted')], { id: 'dup-id' }),
+    ];
+    const result = prepareMessagesForClient(messages);
+    const systemMsgs = result.filter((m) => m.type === 'system');
+    expect(systemMsgs).toHaveLength(1);
+    expect(result.map((m) => m.id)).not.toContain(undefined);
+    // Total should be 4 (user, assistant, system, user) — second system deduplicated
+    expect(result).toHaveLength(4);
+  });
+
   it('passes through error messages', () => {
     const messages = [rawMsg('error', [{ type: 'error', message: 'something broke' }])];
     const result = prepareMessagesForClient(messages);

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -27,12 +27,18 @@ export function prepareMessagesForClient(messages: ChatMessage[], categories?: T
   // handle turnDurationMs (all handled by groupMessages)
   const grouped = groupMessages(filtered);
 
-  // Steps 4–5: Convert to DisplayMessage
+  // Steps 4–5: Convert to DisplayMessage, deduplicating by id.
+  // The CLI can reuse UUIDs (e.g. for compact_boundary entries), which causes
+  // assistant-ui's MessageRepository to throw on duplicate ids.
   const result: DisplayMessage[] = [];
+  const seenIds = new Set<string>();
 
   for (const gMsg of grouped) {
     const display = convertGroupedToDisplay(gMsg, categories);
-    if (display) result.push(display);
+    if (!display) continue;
+    if (seenIds.has(display.id)) continue;
+    seenIds.add(display.id);
+    result.push(display);
   }
 
   return result;


### PR DESCRIPTION
## Summary
- Claude CLI can reuse UUIDs for `compact_boundary` (context compaction) entries in JSONL history. After `groupMessages`, two system messages with the same id survive into the `DisplayMessage[]` array.
- assistant-ui's `MessageRepository` throws `performOp/link: A message with the same id already exists in the parent tree` on the duplicate, crashing the entire chat view with no recovery (persists across restarts).
- Added a `seenIds` set in `prepareMessagesForClient()` to skip messages whose id was already emitted, keeping only the first occurrence.

## Test plan
- [x] New test: `deduplicates messages with the same id (keeps first occurrence)`
- [x] All 740 existing tests pass
- [x] Verify production app no longer crashes when loading chats with duplicate compact_boundary UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)