### PR TITLE
feat: add Copy Reference to Monaco editors (#39)

### DIFF
--- a/.changeset/copy-reference.md
+++ b/.changeset/copy-reference.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Add "Copy Reference" context menu action to Monaco editors

--- a/docs/superpowers/plans/2026-04-04-copy-reference.md
+++ b/docs/superpowers/plans/2026-04-04-copy-reference.md
@@ -1,0 +1,548 @@
+# Copy Reference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Copy Reference" context menu action to Monaco editors that copies `relativePath::SymbolChain` (or `relativePath:line` fallback) to the clipboard.
+
+**Architecture:** A single utility module (`copy-reference.ts`) handles symbol resolution and clipboard writing. Both `MonacoEditor` and `MonacoDiffEditor` register it as a Monaco action. For TS/JS files, the TS language worker provides nested symbol trees via `getNavigationTree`. For other languages, `getWordAtPosition` provides a best-effort fallback.
+
+**Tech Stack:** Monaco Editor 0.55, `@monaco-editor/react`, TypeScript language service worker
+
+**Spec:** `docs/superpowers/specs/2026-04-04-copy-reference-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/desktop/src/renderer/components/editor/copy-reference.ts` | Create | `copyReference()` — symbol resolution + clipboard write |
+| `packages/desktop/src/renderer/components/editor/copy-reference.test.ts` | Create | Unit tests for `buildReference()` and `findSymbolChain()` |
+| `packages/desktop/src/renderer/components/editor/MonacoEditor.tsx` | Modify | Register `mainframe.copyReference` action |
+| `packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx` | Modify | Accept `filePath` prop, register `mainframe.copyReference` action |
+| `packages/desktop/src/renderer/components/center/DiffTab.tsx` | Modify | Pass `filePath` to `MonacoDiffEditor` |
+
+---
+
+## Task 1: Pure Reference Formatting Utility + Tests
+
+**Files:**
+- Create: `packages/desktop/src/renderer/components/editor/copy-reference.ts`
+- Create: `packages/desktop/src/renderer/components/editor/copy-reference.test.ts`
+
+Build the pure functions first — no Monaco dependency, fully testable.
+
+- [ ] **Step 1: Write failing tests for `buildReference()`**
+
+Create the test file:
+
+```ts
+// packages/desktop/src/renderer/components/editor/copy-reference.test.ts
+import { describe, expect, it } from 'vitest';
+import { buildReference } from './copy-reference';
+
+describe('buildReference', () => {
+  it('tier 1: returns path::symbolChain when symbol chain is provided', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42, 'AuthService.validate')).toBe(
+      'packages/core/src/auth.ts::AuthService.validate',
+    );
+  });
+
+  it('tier 2: returns path:line (word) when only word is provided', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42, undefined, 'validate')).toBe(
+      'packages/core/src/auth.ts:42 (validate)',
+    );
+  });
+
+  it('tier 3: returns path:line when neither symbol nor word is available', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42)).toBe('packages/core/src/auth.ts:42');
+  });
+
+  it('uses "untitled" when filePath is undefined', () => {
+    expect(buildReference(undefined, 10)).toBe('untitled:10');
+  });
+
+  it('applies lineOffset to line number in tier 2 and 3', () => {
+    expect(buildReference('file.ts', 5, undefined, 'foo', 100)).toBe('file.ts:105 (foo)');
+    expect(buildReference('file.ts', 5, undefined, undefined, 100)).toBe('file.ts:105');
+  });
+
+  it('does not apply lineOffset to tier 1 (symbol chain)', () => {
+    expect(buildReference('file.ts', 5, 'MyClass.method', undefined, 100)).toBe('file.ts::MyClass.method');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: FAIL — `buildReference` not found.
+
+- [ ] **Step 3: Implement `buildReference()`**
+
+Create the module:
+
+```ts
+// packages/desktop/src/renderer/components/editor/copy-reference.ts
+
+/**
+ * Build a reference string from file path + symbol info.
+ *
+ * Tier 1 (symbol chain): `path::SymbolChain`
+ * Tier 2 (word only):    `path:line (word)`
+ * Tier 3 (nothing):      `path:line`
+ */
+export function buildReference(
+  filePath: string | undefined,
+  line: number,
+  symbolChain?: string,
+  word?: string,
+  lineOffset?: number,
+): string {
+  const path = filePath ?? 'untitled';
+  if (symbolChain) return `${path}::${symbolChain}`;
+  const adjustedLine = line + (lineOffset ?? 0);
+  if (word) return `${path}:${adjustedLine} (${word})`;
+  return `${path}:${adjustedLine}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/editor/copy-reference.ts packages/desktop/src/renderer/components/editor/copy-reference.test.ts
+git commit -m "feat(editor): add buildReference() for copy reference formatting"
+```
+
+---
+
+## Task 2: Navigation Tree Symbol Resolution + Tests
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/editor/copy-reference.ts`
+- Modify: `packages/desktop/src/renderer/components/editor/copy-reference.test.ts`
+
+Add the function that walks a TS `NavigationTree` to find the symbol chain at a given offset.
+
+- [ ] **Step 1: Write failing tests for `findSymbolChain()`**
+
+Append to the test file:
+
+```ts
+import { findSymbolChain } from './copy-reference';
+
+/**
+ * NavigationTree shape from TS language service:
+ * { text: string, kind: string, spans: Array<{ start: number, length: number }>, childItems?: NavigationTree[] }
+ */
+
+describe('findSymbolChain', () => {
+  it('returns deepest matching symbol chain', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 200 }],
+      childItems: [
+        {
+          text: 'MyClass',
+          kind: 'class',
+          spans: [{ start: 10, length: 100 }],
+          childItems: [
+            {
+              text: 'validate',
+              kind: 'method',
+              spans: [{ start: 30, length: 20 }],
+              childItems: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 35)).toBe('MyClass.validate');
+  });
+
+  it('returns single symbol when cursor is in class but not in a method', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 200 }],
+      childItems: [
+        {
+          text: 'MyClass',
+          kind: 'class',
+          spans: [{ start: 10, length: 100 }],
+          childItems: [
+            {
+              text: 'validate',
+              kind: 'method',
+              spans: [{ start: 30, length: 20 }],
+              childItems: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 15)).toBe('MyClass');
+  });
+
+  it('returns top-level function name', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 100 }],
+      childItems: [
+        {
+          text: 'helperFn',
+          kind: 'function',
+          spans: [{ start: 5, length: 40 }],
+          childItems: [],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 20)).toBe('helperFn');
+  });
+
+  it('returns undefined when cursor is outside all symbols', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 100 }],
+      childItems: [
+        {
+          text: 'helperFn',
+          kind: 'function',
+          spans: [{ start: 50, length: 20 }],
+          childItems: [],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 5)).toBeUndefined();
+  });
+
+  it('returns undefined for empty tree', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 0 }],
+      childItems: [],
+    };
+    expect(findSymbolChain(tree, 5)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new tests fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: FAIL — `findSymbolChain` not exported.
+
+- [ ] **Step 3: Implement `findSymbolChain()`**
+
+Add to `copy-reference.ts`:
+
+```ts
+/** Shape of TS NavigationTree returned by the language service worker. */
+export interface NavigationTreeNode {
+  text: string;
+  kind: string;
+  spans: Array<{ start: number; length: number }>;
+  childItems?: NavigationTreeNode[];
+}
+
+/**
+ * Walk a TS NavigationTree depth-first and return the dotted symbol chain
+ * for the deepest node whose span contains `offset`.
+ * Skips the root module node (kind === 'module').
+ */
+export function findSymbolChain(root: NavigationTreeNode, offset: number): string | undefined {
+  const chain: string[] = [];
+
+  function walk(node: NavigationTreeNode): boolean {
+    const inSpan = node.spans.some((s) => offset >= s.start && offset < s.start + s.length);
+    if (!inSpan) return false;
+
+    if (node.kind !== 'module') {
+      chain.push(node.text);
+    }
+
+    if (node.childItems) {
+      for (const child of node.childItems) {
+        if (walk(child)) return true;
+      }
+    }
+
+    return chain.length > 0;
+  }
+
+  walk(root);
+  return chain.length > 0 ? chain.join('.') : undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: All 11 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/editor/copy-reference.ts packages/desktop/src/renderer/components/editor/copy-reference.test.ts
+git commit -m "feat(editor): add findSymbolChain() for TS navigation tree walking"
+```
+
+---
+
+## Task 3: `copyReference()` Entry Point
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/editor/copy-reference.ts`
+
+Add the async function that ties everything together — gets the cursor position from the editor, resolves symbols via the TS worker (or falls back to word-at-cursor), builds the reference, and writes to clipboard. This function is not unit-tested directly because it depends on Monaco editor instances; it will be integration-tested via the UI.
+
+- [ ] **Step 1: Implement `copyReference()`**
+
+Add to `copy-reference.ts`:
+
+```ts
+import type * as monacoType from 'monaco-editor';
+
+/**
+ * Copy a qualified reference string for the symbol at the cursor to the clipboard.
+ * Called by the Monaco `mainframe.copyReference` action in both editors.
+ */
+export async function copyReference(
+  editor: monacoType.editor.ICodeEditor,
+  filePath: string | undefined,
+  monaco: typeof monacoType,
+  lineOffset?: number,
+): Promise<void> {
+  const position = editor.getPosition();
+  const model = editor.getModel();
+  if (!position || !model) return;
+
+  const line = position.lineNumber;
+  const wordInfo = model.getWordAtPosition(position);
+  const word = wordInfo?.word;
+
+  let symbolChain: string | undefined;
+
+  const langId = model.getLanguageId();
+  if (langId === 'typescript' || langId === 'javascript') {
+    try {
+      const getWorker =
+        langId === 'typescript'
+          ? monaco.languages.typescript.getTypeScriptWorker
+          : monaco.languages.typescript.getJavaScriptWorker;
+      const worker = await getWorker();
+      const client = await worker(model.uri);
+      const navTree = await (client as any).getNavigationTree(model.uri.toString());
+      if (navTree) {
+        const offset = model.getOffsetAt(position);
+        symbolChain = findSymbolChain(navTree, offset);
+      }
+    } catch {
+      /* TS worker unavailable — fall back to word */
+    }
+  }
+
+  const reference = buildReference(filePath, line, symbolChain, word, lineOffset);
+
+  try {
+    await navigator.clipboard.writeText(reference);
+  } catch {
+    /* clipboard API failure — silent for v1 */
+  }
+}
+```
+
+Note: the `import type * as monacoType from 'monaco-editor'` should be at the top of the file. Make sure `buildReference` and `findSymbolChain` are already defined above this function in the same file.
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Run existing tests still pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: All 11 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/editor/copy-reference.ts
+git commit -m "feat(editor): add copyReference() entry point with TS worker symbol resolution"
+```
+
+---
+
+## Task 4: Register Action in MonacoEditor
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/editor/MonacoEditor.tsx` (lines 196-202, inside `handleMount`)
+
+- [ ] **Step 1: Add import and register the action**
+
+At the top of `MonacoEditor.tsx`, add the import:
+
+```ts
+import { copyReference } from './copy-reference';
+```
+
+In the `handleMount` callback, after the existing `editor.addAction` for `mainframe.addComment` (line 202), add the copy reference action. This action should be registered unconditionally (not gated behind `onLineComment`), so place it **before** the `if (!onLineComment) return;` guard at line 165.
+
+Insert after line 163 (after `registerDefinitionProvider`) and before line 165 (`if (!onLineComment) return;`):
+
+```ts
+      const filePathRef_val = filePath;
+      editor.addAction({
+        id: 'mainframe.copyReference',
+        label: 'Copy Reference',
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 5,
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyC],
+        run: (ed) => copyReference(ed, filePathRef_val, monaco),
+      });
+```
+
+Note: We capture `filePath` in a local variable to avoid stale closure issues. Since `handleMount` is only called once, this is fine.
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
+git commit -m "feat(editor): register Copy Reference action in MonacoEditor"
+```
+
+---
+
+## Task 5: Register Action in MonacoDiffEditor + Wire filePath
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx` (interface + handleMount)
+- Modify: `packages/desktop/src/renderer/components/center/DiffTab.tsx` (pass filePath prop)
+
+- [ ] **Step 1: Add `filePath` prop to `MonacoDiffEditor`**
+
+In `MonacoDiffEditor.tsx`, add `filePath?: string` to the `MonacoDiffEditorProps` interface:
+
+```ts
+interface MonacoDiffEditorProps {
+  original: string;
+  modified: string;
+  language?: string;
+  filePath?: string;
+  startLine?: number;
+  onLineComment?: (startLine: number, endLine: number, lineContent: string, comment: string) => void;
+  onSubmitReview?: (comments: { startLine: number; endLine: number; lineContent: string; comment: string }[]) => void;
+}
+```
+
+Destructure it in the component:
+
+```ts
+export function MonacoDiffEditor({
+  original,
+  modified,
+  language,
+  filePath,
+  startLine,
+  onLineComment,
+  onSubmitReview,
+}: MonacoDiffEditorProps): React.ReactElement {
+```
+
+- [ ] **Step 2: Add import and register the action in `handleMount`**
+
+At the top of `MonacoDiffEditor.tsx`, add:
+
+```ts
+import { copyReference } from './copy-reference';
+```
+
+In `handleMount`, after `setGetModel(...)` (line 77) and before `if (!onLineComment) return;` (line 91), add:
+
+```ts
+      const filePathRef_val = filePath;
+      const offset = startLine && startLine > 1 ? startLine - 1 : 0;
+      inner.addAction({
+        id: 'mainframe.copyReference',
+        label: 'Copy Reference',
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 5,
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyC],
+        run: (ed) => copyReference(ed, filePathRef_val, monaco, offset),
+      });
+```
+
+Note: `offset` is computed from `startLine` to match how the diff editor offsets line numbers. This is passed as `lineOffset` to `copyReference`, which applies it in the tier 2/3 fallback format.
+
+- [ ] **Step 3: Pass `filePath` from `DiffTab`**
+
+In `DiffTab.tsx`, the `MonacoDiffEditor` JSX (around line 117) does not currently receive `filePath`. Add it:
+
+```tsx
+    <MonacoDiffEditor
+      key={source === 'inline' ? `${original?.length}:${modified?.length}` : filePath}
+      original={original}
+      modified={modified}
+      language={inferLanguage(filePath)}
+      filePath={filePath}
+      startLine={startLine}
+      onLineComment={handleLineComment}
+      onSubmitReview={handleSubmitReview}
+    />
+```
+
+- [ ] **Step 4: Verify the file compiles**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx packages/desktop/src/renderer/components/center/DiffTab.tsx
+git commit -m "feat(editor): register Copy Reference action in MonacoDiffEditor with line offset"
+```
+
+---
+
+## Task 6: Changeset + Typecheck + Final Test Run
+
+**Files:**
+- Create: `.changeset/*.md` (generated by `pnpm changeset`)
+
+- [ ] **Step 1: Add changeset**
+
+Run: `pnpm changeset`
+Select: `@qlan-ro/mainframe-desktop` — `minor`
+Summary: `Add "Copy Reference" context menu action to Monaco editors`
+
+- [ ] **Step 2: Run full typecheck**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 3: Run all copy-reference tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/editor/copy-reference.test.ts`
+Expected: All 11 tests PASS.
+
+- [ ] **Step 4: Commit changeset**
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for copy reference feature"
+```

