### PR TITLE
feat: dynamic Claude model list with CLI probe (#77)

### DIFF
--- a/.changeset/dynamic-claude-models.md
+++ b/.changeset/dynamic-claude-models.md
@@ -1,0 +1,9 @@
+---
+"@qlan-ro/mainframe-types": minor
+"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Add dynamic Claude model list with CLI probe on startup
+
+Expand the hardcoded 4-model list to all 11 known Claude models with capability flags (supportsEffort, supportsFastMode, supportsAutoMode). On daemon startup, probe the CLI via an initialize handshake to get the user's actual available models based on their subscription tier. The desktop model selector updates reactively when the probe completes.

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -33,10 +33,12 @@ describe('ClaudeAdapter.listModels', () => {
   it('returns all 11 known Claude models', async () => {
     const adapter = new ClaudeAdapter();
     const models = await adapter.listModels();
-    expect(models.length).toBe(11);
+    expect(models.length).toBe(13);
     const ids = models.map((m) => m.id);
     expect(ids).toContain('claude-opus-4-6');
+    expect(ids).toContain('opus[1m]');
     expect(ids).toContain('claude-sonnet-4-6');
+    expect(ids).toContain('sonnet[1m]');
     expect(ids).toContain('claude-3-5-haiku-20241022');
     expect(ids).toContain('claude-3-5-sonnet-20241022');
   });

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -29,6 +29,28 @@ describe('ClaudeAdapter.getToolCategories', () => {
   });
 });
 
+describe('ClaudeAdapter.listModels', () => {
+  it('returns all 11 known Claude models', async () => {
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.listModels();
+    expect(models.length).toBe(11);
+    const ids = models.map((m) => m.id);
+    expect(ids).toContain('claude-opus-4-6');
+    expect(ids).toContain('claude-sonnet-4-6');
+    expect(ids).toContain('claude-3-5-haiku-20241022');
+    expect(ids).toContain('claude-3-5-sonnet-20241022');
+  });
+
+  it('includes capability flags on supported models', async () => {
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.listModels();
+    const opus46 = models.find((m) => m.id === 'claude-opus-4-6');
+    expect(opus46?.supportsEffort).toBe(true);
+    expect(opus46?.supportsFastMode).toBe(true);
+    expect(opus46?.supportsAutoMode).toBe(true);
+  });
+});
+
 describe('AdapterRegistry', () => {
   it('includes adapter models in list output', async () => {
     const registry = new AdapterRegistry();

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -64,3 +64,49 @@ describe('AdapterRegistry', () => {
     expect(mock?.models).toEqual(mockModels);
   });
 });
+
+describe('AdapterRegistry.probeAllModels', () => {
+  it('calls probeModels on adapters that support it and emits event', async () => {
+    const probedModels: AdapterModel[] = [{ id: 'probed-model', label: 'Probed' }];
+    const adapter = createMockAdapter([{ id: 'fallback', label: 'Fallback' }]);
+    (adapter as any).probeModels = vi.fn().mockResolvedValue(probedModels);
+
+    const registry = new AdapterRegistry();
+    registry.register(adapter);
+
+    const events: any[] = [];
+    await registry.probeAllModels((event) => events.push(event));
+
+    expect((adapter as any).probeModels).toHaveBeenCalled();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'adapter.models.updated',
+      adapterId: 'mock',
+      models: probedModels,
+    });
+  });
+
+  it('skips adapters without probeModels', async () => {
+    const adapter = createMockAdapter([]);
+    const registry = new AdapterRegistry();
+    registry.register(adapter);
+
+    const events: any[] = [];
+    await registry.probeAllModels((event) => events.push(event));
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('handles probe failure gracefully', async () => {
+    const adapter = createMockAdapter([]);
+    (adapter as any).probeModels = vi.fn().mockResolvedValue(null);
+
+    const registry = new AdapterRegistry();
+    registry.register(adapter);
+
+    const events: any[] = [];
+    await registry.probeAllModels((event) => events.push(event));
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/claude-probe-models.test.ts
+++ b/packages/core/src/__tests__/claude-probe-models.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter, Readable, Writable } from 'node:stream';
+
+// Mock child_process before importing the module under test
+const spawnMock = vi.fn();
+vi.mock('node:child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }));
+
+vi.mock('../../../logger.js', () => ({
+  createChildLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+// Import after mocking
+const { probeModels } = await import('../plugins/builtin/claude/probe-models.js');
+
+function createMockChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const written: string[] = [];
+  child.stdin = new Writable({
+    write(chunk, _enc, cb) {
+      written.push(chunk.toString());
+      cb();
+    },
+  }) as any;
+  child.stdout = new Readable({ read() {} }) as any;
+  child.stderr = new Readable({ read() {} }) as any;
+  child.kill = vi.fn().mockReturnValue(true);
+  Object.defineProperty(child, 'pid', { value: 12345 });
+  (child as any)._written = written;
+  return child;
+}
+
+function emitInitializeResponse(child: ChildProcess, models: unknown[]): void {
+  const response = JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'initialize',
+      request_id: 'test',
+      models,
+      commands: [],
+      agents: [],
+      output_style: 'concise',
+      available_output_styles: ['concise'],
+      account: {},
+    },
+  });
+  (child.stdout as Readable).push(response + '\n');
+}
+
+describe('probeModels', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('sends initialize request and parses model response', async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = probeModels('claude');
+
+    // Wait for the initialize request to be written
+    await vi.waitFor(() => {
+      expect((child as any)._written.length).toBeGreaterThan(0);
+    });
+
+    const sent = JSON.parse((child as any)._written[0]);
+    expect(sent.type).toBe('control_request');
+    expect(sent.request.subtype).toBe('initialize');
+
+    emitInitializeResponse(child, [
+      {
+        value: 'claude-opus-4-6',
+        displayName: 'Opus',
+        description: 'Most capable',
+        supportsEffort: true,
+        supportsFastMode: true,
+        supportsAutoMode: true,
+      },
+      { value: 'claude-sonnet-4-6', displayName: 'Sonnet', description: 'Fast' },
+    ]);
+
+    const result = await promise;
+
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      id: 'claude-opus-4-6',
+      label: 'Opus',
+      supportsEffort: true,
+      supportsFastMode: true,
+      supportsAutoMode: true,
+    });
+    expect(result![1]).toEqual({ id: 'claude-sonnet-4-6', label: 'Sonnet' });
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('returns null on spawn error', async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = probeModels('claude');
+    child.emit('error', new Error('not found'));
+
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+
+  it('returns null on timeout', async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = probeModels('claude');
+    vi.advanceTimersByTime(10_001);
+
+    const result = await promise;
+    expect(result).toBeNull();
+    expect(child.kill).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -1,4 +1,4 @@
-import type { Adapter, AdapterInfo } from '@qlan-ro/mainframe-types';
+import type { Adapter, AdapterInfo, AdapterModel, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 export class AdapterRegistry {
   private adapters = new Map<string, Adapter>();
@@ -19,6 +19,21 @@ export class AdapterRegistry {
     for (const adapter of this.adapters.values()) {
       adapter.killAll();
     }
+  }
+
+  async probeAllModels(emitEvent: (event: DaemonEvent) => void): Promise<void> {
+    const probes = [...this.adapters.values()]
+      .filter(
+        (a): a is Adapter & { probeModels(): Promise<AdapterModel[] | null> } =>
+          typeof (a as any).probeModels === 'function',
+      )
+      .map(async (adapter) => {
+        const models = await adapter.probeModels();
+        if (models) {
+          emitEvent({ type: 'adapter.models.updated', adapterId: adapter.id, models });
+        }
+      });
+    await Promise.allSettled(probes);
   }
 
   async list(): Promise<AdapterInfo[]> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,13 @@ async function main(): Promise<void> {
   await server.start(config.port);
   broadcastEvent = (event) => server.broadcastEvent(event);
 
+  // Probe adapters for dynamic model lists (non-blocking)
+  adapters
+    .probeAllModels((event) => broadcastEvent(event))
+    .catch((err) => {
+      logger.warn({ err }, 'Model probe failed');
+    });
+
   // Non-blocking: backfill worktree parent relationships for existing projects.
   // Failure here must not prevent the daemon from serving requests.
   backfillWorktreeRelationships(db.projects).catch((err) => {

--- a/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
@@ -33,6 +33,7 @@ const execFileAsync = promisify(execFile);
 const logger = createChildLogger('claude-sdk-adapter');
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
+const EXTENDED_CONTEXT_WINDOW = 1_000_000;
 const CLAUDE_MODELS: AdapterModel[] = [
   {
     id: 'claude-opus-4-6',
@@ -43,9 +44,24 @@ const CLAUDE_MODELS: AdapterModel[] = [
     supportsAutoMode: true,
   },
   {
+    id: 'opus[1m]',
+    label: 'Claude Opus 4.6 (1M context)',
+    contextWindow: EXTENDED_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsFastMode: true,
+    supportsAutoMode: true,
+  },
+  {
     id: 'claude-sonnet-4-6',
     label: 'Claude Sonnet 4.6',
     contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'sonnet[1m]',
+    label: 'Claude Sonnet 4.6 (1M context)',
+    contextWindow: EXTENDED_CONTEXT_WINDOW,
     supportsEffort: true,
     supportsAutoMode: true,
   },

--- a/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
@@ -33,13 +33,66 @@ const execFileAsync = promisify(execFile);
 const logger = createChildLogger('claude-sdk-adapter');
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
-// TODO: Use query.supportedModels() for dynamic model discovery instead of hardcoding.
-// Hardcoded for now to match the CLI plugin pattern and avoid spawning a query just for listing.
 const CLAUDE_MODELS: AdapterModel[] = [
-  { id: 'claude-opus-4-6', label: 'Claude Opus 4.6', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-opus-4-5-20251101', label: 'Claude Opus 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  {
+    id: 'claude-opus-4-6',
+    label: 'Claude Opus 4.6',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsFastMode: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-6',
+    label: 'Claude Sonnet 4.6',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-5-20251101',
+    label: 'Claude Opus 4.5',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-5-20250929',
+    label: 'Claude Sonnet 4.5',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-1-20250805',
+    label: 'Claude Opus 4.1',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-20250514',
+    label: 'Claude Sonnet 4',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-20250514',
+    label: 'Claude Opus 4.0',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-3-7-sonnet-20250219',
+    label: 'Claude Sonnet 3.7',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+  },
   { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  { id: 'claude-3-5-sonnet-20241022', label: 'Claude Sonnet 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  { id: 'claude-3-5-haiku-20241022', label: 'Claude Haiku 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
 ];
 
 export class ClaudeSdkAdapter implements Adapter {

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -12,6 +12,7 @@ import type {
   CreateAgentInput,
 } from '@qlan-ro/mainframe-types';
 import { ClaudeSession } from './session.js';
+import { probeModels as doProbeModels } from './probe-models.js';
 import * as skills from './skills.js';
 import { listExternalSessions } from './external-sessions.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
@@ -85,6 +86,7 @@ export class ClaudeAdapter implements Adapter {
   name = 'Claude CLI';
 
   private sessions = new Set<ClaudeSession>();
+  private dynamicModels: AdapterModel[] | null = null;
 
   async isInstalled(): Promise<boolean> {
     return new Promise((resolve) => {
@@ -108,7 +110,15 @@ export class ClaudeAdapter implements Adapter {
   }
 
   async listModels(): Promise<AdapterModel[]> {
-    return CLAUDE_MODELS;
+    return this.dynamicModels ?? CLAUDE_MODELS;
+  }
+
+  async probeModels(): Promise<AdapterModel[] | null> {
+    const models = await doProbeModels('claude');
+    if (models) {
+      this.dynamicModels = models;
+    }
+    return models;
   }
 
   getToolCategories(): ToolCategories {

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -19,10 +19,65 @@ import manifest from './manifest.json' with { type: 'json' };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const CLAUDE_MODELS: AdapterModel[] = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-opus-4-5-20251101', label: 'Opus 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  {
+    id: 'claude-opus-4-6',
+    label: 'Opus 4.6',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsFastMode: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-6',
+    label: 'Sonnet 4.6',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-5-20251101',
+    label: 'Opus 4.5',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-5-20250929',
+    label: 'Sonnet 4.5',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-1-20250805',
+    label: 'Opus 4.1',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-sonnet-4-20250514',
+    label: 'Sonnet 4',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-opus-4-20250514',
+    label: 'Opus 4.0',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'claude-3-7-sonnet-20250219',
+    label: 'Sonnet 3.7',
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+  },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  { id: 'claude-3-5-sonnet-20241022', label: 'Sonnet 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
+  { id: 'claude-3-5-haiku-20241022', label: 'Haiku 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
 ];
 
 export class ClaudeAdapter implements Adapter {

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -19,6 +19,7 @@ import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import manifest from './manifest.json' with { type: 'json' };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
+const EXTENDED_CONTEXT_WINDOW = 1_000_000;
 const CLAUDE_MODELS: AdapterModel[] = [
   {
     id: 'claude-opus-4-6',
@@ -29,9 +30,24 @@ const CLAUDE_MODELS: AdapterModel[] = [
     supportsAutoMode: true,
   },
   {
+    id: 'opus[1m]',
+    label: 'Opus 4.6 (1M context)',
+    contextWindow: EXTENDED_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsFastMode: true,
+    supportsAutoMode: true,
+  },
+  {
     id: 'claude-sonnet-4-6',
     label: 'Sonnet 4.6',
     contextWindow: DEFAULT_CONTEXT_WINDOW,
+    supportsEffort: true,
+    supportsAutoMode: true,
+  },
+  {
+    id: 'sonnet[1m]',
+    label: 'Sonnet 4.6 (1M context)',
+    contextWindow: EXTENDED_CONTEXT_WINDOW,
     supportsEffort: true,
     supportsAutoMode: true,
   },

--- a/packages/core/src/plugins/builtin/claude/probe-models.ts
+++ b/packages/core/src/plugins/builtin/claude/probe-models.ts
@@ -70,9 +70,12 @@ export function probeModels(executable: string): Promise<AdapterModel[] | null> 
       finish(null);
     });
 
+    // CLI exited before sending models — return null (also fires after successful probe; settled guard handles it)
     child.on('exit', () => {
       finish(null);
     });
+
+    child.stderr?.resume();
 
     let buffer = '';
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -90,7 +93,7 @@ export function probeModels(executable: string): Promise<AdapterModel[] | null> 
             finish(models);
           }
         } catch {
-          // skip non-JSON lines
+          /* expected: CLI emits non-JSON lines (progress indicators, hook events, etc.) */
         }
       }
     });

--- a/packages/core/src/plugins/builtin/claude/probe-models.ts
+++ b/packages/core/src/plugins/builtin/claude/probe-models.ts
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { AdapterModel } from '@qlan-ro/mainframe-types';
+import { createChildLogger } from '../../../logger.js';
+
+const log = createChildLogger('claude-probe-models');
+const PROBE_TIMEOUT_MS = 10_000;
+
+interface CliModelInfo {
+  value: string;
+  displayName: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportsFastMode?: boolean;
+  supportsAutoMode?: boolean;
+}
+
+function mapModelInfo(info: CliModelInfo): AdapterModel {
+  const model: AdapterModel = { id: info.value, label: info.displayName };
+  if (info.supportsEffort) model.supportsEffort = true;
+  if (info.supportsFastMode) model.supportsFastMode = true;
+  if (info.supportsAutoMode) model.supportsAutoMode = true;
+  return model;
+}
+
+export function probeModels(executable: string): Promise<AdapterModel[] | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: AdapterModel[] | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill();
+      resolve(result);
+    };
+
+    const child = spawn(
+      executable,
+      [
+        '--output-format',
+        'stream-json',
+        '--input-format',
+        'stream-json',
+        '--verbose',
+        '--permission-prompt-tool',
+        'stdio',
+      ],
+      {
+        cwd: homedir(),
+        shell: process.platform === 'win32',
+        detached: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          FORCE_COLOR: '0',
+          NO_COLOR: '1',
+          CLAUDECODE: undefined,
+        },
+      },
+    );
+
+    const timer = setTimeout(() => {
+      log.warn('probe timed out');
+      finish(null);
+    }, PROBE_TIMEOUT_MS);
+
+    child.on('error', (err) => {
+      log.warn({ err }, 'probe spawn error');
+      finish(null);
+    });
+
+    child.on('exit', () => {
+      finish(null);
+    });
+
+    let buffer = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      let newlineIdx: number;
+      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        if (!line) continue;
+        try {
+          const event = JSON.parse(line);
+          if (event.type === 'control_response' && event.response?.models) {
+            const models = (event.response.models as CliModelInfo[]).map(mapModelInfo);
+            log.info({ count: models.length }, 'probe received models');
+            finish(models);
+          }
+        } catch {
+          // skip non-JSON lines
+        }
+      }
+    });
+
+    // Send initialize control_request
+    const payload = {
+      type: 'control_request',
+      request_id: randomUUID(),
+      request: { subtype: 'initialize' },
+    };
+    child.stdin?.write(JSON.stringify(payload) + '\n');
+  });
+}

--- a/packages/desktop/src/__tests__/lib/adapters.test.ts
+++ b/packages/desktop/src/__tests__/lib/adapters.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { getModelLabel, getModelContextWindow, getModelOptions } from '../../renderer/lib/adapters.js';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+
+const mockAdapters: AdapterInfo[] = [
+  {
+    id: 'claude',
+    name: 'Claude CLI',
+    description: 'Claude CLI adapter',
+    installed: true,
+    models: [
+      { id: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 200_000 },
+      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },
+    ],
+  },
+];
+
+describe('getModelLabel', () => {
+  it('resolves label from adapter-provided models', () => {
+    expect(getModelLabel('claude-opus-4-6', mockAdapters)).toBe('Opus 4.6');
+  });
+
+  it('pattern-matches unknown claude model IDs', () => {
+    expect(getModelLabel('claude-sonnet-99-0-20301231', mockAdapters)).toBe('Sonnet 99.0');
+  });
+
+  it('returns raw ID for non-claude unknown models', () => {
+    expect(getModelLabel('gpt-4o', mockAdapters)).toBe('gpt-4o');
+  });
+});
+
+describe('getModelContextWindow', () => {
+  it('resolves from adapter-provided models', () => {
+    expect(getModelContextWindow('claude-opus-4-6', mockAdapters)).toBe(200_000);
+  });
+
+  it('defaults to 200K for unknown models', () => {
+    expect(getModelContextWindow('unknown-model', mockAdapters)).toBe(200_000);
+  });
+});
+
+describe('getModelOptions', () => {
+  it('returns models for a known adapter', () => {
+    const options = getModelOptions('claude', mockAdapters);
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual({ id: 'claude-opus-4-6', label: 'Opus 4.6' });
+  });
+
+  it('returns empty array for unknown adapter', () => {
+    expect(getModelOptions('unknown', mockAdapters)).toEqual([]);
+  });
+});

--- a/packages/desktop/src/renderer/lib/adapters.ts
+++ b/packages/desktop/src/renderer/lib/adapters.ts
@@ -7,26 +7,12 @@ const ADAPTER_LABEL_FALLBACK: Record<string, string> = {
   opencode: 'OpenCode',
 };
 
-const DEFAULT_CONTEXT_WINDOW = 200_000;
-
-const CLAUDE_MODELS: Array<{ id: string; label: string; contextWindow: number }> = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-opus-4-5-20251101', label: 'Opus 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
-];
-
 const CLAUDE_MODEL_ID_PATTERN = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)(?:-\d+)?$/i;
 
 function getModelMetadata(adapters: AdapterInfo[]): Map<string, { label: string; contextWindow?: number }> {
   const metadata = new Map<string, { label: string; contextWindow?: number }>();
   for (const adapter of adapters) {
     for (const model of adapter.models) {
-      metadata.set(model.id, { label: model.label, contextWindow: model.contextWindow });
-    }
-  }
-  for (const model of CLAUDE_MODELS) {
-    if (!metadata.has(model.id)) {
       metadata.set(model.id, { label: model.label, contextWindow: model.contextWindow });
     }
   }
@@ -58,12 +44,12 @@ export function getModelLabel(modelId: string | undefined, adapters: AdapterInfo
   const match = modelId.match(CLAUDE_MODEL_ID_PATTERN);
   if (!match) return modelId;
 
-  const [, family, major, minor] = match;
+  const [, family = '', major, minor] = match;
   const familyLabel = `${family.slice(0, 1).toUpperCase()}${family.slice(1).toLowerCase()}`;
   return `${familyLabel} ${major}.${minor}`;
 }
 
 export function getModelContextWindow(modelId: string | undefined, adapters: AdapterInfo[]): number {
-  if (!modelId) return DEFAULT_CONTEXT_WINDOW;
-  return getModelMetadata(adapters).get(modelId)?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+  if (!modelId) return 200_000;
+  return getModelMetadata(adapters).get(modelId)?.contextWindow ?? 200_000;
 }

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -4,6 +4,7 @@ import { useTabsStore } from '../store/tabs';
 import { useProjectsStore } from '../store/projects';
 import { usePluginLayoutStore } from '../store/plugins';
 import { useSandboxStore } from '../store/sandbox';
+import { useAdaptersStore } from '../store/adapters';
 import { createLogger } from './logger';
 import { buildLaunchScope } from './launch-scope.js';
 import { notify } from './notify';
@@ -185,6 +186,10 @@ export function routeEvent(event: DaemonEvent): void {
       break;
     case 'message.queued.cleared':
       chats.clearQueuedMessages(event.chatId);
+      break;
+    case 'adapter.models.updated':
+      log.info('event:adapter.models.updated', { adapterId: event.adapterId, count: event.models.length });
+      useAdaptersStore.getState().updateAdapterModels(event.adapterId, event.models);
       break;
     case 'error':
       log.error('daemon error event', { error: event.error });

--- a/packages/desktop/src/renderer/store/adapters.ts
+++ b/packages/desktop/src/renderer/store/adapters.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
-import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import type { AdapterInfo, AdapterModel } from '@qlan-ro/mainframe-types';
 
 interface AdaptersState {
   adapters: AdapterInfo[];
   loading: boolean;
   setAdapters: (adapters: AdapterInfo[]) => void;
   setLoading: (loading: boolean) => void;
+  updateAdapterModels: (adapterId: string, models: AdapterModel[]) => void;
 }
 
 export const useAdaptersStore = create<AdaptersState>((set) => ({
@@ -13,4 +14,8 @@ export const useAdaptersStore = create<AdaptersState>((set) => ({
   loading: false,
   setAdapters: (adapters) => set({ adapters }),
   setLoading: (loading) => set({ loading }),
+  updateAdapterModels: (adapterId, models) =>
+    set((state) => ({
+      adapters: state.adapters.map((a) => (a.id === adapterId ? { ...a, models } : a)),
+    })),
 }));

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -152,6 +152,9 @@ export interface AdapterModel {
   id: string;
   label: string;
   contextWindow?: number;
+  supportsEffort?: boolean;
+  supportsFastMode?: boolean;
+  supportsAutoMode?: boolean;
 }
 
 export interface ExternalSession {
@@ -174,6 +177,7 @@ export interface Adapter {
   isInstalled(): Promise<boolean>;
   getVersion(): Promise<string | null>;
   listModels(): Promise<AdapterModel[]>;
+  probeModels?(): Promise<AdapterModel[] | null>;
 
   createSession(options: SessionOptions): AdapterSession;
   killAll(): void;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -58,7 +58,8 @@ export type DaemonEvent =
   | { type: 'message.queued.cleared'; chatId: string }
   | { type: 'chat.compacting'; chatId: string }
   | { type: 'chat.compactDone'; chatId: string }
-  | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number };
+  | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number }
+  | { type: 'adapter.models.updated'; adapterId: string; models: import('./adapter.js').AdapterModel[] };
 
 export type ClientEvent =
   | { type: 'chat.create'; projectId: string; adapterId: string; model?: string; permissionMode?: PermissionMode }


### PR DESCRIPTION
## Summary
- Expand hardcoded 4-model list to all 11 known Claude models with capability flags (`supportsEffort`, `supportsFastMode`, `supportsAutoMode`)
- Probe the CLI on daemon startup via `initialize` handshake to get the user's actual available models based on subscription tier
- Desktop model selector updates reactively when the probe completes via `adapter.models.updated` event
- Remove duplicate hardcoded model list from desktop package

## Test Plan
- [x] Verify model selector shows all 11 models before any session starts
- [x] Verify model list updates after daemon startup probe completes (if CLI is installed and authenticated)
- [x] Verify provider settings default model dropdown reflects expanded list
- [x] Verify `set_model` still works with model IDs from the list
- [x] Verify graceful degradation when CLI is not installed (hardcoded fallback used)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)