### PR TITLE
feat: add todo-reader skill

### DIFF
--- a/.changeset/todo-reader-skill.md
+++ b/.changeset/todo-reader-skill.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+feat: add todo-reader skill for querying project todos via sqlite3

--- a/.claude/skills/todo-reader/SKILL.md
+++ b/.claude/skills/todo-reader/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: todo-reader
+description: Use when you need to understand project priorities, check what work is pending, summarize todos, or pick the next task to work on
+---
+
+# Todo Reader
+
+Read the project's todo list from SQLite to gather context or produce summaries.
+
+## Database Paths
+
+| DB | Path |
+|----|------|
+| Projects | `~/.mainframe/data.db` |
+| Todos | `~/.mainframe/plugins/todos/data.db` |
+
+## Two-Step Query
+
+**1. Resolve project ID** from the current working directory:
+
+```bash
+sqlite3 ~/.mainframe/data.db "SELECT id FROM projects WHERE path = '$(pwd)';"
+```
+
+**2. Query todos** using that project ID:
+
+```bash
+sqlite3 -json ~/.mainframe/plugins/todos/data.db \
+  "SELECT * FROM todos WHERE project_id = '<PROJECT_ID>' ORDER BY status, order_index, created_at;"
+```
+
+Use `-json` for structured output or `-column -header` for readable tables.
+
+## Schema
+
+| Column | Type | Values |
+|--------|------|--------|
+| id | TEXT | nanoid PK |
+| number | INTEGER | auto-increment per project |
+| project_id | TEXT | FK to projects.id |
+| title | TEXT | required |
+| body | TEXT | markdown |
+| status | TEXT | open, in_progress, done |
+| type | TEXT | bug, feature, enhancement, documentation, question, wont_fix, duplicate, invalid |
+| priority | TEXT | low, medium, high, critical |
+| labels | TEXT | JSON array of strings |
+| assignees | TEXT | JSON array of strings |
+| milestone | TEXT | nullable |
+| order_index | REAL | drag-and-drop sort key |
+| created_at | TEXT | ISO 8601 |
+| updated_at | TEXT | ISO 8601 |
+
+## Example Queries
+
+Count by status:
+```sql
+SELECT status, COUNT(*) as count FROM todos WHERE project_id = ? GROUP BY status;
+```
+
+Open bugs by priority:
+```sql
+SELECT number, title, priority FROM todos
+WHERE project_id = ? AND status = 'open' AND type = 'bug'
+ORDER BY CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END;
+```
+
+Recent activity:
+```sql
+SELECT number, title, status, updated_at FROM todos
+WHERE project_id = ? ORDER BY updated_at DESC LIMIT 10;
+```

--- a/docs/superpowers/specs/2026-03-29-todo-reader-skill-design.md
+++ b/docs/superpowers/specs/2026-03-29-todo-reader-skill-design.md
@@ -1,0 +1,65 @@
+# Todo Reader Skill — Design Spec
+
+## Problem
+
+Agents working in this repo have no way to read the project's todo list. The todos live in a SQLite database managed by the builtin todos plugin. An agent that could query this data would gain context for prioritizing work and summarizing project state.
+
+## Decision
+
+A single SKILL.md file at `.claude/skills/todo-reader/SKILL.md`. No helper scripts.
+
+## How It Works
+
+The skill gives the agent two things: DB paths and the todos table schema. The agent uses `sqlite3` CLI to query directly.
+
+### Two-step lookup
+
+1. Resolve `project_id` from the current working directory:
+   ```sql
+   -- ~/.mainframe/data.db
+   SELECT id FROM projects WHERE path = '<cwd>';
+   ```
+2. Query todos for that project:
+   ```sql
+   -- ~/.mainframe/plugins/todos/data.db
+   SELECT * FROM todos WHERE project_id = '<project_id>';
+   ```
+
+### Schema reference
+
+The skill includes the full column list with types and valid enum values:
+
+| Column | Type | Values |
+|--------|------|--------|
+| id | TEXT | nanoid primary key |
+| number | INTEGER | auto-incremented per project |
+| project_id | TEXT | FK to projects.id |
+| title | TEXT | required |
+| body | TEXT | markdown content |
+| status | TEXT | open, in_progress, done |
+| type | TEXT | bug, feature, enhancement, documentation, question, wont_fix, duplicate, invalid |
+| priority | TEXT | low, medium, high, critical |
+| labels | TEXT | JSON array of strings |
+| assignees | TEXT | JSON array of strings |
+| milestone | TEXT | nullable |
+| order_index | REAL | drag-and-drop ordering |
+| created_at | TEXT | ISO 8601 |
+| updated_at | TEXT | ISO 8601 |
+
+### Output
+
+Raw rows. The agent decides how to classify, group, or summarize based on context. No prescribed format.
+
+### Scope
+
+Current project only. The `project_id` filter ensures the agent sees only todos belonging to the working directory's project.
+
+## What the skill is NOT
+
+- Not a CLI tool or script — just documentation for the agent.
+- Not cross-project — scoped to current project.
+- Not prescriptive about output format — the agent adapts to the question.
+
+## Location
+
+`.claude/skills/todo-reader/SKILL.md` in the mainframe repo (project-scoped).


### PR DESCRIPTION
## Summary
- Add project-scoped skill at `.claude/skills/todo-reader/SKILL.md`
- Gives agents DB paths, schema reference, and query patterns to read todos via `sqlite3` CLI
- Two-step lookup: resolve project ID from working directory, then query todos
- Includes example queries for status counts, priority sorting, and recent activity

## Test plan
- [x] Verify skill appears in skills list in the desktop app
- [x] In a Claude Code session inside mainframe, invoke the skill and confirm it can query todos

🤖 Generated with [Claude Code](https://claude.com/claude-code)