### PR TITLE
fix(desktop): pass default model on createChat and show compacting indicator

### DIFF
--- a/.changeset/default-model-create-chat.md
+++ b/.changeset/default-model-create-chat.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Pass default model when creating new chat sessions and show compacting indicator

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { usePluginShortcuts } from './hooks/usePluginShortcuts';
 import { useSettingsStore } from './store';
 import { getActiveProjectId } from './hooks/useActiveProjectId.js';
 import { daemonClient } from './lib/client';
+import { getDefaultModelForAdapter } from './lib/adapters';
 import { PluginGlobalComponents } from './components/plugins/PluginGlobalComponents';
 
 export default function App(): React.ReactElement {
@@ -28,7 +29,7 @@ export default function App(): React.ReactElement {
         e.preventDefault();
         const projectId = getActiveProjectId();
         if (projectId) {
-          daemonClient.createChat(projectId, 'claude');
+          daemonClient.createChat(projectId, 'claude', getDefaultModelForAdapter('claude'));
         }
       }
     };

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
@@ -10,6 +10,7 @@ import type { AttachmentAdapter, ExternalStoreThreadListAdapter } from '@assista
 import { useChatSession } from '../../../hooks/useChatSession';
 import { convertMessage } from './convert-message';
 import { daemonClient } from '../../../lib/client';
+import { getDefaultModelForAdapter } from '../../../lib/adapters';
 import { archiveChat } from '../../../lib/api';
 import { deleteDraft } from './composer/composer-drafts.js';
 import { useChatsStore } from '../../../store/chats';
@@ -269,7 +270,7 @@ export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeP
       },
       onSwitchToNewThread: () => {
         if (!activeProjectId) return;
-        daemonClient.createChat(activeProjectId, 'claude');
+        daemonClient.createChat(activeProjectId, 'claude', getDefaultModelForAdapter('claude'));
       },
       onArchive: async (threadId: string) => {
         const chat = chats.find((c) => c.id === threadId);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ThreadPrimitive, useThread } from '@assistant-ui/react';
 import { Loader2 } from 'lucide-react';
 import { useMainframeRuntime } from './MainframeRuntimeProvider';
+import { useChatsStore } from '../../../store/chats';
 import { PermissionCard } from '../PermissionCard';
 import { AskUserQuestionCard } from '../AskUserQuestionCard';
 import { PlanApprovalCard } from '../PlanApprovalCard';
