### PR TITLE
feat(core,desktop): detect GitHub PRs created during sessions and display a PR badge

### DIFF
--- a/.changeset/detect-session-prs.md
+++ b/.changeset/detect-session-prs.md
@@ -4,4 +4,4 @@
 "@qlan-ro/mainframe-desktop": minor
 ---
 
-Detect GitHub PRs created during sessions and display a PR badge in the chat header
+Detect GitHub PRs created during sessions and display a PR badge in the chat header. Distinguish created vs mentioned PRs using command-level detection (gh pr create, glab mr create, az repos pr create). Created PRs get a green badge and session list icon; mentioned PRs get a muted badge.

--- a/.changeset/detect-session-prs.md
+++ b/.changeset/detect-session-prs.md
@@ -1,0 +1,7 @@
+---
+"@qlan-ro/mainframe-types": minor
+"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-desktop": minor
+---
+
+Detect GitHub PRs created during sessions and display a PR badge in the chat header

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -344,7 +344,7 @@ function buildSessionSink(
       emitEvent({ type: 'todos.updated', chatId, todos });
     },
 
-    onPrDetected(pr: { url: string; owner: string; repo: string; number: number }) {
+    onPrDetected(pr: import('@qlan-ro/mainframe-types').DetectedPr) {
       emitEvent({ type: 'chat.prDetected', chatId, pr });
     },
 

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -344,6 +344,10 @@ function buildSessionSink(
       emitEvent({ type: 'todos.updated', chatId, todos });
     },
 
+    onPrDetected(pr: { url: string; owner: string; repo: string; number: number }) {
+      emitEvent({ type: 'chat.prDetected', chatId, pr });
+    },
+
     onError(error: Error) {
       emitEvent({ type: 'error', chatId, error: error.message });
     },

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -343,7 +343,7 @@ export class ChatLifecycleManager {
             const key = `${pr.owner}/${pr.repo}/${pr.number}`;
             if (seenPrs.has(key)) continue;
             seenPrs.add(key);
-            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr });
+            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr: { ...pr, source: 'mentioned' } });
           }
         }
       }

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -358,7 +358,7 @@ export class ChatLifecycleManager {
             const key = `${pr.owner}/${pr.repo}/${pr.number}`;
             if (seenPrs.has(key)) continue;
             seenPrs.add(key);
-            const toolUseId = (block as Record<string, unknown>).tool_use_id as string | undefined;
+            const toolUseId = (block as Record<string, unknown>).toolUseId as string | undefined;
             const source = toolUseId && pendingCreates.has(toolUseId) ? ('created' as const) : ('mentioned' as const);
             if (source === 'created') pendingCreates.delete(toolUseId!);
             this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr: { ...pr, source } });

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -11,6 +11,7 @@ const execFileAsync = promisify(execFileCb);
 import { createChildLogger } from '../logger.js';
 import { generateTitle } from './title-generator.js';
 import { extractMentionsFromText } from './context-tracker.js';
+import { parsePrUrl } from '../plugins/builtin/claude/events.js';
 import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { ActiveChat } from './types.js';
@@ -326,6 +327,23 @@ export class ChatLifecycleManager {
             // Skip command/skill injections — they contain example @-patterns
             if (/<mainframe-command|<command-name>/.test(text)) continue;
             extractMentionsFromText(chatId, text, this.deps.db);
+          }
+        }
+
+        // Scan tool_result blocks in history for PR URLs so old sessions
+        // also display the PR badge after a daemon restart.
+        const seenPrs = new Set<string>();
+        for (const msg of cached) {
+          if (msg.type !== 'tool_result') continue;
+          for (const block of msg.content) {
+            if (block.type !== 'tool_result') continue;
+            const text = typeof block.content === 'string' ? block.content : '';
+            const pr = parsePrUrl(text);
+            if (!pr) continue;
+            const key = `${pr.owner}/${pr.repo}/${pr.number}`;
+            if (seenPrs.has(key)) continue;
+            seenPrs.add(key);
+            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr });
           }
         }
       }

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -11,7 +11,7 @@ const execFileAsync = promisify(execFileCb);
 import { createChildLogger } from '../logger.js';
 import { generateTitle } from './title-generator.js';
 import { extractMentionsFromText } from './context-tracker.js';
-import { parsePrUrl } from '../plugins/builtin/claude/events.js';
+import { extractPrFromToolResult, PR_CREATE_COMMANDS } from '../plugins/builtin/claude/events.js';
 import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { ActiveChat } from './types.js';
@@ -330,20 +330,38 @@ export class ChatLifecycleManager {
           }
         }
 
-        // Scan tool_result blocks in history for PR URLs so old sessions
-        // also display the PR badge after a daemon restart.
+        // Scan history for PR URLs with command-level correlation.
+        // Walk messages in order: assistant tool_use blocks identify PR-create
+        // commands; subsequent tool_result blocks with PR URLs are classified.
         const seenPrs = new Set<string>();
