### PR TITLE
fix(core): fix live session diffs and context.updated timing

### DIFF
--- a/.changeset/fix-context-updated-timing.md
+++ b/.changeset/fix-context-updated-timing.md
@@ -1,0 +1,10 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+fix(core): emit context.updated after tool_result instead of tool_use
+
+Moves the context.updated event from onMessage (fires before tool execution)
+to onToolResult (fires after). This ensures ChangesTab session-diffs and
+EditorTab file refreshes see the completed data instead of racing with the
+CLI tool execution.

--- a/.claude/skills/debugging-live-events/SKILL.md
+++ b/.claude/skills/debugging-live-events/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: debugging-live-events
+description: Use when investigating mismatches between live stream-json events and JSONL history, missing event fields, permission issues, or unexpected behavior in the Claude adapter event pipeline. Also use when session features work after daemon restart but not during live sessions.
+---
+
+# Debugging Live Stream-JSON Events
+
+## Overview
+
+The Claude CLI emits events via `--output-format stream-json` (live) and writes them to JSONL files on disk (history). These two formats can differ in key naming and field availability. This skill shows how to inspect raw event data to find mismatches.
+
+## When to Use
+
+- Feature works after daemon restart (history path) but not during live sessions
+- `modifiedFile`, `originalFile`, `structuredPatch` or other fields are missing in live mode
+- Permission responses aren't being persisted or honored
+- Any suspicion that stream-json event shape differs from JSONL entries
+
+## Key Insight: snake_case vs camelCase
+
+Stream-json uses **snake_case** keys. JSONL history uses **camelCase**.
+
+| Stream-JSON (live) | JSONL (history) |
+|---------------------|-----------------|
+| `tool_use_result` | `toolUseResult` |
+| `request_id` | `requestId` |
+| `tool_use_id` | `toolUseId` |
+| `tool_name` | `toolName` |
+| `permission_suggestions` | `permissionSuggestions` |
+
+Always check both casings when reading event fields.
+
+## Technique
+
+### 1. Add debug logging to the event handler
+
+The entry point is `packages/core/src/plugins/builtin/claude/events.ts`. Each event type has a handler: `handleAssistantEvent`, `handleUserEvent`, `handleControlRequestEvent`, `handleResultEvent`.
+
+Add `log.warn` (not debug/trace, so it appears in default log level) with:
+- `Object.keys(event)` or `Object.keys(subObject)` to discover available fields
+- The raw values of fields you're investigating (truncated with `.slice(0, 200)`)
+- Both snake_case and camelCase variants to confirm which one has data
+
+```typescript
+// Example: inspecting user event for tool_result data
+log.warn(
+  {
+    eventKeys: Object.keys(event),
+    hasTurCamel: !!event.toolUseResult,
+    hasTurSnake: !!event.tool_use_result,
+    turSnakeKeys: event.tool_use_result ? Object.keys(event.tool_use_result) : [],
+  },
+  'DEBUG raw event data',
+);
+```
+
+### 2. Trigger the event
+
+The dev daemon (`tsx watch`) auto-restarts on file changes. Trigger the relevant action in the dev app (port 31416).
+
+### 3. Read the logs
+
+```bash
+# Dev app logs
+grep "DEBUG" ~/.mainframe_dev/logs/server.$(date +%Y-%m-%d).log | tail -5
+
+# Production app logs
+grep "DEBUG" ~/.mainframe/logs/server.$(date +%Y-%m-%d).log | tail -5
+```
+
+### 4. Clean up
+
+Remove all debug logging before committing.
+
+## Event Pipeline Reference
+
+```
+CLI stdout (stream-json, snake_case)
+  -> events.ts: handleEvent() dispatches by event.type
+    -> handleAssistantEvent: sink.onMessage(content)
+    -> handleUserEvent: sink.onToolResult(content) via buildToolResultBlocks()
+    -> handleControlRequestEvent: sink.onPermission(request)
+    -> handleResultEvent: sink.onResult(data)
+  -> event-handler.ts: buildSessionSink() processes sink callbacks
+    -> Caches messages, emits DaemonEvents to WebSocket clients
+
+CLI JSONL files (camelCase, includes toolUseResult)
+  -> history.ts: loadHistory() reads on daemon restart / --resume
+    -> convertUserEntry() via buildToolResultBlocks() (same function, different input casing)
+```
+
+## Common Pitfalls
+
+- **Logging at debug/trace level**: Dev daemon default is INFO. Use `log.warn` for temporary debug output.
+- **Assuming stream-json matches JSONL**: Always verify field names empirically.
+- **Forgetting to check nested objects**: The top-level event key might exist but inner fields may also differ in casing (e.g. `tool_use_result.oldString` vs `toolUseResult.oldString`).

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -188,6 +188,81 @@ describe('EventHandler skill_file announcement', () => {
   });
 });
 
