### PR TITLE
fix: kanban board UX fixes (#82)

### DIFF
--- a/.changeset/fix-plugin-chat-service-provider-defaults.md
+++ b/.changeset/fix-plugin-chat-service-provider-defaults.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-types': patch
+---
+
+fix(core): resolve provider default model and permissionMode in plugin chat service

--- a/packages/core/src/__tests__/plugins/builtin/todos.test.ts
+++ b/packages/core/src/__tests__/plugins/builtin/todos.test.ts
@@ -20,7 +20,7 @@ const todosManifest: PluginManifest = {
 
 let tmpDir: string;
 
-function makeApp() {
+function makeApp(settingsOverride?: (namespace: string, key: string) => string | null) {
   tmpDir = mkdtempSync(join(tmpdir(), 'mf-todos-test-'));
   const router = Router();
   const app = express();
@@ -55,7 +55,7 @@ function makeApp() {
         get: vi.fn().mockReturnValue(null),
       },
       settings: {
-        get: vi.fn().mockReturnValue(null),
+        get: vi.fn().mockImplementation(settingsOverride ?? (() => null)),
         set: vi.fn(),
       },
     } as unknown as PluginContextDeps['db'],
@@ -67,7 +67,7 @@ function makeApp() {
   const ctx = buildPluginContext(deps);
   activate(ctx);
   app.use('/', router);
-  return { app, emitEvent };
+  return { app, emitEvent, deps };
 }
 
 afterEach(() => {
@@ -119,5 +119,19 @@ describe('todos plugin routes', () => {
     expect(res.body.chatId).toBe('chat-1');
     expect(res.body.initialMessage).toContain('Big feature');
     expect(emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.created' }));
+  });
+
+  it('POST /todos/:id/start-session reads provider defaults for model and permissionMode', async () => {
+    const settingsOverride = (namespace: string, key: string): string | null => {
+      if (namespace === 'provider' && key === 'claude.defaultModel') return 'opus';
+      if (namespace === 'provider' && key === 'claude.defaultMode') return 'plan';
+      return null;
+    };
+    const { app, deps } = makeApp(settingsOverride);
+    const create = await request(app).post('/todos').send({ projectId: 'proj-1', title: 'Big feature' });
+    const id = create.body.todo.id as string;
+    const res = await request(app).post(`/todos/${id}/start-session`).send({ projectId: 'proj-1' });
+    expect(res.status).toBe(200);
+    expect(deps.db.chats.create).toHaveBeenCalledWith('proj-1', 'claude', 'opus', 'plan');
   });
 });

--- a/packages/core/src/plugins/services/chat-service.ts
+++ b/packages/core/src/plugins/services/chat-service.ts
@@ -45,8 +45,29 @@ export function buildChatService(
 
     ...(has('chat:create')
       ? {
-          async createChat({ projectId, adapterId, model }) {
-            const chat = db.chats.create(projectId, adapterId ?? 'claude', model);
+          async createChat({
+            projectId,
+            adapterId,
+            model,
+            permissionMode,
+          }: {
+            projectId: string;
+            adapterId?: string;
+            model?: string;
+            permissionMode?: string;
+          }) {
+            const effectiveAdapter = adapterId ?? 'claude';
+            let effectiveModel = model;
+            let effectiveMode = permissionMode;
+
+            if (!effectiveModel || !effectiveMode) {
+              const defaultModel = db.settings.get('provider', `${effectiveAdapter}.defaultModel`);
+              const defaultMode = db.settings.get('provider', `${effectiveAdapter}.defaultMode`);
+              if (!effectiveModel && defaultModel) effectiveModel = defaultModel;
+              if (!effectiveMode && defaultMode) effectiveMode = defaultMode;
+            }
+
+            const chat = db.chats.create(projectId, effectiveAdapter, effectiveModel, effectiveMode);
             emitEvent({ type: 'chat.created', chat });
             return { chatId: chat.id };
           },

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -117,6 +117,22 @@ export function ComposerCard() {
   composerRuntimeRef.current = composerRuntime;
   const chatIdRef = useRef(chatId);
   chatIdRef.current = chatId;
+  const lastTextRef = useRef('');
+
+  useEffect(() => {
+    try {
+      lastTextRef.current = composerRuntime.getState()?.text ?? '';
+    } catch {
+      /* not ready */
+    }
+    return composerRuntime.subscribe(() => {
+      try {
+        lastTextRef.current = composerRuntime.getState()?.text ?? '';
+      } catch {
+        /* disposed */
+      }
+    });
+  }, [composerRuntime]);
 
   useEffect(() => {
     const draft = getDraft(chatId);
@@ -125,6 +141,7 @@ export function ComposerCard() {
       const restore = () => {
         try {
           composerRuntime.setText(draft.text);
+          lastTextRef.current = draft.text;
           // Only add attachments if the runtime doesn't already have them
           // (React StrictMode re-runs effects without destroying the runtime)
           const existing = composerRuntime.getState()?.attachments?.length ?? 0;
@@ -153,8 +170,8 @@ export function ComposerCard() {
 
     return () => {
       try {
+        const text = lastTextRef.current;
         const state = composerRuntimeRef.current.getState();
-        const text = state?.text ?? '';
         const attachments = (state?.attachments ?? []).map(
           (a: { type: string; name: string; contentType?: string; content?: unknown[] }) => ({
             type: a.type,
@@ -177,6 +194,7 @@ export function ComposerCard() {
     if (pendingInvocation) {
       try {
         composerRuntime.setText(pendingInvocation);
+        lastTextRef.current = pendingInvocation;
         focusComposerInput();
       } catch (err) {
         log.warn('failed to set pending invocation', { err: String(err) });

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
@@ -131,7 +131,7 @@ export function WorktreePopover({ chatId, hasMessages, onClose }: WorktreePopove
       setBranches(localNames);
       setCurrentBranch(result.current);
       setBaseBranch(result.current || localNames[0] || '');
-      setBranchName(`session/${chatId.slice(0, 8)}`);
+      setBranchName('');
     });
 
     const fetchWorktreeList = getProjectWorktrees(projectId).then((result) => {
@@ -325,7 +325,7 @@ export function WorktreePopover({ chatId, hasMessages, onClose }: WorktreePopove
                 setBranchName(e.target.value);
                 setError(null);
               }}
-              placeholder={isMidSession ? 'feature/my-branch' : `session/${chatId.slice(0, 8)}`}
+              placeholder="feat/my-branch"
               className="w-full rounded-mf-input border border-mf-border bg-mf-panel-bg px-2 py-1.5 text-mf-small text-mf-text-primary font-mono outline-none placeholder:text-mf-text-secondary"
             />
             {validationError && <span className="text-mf-small text-mf-destructive mt-1 block">{validationError}</span>}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
@@ -103,7 +103,7 @@ export function WorktreePopover({ chatId, hasMessages, onClose }: WorktreePopove
   const [branchName, setBranchName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [tab, setTab] = useState<'existing' | 'new'>('existing');
+  const [tab, setTab] = useState<'existing' | 'new'>('new');
   const [worktrees, setWorktrees] = useState<{ path: string; branch: string | null }[]>([]);
 
   const worktreePath = chat?.worktreePath;
@@ -137,7 +137,7 @@ export function WorktreePopover({ chatId, hasMessages, onClose }: WorktreePopove
     const fetchWorktreeList = getProjectWorktrees(projectId).then((result) => {
       if (cancelled) return;
       setWorktrees(result.worktrees);
-      if (result.worktrees.length === 0) setTab('new');
+      if (result.worktrees.length > 0) setTab('existing');
     });
 
     Promise.all([fetchBranches, fetchWorktreeList])

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/WorktreePopover.tsx
@@ -137,7 +137,7 @@ export function WorktreePopover({ chatId, hasMessages, onClose }: WorktreePopove
     const fetchWorktreeList = getProjectWorktrees(projectId).then((result) => {
       if (cancelled) return;
       setWorktrees(result.worktrees);
-      if (result.worktrees.length > 0) setTab('existing');
+      // tab defaults to 'new' — no override needed
     });
 
     Promise.all([fetchBranches, fetchWorktreeList])

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -5,20 +5,14 @@ import { createLogger } from '../../lib/logger';
 const log = createLogger('renderer:todos');
 import { todosApi, type Todo, type TodoStatus, type CreateTodoInput } from '../../lib/api/todos-api';
 import type { PendingAttachment } from './TodoModal';
-import {
-  TodoFilterBar,
-  type TodoFilters,
-  type TodoSort,
-  matchesFilters,
-  extractAllLabels,
-  sortTodos,
-} from './TodoFilterBar';
+import { TodoFilterBar, matchesFilters, extractAllLabels, sortTodos } from './TodoFilterBar';
 import { TodoCard } from './TodoCard';
 import { TodoModal } from './TodoModal';
 import { usePluginLayoutStore } from '../../store';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useSkillsStore } from '../../store/skills';
 import { useSandboxStore } from '../../store/sandbox';
+import { useTodosFilterStore } from '../../store/todos-filters';
 import { daemonClient } from '../../lib/client';
 
 const COLUMNS: { status: TodoStatus; label: string }[] = [
@@ -34,13 +28,10 @@ export function TodosPanel(): React.ReactElement {
   const [modalOpen, setModalOpen] = useState(false);
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
   const [attachmentCounts, setAttachmentCounts] = useState<Record<string, number>>({});
-  const [filters, setFilters] = useState<TodoFilters>({
-    types: [],
-    priorities: [],
-    labels: [],
-    search: '',
-  });
-  const [sort, setSort] = useState<TodoSort>({ key: 'number', dir: 'desc' });
+  const filters = useTodosFilterStore((s) => s.filters);
+  const setFilters = useTodosFilterStore((s) => s.setFilters);
+  const sort = useTodosFilterStore((s) => s.sort);
+  const setSort = useTodosFilterStore((s) => s.setSort);
   const activeProjectId = useActiveProjectId();
 
   const loadAttachmentCounts = useCallback(async (todoIds: string[]) => {

--- a/packages/desktop/src/renderer/store/todos-filters.test.ts
+++ b/packages/desktop/src/renderer/store/todos-filters.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTodosFilterStore } from './todos-filters';
+
+describe('useTodosFilterStore', () => {
+  beforeEach(() => {
+    useTodosFilterStore.getState().resetFilters();
+  });
+
+  it('starts with empty filters and default sort', () => {
+    const { filters, sort } = useTodosFilterStore.getState();
+    expect(filters).toEqual({ types: [], priorities: [], labels: [], search: '' });
+    expect(sort).toEqual({ key: 'number', dir: 'desc' });
+  });
+
+  it('setFilters updates filters', () => {
+    useTodosFilterStore.getState().setFilters({ types: ['bug'], priorities: [], labels: [], search: 'test' });
+    expect(useTodosFilterStore.getState().filters.types).toEqual(['bug']);
+    expect(useTodosFilterStore.getState().filters.search).toBe('test');
+  });
+
+  it('setSort updates sort', () => {
+    useTodosFilterStore.getState().setSort({ key: 'priority', dir: 'asc' });
+    expect(useTodosFilterStore.getState().sort).toEqual({ key: 'priority', dir: 'asc' });
+  });
+
+  it('resetFilters restores defaults', () => {
+    useTodosFilterStore.getState().setFilters({ types: ['bug'], priorities: ['high'], labels: [], search: '' });
+    useTodosFilterStore.getState().setSort({ key: 'priority', dir: 'asc' });
+    useTodosFilterStore.getState().resetFilters();
+    expect(useTodosFilterStore.getState().filters).toEqual({ types: [], priorities: [], labels: [], search: '' });
+    expect(useTodosFilterStore.getState().sort).toEqual({ key: 'number', dir: 'desc' });
+  });
+});

--- a/packages/desktop/src/renderer/store/todos-filters.ts
+++ b/packages/desktop/src/renderer/store/todos-filters.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import type { TodoFilters, TodoSort } from '../components/todos/TodoFilterBar';
+
+const DEFAULT_FILTERS: TodoFilters = { types: [], priorities: [], labels: [], search: '' };
+const DEFAULT_SORT: TodoSort = { key: 'number', dir: 'desc' };
+
+interface TodosFilterStore {
+  filters: TodoFilters;
+  sort: TodoSort;
+  setFilters: (f: TodoFilters) => void;
+  setSort: (s: TodoSort) => void;
+  resetFilters: () => void;
+}
+
+export const useTodosFilterStore = create<TodosFilterStore>((set) => ({
+  filters: { ...DEFAULT_FILTERS },
+  sort: { ...DEFAULT_SORT },
+  setFilters: (filters) => set({ filters }),
+  setSort: (sort) => set({ sort }),
+  resetFilters: () => set({ filters: { ...DEFAULT_FILTERS }, sort: { ...DEFAULT_SORT } }),
+}));

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -103,6 +103,7 @@ export interface ChatServiceAPI {
     projectId: string;
     adapterId?: string;
     model?: string;
+    permissionMode?: string;
     initialMessage?: string;
   }) => Promise<{ chatId: string }>;
 }


### PR DESCRIPTION
## Summary
- **Composer drafts**: Fix draft persistence when text is set programmatically (e.g. starting a TODO session) — track text in a ref instead of querying the potentially-disposed runtime
- **Permission mode**: Plugin chat service now resolves provider default model and permissionMode from settings, matching the WebSocket path
- **TODO filters**: Move filter/sort state from local useState to a Zustand store so selections survive view switches
- **Worktree branch name**: Replace cryptic `session/<shortid>` prefill with empty field and `feat/my-branch` placeholder

Closes #82

## Test plan
- [x] Start a TODO from kanban → switch sessions → switch back → composer text is restored
- [x] Set a default permission mode in provider settings → start a TODO session → verify the new chat uses the configured mode
- [x] Open TODOs → set filters → switch to chat → switch back → filters are preserved
- [x] Open worktree popover → branch name input is empty with placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)