+        const pendingCreates = new Set<string>();
         for (const msg of cached) {
+          if (msg.type === 'assistant') {
+            for (const block of msg.content) {
+              if (block.type === 'tool_use') {
+                const name = (block as Record<string, unknown>).name as string | undefined;
+                if (name === 'Bash' || name === 'BashTool') {
+                  const input = (block as Record<string, unknown>).input as { command?: string } | undefined;
+                  if (input?.command && PR_CREATE_COMMANDS.some((re) => re.test(input.command!))) {
+                    pendingCreates.add((block as Record<string, unknown>).id as string);
+                  }
+                }
+              }
+            }
+          }
           if (msg.type !== 'tool_result') continue;
           for (const block of msg.content) {
             if (block.type !== 'tool_result') continue;
             const text = typeof block.content === 'string' ? block.content : '';
-            const pr = parsePrUrl(text);
+            const pr = extractPrFromToolResult(text);
             if (!pr) continue;
             const key = `${pr.owner}/${pr.repo}/${pr.number}`;
             if (seenPrs.has(key)) continue;
             seenPrs.add(key);
-            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr: { ...pr, source: 'mentioned' } });
+            const toolUseId = (block as Record<string, unknown>).tool_use_id as string | undefined;
+            const source = toolUseId && pendingCreates.has(toolUseId) ? ('created' as const) : ('mentioned' as const);
+            if (source === 'created') pendingCreates.delete(toolUseId!);
+            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr: { ...pr, source } });
           }
         }
       }

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SessionSink } from '@qlan-ro/mainframe-types';
-import { handleStdout, parsePrUrl, PR_URL_REGEX } from '../events.js';
+import {
+  handleStdout,
+  parsePrUrl,
+  parseAzurePrUrl,
+  extractPrFromToolResult,
+  PR_URL_REGEX,
+  AZURE_PR_URL_REGEX,
+  PR_CREATE_COMMANDS,
+} from '../events.js';
 import type { ClaudeSession } from '../session.js';
 
 function createMockSink(): SessionSink {
@@ -33,6 +41,7 @@ function createMockSession(): ClaudeSession {
       lastAssistantUsage: undefined,
       activeTasks: new Map(),
       pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
     },
     clearInterruptTimer: vi.fn(),
     requestContextUsage: vi.fn(),
@@ -54,6 +63,18 @@ describe('PR_URL_REGEX', () => {
   it('matches PR URL embedded in surrounding text', () => {
     const text = 'Pull request created at https://github.com/foo/bar/pull/42 — done!';
     expect(PR_URL_REGEX.test(text)).toBe(true);
+  });
+});
+
+describe('AZURE_PR_URL_REGEX', () => {
+  it('matches an Azure DevOps PR URL', () => {
+    const url = 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/42';
+    expect(AZURE_PR_URL_REGEX.test(url)).toBe(true);
+  });
+
+  it('does not match other Azure URLs', () => {
+    expect(AZURE_PR_URL_REGEX.test('https://dev.azure.com/myorg/myproject/_git/myrepo/commit/abc')).toBe(false);
+    expect(AZURE_PR_URL_REGEX.test('https://dev.azure.com/myorg')).toBe(false);
   });
 });
 
@@ -81,35 +102,207 @@ describe('parsePrUrl', () => {
   });
 });
 
-describe('PR detection via handleStdout', () => {
-  it('calls sink.onPrDetected when tool_result contains a GitHub PR URL', () => {
+describe('parseAzurePrUrl', () => {
+  it('parses an Azure DevOps PR URL', () => {
+    const result = parseAzurePrUrl('https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/42');
+    expect(result).toEqual({
+      url: 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/42',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 42,
+    });
+  });
+
+  it('returns null for non-matching text', () => {
+    expect(parseAzurePrUrl('https://github.com/owner/repo/pull/1')).toBeNull();
+    expect(parseAzurePrUrl('no URL here')).toBeNull();
+  });
+});
+
+describe('command-level PR detection', () => {
+  it('detects source: created when gh pr create tool_use precedes tool_result with PR URL', () => {
     const sink = createMockSink();
     const session = createMockSession();
 
-    const event = {
+    // Step 1: assistant event with gh pr create tool_use
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_pr_1',
+            name: 'Bash',
+            input: { command: 'gh pr create --title "feat" --body "desc"' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+
+    // Verify tool_use_id was stashed
+    expect(session.state.pendingPrCreates.has('tu_pr_1')).toBe(true);
+
+    // Step 2: user event with tool_result containing PR URL
+    const userEvent = {
       type: 'user',
       message: {
         content: [
           {
             type: 'tool_result',
-            tool_use_id: 'tu_1',
-            content: 'Pull request created: https://github.com/myorg/myrepo/pull/99',
+            tool_use_id: 'tu_pr_1',
+            content: 'https://github.com/myorg/myrepo/pull/99',
           },
         ],
       },
     };
-
-    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
 
     expect(sink.onPrDetected).toHaveBeenCalledWith({
       url: 'https://github.com/myorg/myrepo/pull/99',
       owner: 'myorg',
       repo: 'myrepo',
       number: 99,
+      source: 'created',
+    });
+
+    // pendingPrCreates should be consumed
+    expect(session.state.pendingPrCreates.has('tu_pr_1')).toBe(false);
+  });
+
+  it('detects source: mentioned when no matching tool_use preceded tool_result', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_other',
+            content: 'See https://github.com/myorg/myrepo/pull/50 for context',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/myorg/myrepo/pull/50',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 50,
+      source: 'mentioned',
     });
   });
 
-  it('does not call sink.onPrDetected when tool_result has no PR URL', () => {
+  it('stashes tool_use_id for glab mr create', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_gl_1',
+            name: 'BashTool',
+            input: { command: 'glab mr create --fill' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrCreates.has('tu_gl_1')).toBe(true);
+  });
+
+  it('stashes tool_use_id for az repos pr create', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_az_1',
+            name: 'Bash',
+            input: { command: 'az repos pr create --source-branch feat --target-branch main' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrCreates.has('tu_az_1')).toBe(true);
+  });
+
+  it('parses Azure DevOps URL in tool_result', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    // Stash the az command
+    session.state.pendingPrCreates.add('tu_az_2');
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_az_2',
+            content: 'Created: https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/7',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/7',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 7,
+      source: 'created',
+    });
+  });
+
+  it('parses Azure JSON output with pullRequestId', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    session.state.pendingPrCreates.add('tu_az_3');
+
+    const jsonOutput =
+      '{"pullRequestId": 42, "name": "my-repo", "url": "https://dev.azure.com/myorg/myproject/_apis/git/repositories/my-repo/pullRequests/42"}';
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_az_3',
+            content: jsonOutput,
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        number: 42,
+        repo: 'my-repo',
+        source: 'created',
+      }),
+    );
+  });
+
+  it('does not call onPrDetected when tool_result has no PR URL', () => {
     const sink = createMockSink();
     const session = createMockSession();
 
@@ -125,31 +318,52 @@ describe('PR detection via handleStdout', () => {
         ],
       },
     };
-
     handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
 
     expect(sink.onPrDetected).not.toHaveBeenCalled();
   });
 