+describe('EventHandler context.updated timing', () => {
+  let db: any;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+
+  const chatId = 'chat-ctx';
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    messages = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    activeChats = new Map();
+    activeChats.set(chatId, {
+      chat: { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'working' },
+      session: { id: 'session-1', adapterId: 'claude' },
+    });
+  });
+
+  it('does not emit context.updated on assistant message with tool_use', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'tool_use', id: 'toolu_1', name: 'Edit', input: { file_path: '/foo/bar.ts' } }]);
+
+    const ctxEvents = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'context.updated');
+    expect(ctxEvents).toHaveLength(0);
+  });
+
+  it('emits context.updated with filePaths on tool_result for Write/Edit', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    // Step 1: assistant sends tool_use
+    sink.onMessage([
+      { type: 'tool_use', id: 'toolu_1', name: 'Edit', input: { file_path: '/foo/bar.ts' } },
+      { type: 'tool_use', id: 'toolu_2', name: 'Write', input: { file_path: '/foo/baz.ts' } },
+    ]);
+
+    // Step 2: tool results arrive
+    sink.onToolResult([{ type: 'tool_result', toolUseId: 'toolu_1', content: 'ok', isError: false }]);
+
+    const ctxEvents = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'context.updated');
+    expect(ctxEvents).toHaveLength(1);
+    expect(ctxEvents[0][0].filePaths).toEqual(['/foo/bar.ts']);
+
+    emitEvent.mockClear();
+
+    sink.onToolResult([{ type: 'tool_result', toolUseId: 'toolu_2', content: 'ok', isError: false }]);
+
+    const ctxEvents2 = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'context.updated');
+    expect(ctxEvents2).toHaveLength(1);
+    expect(ctxEvents2[0][0].filePaths).toEqual(['/foo/baz.ts']);
+  });
+
+  it('does not emit context.updated for non-file tool_results', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    // assistant sends a Bash tool_use
+    sink.onMessage([{ type: 'tool_use', id: 'toolu_bash', name: 'Bash', input: { command: 'ls' } }]);
+
+    sink.onToolResult([{ type: 'tool_result', toolUseId: 'toolu_bash', content: 'file1\nfile2', isError: false }]);
+
+    const ctxEvents = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'context.updated');
+    expect(ctxEvents).toHaveLength(0);
+  });
+});
+
 describe('EventHandler onPermission — yolo no longer auto-approves', () => {
   let db: any;
   let messages: MessageCache;

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -229,8 +229,13 @@ describe('EventHandler context.updated timing', () => {
 
     // Step 1: assistant sends tool_use
     sink.onMessage([
-      { type: 'tool_use', id: 'toolu_1', name: 'Edit', input: { file_path: '/foo/bar.ts' } },
-      { type: 'tool_use', id: 'toolu_2', name: 'Write', input: { file_path: '/foo/baz.ts' } },
+      {
+        type: 'tool_use',
+        id: 'toolu_1',
+        name: 'Edit',
+        input: { file_path: '/foo/bar.ts', old_string: 'a', new_string: 'b' },
+      },
+      { type: 'tool_use', id: 'toolu_2', name: 'Write', input: { file_path: '/foo/baz.ts', content: 'new file' } },
     ]);
 
     // Step 2: tool results arrive

--- a/packages/core/src/__tests__/file-edit-flow.test.ts
+++ b/packages/core/src/__tests__/file-edit-flow.test.ts
@@ -130,7 +130,7 @@ describe('file-edit flow', () => {
         type: 'tool_use',
         id: 'tu-1',
         name: 'Write',
-        input: { file_path: 'src/main.ts', content: 'export const x = 1;' },
+        input: { file_path: 'src/main.ts', content: 'export const x = 42;' },
       },
     ]);
     await sleep(50);

--- a/packages/core/src/__tests__/file-edit-flow.test.ts
+++ b/packages/core/src/__tests__/file-edit-flow.test.ts
@@ -124,7 +124,7 @@ describe('file-edit flow', () => {
       if (e.type === 'context.updated') contextUpdated.push(e);
     });
 
-    // Emit message with Write tool_use using relative path
+    // Emit assistant message with Write tool_use (before execution)
     adapter.currentSession!.simulateMessage([
       {
         type: 'tool_use',
@@ -135,7 +135,16 @@ describe('file-edit flow', () => {
     ]);
     await sleep(50);
 
-    // context.updated was emitted
+    // context.updated should NOT fire on tool_use (tool hasn't executed yet)
+    expect(contextUpdated.length).toBe(0);
+
+    // Emit tool_result (after execution)
+    adapter.currentSession!.simulateToolResult([
+      { type: 'tool_result', toolUseId: 'tu-1', content: 'ok', isError: false },
+    ]);
+    await sleep(50);
+
+    // context.updated fires AFTER tool_result is cached
     expect(contextUpdated.length).toBeGreaterThanOrEqual(1);
   }, 10_000);
 });

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -81,7 +81,7 @@ function buildSessionSink(
   }
 
   // Track tool_use id → file_path so onToolResult can emit context.updated
-  // AFTER the tool has executed and the result is cached.
+  // with the affected paths after the tool has executed.
   const pendingFilePaths = new Map<string, string>();
 
   return {
@@ -131,23 +131,21 @@ function buildSessionSink(
     },
 
     onToolResult(content: any[]) {
+      const editedPaths: string[] = [];
+      for (const block of content) {
+        if (block.type !== 'tool_result' || block.isError) continue;
+        const fp = pendingFilePaths.get(block.toolUseId);
+        if (fp) {
+          editedPaths.push(fp);
+          pendingFilePaths.delete(block.toolUseId);
+        }
+      }
+
       const message = messages.createTransientMessage(chatId, 'tool_result', content);
       messages.append(chatId, message);
       emitEvent({ type: 'message.added', chatId, message });
       emitDisplay();
 
-      // Emit context.updated AFTER the tool_result is cached so that
-      // ChangesTab (session-diffs) and EditorTab see the completed data.
-      const editedPaths: string[] = [];
-      for (const block of content) {
-        if (block.type === 'tool_result') {
-          const fp = pendingFilePaths.get(block.toolUseId);
-          if (fp) {
-            editedPaths.push(fp);
-            pendingFilePaths.delete(block.toolUseId);
-          }
-        }
-      }
       if (editedPaths.length > 0) {
         emitEvent({ type: 'context.updated', chatId, filePaths: editedPaths });
       }

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -80,6 +80,10 @@ function buildSessionSink(
     emitDisplayDelta(chatId, messages, displayCache, categories, emitEvent);
   }
 
+  // Track tool_use id → file_path so onToolResult can emit context.updated
+  // AFTER the tool has executed and the result is cached.
+  const pendingFilePaths = new Map<string, string>();
+
   return {
     onInit(sessionId: string) {
       const active = getActiveChat(chatId);
@@ -91,15 +95,11 @@ function buildSessionSink(
 
     onMessage(content: any[], metadata?: MessageMetadata) {
       log.debug({ chatId, blockCount: content.length }, 'assistant message received');
-      const editedPaths: string[] = [];
       for (const block of content) {
         if (block.type === 'tool_use' && (block.name === 'Write' || block.name === 'Edit')) {
           const fp = (block.input as Record<string, unknown>)?.file_path as string | undefined;
-          if (fp) editedPaths.push(fp);
+          if (fp) pendingFilePaths.set(block.id as string, fp);
         }
-      }
-      if (editedPaths.length > 0) {
-        emitEvent({ type: 'context.updated', chatId, filePaths: editedPaths });
       }
       const hasEnterPlanMode = content.some((b: any) => b.type === 'tool_use' && b.name === 'EnterPlanMode');
       if (hasEnterPlanMode) {
@@ -135,6 +135,22 @@ function buildSessionSink(
       messages.append(chatId, message);
       emitEvent({ type: 'message.added', chatId, message });
       emitDisplay();
+
+      // Emit context.updated AFTER the tool_result is cached so that
+      // ChangesTab (session-diffs) and EditorTab see the completed data.
+      const editedPaths: string[] = [];
+      for (const block of content) {
+        if (block.type === 'tool_result') {
+          const fp = pendingFilePaths.get(block.toolUseId);
+          if (fp) {
+            editedPaths.push(fp);
+            pendingFilePaths.delete(block.toolUseId);
+          }
+        }
+      }
+      if (editedPaths.length > 0) {
+        emitEvent({ type: 'context.updated', chatId, filePaths: editedPaths });
+      }
     },
 
     onPermission(request: any) {

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -82,7 +82,8 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   const message = event.message as { content: Array<Record<string, unknown>> } | undefined;
   if (!message?.content) return;
 
-  const tur = event.toolUseResult as Record<string, unknown> | undefined;
+  // Stream-json uses snake_case; JSONL uses camelCase
+  const tur = (event.tool_use_result ?? event.toolUseResult) as Record<string, unknown> | undefined;
 
   // Use shared builder — same logic as convertUserEntry in claude-history.ts
   const toolResultContent: MessageContent[] = buildToolResultBlocks(message as Record<string, unknown>, tur);

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -311,12 +311,16 @@ export class ClaudeSession implements AdapterSession {
     }
     const project: ContextFile[] = [];
     for (const name of ['CLAUDE.md', 'AGENTS.md']) {
-      const p = path.join(this.projectPath, name);
-      if (existsSync(p)) {
-        try {
-          project.push({ path: name, content: readFileSync(p, 'utf-8'), source: 'project' });
-        } catch {
-          /* expected */
+      // Check both project root and .claude/ subdirectory
+      for (const dir of [this.projectPath, path.join(this.projectPath, '.claude')]) {
+        const p = path.join(dir, name);
+        if (existsSync(p)) {
+          try {
+            const relPath = path.relative(this.projectPath, p);
+            project.push({ path: relPath, content: readFileSync(p, 'utf-8'), source: 'project' });
+          } catch {
+            /* expected */
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Fix context.updated timing**: emit `context.updated` after `tool_result` (post-execution) instead of on `tool_use` (pre-execution), so the Changes panel and open editors refresh with actual file changes
- **Fix stream-json key casing**: read `tool_use_result` (snake_case) from live stream-json events — the code was reading `toolUseResult` (camelCase) which only exists in JSONL history, causing `modifiedFile`/`originalFile` to always be undefined during live sessions
- **Support `.claude/CLAUDE.md`**: check both project root and `.claude/` subdirectory for CLAUDE.md and AGENTS.md context files
- **Add debugging skill**: documents the technique for inspecting raw stream-json events vs JSONL history

## Test plan

- [x] Unit tests for context.updated timing (emit on tool_result, not tool_use)
- [x] Unit tests for context.updated with filePaths per tool
- [x] Integration test for file-edit flow timing
- [x] All 736 existing tests pass
- [x] Typecheck passes
- [x] Manual verification: session changes appear during live sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)