### PR TITLE
fix(desktop): prevent stale messages when switching projects

### DIFF
--- a/.changeset/fix-project-switch-stale-messages.md
+++ b/.changeset/fix-project-switch-stale-messages.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Fix stale messages showing after project switch by removing duplicate useProject() call from ChatsPanel

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -6,7 +6,6 @@ const log = createLogger('renderer:panels');
 import { useChatsStore, useProjectsStore } from '../../store';
 import type { SessionStatus } from '../../store/chats';
 import { useTabsStore } from '../../store/tabs';
-import { useProject } from '../../hooks/useAppInit';
 import { daemonClient } from '../../lib/client';
 import { archiveChat, getExternalSessions, importExternalSession } from '../../lib/api';
 import { cn } from '../../lib/utils';
@@ -42,8 +41,15 @@ export function ChatsPanel(): React.ReactElement {
   const { activeProjectId } = useProjectsStore();
   const { chats, activeChatId, setActiveChat, removeChat } = useChatsStore();
   const adapters = useAdaptersStore((s) => s.adapters);
-  const { createChat } = useProject(activeProjectId);
   const externalSessionCount = useChatsStore((s) => s.externalSessionCount);
+
+  const createChat = useCallback(
+    (adapterId: string, model?: string) => {
+      if (!activeProjectId) return;
+      daemonClient.createChat(activeProjectId, adapterId, model);
+    },
+    [activeProjectId],
+  );
 
   const [showImport, setShowImport] = useState(false);
   const [externalSessions, setExternalSessions] = useState<ExternalSession[]>([]);

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -115,8 +115,8 @@ export function useProject(projectId: string | null) {
         const sorted = [...chatsList].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
         const mostRecent = sorted[0]!;
         useChatsStore.getState().setActiveChat(mostRecent.id);
+        useTabsStore.getState().openChatTab(mostRecent.id, mostRecent.title);
         if (!hasRestoredTabs) {
-          useTabsStore.getState().openChatTab(mostRecent.id, mostRecent.title);
           daemonClient.subscribe(mostRecent.id);
         }
       }


### PR DESCRIPTION
## Summary

- **Root cause**: `useProject()` was called from both `CenterPanel` and `ChatsPanel`, each with its own `prevProjectIdRef`. This caused `switchProject()` to run twice per project change — the second call saved the *just-restored* target project's tabs under the previous project's key, corrupting its saved tab state. Switching back later restored the wrong project's tabs, rendering messages from the wrong chat.
- Remove `useProject()` from `ChatsPanel`; inline `createChat` via `daemonClient.createChat()` directly
- Always open a tab in the `loadChats` fallback when restored tabs point to invalid chatIds (defense-in-depth for archived/stale sessions)

## Test plan

- [x] Switch between two projects with existing sessions — verify correct messages display each time
- [x] Switch projects rapidly back and forth 5+ times — verify no tab state corruption
- [x] Archive a session, switch away, switch back — verify fallback selects most recent chat correctly
- [x] Create new session from ChatsPanel "+" button — verify it still works after inlining `createChat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)