-  it('does not call sink.onPrDetected for non-PR GitHub URLs in tool_result', () => {
+  it('does not stash tool_use_id for non-Bash tools', () => {
     const sink = createMockSink();
     const session = createMockSession();
 
     const event = {
-      type: 'user',
+      type: 'assistant',
       message: {
         content: [
           {
-            type: 'tool_result',
-            tool_use_id: 'tu_1',
-            content: 'See https://github.com/org/repo/issues/5 for context',
+            type: 'tool_use',
+            id: 'tu_edit_1',
+            name: 'Edit',
+            input: { command: 'gh pr create' },
           },
         ],
       },
     };
-
     handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
 
-    expect(sink.onPrDetected).not.toHaveBeenCalled();
+    expect(session.state.pendingPrCreates.size).toBe(0);
+  });
+
+  it('does not stash tool_use_id for non-create gh commands', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_view_1',
+            name: 'Bash',
+            input: { command: 'gh pr view 123' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrCreates.size).toBe(0);
   });
 });

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -4,9 +4,11 @@ import {
   handleStdout,
   parsePrUrl,
   parseAzurePrUrl,
+  parseGitlabMrUrl,
   extractPrFromToolResult,
   PR_URL_REGEX,
   AZURE_PR_URL_REGEX,
+  GITLAB_MR_URL_REGEX,
   PR_CREATE_COMMANDS,
 } from '../events.js';
 import type { ClaudeSession } from '../session.js';
