### PR TITLE
fix(desktop): allow app-protocol URLs in markdown chat messages

### DIFF
--- a/.changeset/allow-app-protocol-urls.md
+++ b/.changeset/allow-app-protocol-urls.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Allow app-protocol URLs (slack://, vscode://, figma://, etc.) to render as clickable links in chat messages

--- a/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/PlanApprovalCard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { ClipboardList, ShieldOff, FileEdit, Shield, ChevronDown } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { urlTransform, remarkAppLinks } from '../../lib/markdown-url-transform';
 import type { ControlRequest, ControlUpdate } from '@qlan-ro/mainframe-types';
 import { Button } from '../ui/button';
 
@@ -74,7 +75,9 @@ export function PlanApprovalCard({ request, onRespond }: PlanApprovalCardProps):
         {plan && (
           <div className="max-h-[300px] overflow-y-auto rounded-mf-input bg-mf-input-bg p-3">
             <div className="aui-md text-mf-chat text-mf-text-primary">
-              <Markdown remarkPlugins={[remarkGfm]}>{plan}</Markdown>
+              <Markdown remarkPlugins={[remarkGfm, remarkAppLinks]} urlTransform={urlTransform}>
+                {plan}
+              </Markdown>
             </div>
           </div>
         )}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -8,10 +8,11 @@ import { markdownComponents } from '../parts/markdown-text';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
 import { useSkillsStore } from '../../../../store/skills';
 import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
+import { urlTransform, remarkAppLinks } from '../../../../lib/markdown-url-transform';
 import { PLAN_PREFIX, highlightMentions, resolveSkillName, parseRawCommand } from '../message-parsing';
 import { ImageThumbs, FileAttachmentThumbs } from './ImageThumbs';
 
-const REMARK_PLUGINS = [remarkGfm];
+const REMARK_PLUGINS = [remarkGfm, remarkAppLinks];
 
 function MentionParagraph({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
   return <p {...props}>{highlightMentions(children)}</p>;
@@ -80,7 +81,7 @@ export function UserMessage() {
           </div>
           <div className="px-4 py-3">
             <div className="aui-md text-mf-chat text-mf-text-primary">
-              <Markdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
+              <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={urlTransform} components={markdownComponents}>
                 {planBody}
               </Markdown>
             </div>
@@ -126,7 +127,7 @@ export function UserMessage() {
       {hasTextContent && (
         <div className="max-w-[75%] bg-mf-hover rounded-[12px_12px_4px_12px] px-4 py-2.5">
           <div className="aui-md text-mf-chat text-mf-text-primary">
-            <Markdown remarkPlugins={REMARK_PLUGINS} components={userComponents}>
+            <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={urlTransform} components={userComponents}>
               {cleanText}
             </Markdown>
           </div>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
@@ -7,6 +7,7 @@ import {
 } from '@assistant-ui/react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '../../../../lib/utils';
+import { urlTransform as markdownUrlTransform, remarkAppLinks } from '../../../../lib/markdown-url-transform';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../ui/tooltip';
 import { CodeHeader } from './CodeHeader';
 import { SyntaxHighlightedCode } from './SyntaxHighlightedCode';
@@ -153,10 +154,17 @@ export const markdownComponents = unstable_memoizeMarkdownComponents({
   CodeHeader,
 });
 
-const REMARK_PLUGINS = [remarkGfm];
+const REMARK_PLUGINS = [remarkGfm, remarkAppLinks];
 
 export const MarkdownText: TextMessagePartComponent = memo(() => {
-  return <MarkdownTextPrimitive className="aui-md" remarkPlugins={REMARK_PLUGINS} components={markdownComponents} />;
+  return (
+    <MarkdownTextPrimitive
+      className="aui-md"
+      remarkPlugins={REMARK_PLUGINS}
+      urlTransform={markdownUrlTransform}
+      components={markdownComponents}
+    />
+  );
 });
 
 MarkdownText.displayName = 'MarkdownText';

--- a/packages/desktop/src/renderer/lib/markdown-url-transform.ts
+++ b/packages/desktop/src/renderer/lib/markdown-url-transform.ts
@@ -1,0 +1,78 @@
+import { defaultUrlTransform } from 'react-markdown';
+import type { Root, Text, Link } from 'mdast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Protocols that the Electron main process allows via shell.openExternal.
+ * Keep in sync with ALLOWED_SCHEMES in packages/desktop/src/main/index.ts.
+ */
+const EXTRA_SAFE_PROTOCOLS =
+  /^(slack|vscode|vscode-insiders|cursor|jetbrains|idea|zed|figma|linear|notion|discord|tel)$/i;
+
+/** Matches bare app-protocol URLs in text (e.g. slack://channel?team=...) */
+const APP_URL_RE =
+  /\b((?:slack|vscode|vscode-insiders|cursor|jetbrains|idea|zed|figma|linear|notion|discord|tel):\/\/[^\s<>)\]]*)/gi;
+
+/**
+ * Extends react-markdown's default URL sanitiser to allow the same app-protocol
+ * URLs that the Electron main process already permits.
+ */
+export function urlTransform(url: string): string {
+  const colon = url.indexOf(':');
+  if (colon !== -1) {
+    const slash = url.indexOf('/');
+    const questionMark = url.indexOf('?');
+    const numberSign = url.indexOf('#');
+    const isProtocol =
+      (slash === -1 || colon < slash) &&
+      (questionMark === -1 || colon < questionMark) &&
+      (numberSign === -1 || colon < numberSign);
+
+    if (isProtocol && EXTRA_SAFE_PROTOCOLS.test(url.slice(0, colon))) {
+      return url;
+    }
+  }
+  return defaultUrlTransform(url);
+}
+
+/**
+ * Remark plugin that turns bare app-protocol URLs (slack://, vscode://, etc.)
+ * into clickable links. remark-gfm only autolinks http(s) URLs.
+ */
+export const remarkAppLinks: Plugin<[], Root> = () => {
+  return (tree: Root) => {
+    visit(tree, 'text', (node: Text, index, parent) => {
+      if (!parent || index === undefined) return;
+      // Don't process text already inside a link
+      if (parent.type === 'link') return;
+
+      const matches = [...node.value.matchAll(APP_URL_RE)];
+      if (matches.length === 0) return;
+
+      const children: (Text | Link)[] = [];
+      let lastEnd = 0;
+
+      for (const match of matches) {
+        const start = match.index!;
+        const url = match[0]!;
+
+        if (start > lastEnd) {
+          children.push({ type: 'text', value: node.value.slice(lastEnd, start) });
+        }
+        children.push({
+          type: 'link',
+          url,
+          children: [{ type: 'text', value: url }],
+        });
+        lastEnd = start + url.length;
+      }
+
+      if (lastEnd < node.value.length) {
+        children.push({ type: 'text', value: node.value.slice(lastEnd) });
+      }
+
+      parent.children.splice(index, 1, ...children);
+    });
+  };
+};


### PR DESCRIPTION
## Summary
- `react-markdown`'s `defaultUrlTransform` only allows `http(s)`, `mailto`, `xmpp`, and `ircs` — silently stripping `slack://`, `vscode://`, `figma://`, etc. to empty strings
- `remark-gfm` only autolinks `http(s)` bare URLs, so bare `slack://channel?...` never became `<a>` tags
- Added custom `urlTransform` and `remarkAppLinks` remark plugin that permit the same protocols already allowed by Electron's `openExternalSafe`
- Applied to all three markdown render sites: assistant messages, user messages, and plan approval cards

## Test plan
- [x] Paste a bare `slack://channel?team=T0DHZBP3N&id=C0ANV2QNBPC` URL in chat — should render as a clickable link
- [x] Verify `[Open in Slack](slack://channel?team=...)` markdown links render and open correctly
- [x] Verify `vscode://`, `figma://`, `linear://` URLs also work
- [x] Verify regular `https://` links still work as before
- [ ] Verify `javascript:` and other dangerous protocols are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)