--- a/docs/superpowers/specs/2026-04-04-copy-reference-design.md
+++ b/docs/superpowers/specs/2026-04-04-copy-reference-design.md
@@ -1,0 +1,100 @@
+# Copy Reference
+
+Add a "Copy Reference" context menu action to Monaco editors. Copies a qualified reference string (`relativePath::SymbolChain` or `relativePath:line` fallback) to the clipboard.
+
+## Context
+
+IntelliJ's "Copy Reference" produces fully-qualified symbol paths like `com.example.Service.method`. We adapt this for a polyglot TypeScript-centric editor: best-effort symbol resolution via Monaco's `DocumentSymbolProvider`, with a clean line-number fallback for unsupported languages.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Symbol resolution | Multi-language, best-effort via Monaco DocumentSymbolProvider | TS/JS/CSS/JSON supported out of the box; graceful fallback for others |
+| Output format | `relativePath::SymbolChain` / `relativePath:line` | `::` clearly separates path from symbol; matches existing `file_path:line_number` convention |
+| Path style | Repo-relative | Unambiguous in a monorepo; matches git and tooling conventions |
+| Approach | Monaco `editor.addAction()` | Follows existing "Add Agent Context" pattern; no custom HTML menu needed |
+
+## Format Specification
+
+Three tiers, highest-resolution first:
+
+1. **Symbol resolved:** `packages/core/src/auth.ts::AuthService.validate`
+2. **No symbol, word at cursor:** `packages/core/src/auth.ts:42 (validate)`
+3. **Nothing resolvable:** `packages/core/src/auth.ts:42`
+
+## Architecture
+
+### New File: `editor/copy-reference.ts`
+
+Single exported function:
+
+```ts
+async function copyReference(
+  editor: monacoType.editor.ICodeEditor,
+  filePath: string | undefined,
+  monaco: typeof monacoType,
+  lineOffset?: number,
+): Promise<void>
+```
+
+Steps:
+1. Get cursor position from editor
+2. Get the text model
+3. Request document symbols via `monaco.editor.getModelMarkers` — actually, use `monaco.languages.DocumentSymbolProvider` registered for the model's language
+4. Walk the symbol tree depth-first to find the deepest symbol whose range contains the cursor
+5. Build ancestor chain (e.g., `ClassName.methodName`)
+6. Compose reference string per format spec above
+7. Apply `lineOffset` (for diff editor with `startLine`) to fallback line numbers
+8. Copy to clipboard via `navigator.clipboard.writeText()`
+
+### Symbol Resolution Strategy
+
+**TypeScript/JavaScript files:** Use the TS language service worker via `monaco.languages.typescript.getTypeScriptWorker()`. Call `client.getNavigationTree(uri)` to get the full symbol tree, then walk it to find the deepest node containing the cursor. Build the ancestor chain (e.g., `ClassName.methodName`).
+
+**All other languages:** Use `model.getWordAtPosition(position)` for the word at cursor. No symbol nesting — produce `path:line (word)` or `path:line`.
+
+This gives high-quality results for TS/JS (the primary languages in this codebase) without depending on unstable internal Monaco APIs.
+
+## Components Changed
+
+| File | Change |
+|------|--------|
+| `editor/copy-reference.ts` | **New.** `copyReference()` utility function |
+| `editor/MonacoEditor.tsx` | Register `mainframe.copyReference` action in `handleMount` |
+| `editor/MonacoDiffEditor.tsx` | Accept new `filePath?: string` prop; register action in `handleMount` |
+| `center/DiffTab.tsx` | Pass `filePath` prop through to `MonacoDiffEditor` |
+
+## Action Registration
+
+Both editors register in `handleMount`:
+
+```ts
+editor.addAction({
+  id: 'mainframe.copyReference',
+  label: 'Copy Reference',
+  contextMenuGroupId: '9_cutcopypaste',
+  contextMenuOrder: 5,
+  keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyC],
+  run: (ed) => copyReference(ed, filePath, monaco),
+});
+```
+
+- **Menu group:** `9_cutcopypaste` — appears near Cut/Copy/Paste in Monaco's native context menu
+- **Keyboard shortcut:** `Cmd+Shift+Alt+C` (matches IntelliJ convention)
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| No `filePath` (untitled buffer) | Use `"untitled"` as path component |
+| Diff editor with `startLine` offset | Add offset to line number in fallback format |
+| Clipboard API failure | Catch silently — no toast for v1 |
+| Cursor not on any word | Produce `path:line` (tier 3) |
+| TS worker unavailable | Fall back to word-at-cursor (tier 2/3) |
+
+## Out of Scope
+
+- Custom toast/notification on successful copy
+- Copy reference from file tree (separate feature)
+- Multi-cursor / selection-range references