@@ -116,6 +118,66 @@ describe('parseAzurePrUrl', () => {
   it('returns null for non-matching text', () => {
     expect(parseAzurePrUrl('https://github.com/owner/repo/pull/1')).toBeNull();
     expect(parseAzurePrUrl('no URL here')).toBeNull();
+  });
+});
+
+describe('GITLAB_MR_URL_REGEX', () => {
+  it('matches a GitLab MR URL', () => {
+    const url = 'https://gitlab.com/mygroup/myrepo/-/merge_requests/42';
+    expect(GITLAB_MR_URL_REGEX.test(url)).toBe(true);
+  });
+
+  it('does not match other GitLab URLs', () => {
+    expect(GITLAB_MR_URL_REGEX.test('https://gitlab.com/mygroup/myrepo/-/issues/1')).toBe(false);
+    expect(GITLAB_MR_URL_REGEX.test('https://gitlab.com/mygroup')).toBe(false);
+  });
+});
+
+describe('parseGitlabMrUrl', () => {
+  it('parses a GitLab MR URL', () => {
+    const result = parseGitlabMrUrl('https://gitlab.com/acme/backend/-/merge_requests/99');
+    expect(result).toEqual({
+      url: 'https://gitlab.com/acme/backend/-/merge_requests/99',
+      owner: 'acme',
+      repo: 'backend',
+      number: 99,
+    });
+  });
+
+  it('returns null for non-matching text', () => {
+    expect(parseGitlabMrUrl('https://github.com/owner/repo/pull/1')).toBeNull();
+    expect(parseGitlabMrUrl('no URL here')).toBeNull();
+  });
+});
+
+describe('extractPrFromToolResult', () => {
+  it('extracts GitHub PR URL', () => {
+    const result = extractPrFromToolResult('Created https://github.com/acme/repo/pull/7');
+    expect(result).toEqual({ url: 'https://github.com/acme/repo/pull/7', owner: 'acme', repo: 'repo', number: 7 });
+  });
+
+  it('extracts GitLab MR URL', () => {
+    const result = extractPrFromToolResult('Created https://gitlab.com/acme/backend/-/merge_requests/99');
+    expect(result).toEqual({
+      url: 'https://gitlab.com/acme/backend/-/merge_requests/99',
+      owner: 'acme',
+      repo: 'backend',
+      number: 99,
+    });
+  });
+
+  it('extracts Azure DevOps PR URL', () => {
+    const result = extractPrFromToolResult('https://dev.azure.com/myorg/proj/_git/myrepo/pullrequest/5');
+    expect(result).toEqual({
+      url: 'https://dev.azure.com/myorg/proj/_git/myrepo/pullrequest/5',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 5,
+    });
+  });
+
+  it('returns null for text without PR URLs', () => {
+    expect(extractPrFromToolResult('just some output')).toBeNull();
   });
 });
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+import { handleStdout, parsePrUrl, PR_URL_REGEX } from '../events.js';
+import type { ClaudeSession } from '../session.js';
+
+function createMockSink(): SessionSink {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: vi.fn(),
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+  };
+}
+
+function createMockSession(): ClaudeSession {
+  return {
+    id: 'test-session',
+    state: {
+      buffer: '',
+      chatId: null,
+      status: 'ready',
+      lastAssistantUsage: undefined,
+      activeTasks: new Map(),
+      pendingCancelCallbacks: new Map(),
+    },
+    clearInterruptTimer: vi.fn(),
+    requestContextUsage: vi.fn(),
+  } as unknown as ClaudeSession;
+}
+
+describe('PR_URL_REGEX', () => {
+  it('matches a standard GitHub PR URL', () => {
+    const url = 'https://github.com/owner/repo/pull/123';
+    expect(PR_URL_REGEX.test(url)).toBe(true);
+  });
+
+  it('does not match a non-PR GitHub URL', () => {
+    expect(PR_URL_REGEX.test('https://github.com/owner/repo/issues/123')).toBe(false);
+    expect(PR_URL_REGEX.test('https://github.com/owner/repo')).toBe(false);
+    expect(PR_URL_REGEX.test('https://example.com/pull/123')).toBe(false);
+  });
+
+  it('matches PR URL embedded in surrounding text', () => {
+    const text = 'Pull request created at https://github.com/foo/bar/pull/42 — done!';
+    expect(PR_URL_REGEX.test(text)).toBe(true);
+  });
+});
+
+describe('parsePrUrl', () => {
+  it('parses a valid PR URL into structured data', () => {
+    const result = parsePrUrl('https://github.com/acme/my-repo/pull/456');
+    expect(result).toEqual({
+      url: 'https://github.com/acme/my-repo/pull/456',
+      owner: 'acme',
+      repo: 'my-repo',
+      number: 456,
+    });
+  });
+
+  it('returns null for non-matching text', () => {
+    expect(parsePrUrl('https://github.com/owner/repo/issues/10')).toBeNull();
+    expect(parsePrUrl('no URL here')).toBeNull();
+  });
+
+  it('extracts the first PR URL when multiple are present', () => {
+    const text = 'https://github.com/org/alpha/pull/1 and https://github.com/org/beta/pull/2';
+    const result = parsePrUrl(text);
+    expect(result?.repo).toBe('alpha');
+    expect(result?.number).toBe(1);
+  });
+});
+
+describe('PR detection via handleStdout', () => {
+  it('calls sink.onPrDetected when tool_result contains a GitHub PR URL', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_1',
+            content: 'Pull request created: https://github.com/myorg/myrepo/pull/99',
+          },
+        ],
+      },
+    };
+
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/myorg/myrepo/pull/99',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 99,
+    });
+  });
+
+  it('does not call sink.onPrDetected when tool_result has no PR URL', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_1',
+            content: 'Command ran successfully with exit code 0',
+          },
+        ],
+      },
+    };
+
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(sink.onPrDetected).not.toHaveBeenCalled();
+  });
+
+  it('does not call sink.onPrDetected for non-PR GitHub URLs in tool_result', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_1',
+            content: 'See https://github.com/org/repo/issues/5 for context',
+          },
+        ],
+      },
+    };
+
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(sink.onPrDetected).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
@@ -19,6 +19,7 @@ function createMockSink(): SessionSink {
     onSkillFile: vi.fn(),
     onQueuedProcessed: vi.fn(),
     onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -12,6 +12,18 @@ import { createChildLogger } from '../../../logger.js';
 
 const log = createChildLogger('claude:events');
 
+export const PR_URL_REGEX = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/;
+
+export function parsePrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
+  const match = PR_URL_REGEX.exec(text);
+  if (!match) return null;
+  const owner = match[1];
+  const repo = match[2];
+  const number = parseInt(match[3]!, 10);
+  if (!owner || !repo || isNaN(number)) return null;
+  return { url: match[0], owner, repo, number };
+}
+
 export function handleStdout(session: ClaudeSession, chunk: Buffer, sink: SessionSink): void {
   session.state.buffer += chunk.toString();
   const lines = session.state.buffer.split('\n');
@@ -138,6 +150,10 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       const planMatch = text.match(/Your plan has been saved to: (\/\S+\.md)/);
       if (planMatch?.[1]) {
         sink.onPlanFile(planMatch[1].trim());
+      }
+      const pr = parsePrUrl(text);
+      if (pr) {
+        sink.onPrDetected(pr);
       }
     } else if (block.type === 'text') {
       const text = (block.text as string) || '';

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -14,6 +14,8 @@ const log = createChildLogger('claude:events');
 
 export const PR_URL_REGEX = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/;
 
+export const GITLAB_MR_URL_REGEX = /https:\/\/gitlab\.com\/([^/\s]+)\/([^/\s]+)\/-\/merge_requests\/(\d+)/;
+
 export const AZURE_PR_URL_REGEX = /https:\/\/dev\.azure\.com\/([^/\s]+)\/[^/\s]+\/_git\/([^/\s]+)\/pullrequest\/(\d+)/;
 
 const AZURE_PR_ID_REGEX = /"pullRequestId"\s*:\s*(\d+)/;
@@ -30,6 +32,16 @@ function isPrCreateCommand(command: string): boolean {
 
 export function parsePrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
   const match = PR_URL_REGEX.exec(text);
+  if (!match) return null;
+  const owner = match[1];
+  const repo = match[2];
+  const number = parseInt(match[3]!, 10);
+  if (!owner || !repo || isNaN(number)) return null;
+  return { url: match[0], owner, repo, number };
+}
+
+export function parseGitlabMrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
+  const match = GITLAB_MR_URL_REGEX.exec(text);
   if (!match) return null;
   const owner = match[1];
   const repo = match[2];
@@ -66,7 +78,7 @@ function parseAzurePrJson(text: string): { url: string; owner: string; repo: str
 export function extractPrFromToolResult(
   text: string,
 ): { url: string; owner: string; repo: string; number: number } | null {
-  return parsePrUrl(text) ?? parseAzurePrUrl(text) ?? parseAzurePrJson(text);
+  return parsePrUrl(text) ?? parseGitlabMrUrl(text) ?? parseAzurePrUrl(text) ?? parseAzurePrJson(text);
 }
 
 export function handleStdout(session: ClaudeSession, chunk: Buffer, sink: SessionSink): void {

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -14,6 +14,20 @@ const log = createChildLogger('claude:events');
 
 export const PR_URL_REGEX = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/;
 
+export const AZURE_PR_URL_REGEX = /https:\/\/dev\.azure\.com\/([^/\s]+)\/[^/\s]+\/_git\/([^/\s]+)\/pullrequest\/(\d+)/;
+
+const AZURE_PR_ID_REGEX = /"pullRequestId"\s*:\s*(\d+)/;
+
+export const PR_CREATE_COMMANDS: RegExp[] = [
+  /\bgh\s+pr\s+create\b/,
+  /\bglab\s+mr\s+create\b/,
+  /\baz\s+repos\s+pr\s+create\b/,
+];
+
+function isPrCreateCommand(command: string): boolean {
+  return PR_CREATE_COMMANDS.some((re) => re.test(command));
+}
+
 export function parsePrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
   const match = PR_URL_REGEX.exec(text);
   if (!match) return null;
@@ -22,6 +36,37 @@ export function parsePrUrl(text: string): { url: string; owner: string; repo: st
   const number = parseInt(match[3]!, 10);
   if (!owner || !repo || isNaN(number)) return null;
   return { url: match[0], owner, repo, number };
+}
+
+export function parseAzurePrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
+  const match = AZURE_PR_URL_REGEX.exec(text);
+  if (!match) return null;
+  const owner = match[1];
+  const repo = match[2];
+  const number = parseInt(match[3]!, 10);
+  if (!owner || !repo || isNaN(number)) return null;
+  return { url: match[0], owner, repo, number };
+}
+
+function parseAzurePrJson(text: string): { url: string; owner: string; repo: string; number: number } | null {
+  const idMatch = AZURE_PR_ID_REGEX.exec(text);
+  if (!idMatch) return null;
+  const number = parseInt(idMatch[1]!, 10);
+  if (isNaN(number)) return null;
+  const repoMatch = /"name"\s*:\s*"([^"]+)"/.exec(text);
+  const orgMatch = /dev\.azure\.com\/([^/"]+)/.exec(text);
+  return {
+    url: text.trim(),
+    owner: orgMatch?.[1] ?? 'azure',
+    repo: repoMatch?.[1] ?? 'unknown',
+    number,
+  };
+}
+
+export function extractPrFromToolResult(
+  text: string,
+): { url: string; owner: string; repo: string; number: number } | null {
+  return parsePrUrl(text) ?? parseAzurePrUrl(text) ?? parseAzurePrJson(text);
 }
 
 export function handleStdout(session: ClaudeSession, chunk: Buffer, sink: SessionSink): void {
@@ -94,17 +139,26 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
   }
   if (message?.content) {
     for (const block of message.content) {
-      if (block.type === 'tool_use' && block.name === 'TodoWrite') {
-        const input = block.input as { todos?: unknown[] };
-        if (Array.isArray(input?.todos)) {
-          const valid = input.todos.filter(
-            (t): t is import('@qlan-ro/mainframe-types').TodoItem =>
-              typeof t === 'object' &&
-              t !== null &&
-              typeof (t as Record<string, unknown>).content === 'string' &&
-              typeof (t as Record<string, unknown>).status === 'string',
-          );
-          if (valid.length > 0) sink.onTodoUpdate(valid);
+      if (block.type === 'tool_use') {
+        if (block.name === 'TodoWrite') {
+          const input = block.input as { todos?: unknown[] };
+          if (Array.isArray(input?.todos)) {
+            const valid = input.todos.filter(
+              (t): t is import('@qlan-ro/mainframe-types').TodoItem =>
+                typeof t === 'object' &&
+                t !== null &&
+                typeof (t as Record<string, unknown>).content === 'string' &&
+                typeof (t as Record<string, unknown>).status === 'string',
+            );
+            if (valid.length > 0) sink.onTodoUpdate(valid);
+          }
+        }
+        const name = block.name as string;
+        if (name === 'Bash' || name === 'BashTool') {
+          const input = block.input as { command?: string } | undefined;
+          if (input?.command && isPrCreateCommand(input.command)) {
+            session.state.pendingPrCreates.add(block.id as string);
+          }
         }
       }
     }
@@ -151,9 +205,12 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       if (planMatch?.[1]) {
         sink.onPlanFile(planMatch[1].trim());
       }
-      const pr = parsePrUrl(text);
+      const pr = extractPrFromToolResult(text);
       if (pr) {
-        sink.onPrDetected(pr);
+        const toolUseId = block.tool_use_id as string | undefined;
+        const source = toolUseId && session.state.pendingPrCreates.has(toolUseId) ? 'created' : 'mentioned';
+        if (source === 'created') session.state.pendingPrCreates.delete(toolUseId!);
+        sink.onPrDetected({ ...pr, source });
       }
     } else if (block.type === 'text') {
       const text = (block.text as string) || '';

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -61,6 +61,8 @@ export interface ClaudeSessionState {
   interruptTimer: ReturnType<typeof setTimeout> | null;
   /** Pending cancel_async_message callbacks keyed by request_id */
   pendingCancelCallbacks: Map<string, (cancelled: boolean) => void>;
+  /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
+  pendingPrCreates: Set<string>;
 }
 
 /**
@@ -98,6 +100,7 @@ export class ClaudeSession implements AdapterSession {
       activeTasks: new Map(),
       interruptTimer: null,
       pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
     };
   }
 

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -42,6 +42,7 @@ const nullSink: SessionSink = {
   onSkillFile: () => {},
   onQueuedProcessed: () => {},
   onTodoUpdate: () => {},
+  onPrDetected: () => {},
 };
 
 export interface ClaudeSessionState {

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -49,6 +49,7 @@ const nullSink: SessionSink = {
   onSkillFile: () => {},
   onQueuedProcessed: () => {},
   onTodoUpdate: () => {},
+  onPrDetected: () => {},
 };
 
 export class CodexSession implements AdapterSession {

--- a/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
+++ b/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
@@ -5,6 +5,7 @@ import { useAdaptersStore } from '../../store/adapters';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { getAdapterLabel, getModelContextWindow, getModelLabel } from '../../lib/adapters';
+import { PrBadge } from './PrBadge';
 
 const ADAPTER_ACCENT: Record<string, string> = {
   claude: 'bg-mf-accent-claude',
@@ -143,6 +144,8 @@ export function ChatSessionBar({ chatId }: ChatSessionBarProps): React.ReactElem
             </div>
           </>
         )}
+
+        <PrBadge chatId={chatId} />
       </div>
 
       {/* Center: status */}

--- a/packages/desktop/src/renderer/components/chat/PrBadge.tsx
+++ b/packages/desktop/src/renderer/components/chat/PrBadge.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { GitPullRequest } from 'lucide-react';
+import { useChatsStore } from '../../store/chats';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
+
+interface PrBadgeProps {
+  chatId: string;
+}
+
+function openUrl(url: string): void {
+  if (window.electron?.openExternal) {
+    window.electron.openExternal(url).catch((err: unknown) => {
+      console.warn('[PrBadge] openExternal failed', err);
+    });
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
+
+export function PrBadge({ chatId }: PrBadgeProps): React.ReactElement | null {
+  const prs = useChatsStore((s) => s.detectedPrs.get(chatId));
+
+  if (!prs || prs.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1">
+      {prs.map((pr) => (
+        <Tooltip key={`${pr.owner}/${pr.repo}/${pr.number}`}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => openUrl(pr.url)}
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a7f37] text-white hover:bg-[#2ea043] transition-colors"
+              aria-label={`Open PR #${pr.number} in ${pr.owner}/${pr.repo}`}
+            >
+              <GitPullRequest size={10} className="shrink-0" />
+              <span>#{pr.number}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {pr.owner}/{pr.repo} #{pr.number}
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/chat/PrBadge.tsx
+++ b/packages/desktop/src/renderer/components/chat/PrBadge.tsx
@@ -30,7 +30,11 @@ export function PrBadge({ chatId }: PrBadgeProps): React.ReactElement | null {
             <button
               type="button"
               onClick={() => openUrl(pr.url)}
-              className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a7f37] text-white hover:bg-[#2ea043] transition-colors"
+              className={
+                pr.source === 'created'
+                  ? 'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a7f37] text-white hover:bg-[#2ea043] transition-colors'
+                  : 'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-mf-text-secondary opacity-40 text-white hover:opacity-60 transition-colors'
+              }
               aria-label={`Open PR #${pr.number} in ${pr.owner}/${pr.repo}`}
             >
               <GitPullRequest size={10} className="shrink-0" />

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -115,9 +115,9 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const isUnread = unreadChatIds.has(chat.id);
-  const hasCreatedPr = useChatsStore((s) => {
+  const createdPrUrl = useChatsStore((s) => {
     const prs = s.detectedPrs.get(chat.id);
-    return prs?.some((p) => p.source === 'created') ?? false;
+    return prs?.find((p) => p.source === 'created')?.url ?? null;
   });
 
   const handleCommitRename = useCallback(() => {
@@ -165,6 +165,24 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1">
+              {createdPrUrl && !editing && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        window.open(createdPrUrl, '_blank');
+                      }}
+                      className="w-5 h-5 shrink-0 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
+                      aria-label="Open PR"
+                    >
+                      <GitPullRequest size={13} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Open PR</TooltipContent>
+                </Tooltip>
+              )}
               {editing ? (
                 <input
                   ref={inputRef}
@@ -185,9 +203,6 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
                 >
                   {chat.title || 'Untitled session'}
                 </div>
-              )}
-              {hasCreatedPr && !editing && (
-                <GitPullRequest size={12} className="shrink-0 text-[#1a7f37]" aria-label="Has created PR" />
               )}
             </div>
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Archive, FolderOpen, GitBranch, Clock, Loader2, Pencil } from 'lucide-react';
+import { Archive, FolderOpen, GitBranch, GitPullRequest, Clock, Loader2, Pencil } from 'lucide-react';
 import type { Chat } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
@@ -115,6 +115,10 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const isUnread = unreadChatIds.has(chat.id);
+  const hasCreatedPr = useChatsStore((s) => {
+    const prs = s.detectedPrs.get(chat.id);
+    return prs?.some((p) => p.source === 'created') ?? false;
+  });
 
   const handleCommitRename = useCallback(() => {
     setEditing(false);
@@ -160,27 +164,32 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
             )}
           </div>
           <div className="flex-1 min-w-0">
-            {editing ? (
-              <input
-                ref={inputRef}
-                value={editTitle}
-                onChange={(e) => setEditTitle(e.target.value)}
-                onBlur={handleCommitRename}
-                onKeyDown={handleRenameKeyDown}
-                onClick={(e) => e.stopPropagation()}
-                className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
-              />
-            ) : (
-              <div
-                className={cn(
-                  'text-mf-small truncate',
-                  isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                  isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                )}
-              >
-                {chat.title || 'Untitled session'}
-              </div>
-            )}
+            <div className="flex items-center gap-1">
+              {editing ? (
+                <input
+                  ref={inputRef}
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  onBlur={handleCommitRename}
+                  onKeyDown={handleRenameKeyDown}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
+                />
+              ) : (
+                <div
+                  className={cn(
+                    'text-mf-small truncate',
+                    isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                    isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+                  )}
+                >
+                  {chat.title || 'Untitled session'}
+                </div>
+              )}
+              {hasCreatedPr && !editing && (
+                <GitPullRequest size={12} className="shrink-0 text-[#1a7f37]" aria-label="Has created PR" />
+              )}
+            </div>
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">
               {projectName && (
                 <>

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -115,9 +115,9 @@ function ChatRow({
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const isUnread = unreadChatIds.has(chat.id);
-  const hasCreatedPr = useChatsStore((s) => {
+  const createdPrUrl = useChatsStore((s) => {
     const prs = s.detectedPrs.get(chat.id);
-    return prs?.some((p) => p.source === 'created') ?? false;
+    return prs?.find((p) => p.source === 'created')?.url ?? null;
   });
 
   const handleCommitRename = useCallback(() => {
@@ -160,6 +160,24 @@ function ChatRow({
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1">
+              {createdPrUrl && !editing && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        window.open(createdPrUrl, '_blank');
+                      }}
+                      className="w-5 h-5 shrink-0 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
+                      aria-label="Open PR"
+                    >
+                      <GitPullRequest size={13} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Open PR</TooltipContent>
+                </Tooltip>
+              )}
               {editing ? (
                 <input
                   ref={inputRef}
@@ -186,9 +204,6 @@ function ChatRow({
                   </TooltipTrigger>
                   <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
                 </Tooltip>
-              )}
-              {hasCreatedPr && !editing && (
-                <GitPullRequest size={12} className="shrink-0 text-[#1a7f37]" aria-label="Has created PR" />
               )}
             </div>
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -1,5 +1,16 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus, Archive, Pencil, ChevronDown, ChevronRight, Bot, GitBranch, Clock, Loader2 } from 'lucide-react';
+import {
+  Plus,
+  Archive,
+  Pencil,
+  ChevronDown,
+  ChevronRight,
+  Bot,
+  GitBranch,
+  GitPullRequest,
+  Clock,
+  Loader2,
+} from 'lucide-react';
 import type { Project, Chat } from '@qlan-ro/mainframe-types';
 import type { SessionStatus } from '../../store/chats';
 import { useChatsStore } from '../../store';
@@ -104,6 +115,10 @@ function ChatRow({
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const isUnread = unreadChatIds.has(chat.id);
+  const hasCreatedPr = useChatsStore((s) => {
+    const prs = s.detectedPrs.get(chat.id);
+    return prs?.some((p) => p.source === 'created') ?? false;
+  });
 
   const handleCommitRename = useCallback(() => {
     setEditing(false);
@@ -144,33 +159,38 @@ function ChatRow({
             isUnread={isUnread}
           />
           <div className="flex-1 min-w-0">
-            {editing ? (
-              <input
-                ref={inputRef}
-                value={editTitle}
-                onChange={(e) => setEditTitle(e.target.value)}
-                onBlur={handleCommitRename}
-                onKeyDown={handleRenameKeyDown}
-                onClick={(e) => e.stopPropagation()}
-                className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
-              />
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className={cn(
-                      'text-mf-small truncate',
-                      isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                      isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                    )}
-                    tabIndex={0}
-                  >
-                    {chat.title || 'Untitled session'}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
-              </Tooltip>
-            )}
+            <div className="flex items-center gap-1">
+              {editing ? (
+                <input
+                  ref={inputRef}
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  onBlur={handleCommitRename}
+                  onKeyDown={handleRenameKeyDown}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
+                />
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        'text-mf-small truncate',
+                        isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                        isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+                      )}
+                      tabIndex={0}
+                    >
+                      {chat.title || 'Untitled session'}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
+                </Tooltip>
+              )}
+              {hasCreatedPr && !editing && (
+                <GitPullRequest size={12} className="shrink-0 text-[#1a7f37]" aria-label="Has created PR" />
+              )}
+            </div>
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">
               <Bot size={10} className="shrink-0" />
               <span className="truncate">{getAdapterLabel(chat.adapterId, adapters)}</span>

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -148,6 +148,10 @@ export function routeEvent(event: DaemonEvent): void {
       log.debug('event:todos.updated', { chatId: event.chatId, count: event.todos.length });
       chats.setTodos(event.chatId, event.todos);
       break;
+    case 'chat.prDetected':
+      log.info('event:chat.prDetected', { chatId: event.chatId, prNumber: event.pr.number, repo: event.pr.repo });
+      chats.addDetectedPr(event.chatId, event.pr);
+      break;
     case 'sessions.external.count':
       break;
     case 'plugin.notification':

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -172,6 +172,8 @@ export const useChatsStore = create<ChatsState>((set) => ({
       compactingChats.delete(id);
       const todos = new Map(state.todos);
       todos.delete(id);
+      const detectedPrs = new Map(state.detectedPrs);
+      detectedPrs.delete(id);
       return {
         chats: state.chats.filter((c) => c.id !== id),
         activeChatId: state.activeChatId === id ? null : state.activeChatId,
@@ -182,6 +184,7 @@ export const useChatsStore = create<ChatsState>((set) => ({
         contextUsage,
         compactingChats,
         todos,
+        detectedPrs,
       };
     }),
   addMessage: (chatId, message) =>

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -6,7 +6,10 @@ import type {
   AdapterProcess,
   QueuedMessageRef,
   TodoItem,
+  DetectedPr,
 } from '@qlan-ro/mainframe-types';
+
+export type { DetectedPr } from '@qlan-ro/mainframe-types';
 
 export type SessionStatus = 'idle' | 'working' | 'waiting';
 
@@ -35,13 +38,6 @@ export interface ContextUsageState {
   percentage: number;
   totalTokens: number;
   maxTokens: number;
-}
-
-export interface DetectedPr {
-  url: string;
-  owner: string;
-  repo: string;
-  number: number;
 }
 
 interface ChatsState {
@@ -300,9 +296,17 @@ export const useChatsStore = create<ChatsState>((set) => ({
     set((state) => {
       const next = new Map(state.detectedPrs);
       const existing = next.get(chatId) ?? [];
-      // Deduplicate by PR number within the same repo
-      const isDuplicate = existing.some((p) => p.owner === pr.owner && p.repo === pr.repo && p.number === pr.number);
-      if (isDuplicate) return state;
+      const idx = existing.findIndex((p) => p.owner === pr.owner && p.repo === pr.repo && p.number === pr.number);
+      if (idx >= 0) {
+        // Upgrade mentioned → created if applicable
+        if (existing[idx]!.source === 'mentioned' && pr.source === 'created') {
+          const updated = [...existing];
+          updated[idx] = pr;
+          next.set(chatId, updated);
+          return { detectedPrs: next };
+        }
+        return state;
+      }
       next.set(chatId, [...existing, pr]);
       return { detectedPrs: next };
     }),

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -16,6 +16,13 @@ export interface ContextUsageState {
   maxTokens: number;
 }
 
+export interface DetectedPr {
+  url: string;
+  owner: string;
+  repo: string;
+  number: number;
+}
+
 interface ChatsState {
   chats: Chat[];
   activeChatId: string | null;
@@ -28,6 +35,7 @@ interface ChatsState {
   contextUsage: Map<string, ContextUsageState>;
   unreadChatIds: Set<string>;
   todos: Map<string, TodoItem[]>;
+  detectedPrs: Map<string, DetectedPr[]>;
 
   markUnread: (chatId: string) => void;
   clearUnread: (chatId: string) => void;
@@ -51,6 +59,7 @@ interface ChatsState {
   setCompacting: (chatId: string, compacting: boolean) => void;
   setContextUsage: (chatId: string, usage: ContextUsageState) => void;
   setTodos: (chatId: string, todos: TodoItem[]) => void;
+  addDetectedPr: (chatId: string, pr: DetectedPr) => void;
 }
 
 export const useChatsStore = create<ChatsState>((set) => ({
@@ -65,6 +74,7 @@ export const useChatsStore = create<ChatsState>((set) => ({
   contextUsage: new Map(),
   unreadChatIds: new Set(),
   todos: new Map(),
+  detectedPrs: new Map(),
 
   markUnread: (chatId) =>
     set((state) => {
@@ -241,5 +251,15 @@ export const useChatsStore = create<ChatsState>((set) => ({
       const next = new Map(state.todos);
       next.set(chatId, todos);
       return { todos: next };
+    }),
+  addDetectedPr: (chatId, pr) =>
+    set((state) => {
+      const next = new Map(state.detectedPrs);
+      const existing = next.get(chatId) ?? [];
+      // Deduplicate by PR number within the same repo
+      const isDuplicate = existing.some((p) => p.owner === pr.owner && p.repo === pr.repo && p.number === pr.number);
+      if (isDuplicate) return state;
+      next.set(chatId, [...existing, pr]);
+      return { detectedPrs: next };
     }),
 }));

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -115,6 +115,7 @@ export interface SessionSink {
   onSkillFile(entry: import('./context.js').SkillFileEntry): void;
   onQueuedProcessed(uuid: string): void;
   onTodoUpdate(todos: import('./chat.js').TodoItem[]): void;
+  onPrDetected(pr: { url: string; owner: string; repo: string; number: number }): void;
 }
 
 export interface AdapterSession {

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -100,6 +100,14 @@ export interface ContextUsage {
   maxTokens: number;
 }
 
+export interface DetectedPr {
+  url: string;
+  owner: string;
+  repo: string;
+  number: number;
+  source: 'created' | 'mentioned';
+}
+
 export interface SessionSink {
   onInit(sessionId: string): void;
   onMessage(content: import('./chat.js').MessageContent[], metadata?: MessageMetadata): void;
@@ -115,7 +123,7 @@ export interface SessionSink {
   onSkillFile(entry: import('./context.js').SkillFileEntry): void;
   onQueuedProcessed(uuid: string): void;
   onTodoUpdate(todos: import('./chat.js').TodoItem[]): void;
-  onPrDetected(pr: { url: string; owner: string; repo: string; number: number }): void;
+  onPrDetected(pr: DetectedPr): void;
 }
 
 export interface AdapterSession {

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -60,7 +60,8 @@ export type DaemonEvent =
   | { type: 'chat.compactDone'; chatId: string }
   | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number }
   | { type: 'adapter.models.updated'; adapterId: string; models: import('./adapter.js').AdapterModel[] }
-  | { type: 'todos.updated'; chatId: string; todos: import('./chat.js').TodoItem[] };
+  | { type: 'todos.updated'; chatId: string; todos: import('./chat.js').TodoItem[] }
+  | { type: 'chat.prDetected'; chatId: string; pr: { url: string; owner: string; repo: string; number: number } };
 
 export type ClientEvent =
   | { type: 'chat.create'; projectId: string; adapterId: string; model?: string; permissionMode?: PermissionMode }

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -61,7 +61,7 @@ export type DaemonEvent =
   | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number }
   | { type: 'adapter.models.updated'; adapterId: string; models: import('./adapter.js').AdapterModel[] }
   | { type: 'todos.updated'; chatId: string; todos: import('./chat.js').TodoItem[] }
-  | { type: 'chat.prDetected'; chatId: string; pr: { url: string; owner: string; repo: string; number: number } };
+  | { type: 'chat.prDetected'; chatId: string; pr: import('./adapter.js').DetectedPr };
 
 export type ClientEvent =
   | { type: 'chat.create'; projectId: string; adapterId: string; model?: string; permissionMode?: PermissionMode }


### PR DESCRIPTION
## Summary
- **Command-level PR detection**: Correlate `tool_use` blocks (`gh pr create`, `glab mr create`, `az repos pr create`) with subsequent `tool_result` blocks to distinguish "created" vs "mentioned" PRs
- **Multi-provider support**: Parse GitHub, GitLab MR, and Azure DevOps PR URLs (including Azure JSON output with `pullRequestId`)
- **History replay**: On session resume, walk cached messages to reconstruct PR detection state with correct `toolUseId` (camelCase) field matching
- **Desktop UI**: Green `PrBadge` in chat header, clickable PR icon in session list (both `FlatSessionRow` and `ProjectGroup` views) that opens the PR URL in browser
- **Store dedup**: `addDetectedPr` supports mentioned→created upgrade and prevents duplicate entries

## Test plan
- [x] Start a session, have the agent run `gh pr create` → verify green PR badge appears in chat header and green PR icon appears in session list
- [x] Click the session list PR icon → verify it opens the PR URL in the browser
- [x] Click the chat header PR badge → verify it opens the PR URL
- [x] Reload the app → verify PR badges/icons restore from history replay
- [x] Verify "mentioned" PRs (from `gh pr view` output) show muted badge, not green
- [x] Run `pnpm test` in core → verify all 27 PR detection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)