### PR TITLE
fix(desktop): make entire project row clickable in dropdown

### DIFF
--- a/.changeset/fix-project-dropdown-click.md
+++ b/.changeset/fix-project-dropdown-click.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(desktop): make entire project row clickable in projects dropdown
+
+Clicking the right side of a project row (outside the text button) did nothing.
+Added onClick to the row container so any click switches the project, unless
+the delete confirmation is active.

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -232,13 +232,7 @@ export function TitleBar({
                     ) : (
                       /* Normal project row */
                       <>
-                        <button
-                          onClick={() => {
-                            setActiveProject(project.id);
-                            setDropdownOpen(false);
-                          }}
-                          className="flex-1 flex items-center gap-2 text-left min-w-0"
-                        >
+                        <div className="flex-1 flex items-center gap-2 text-left min-w-0">
                           <div
                             className={cn(
                               'w-5 h-5 rounded flex items-center justify-center text-mf-body font-semibold shrink-0',
@@ -255,7 +249,7 @@ export function TitleBar({
                           >
                             {project.name}
                           </span>
-                        </button>
+                        </div>
 
                         {/* Hover-reveal remove button */}
                         {isHovering && (

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -196,9 +196,15 @@ export function TitleBar({
                 return (
                   <div
                     key={project.id}
-                    className="relative flex items-center px-3 py-2 hover:bg-mf-app-bg transition-colors group"
+                    className="relative flex items-center px-3 py-2 hover:bg-mf-app-bg transition-colors group cursor-pointer"
                     onMouseEnter={() => setHoveringId(project.id)}
                     onMouseLeave={() => handleMouseLeave(project.id)}
+                    onClick={() => {
+                      if (!isConfirming) {
+                        setActiveProject(project.id);
+                        setDropdownOpen(false);
+                      }
+                    }}
                   >
                     {isConfirming ? (
                       /* Inline confirm state: ✓ / ✗ */


### PR DESCRIPTION
## Summary
- Clicking the right area of a project row in the projects dropdown did nothing — only the inner text button had a click handler
- Added `onClick` to the row container div so clicking anywhere in the row switches the active project
- Guarded by `isConfirming` check so delete confirmation flow is unaffected; delete button already uses `stopPropagation`

## Test plan
- [x] Open the projects dropdown
- [x] Click on the right side of a project row (outside the project name text) — should switch to that project
- [x] Hover over a row, click the X button — should show delete confirmation (not switch project)
- [x] In delete confirmation state, click the row — should not switch project

🤖 Generated with [Claude Code](https://claude.com/claude-code)