### PR TITLE
fix: worktree uses branch name for directory + pre-push hook worktree fix

### DIFF
--- a/.changeset/fix-worktree-branch-name.md
+++ b/.changeset/fix-worktree-branch-name.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Use the provided branch name for the worktree directory instead of a chatId prefix

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,5 @@
+unset GIT_DIR
+
 branch=$(git rev-parse --abbrev-ref HEAD)
 
 # Skip changeset check on main and release branches
@@ -14,3 +16,4 @@ if ! npx changeset status --since=origin/main > /dev/null 2>&1; then
   echo ""
   exit 1
 fi
+exit 0

--- a/packages/core/src/__tests__/workspace/worktree-create.test.ts
+++ b/packages/core/src/__tests__/workspace/worktree-create.test.ts
@@ -67,9 +67,10 @@ describe('createWorktree', () => {
     removeWorktree(repoDir, info.worktreePath, info.branchName);
   });
 
-  it('uses chatId prefix for worktree directory name', () => {
+  it('uses sanitized branch name for worktree directory name', () => {
     const info = createWorktree(repoDir, 'abcdef12rest', '.worktrees', defaultBranch, 'session/abcdef12');
-    expect(info.worktreePath).toContain('abcdef12');
+    expect(info.worktreePath).toContain('session-abcdef12');
+    expect(info.worktreePath).not.toContain('abcdef12rest');
     removeWorktree(repoDir, info.worktreePath, info.branchName);
   });
 });

--- a/packages/core/src/workspace/worktree.ts
+++ b/packages/core/src/workspace/worktree.ts
@@ -70,9 +70,9 @@ export function createWorktree(
   baseBranch: string,
   branchName: string,
 ): WorktreeInfo {
-  const shortId = chatId.slice(0, 8);
+  const sanitizedBranch = branchName.replace(/\//g, '-');
   const worktreeDir = path.join(projectPath, dirName);
-  const worktreePath = path.join(worktreeDir, shortId);
+  const worktreePath = path.join(worktreeDir, sanitizedBranch);
 
   mkdirSync(worktreeDir, { recursive: true });
   execFileSync('git', ['worktree', 'add', '-b', branchName, worktreePath, baseBranch], {


### PR DESCRIPTION
## Summary

- **Worktree directory naming (#46):** `createWorktree()` used `chatId.slice(0, 8)` as the directory name, ignoring the user-provided branch name. A branch like `feature/cool-thing` would create `.worktrees/a1b2c3d4` instead of `.worktrees/feature-cool-thing`. Now uses the sanitized branch name (slashes replaced with hyphens).

- **Pre-push hook in worktrees:** The changeset check in `.husky/pre-push` failed in every worktree push because Git sets `GIT_DIR` to the worktree's internal git path, which confuses `changeset status` into not finding changeset files. Fixed by unsetting `GIT_DIR`. Also added `exit 0` to prevent a macOS `/bin/sh` hang when a Node process is the last command in a script file.

Closes #46

## Test plan

- [x] `worktree-create.test.ts` updated and passing
- [x] `fork-to-worktree.test.ts` passing
- [x] `worktree.test.ts` (routes) passing
- [ ] Manual: create a worktree with branch `feature/test` → verify directory is `.worktrees/feature-test`
- [ ] Manual: push from a worktree → verify pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)