--- a/packages/desktop/src/renderer/components/center/DiffTab.tsx
+++ b/packages/desktop/src/renderer/components/center/DiffTab.tsx
@@ -119,6 +119,7 @@ export function DiffTab({
       original={original}
       modified={modified}
       language={inferLanguage(filePath)}
+      filePath={filePath}
       startLine={startLine}
       onLineComment={handleLineComment}
       onSubmitReview={handleSubmitReview}

--- a/packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx
@@ -6,6 +6,7 @@ import { Send } from 'lucide-react';
 import { InlineCommentWidget } from './InlineCommentWidget';
 import { useInlineComments } from './useInlineComments';
 import { setActiveDiffEditor } from './diff-nav';
+import { copyReference } from './copy-reference';
 import { useTabsStore } from '../../store/tabs';
 import './setup';
 
@@ -13,6 +14,7 @@ interface MonacoDiffEditorProps {
   original: string;
   modified: string;
   language?: string;
+  filePath?: string;
   startLine?: number;
   onLineComment?: (startLine: number, endLine: number, lineContent: string, comment: string) => void;
   onSubmitReview?: (comments: { startLine: number; endLine: number; lineContent: string; comment: string }[]) => void;
@@ -22,6 +24,7 @@ export function MonacoDiffEditor({
   original,
   modified,
   language,
+  filePath,
   startLine,
   onLineComment,
   onSubmitReview,
@@ -86,6 +89,16 @@ export function MonacoDiffEditor({
           const firstLine = changes[0]!.modifiedStartLineNumber || 1;
           inner.revealLineInCenter(firstLine);
         }
+      });
+
+      const copyRefOffset = startLine && startLine > 1 ? startLine - 1 : 0;
+      inner.addAction({
+        id: 'mainframe.copyReference',
+        label: 'Copy Reference',
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 5,
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyC],
+        run: (ed) => copyReference(ed, filePath, monaco, copyRefOffset),
       });
 
       if (!onLineComment) return;

--- a/packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoDiffEditor.tsx
@@ -140,6 +140,8 @@ export function MonacoDiffEditor({
         run: () => openCommentRef.current(inner),
       });
     },
+    // filePath and startLine intentionally omitted: handleMount fires once per mount,
+    // and DiffTab re-keys this component whenever filePath changes.
     [onLineComment, openComment],
   );
 

--- a/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
@@ -7,6 +7,7 @@ import { InlineCommentWidget } from './InlineCommentWidget';
 import { useInlineComments } from './useInlineComments';
 import './setup';
 import { registerDefinitionProvider } from './navigation';
+import { copyReference } from './copy-reference';
 import { useProjectsStore } from '../../store';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useTabsStore } from '../../store/tabs';
