### PR TITLE
chore: add batch implementation workflow to todos skill

### DIFF
--- a/.claude/skills/todos/SKILL.md
+++ b/.claude/skills/todos/SKILL.md
@@ -1,101 +1,140 @@
 ---
 name: todos
-description: Use when you need to understand project priorities, check what work is pending, summarize todos, or pick the next task to work on
+description: Use when you need to understand project priorities, check what work is pending, summarize todos, pick the next task, or batch-implement multiple todos as PRs
 ---
 
-# Todo Reader
+# Todos
 
-Read the project's todo list from SQLite to gather context or produce summaries.
-
-Do NOT explore, list tables, or list databases. All paths, table names, and schemas are documented below.
+Read, analyse, and batch-implement the project's todo list.
 
 ## Databases
 
 ### `~/.mainframe/mainframe.db` (Projects DB)
 
-Only the `projects` table is relevant to this skill.
-
 ```sql
 CREATE TABLE projects (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
-  path TEXT NOT NULL UNIQUE,        -- absolute filesystem path
+  path TEXT NOT NULL UNIQUE,
   created_at TEXT NOT NULL,
   last_opened_at TEXT NOT NULL,
   parent_project_id TEXT REFERENCES projects(id)
 );
-CREATE INDEX idx_projects_path ON projects(path);
 ```
 
 ### `~/.mainframe/plugins/todos/data.db` (Todos DB)
 
-Only the `todos` table exists in this database.
-
 ```sql
 CREATE TABLE todos (
   id TEXT PRIMARY KEY,              -- nanoid
-  number INTEGER NOT NULL DEFAULT 0,-- auto-increment per project
-  project_id TEXT NOT NULL DEFAULT '',-- FK to projects.id
+  number INTEGER NOT NULL DEFAULT 0,
+  project_id TEXT NOT NULL DEFAULT '',
   title TEXT NOT NULL,
-  body TEXT NOT NULL DEFAULT '',     -- markdown
-  status TEXT NOT NULL DEFAULT 'open',   -- open | in_progress | done
-  type TEXT NOT NULL DEFAULT 'feature',  -- bug | feature | enhancement | documentation | question | wont_fix | duplicate | invalid
-  priority TEXT NOT NULL DEFAULT 'medium',-- low | medium | high | critical
-  labels TEXT NOT NULL DEFAULT '[]',     -- JSON array of strings
-  assignees TEXT NOT NULL DEFAULT '[]',  -- JSON array of strings
-  milestone TEXT,                        -- nullable
-  order_index REAL NOT NULL DEFAULT 0,   -- drag-and-drop sort key
-  created_at TEXT NOT NULL,              -- ISO 8601
-  updated_at TEXT NOT NULL               -- ISO 8601
+  body TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  type TEXT NOT NULL DEFAULT 'feature',
+  priority TEXT NOT NULL DEFAULT 'medium',
+  labels TEXT NOT NULL DEFAULT '[]',
+  assignees TEXT NOT NULL DEFAULT '[]',
+  milestone TEXT,
+  order_index REAL NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
 );
 ```
 
-**Note:** `~/.mainframe/data.db` exists but has no tables — do not use it.
+**Note:** `~/.mainframe/data.db` exists but has no tables.
 
 ## Two-Step Query
 
-**1. Resolve project ID** from the current working directory:
-
 ```bash
+# 1. Resolve project ID
 sqlite3 ~/.mainframe/mainframe.db "SELECT id FROM projects WHERE path = '$(pwd)';"
-```
 
-**2. Query todos** using that project ID:
-
-```bash
+# 2. Query todos
 sqlite3 -json ~/.mainframe/plugins/todos/data.db \
-  "SELECT * FROM todos WHERE project_id = '<PROJECT_ID>' ORDER BY status, order_index, created_at;"
+  "SELECT * FROM todos WHERE project_id = '<ID>' ORDER BY status, order_index, created_at;"
 ```
-
-Use `-json` for structured output or `-column -header` for readable tables.
 
 ## Inserting Todos
 
