### PR TITLE
perf(desktop): optimize Zustand selectors and add React.memo

### DIFF
--- a/.changeset/perf-react-selectors.md
+++ b/.changeset/perf-react-selectors.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Optimize Zustand store selectors and add React.memo to list components to reduce re-renders

--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Settings, HelpCircle, ListChecks } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 import { usePluginLayoutStore, useSettingsStore } from '../store';
 import { PluginIcon } from './plugins/PluginIcon';
 import { RailButton, RailSection } from './zone/RailSection';
 
 export function LeftRail(): React.ReactElement {
-  const fullviewContributions = usePluginLayoutStore((s) => s.contributions.filter((c) => c.zone === 'fullview'));
+  const fullviewContributions = usePluginLayoutStore(
+    useShallow((s) => s.contributions.filter((c) => c.zone === 'fullview')),
+  );
   const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
 
   return (

--- a/packages/desktop/src/renderer/components/LeftRail.tsx
+++ b/packages/desktop/src/renderer/components/LeftRail.tsx
@@ -5,7 +5,7 @@ import { PluginIcon } from './plugins/PluginIcon';
 import { RailButton, RailSection } from './zone/RailSection';
 
 export function LeftRail(): React.ReactElement {
-  const fullviewContributions = usePluginLayoutStore((s) => s.contributions).filter((c) => c.zone === 'fullview');
+  const fullviewContributions = usePluginLayoutStore((s) => s.contributions.filter((c) => c.zone === 'fullview'));
   const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
 
   return (

--- a/packages/desktop/src/renderer/components/center/CenterPanel.tsx
+++ b/packages/desktop/src/renderer/components/center/CenterPanel.tsx
@@ -27,9 +27,11 @@ function ChatTabDot({ chatId }: { chatId: string }): React.ReactElement {
 }
 
 export function CenterPanel(): React.ReactElement {
-  const { tabs, activePrimaryTabId } = useTabsStore();
+  const tabs = useTabsStore((s) => s.tabs);
+  const activePrimaryTabId = useTabsStore((s) => s.activePrimaryTabId);
   const activeProjectId = useActiveProjectId();
-  const { activeChatId, addPendingPermission } = useChatsStore();
+  const activeChatId = useChatsStore((s) => s.activeChatId);
+  const addPendingPermission = useChatsStore((s) => s.addPendingPermission);
   const { createChat } = useProject(activeProjectId);
 
   React.useEffect(() => {

--- a/packages/desktop/src/renderer/components/panels/FilesTab.tsx
+++ b/packages/desktop/src/renderer/components/panels/FilesTab.tsx
@@ -28,28 +28,35 @@ interface ContextMenuState {
   items: ContextMenuItem[];
 }
 
+interface FileTreeNodeProps {
+  entry: FileEntry;
+  depth: number;
+  projectPath: string;
+  activeProjectId: string | null;
+  activeChatId: string | null;
+  revealPath: string | null;
+  onContextMenu: (e: React.MouseEvent, entryPath: string, entryType: 'file' | 'directory') => void;
+  onOpenEditorTab: (path: string) => void;
+  onToggleTreePath: (path: string) => void;
+  onClearRevealPath: () => void;
+  refreshKey: number;
+}
+
 function FileTreeNode({
   entry,
   depth,
   projectPath,
+  activeProjectId,
+  activeChatId,
+  revealPath,
   onContextMenu,
+  onOpenEditorTab,
+  onToggleTreePath,
+  onClearRevealPath,
   refreshKey,
-}: {
-  entry: FileEntry;
-  depth: number;
-  projectPath: string;
-  onContextMenu: (e: React.MouseEvent, entryPath: string, entryType: 'file' | 'directory') => void;
-  refreshKey: number;
-}): React.ReactElement {
+}: FileTreeNodeProps): React.ReactElement {
   const [children, setChildren] = useState<FileEntry[]>([]);
-  const activeProjectId = useActiveProjectId();
-  const activeChatId = useChatsStore((s) => s.activeChatId);
-  const openEditorTab = useTabsStore((s) => s.openEditorTab);
   const expanded = useTabsStore((s) => entry.type === 'directory' && s.expandedPaths.includes(entry.path));
-  const toggleTreePath = useTabsStore((s) => s.toggleTreePath);
-  const revealPath = useTabsStore((s) => s.revealPath);
-  const clearRevealPath = useTabsStore((s) => s.clearRevealPath);
-
   const isActive = useTabsStore(
     (s) => entry.type === 'file' && s.fileView?.type === 'editor' && s.fileView.filePath === entry.path,
   );
@@ -76,15 +83,15 @@ function FileTreeNode({
   useEffect(() => {
     if (revealPath === entry.path && nodeRef.current) {
       nodeRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      clearRevealPath();
+      onClearRevealPath();
     }
-  }, [revealPath, entry.path, clearRevealPath]);
+  }, [revealPath, entry.path, onClearRevealPath]);
 
   const handleClick = (): void => {
     if (entry.type === 'directory') {
-      toggleTreePath(entry.path);
+      onToggleTreePath(entry.path);
     } else {
-      openEditorTab(entry.path);
+      onOpenEditorTab(entry.path);
     }
   };
 
@@ -130,7 +137,13 @@ function FileTreeNode({
             entry={child}
             depth={depth + 1}
             projectPath={projectPath}
+            activeProjectId={activeProjectId}
+            activeChatId={activeChatId}
+            revealPath={revealPath}
             onContextMenu={onContextMenu}
+            onOpenEditorTab={onOpenEditorTab}
+            onToggleTreePath={onToggleTreePath}
+            onClearRevealPath={onClearRevealPath}
             refreshKey={refreshKey}
           />
         ))}
@@ -140,13 +153,15 @@ function FileTreeNode({
 
 export function FilesTab(): React.ReactElement {
   const activeProjectId = useActiveProjectId();
-  const { projects } = useProjectsStore();
+  const activeProject = useProjectsStore((s) => s.projects.find((p) => p.id === activeProjectId));
   const activeChatId = useChatsStore((s) => s.activeChatId);
-  const activeProject = projects.find((p) => p.id === activeProjectId);
-  const activeChat = useChatsStore((s) => s.chats.find((c) => c.id === s.activeChatId));
+  const activeChatWorktreePath = useChatsStore((s) => s.chats.find((c) => c.id === s.activeChatId)?.worktreePath);
   const [rootEntries, setRootEntries] = useState<FileEntry[]>([]);
   const rootExpanded = useTabsStore((s) => s.expandedPaths.includes('.'));
   const toggleTreePath = useTabsStore((s) => s.toggleTreePath);
+  const revealPath = useTabsStore((s) => s.revealPath);
+  const openEditorTab = useTabsStore((s) => s.openEditorTab);
+  const clearRevealPath = useTabsStore((s) => s.clearRevealPath);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [findInPath, setFindInPath] = useState<{ scopePath: string; scopeType: 'file' | 'directory' } | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -230,7 +245,7 @@ export function FilesTab(): React.ReactElement {
     return <div className="text-mf-small text-mf-text-secondary text-center py-4">No project selected</div>;
   }
 
-  const displayPath = activeChat?.worktreePath ?? activeProject.path;
+  const displayPath = activeChatWorktreePath ?? activeProject.path;
 
   return (
     <>
@@ -273,7 +288,13 @@ export function FilesTab(): React.ReactElement {
                 entry={entry}
                 depth={1}
                 projectPath={activeProject.path}
+                activeProjectId={activeProjectId}
+                activeChatId={activeChatId}
+                revealPath={revealPath}
                 onContextMenu={handleContextMenu}
+                onOpenEditorTab={openEditorTab}
+                onToggleTreePath={toggleTreePath}
+                onClearRevealPath={clearRevealPath}
                 refreshKey={refreshKey}
               />
             ))}

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -37,7 +37,7 @@ interface FlatSessionRowProps {
   unregisterRenameCallback?: (chatId: string) => void;
 }
 
-export function FlatSessionRow({
+export const FlatSessionRow = React.memo(function FlatSessionRow({
   chat,
   projectName,
   onContextMenu,
@@ -246,4 +246,4 @@ export function FlatSessionRow({
       </div>
     </div>
   );
-}
+});

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -245,7 +245,7 @@ interface ProjectGroupProps {
   unregisterRenameCallback?: (chatId: string) => void;
 }
 
-export function ProjectGroup({
+export const ProjectGroup = React.memo(function ProjectGroup({
   project,
   chats,
   parentName,
@@ -388,4 +388,4 @@ export function ProjectGroup({
       )}
     </div>
   );
-}
+});

--- a/packages/desktop/src/renderer/components/todos/TodoCard.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodoCard.tsx
@@ -30,7 +30,13 @@ interface Props {
   onStartSession: (todo: Todo) => void;
 }
 
-export function TodoCard({ todo, attachmentCount, onEdit, onDelete, onStartSession }: Props): React.ReactElement {
+export const TodoCard = React.memo(function TodoCard({
+  todo,
+  attachmentCount,
+  onEdit,
+  onDelete,
+  onStartSession,
+}: Props): React.ReactElement {
   return (
     <div
       data-testid="todo-card"
@@ -139,4 +145,4 @@ export function TodoCard({ todo, attachmentCount, onEdit, onDelete, onStartSessi
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
- **#91** Fix re-render waste across the desktop app:
  - `CenterPanel`: replace full-store destructuring with individual selectors
  - `FlatSessionRow`, `ProjectGroup`, `TodoCard`: wrap with `React.memo`
  - `FilesTab`: reduce `FileTreeNode` from 6 store subscriptions to 2 (pass stable props from parent)
  - `LeftRail`: move `.filter()` inside Zustand selectors
  - `FilesTab`: replace `.chats.find()` with primitive selectors

## Test plan
- [x] Session list renders without visual regression
- [ ] File tree expands/collapses correctly
- [x] Todo cards update status correctly
- [ ] No console errors or React warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)