@@ -161,6 +162,15 @@ export function MonacoEditor({
       if (filePath && language) {
         registerDefinitionProvider(monaco, language, filePath);
       }
+
+      editor.addAction({
+        id: 'mainframe.copyReference',
+        label: 'Copy Reference',
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 5,
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyC],
+        run: (ed) => copyReference(ed, filePath, monaco),
+      });
 
       if (!onLineComment) return;
 

--- a/packages/desktop/src/renderer/components/editor/copy-reference.test.ts
+++ b/packages/desktop/src/renderer/components/editor/copy-reference.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { buildReference } from './copy-reference';
+
+describe('buildReference', () => {
+  it('tier 1: returns path::symbolChain when symbol chain is provided', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42, 'AuthService.validate')).toBe(
+      'packages/core/src/auth.ts::AuthService.validate',
+    );
+  });
+
+  it('tier 2: returns path:line (word) when only word is provided', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42, undefined, 'validate')).toBe(
+      'packages/core/src/auth.ts:42 (validate)',
+    );
+  });
+
+  it('tier 3: returns path:line when neither symbol nor word is available', () => {
+    expect(buildReference('packages/core/src/auth.ts', 42)).toBe('packages/core/src/auth.ts:42');
+  });
+
+  it('uses "untitled" when filePath is undefined', () => {
+    expect(buildReference(undefined, 10)).toBe('untitled:10');
+  });
+
+  it('applies lineOffset to line number in tier 2 and 3', () => {
+    expect(buildReference('file.ts', 5, undefined, 'foo', 100)).toBe('file.ts:105 (foo)');
+    expect(buildReference('file.ts', 5, undefined, undefined, 100)).toBe('file.ts:105');
+  });
+
+  it('does not apply lineOffset to tier 1 (symbol chain)', () => {
+    expect(buildReference('file.ts', 5, 'MyClass.method', undefined, 100)).toBe('file.ts::MyClass.method');
+  });
+});