-Generate a random 21-char alphanumeric ID and compute the next `number`:
+Generate a 21-char alphanumeric ID, compute next `number`:
 
 ```bash
 sqlite3 ~/.mainframe/plugins/todos/data.db \
-  "SELECT COALESCE(MAX(number), 0) + 1 FROM todos WHERE project_id = '<PROJECT_ID>';"
+  "SELECT COALESCE(MAX(number), 0) + 1 FROM todos WHERE project_id = '<ID>';"
 ```
 
-Then insert with all required columns. Timestamps use ISO 8601 UTC.
+## Batch Implementation Workflow
+
+When the user asks to find candidates and implement them (e.g. "find todos to fix", "batch implement", "prepare PRs"):
+
+### Phase 1: Analyse and Present
+
+1. Query all open/in_progress todos
+2. Group by code area (labels, affected packages, theme)
+3. Assess each: can it be done autonomously? (well-scoped, no user input needed, no design decisions)
+4. Present a table with candidates, grouped by area, marking autonomy confidence
+5. **Wait for user approval** before proceeding
+
+### Phase 2: Group into PRs
+
+After user selects todos, group them to minimize PR count:
+
+- Related changes in the same package/area go together
+- Bugs + features in the same area can share a PR
+- Keep PRs reviewable (max ~5 todos per PR unless they're trivial)
+- Name each PR group with a descriptive slug (e.g. `todos-plugin-enhancements`, `desktop-ux-fixes`)
+
+Present the grouping plan. Proceed on approval (explicit or implicit).
+
+### Phase 3: Create Worktrees and Dispatch
+
+**REQUIRED SUB-SKILL:** Use `superpowers:using-git-worktrees` for all worktree creation. Create one worktree per PR group with descriptive names matching the PR slug (e.g. `todos-enhancements`, `desktop-ux`).
+
+Do NOT use `isolation: "worktree"` on the Agent tool — it generates cryptic names like `agent-a2679050`.
+
+Then dispatch agents to those worktree paths:
+
+```
+Agent(prompt: "Work in /path/to/.worktrees/todos-enhancements. Implement: ...")
+```
+
+Each agent prompt must include:
+- The worktree path to work in
+- Full context for each todo (number, title, body, labels)
+- Relevant codebase context (file paths, architecture, patterns)
+- Build/test commands to verify
+- Instructions to commit on the existing branch and create a changeset
+
+### Phase 4: Create PRs
+
+After agents complete:
+1. Verify each worktree builds cleanly
+2. Push branches and create PRs with `gh pr create`
+3. Handle submodules separately (push to their own remote, create PR there)
+4. Report final PR list to user
+
+### Phase 5: Cleanup
+
+After user merges or explicitly asks:
+```bash
+git worktree remove .worktrees/<slug>
+git branch -d <branch-name>  # only if merged
+```
 
 ## Example Queries
 
-Count by status:
 ```sql
-SELECT status, COUNT(*) as count FROM todos WHERE project_id = ? GROUP BY status;
-```
+-- Count by status
+SELECT status, COUNT(*) FROM todos WHERE project_id = ? GROUP BY status;
 
-Open bugs by priority:
-```sql
+-- Open bugs by priority
 SELECT number, title, priority FROM todos
 WHERE project_id = ? AND status = 'open' AND type = 'bug'
 ORDER BY CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END;
-```
 
-Recent activity:
-```sql
+-- Recent activity
 SELECT number, title, status, updated_at FROM todos
 WHERE project_id = ? ORDER BY updated_at DESC LIMIT 10;
 ```


### PR DESCRIPTION
## Summary
- Extends the todos skill from read-only queries to a full batch implementation workflow
- Adds 5-phase process: analyse → group into PRs → create named worktrees → dispatch agents → create PRs
- Explicit guidance to create worktrees manually with descriptive names instead of using Agent tool's `isolation: "worktree"` (which generates cryptic `agent-a2679050` names)
- Trims DB schema comments for conciseness

## Test plan
- [x] Invoke `/todos` with "find candidates to implement" — should follow the phased workflow
- [x] Verify worktrees get descriptive names like `.worktrees/todos-enhancements` not `.claude/worktrees/agent-abc123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)