### PR TITLE
feat(desktop): clickable file paths in tool cards (#69)

### DIFF
--- a/.changeset/clickable-paths.md
+++ b/.changeset/clickable-paths.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": minor
+---
+
+feat(desktop): make file paths in tool cards clickable to open in editor

--- a/packages/desktop/src/__tests__/components/tools/EditFileCard.test.tsx
+++ b/packages/desktop/src/__tests__/components/tools/EditFileCard.test.tsx
@@ -2,11 +2,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-vi.mock('../../../renderer/store/tabs.js', () => ({
-  useTabsStore: {
-    getState: vi.fn().mockReturnValue({ openInlineDiffTab: vi.fn() }),
-  },
-}));
+vi.mock('../../../renderer/store/tabs.js', () => {
+  const state = { openInlineDiffTab: vi.fn(), openEditorTab: vi.fn(), revealFileInTree: vi.fn() };
+  const useTabsStore: any = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
+  useTabsStore.getState = vi.fn().mockReturnValue(state);
+  return { useTabsStore };
+});
 
 // useProjectsStore and useUIStore are imported transitively through tabs.ts
 // The mock above replaces the module before those imports are resolved.
@@ -17,7 +18,11 @@ import { TooltipProvider } from '../../../renderer/components/ui/tooltip.js';
 
 describe('EditFileCard', () => {
   beforeEach(() => {
-    vi.mocked(useTabsStore.getState).mockReturnValue({ openInlineDiffTab: vi.fn() });
+    vi.mocked(useTabsStore.getState).mockReturnValue({
+      openInlineDiffTab: vi.fn(),
+      openEditorTab: vi.fn(),
+      revealFileInTree: vi.fn(),
+    });
   });
 
   it('renders shortened filename (last 2 path segments)', () => {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/EditFileCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/EditFileCard.tsx
@@ -6,9 +6,9 @@ import { useTabsStore } from '../../../../../store/tabs';
 import { FileTypeIcon } from '../FileTypeIcon';
 import { CollapsibleToolCard } from './CollapsibleToolCard';
 import {
+  ClickableFilePath,
   StatusDot,
   cardStyle,
-  shortFilename,
   isStructuredResult,
   stripErrorXml,
   countDiffStats,
@@ -55,14 +55,7 @@ export function EditFileCard({ args, result, isError }: ToolCardProps) {
       header={
         <>
           <FileTypeIcon filePath={filePath} />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="font-mono text-mf-accent truncate text-mf-body" tabIndex={0}>
-                {shortFilename(filePath)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{filePath}</TooltipContent>
-          </Tooltip>
+          <ClickableFilePath filePath={filePath} />
         </>
       }
       statusDot={<StatusDot result={result} isError={isError} />}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/ReadFileCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/ReadFileCard.tsx
@@ -1,7 +1,6 @@
 import { Eye } from 'lucide-react';
-import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
 import { CollapsibleToolCard } from './CollapsibleToolCard';
-import { ErrorDot, shortFilename, stripErrorXml, type ToolCardProps } from './shared';
+import { ClickableFilePath, ErrorDot, stripErrorXml, type ToolCardProps } from './shared';
 
 export function ReadFileCard({ args, result, isError }: ToolCardProps) {
   const filePath = (args.file_path as string) || '';
@@ -14,14 +13,7 @@ export function ReadFileCard({ args, result, isError }: ToolCardProps) {
       header={
         <>
           <Eye size={15} className="text-mf-text-secondary/40 shrink-0" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="font-mono text-mf-text-secondary/60 truncate text-mf-body" tabIndex={0}>
-                {shortFilename(filePath)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{filePath}</TooltipContent>
-          </Tooltip>
+          <ClickableFilePath filePath={filePath} />
         </>
       }
       statusDot={<ErrorDot isError={isError} />}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/WriteFileCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/WriteFileCard.tsx
@@ -6,9 +6,9 @@ import { useTabsStore } from '../../../../../store/tabs';
 import { FileTypeIcon } from '../FileTypeIcon';
 import { CollapsibleToolCard } from './CollapsibleToolCard';
 import {
+  ClickableFilePath,
   StatusDot,
   cardStyle,
-  shortFilename,
   isStructuredResult,
   stripErrorXml,
   countDiffStats,
@@ -49,14 +49,7 @@ export function WriteFileCard({ args, result, isError }: ToolCardProps) {
       header={
         <>
           <FileTypeIcon filePath={filePath} />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="font-mono text-mf-accent truncate text-mf-body" tabIndex={0}>
-                {shortFilename(filePath)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{filePath}</TooltipContent>
-          </Tooltip>
+          <ClickableFilePath filePath={filePath} />
         </>
       }
       statusDot={<StatusDot result={result} isError={isError} />}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { structuredPatch } from 'diff';
 import type { DiffHunk } from '@qlan-ro/mainframe-types';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+import { useTabsStore } from '../../../../../store/tabs';
 export function stripErrorXml(text: string): string {
   return text.replace(/<\/?(?:tool_use_error|error)>/g, '').trim();
 }
@@ -46,6 +48,32 @@ export function cardStyle(result: unknown, isError: boolean | undefined): string
 export function shortFilename(filePath: string): string {
   const parts = filePath.split('/');
   return parts.length > 2 ? parts.slice(-2).join('/') : filePath;
+}
+
+export function ClickableFilePath({ filePath }: { filePath: string }) {
+  const openEditorTab = useTabsStore((s) => s.openEditorTab);
+  const revealFileInTree = useTabsStore((s) => s.revealFileInTree);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    openEditorTab(filePath);
+    revealFileInTree(filePath);
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={handleClick}
+          className="font-mono text-mf-accent truncate text-mf-body hover:underline cursor-pointer"
+          tabIndex={0}
+        >
+          {shortFilename(filePath)}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{filePath}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function countDiffStats(hunks: DiffHunk[]): { added: number; removed: number } {


### PR DESCRIPTION
## Summary
- New `ClickableFilePath` component in tool card shared utilities
- File path headers in ReadFileCard, EditFileCard, and WriteFileCard now open the file in the editor and reveal it in the file tree on click
- `e.stopPropagation()` prevents card collapse when clicking the path

Closes #69

## Test plan
- [x] Click a file path in a Read tool card — verify file opens in editor and highlights in tree
- [x] Click a file path in an Edit tool card — verify same behavior; ExternalLink diff button still works
- [x] Click a file path in a Write tool card — verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)