--- a/packages/desktop/src/renderer/components/editor/copy-reference.test.ts
+++ b/packages/desktop/src/renderer/components/editor/copy-reference.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildReference } from './copy-reference';
+import { buildReference, findSymbolChain } from './copy-reference';
 
 describe('buildReference', () => {
   it('tier 1: returns path::symbolChain when symbol chain is provided', () => {
@@ -29,5 +29,104 @@ describe('buildReference', () => {
 
   it('does not apply lineOffset to tier 1 (symbol chain)', () => {
     expect(buildReference('file.ts', 5, 'MyClass.method', undefined, 100)).toBe('file.ts::MyClass.method');
+  });
+});
+
+/**
+ * NavigationTree shape from TS language service:
+ * { text: string, kind: string, spans: Array<{ start: number, length: number }>, childItems?: NavigationTree[] }
+ */
+
+describe('findSymbolChain', () => {
+  it('returns deepest matching symbol chain', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 200 }],
+      childItems: [
+        {
+          text: 'MyClass',
+          kind: 'class',
+          spans: [{ start: 10, length: 100 }],
+          childItems: [
+            {
+              text: 'validate',
+              kind: 'method',
+              spans: [{ start: 30, length: 20 }],
+              childItems: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 35)).toBe('MyClass.validate');
+  });
+
+  it('returns single symbol when cursor is in class but not in a method', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 200 }],
+      childItems: [
+        {
+          text: 'MyClass',
+          kind: 'class',
+          spans: [{ start: 10, length: 100 }],
+          childItems: [
+            {
+              text: 'validate',
+              kind: 'method',
+              spans: [{ start: 30, length: 20 }],
+              childItems: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 15)).toBe('MyClass');
+  });
+
+  it('returns top-level function name', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 100 }],
+      childItems: [
+        {
+          text: 'helperFn',
+          kind: 'function',
+          spans: [{ start: 5, length: 40 }],
+          childItems: [],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 20)).toBe('helperFn');
+  });
+
+  it('returns undefined when cursor is outside all symbols', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 100 }],
+      childItems: [
+        {
+          text: 'helperFn',
+          kind: 'function',
+          spans: [{ start: 50, length: 20 }],
+          childItems: [],
+        },
+      ],
+    };
+    expect(findSymbolChain(tree, 5)).toBeUndefined();
+  });
+
+  it('returns undefined for empty tree', () => {
+    const tree = {
+      text: '"module"',
+      kind: 'module',
+      spans: [{ start: 0, length: 0 }],
+      childItems: [],
+    };
+    expect(findSymbolChain(tree, 5)).toBeUndefined();
   });
 });

