### PR TITLE
fix(desktop): show error toasts for failed git actions

### DIFF
--- a/.changeset/git-error-toasts.md
+++ b/.changeset/git-error-toasts.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+fix(desktop): show error toasts for failed git actions (checkout, rename, fetch, abort, create branch)

--- a/packages/desktop/src/renderer/components/git/useBranchActions.ts
+++ b/packages/desktop/src/renderer/components/git/useBranchActions.ts
@@ -58,6 +58,9 @@ export function useBranchActions(projectId: string, onBranchChanged: () => void,
     setBusyAction(action ?? null);
     try {
       await fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      toast.error(msg);
     } finally {
       setBusy(false);
       setBusyAction(null);

--- a/packages/desktop/src/renderer/lib/api/http.ts
+++ b/packages/desktop/src/renderer/lib/api/http.ts
@@ -2,9 +2,20 @@ const host: string = (import.meta.env as Record<string, string>)['VITE_DAEMON_HO
 const port: string = (import.meta.env as Record<string, string>)['VITE_DAEMON_HTTP_PORT'] ?? '31415';
 const API_BASE = `http://${host}:${port}`;
 
+async function extractErrorMessage(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (typeof data.error === 'string') return data.error;
+    if (typeof data.message === 'string') return data.message;
+  } catch {
+    /* response body not JSON */
+  }
+  return `HTTP ${res.status}`;
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) throw new Error(await extractErrorMessage(res));
   return res.json();
 }
 
@@ -14,7 +25,7 @@ async function postJson<T>(url: string, body?: unknown): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) throw new Error(await extractErrorMessage(res));
   return res.json();
 }
 
@@ -24,13 +35,13 @@ async function putJson<T>(url: string, body: unknown): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) throw new Error(await extractErrorMessage(res));
   return res.json();
 }
 
 async function deleteRequest(url: string): Promise<void> {
   const res = await fetch(url, { method: 'DELETE' });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) throw new Error(await extractErrorMessage(res));
 }
 
 export { API_BASE, fetchJson, postJson, putJson, deleteRequest };


### PR DESCRIPTION
## Summary
- Add catch handler in `withBusy()` so all git actions (checkout, rename, fetch, abort, create branch) display error toasts on failure instead of silently swallowing
- Extract server error message from response body in HTTP helpers (`fetchJson`, `postJson`, `putJson`, `deleteRequest`) instead of showing generic "HTTP 500"

## Test plan
- [ ] Attempt checkout of a branch locked by a worktree — should show toast with the git error
- [ ] Trigger a rename/fetch/create failure — should show descriptive error toast
- [ ] Verify successful operations still show success toasts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)