### PR TITLE
fix(mobile): thinking indicator, live updates, new session flow

### DIFF
--- a/.changeset/mobile-improvements.md
+++ b/.changeset/mobile-improvements.md
@@ -1,0 +1,11 @@
+---
+"@qlan-ro/mainframe-mobile": patch
+---
+
+Fix thinking indicator and chat updates, improve new session flow
+
+- Call `resumeChat` when opening a chat so the daemon streams real-time events
+- Add ThinkingIndicator component that pulses while the agent is working
+- Restore pending permissions and refetch messages on WebSocket reconnect
+- Add `createChat` and `resumeChat` methods to mobile DaemonClient
+- Add FAB button on sessions screen to create new sessions with auto-navigation


### PR DESCRIPTION
## Summary
- **#31 Thinking indicator + live updates**: Root cause was missing `resumeChat` call — mobile only called `subscribe` but never `resumeChat`, so the daemon never streamed real-time events. Added `resumeChat`/`createChat` methods to mobile DaemonClient, added ThinkingIndicator animated component, and added WS reconnect handling with message refetch.
- **#32 New session flow**: Added FAB button on sessions screen that creates a chat and auto-navigates to it. Smart project selection (uses filter, single project, or shows picker). Loading state with timeout safety.

Closes #31, closes #32.

## Test plan
- [ ] Open a session on mobile — messages load and update in real-time
- [ ] Send a message — thinking dots appear while agent is working
- [ ] Verify thinking dots disappear when response arrives
- [ ] Disconnect WiFi briefly, reconnect — chat should recover and refetch
- [ ] Tap FAB button on sessions list — new session created, auto-navigated
- [ ] With project filter active, tap FAB — creates session for filtered project
- [ ] Verify loading spinner on FAB during creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)