--- a/packages/desktop/src/renderer/components/editor/copy-reference.ts
+++ b/packages/desktop/src/renderer/components/editor/copy-reference.ts
@@ -1,3 +1,5 @@
+import type * as monacoType from 'monaco-editor';
+
 /** Shape of TS NavigationTree returned by the language service worker. */
 export interface NavigationTreeNode {
   text: string;
@@ -54,4 +56,51 @@ export function buildReference(
   const adjustedLine = line + (lineOffset ?? 0);
   if (word) return `${path}:${adjustedLine} (${word})`;
   return `${path}:${adjustedLine}`;
+}
+
+/**
+ * Copy a qualified reference string for the symbol at the cursor to the clipboard.
+ * Called by the Monaco `mainframe.copyReference` action in both editors.
+ */
+export async function copyReference(
+  editor: monacoType.editor.ICodeEditor,
+  filePath: string | undefined,
+  monaco: typeof monacoType,
+  lineOffset?: number,
+): Promise<void> {
+  const position = editor.getPosition();
+  const model = editor.getModel();
+  if (!position || !model) return;
+
+  const line = position.lineNumber;
+  const wordInfo = model.getWordAtPosition(position);
+  const word = wordInfo?.word;
+
+  let symbolChain: string | undefined;
+
+  const langId = model.getLanguageId();
+  if (langId === 'typescript' || langId === 'javascript') {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tsLang = monaco.languages.typescript as any;
+      const getWorker = langId === 'typescript' ? tsLang.getTypeScriptWorker : tsLang.getJavaScriptWorker;
+      const worker = await getWorker();
+      const client = await worker(model.uri);
+      const navTree = await (client as any).getNavigationTree(model.uri.toString());
+      if (navTree) {
+        const offset = model.getOffsetAt(position);
+        symbolChain = findSymbolChain(navTree, offset);
+      }
+    } catch {
+      /* TS worker unavailable — fall back to word */
+    }
+  }
+
+  const reference = buildReference(filePath, line, symbolChain, word, lineOffset);
+
+  try {
+    await navigator.clipboard.writeText(reference);
+  } catch {
+    /* clipboard API failure — silent for v1 */
+  }
 }

