### PR TITLE
fix(core): only update session updatedAt on user message send

### DIFF
--- a/.changeset/fix-updated-at-on-send.md
+++ b/.changeset/fix-updated-at-on-send.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Only update session updatedAt timestamp when user sends a message, not on AI responses

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -201,16 +201,22 @@ describe('ChatsRepository', () => {
       expect(fetched!.processState).toBe('working');
     });
 
-    it('always updates updated_at', () => {
+    it('updates updated_at only when explicitly passed', () => {
       const chat = chats.create(projectId, 'claude');
 
-      // Set an old timestamp so the update is guaranteed to differ
+      // Set an old timestamp
       db.prepare('UPDATE chats SET updated_at = ? WHERE id = ?').run('2020-01-01T00:00:00.000Z', chat.id);
 
+      // update without updatedAt should NOT change it
       chats.update(chat.id, { title: 'Trigger update' });
+      const afterTitle = chats.get(chat.id);
+      expect(afterTitle!.updatedAt).toBe('2020-01-01T00:00:00.000Z');
 
-      const fetched = chats.get(chat.id);
-      expect(fetched!.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+      // update with explicit updatedAt should change it
+      const now = new Date().toISOString();
+      chats.update(chat.id, { updatedAt: now });
+      const afterExplicit = chats.get(chat.id);
+      expect(afterExplicit!.updatedAt).toBe(now);
     });
 
     it('updates mentions as JSON', () => {

--- a/packages/core/src/chat/__tests__/command-routing.test.ts
+++ b/packages/core/src/chat/__tests__/command-routing.test.ts
@@ -175,7 +175,7 @@ describe('ChatManager command routing', () => {
       command: { name: 'compact', source: 'claude' },
     });
 
-    expect(db.chats.update).toHaveBeenCalledWith('chat-1', { processState: 'working' });
+    expect(db.chats.update).toHaveBeenCalledWith('chat-1', expect.objectContaining({ processState: 'working' }));
   });
 
   it('calls plain sendMessage with raw content when no metadata is provided', async () => {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -212,8 +212,10 @@ export class ChatManager {
       } else {
         await postStart.session.sendCommand(name, args);
       }
+      const now = new Date().toISOString();
       postStart.chat.processState = 'working';
-      this.db.chats.update(chatId, { processState: 'working' });
+      postStart.chat.updatedAt = now;
+      this.db.chats.update(chatId, { processState: 'working', updatedAt: now });
       this.emitEvent({ type: 'chat.updated', chat: postStart.chat });
       return;
     }
@@ -255,12 +257,13 @@ export class ChatManager {
       postStart.chat.title = title;
       this.db.chats.update(chatId, { title });
       this.emitEvent({ type: 'chat.updated', chat: postStart.chat });
-
       this.lifecycle.doGenerateTitle(chatId, content).catch(() => {});
     }
 
+    const now = new Date().toISOString();
     postStart.chat.processState = 'working';
-    this.db.chats.update(chatId, { processState: 'working' });
+    postStart.chat.updatedAt = now;
+    this.db.chats.update(chatId, { processState: 'working', updatedAt: now });
     this.emitEvent({ type: 'chat.updated', chat: postStart.chat });
 
     await postStart.session.sendMessage(outgoingContent, images.length > 0 ? images : undefined);

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -108,6 +108,7 @@ export class ChatsRepository {
     branchName: { column: 'branch_name', transform: (v) => v ?? null },
     mentions: { column: 'mentions', transform: (v) => JSON.stringify(v) },
     processState: { column: 'process_state' },
+    updatedAt: { column: 'updated_at' },
   };
 
   update(id: string, updates: Partial<Chat>): void {
@@ -122,8 +123,7 @@ export class ChatsRepository {
       }
     }
 
-    sets.push('updated_at = ?');
-    values.push(new Date().toISOString());
+    if (sets.length === 0) return;
     values.push(id);
 
     this.db.prepare(`UPDATE chats SET ${sets.join(', ')} WHERE id = ?`).run(...values);


### PR DESCRIPTION
## Summary
- Removed automatic `updated_at` bump from `ChatsRepository.update()` — it was firing on every DB write (AI responses, process exit, session init), making sidebar timestamps misleading
- `updatedAt` is now only set explicitly in `sendMessage`, so the sidebar reflects when the user last interacted
- Fixed in-memory chat object sync so the UI receives the correct timestamp immediately via WebSocket

## Test plan
- [x] Send a message to a week-old session — sidebar should show "Today" or current time
- [x] Wait for AI response — sidebar timestamp should NOT change
- [x] Verify session list ordering still works (sorted by `updated_at DESC`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)