@@ -24,11 +25,13 @@ function EmptyState() {
 
 function GeneratingIndicator() {
   const thread = useThread();
+  const activeChatId = useChatsStore((s) => s.activeChatId);
+  const isCompacting = useChatsStore((s) => (activeChatId ? s.compactingChats.has(activeChatId) : false));
   if (!thread.isRunning) return null;
   return (
     <div className="flex items-center gap-2 py-2 text-mf-text-secondary text-mf-body">
       <Loader2 size={14} className="animate-spin motion-reduce:animate-none text-mf-accent" />
-      <span>Thinking...</span>
+      <span>{isCompacting ? 'Compacting...' : 'Thinking...'}</span>
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -13,6 +13,7 @@ import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { DirectoryPickerModal } from '../DirectoryPickerModal';
 import { daemonClient } from '../../lib/client';
+import { getDefaultModelForAdapter } from '../../lib/adapters';
 import { ProjectGroup } from './ProjectGroup';
 import { FlatSessionRow } from './FlatSessionRow';
 import { ImportSessionsPopover } from './ImportSessionsPopover';
@@ -224,18 +225,18 @@ export function ChatsPanel(): React.ReactElement {
   const handleNewSessionClick = useCallback(() => {
     if (projects.length === 0) return;
     if (filterProjectId) {
-      daemonClient.createChat(filterProjectId, 'claude');
+      daemonClient.createChat(filterProjectId, 'claude', getDefaultModelForAdapter('claude'));
       return;
     }
     if (projects.length === 1) {
-      daemonClient.createChat(projects[0]!.id, 'claude');
+      daemonClient.createChat(projects[0]!.id, 'claude', getDefaultModelForAdapter('claude'));
       return;
     }
     setShowNewSessionPopover((prev) => !prev);
   }, [projects, filterProjectId]);
 
   const handleNewSessionInProject = useCallback((projectId: string) => {
-    daemonClient.createChat(projectId, 'claude');
+    daemonClient.createChat(projectId, 'claude', getDefaultModelForAdapter('claude'));
     setShowNewSessionPopover(false);
   }, []);
 

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -6,6 +6,7 @@ import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
 import { useAdaptersStore } from '../../store/adapters';
 import { daemonClient } from '../../lib/client';
+import { getDefaultModelForAdapter } from '../../lib/adapters';
 import { archiveChat, renameChat } from '../../lib/api';
 import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
 import { cn } from '../../lib/utils';
@@ -314,7 +315,7 @@ export function ProjectGroup({
   const handleNewSession = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      daemonClient.createChat(project.id, 'claude');
+      daemonClient.createChat(project.id, 'claude', getDefaultModelForAdapter('claude'));
     },
     [project.id],
   );

--- a/packages/desktop/src/renderer/components/sandbox/LaunchPopover.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/LaunchPopover.tsx
@@ -10,6 +10,7 @@ import { useLaunchConfig } from '../../hooks/useLaunchConfig';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { useLaunchScopeKey } from '../../hooks/useLaunchScopeKey.js';
 import { daemonClient } from '../../lib/client';
+import { getDefaultModelForAdapter } from '../../lib/adapters';
 import type { LaunchConfiguration } from '@qlan-ro/mainframe-types';
 import { cn } from '../../lib/utils';
 
@@ -125,7 +126,7 @@ export function LaunchPopover({ onClose }: Props): React.ReactElement {
           if (chatId) {
             daemonClient.sendMessage(chatId, '/launch-config');
           } else {
-            daemonClient.createChat(activeProject.id, 'claude');
+            daemonClient.createChat(activeProject.id, 'claude', getDefaultModelForAdapter('claude'));
             const unsub = useChatsStore.subscribe((state) => {
               if (state.activeChatId) {
                 daemonClient.sendMessage(state.activeChatId, '/launch-config');

--- a/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
@@ -21,6 +21,7 @@ import { useActiveProjectId, getActiveProjectId } from '../../hooks/useActivePro
 import { useLaunchScopeKey } from '../../hooks/useLaunchScopeKey.js';
 import { useUIStore } from '../../store/ui';
 import { daemonClient } from '../../lib/client';
+import { getDefaultModelForAdapter } from '../../lib/adapters';
 import { useLaunchConfig } from '../../hooks/useLaunchConfig';
 
 // CSS selector generator — injected into the webview page
@@ -281,7 +282,7 @@ export function PreviewTab(): React.ReactElement {
 
       if (!useChatsStore.getState().activeChatId) {
         const projectId = getActiveProjectId();
-        if (projectId) daemonClient.createChat(projectId, 'claude');
+        if (projectId) daemonClient.createChat(projectId, 'claude', getDefaultModelForAdapter('claude'));
       }
     } catch (err) {
       console.warn('[sandbox] full screenshot failed', err);
@@ -321,7 +322,7 @@ export function PreviewTab(): React.ReactElement {
       // Auto-create a chat session if none is active so the composer appears
       if (!useChatsStore.getState().activeChatId) {
         const projectId = getActiveProjectId();
-        if (projectId) daemonClient.createChat(projectId, 'claude');
+        if (projectId) daemonClient.createChat(projectId, 'claude', getDefaultModelForAdapter('claude'));
       }
     } catch (err) {
       console.warn('[sandbox] inspect failed', err);

--- a/packages/desktop/src/renderer/lib/adapters.ts
+++ b/packages/desktop/src/renderer/lib/adapters.ts
@@ -1,4 +1,6 @@
 import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import { useSettingsStore } from '../store/settings';
+import { useAdaptersStore } from '../store/adapters';
 
 const ADAPTER_LABEL_FALLBACK: Record<string, string> = {
   claude: 'Claude',
@@ -47,6 +49,17 @@ export function getModelLabel(modelId: string | undefined, adapters: AdapterInfo
   const [, family = '', major, minor] = match;
   const familyLabel = `${family.slice(0, 1).toUpperCase()}${family.slice(1).toLowerCase()}`;
   return `${familyLabel} ${major}.${minor}`;
+}
+
+/**
+ * Resolve the default model for an adapter: provider setting → first model in list.
+ * Safe to call outside React (reads stores via getState()).
+ */
+export function getDefaultModelForAdapter(adapterId: string): string | undefined {
+  const providerDefault = useSettingsStore.getState().providers[adapterId]?.defaultModel;
+  if (providerDefault) return providerDefault;
+  const adapter = useAdaptersStore.getState().adapters.find((a) => a.id === adapterId);
+  return adapter?.models[0]?.id;
 }
 
 export function getModelContextWindow(modelId: string | undefined, adapters: AdapterInfo[]): number {

--- a/packages/desktop/src/renderer/lib/send-comment-message.ts
+++ b/packages/desktop/src/renderer/lib/send-comment-message.ts
@@ -1,6 +1,7 @@
 import { daemonClient } from './client';
 import { useChatsStore } from '../store/chats';
 import { getActiveProjectId } from '../hooks/useActiveProjectId.js';
+import { getDefaultModelForAdapter } from './adapters';
 import { createLogger } from './logger';
 
 const log = createLogger('renderer:chat');
@@ -37,7 +38,7 @@ export function sendCommentMessage(formatted: string, explicitChatId?: string): 
     }
   });
 
-  daemonClient.createChat(projectId, 'claude');
+  daemonClient.createChat(projectId, 'claude', getDefaultModelForAdapter('claude'));
 }
 
 function ensureResumedAndSend(chatId: string, content: string): void {


### PR DESCRIPTION
## Summary
- All `daemonClient.createChat()` call sites now pass the user's configured default model (via `getDefaultModelForAdapter`) so new sessions start with the correct model instead of relying on the adapter's hardcoded default.
- Adds a "Compacting..." indicator in the thread's `GeneratingIndicator` when context compaction is in progress.

## Test plan
- [x] Create a new chat via keyboard shortcut (Cmd+N) — verify it uses the configured default model
- [x] Create a new chat from the sidebar — verify correct model
- [x] Switch to a new thread via assistant-ui — verify correct model
- [x] Trigger context compaction — verify "Compacting..." text appears instead of "Thinking..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)