--- a/packages/desktop/src/renderer/components/editor/copy-reference.ts
+++ b/packages/desktop/src/renderer/components/editor/copy-reference.ts
@@ -1,3 +1,40 @@
+/** Shape of TS NavigationTree returned by the language service worker. */
+export interface NavigationTreeNode {
+  text: string;
+  kind: string;
+  spans: Array<{ start: number; length: number }>;
+  childItems?: NavigationTreeNode[];
+}
+
+/**
+ * Walk a TS NavigationTree depth-first and return the dotted symbol chain
+ * for the deepest node whose span contains `offset`.
+ * Skips the root module node (kind === 'module').
+ */
+export function findSymbolChain(root: NavigationTreeNode, offset: number): string | undefined {
+  const chain: string[] = [];
+
+  function walk(node: NavigationTreeNode): boolean {
+    const inSpan = node.spans.some((s) => offset >= s.start && offset < s.start + s.length);
+    if (!inSpan) return false;
+
+    if (node.kind !== 'module') {
+      chain.push(node.text);
+    }
+
+    if (node.childItems) {
+      for (const child of node.childItems) {
+        if (walk(child)) return true;
+      }
+    }
+
+    return chain.length > 0;
+  }
+
+  walk(root);
+  return chain.length > 0 ? chain.join('.') : undefined;
+}
+
 /**
  * Build a reference string from file path + symbol info.
  *

--- a/packages/desktop/src/renderer/components/editor/copy-reference.ts
+++ b/packages/desktop/src/renderer/components/editor/copy-reference.ts
@@ -1,0 +1,20 @@
+/**
+ * Build a reference string from file path + symbol info.
+ *
+ * Tier 1 (symbol chain): `path::SymbolChain`
+ * Tier 2 (word only):    `path:line (word)`
+ * Tier 3 (nothing):      `path:line`
+ */
+export function buildReference(
+  filePath: string | undefined,
+  line: number,
+  symbolChain?: string,
+  word?: string,
+  lineOffset?: number,
+): string {
+  const path = filePath ?? 'untitled';
+  if (symbolChain) return `${path}::${symbolChain}`;
+  const adjustedLine = line + (lineOffset ?? 0);
+  if (word) return `${path}:${adjustedLine} (${word})`;
+  return `${path}:${adjustedLine}`;
+}


### PR DESCRIPTION
## Summary
- Add "Copy Reference" right-click context menu action to both `MonacoEditor` and `MonacoDiffEditor`
- For TS/JS files, resolves the full symbol chain via the TypeScript language service worker (e.g., `packages/core/src/auth.ts::AuthService.validate`)
- Falls back to `path:line (word)` or `path:line` for other languages or when symbols are unavailable
- Keyboard shortcut: `Cmd+Shift+Alt+C` (matches IntelliJ convention)

## Test Plan
- [x] 11 unit tests for `buildReference()` and `findSymbolChain()` — all passing
- [x] Manual: open a TS file in the editor, right-click a method → "Copy Reference" → paste and verify format
- [x] Manual: open a diff view, right-click → verify line offset is applied correctly
- [x] Manual: open a non-TS file (e.g., JSON, Python) → verify fallback format with word/line

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)