### PR TITLE
feat: pin sessions to top of session list

### DIFF
--- a/.changeset/feat-pin-session.md
+++ b/.changeset/feat-pin-session.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Add session pinning to keep important sessions at the top of the list

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -236,6 +236,50 @@ describe('ChatsRepository', () => {
       const fetched = chats.get(chat.id);
       expect(fetched!.mentions).toEqual(mentions);
     });
+
+    it('pins a chat and returns pinned: true', () => {
+      const chat = chats.create(projectId, 'claude');
+      expect(chats.get(chat.id)!.pinned).toBe(false);
+
+      chats.update(chat.id, { pinned: true });
+      expect(chats.get(chat.id)!.pinned).toBe(true);
+    });
+
+    it('unpins a chat and returns pinned: false', () => {
+      const chat = chats.create(projectId, 'claude');
+      chats.update(chat.id, { pinned: true });
+      chats.update(chat.id, { pinned: false });
+      expect(chats.get(chat.id)!.pinned).toBe(false);
+    });
+  });
+
+  describe('pinned ordering', () => {
+    it('list() returns pinned chats before unpinned ones', () => {
+      const older = chats.create(projectId, 'claude');
+      const newer = chats.create(projectId, 'claude');
+      chats.update(older.id, { updatedAt: new Date(Date.now() - 5000).toISOString() });
+      chats.update(newer.id, { updatedAt: new Date(Date.now()).toISOString() });
+
+      // Pin the older chat — it should now appear first
+      chats.update(older.id, { pinned: true });
+
+      const all = chats.list(projectId);
+      expect(all[0]!.id).toBe(older.id);
+      expect(all[1]!.id).toBe(newer.id);
+    });
+
+    it('listAll() returns pinned chats before unpinned ones', () => {
+      const c1 = chats.create(projectId, 'claude');
+      const c2 = chats.create(projectId, 'claude');
+      chats.update(c1.id, { updatedAt: new Date(Date.now() - 5000).toISOString() });
+      chats.update(c2.id, { updatedAt: new Date(Date.now()).toISOString() });
+
+      chats.update(c1.id, { pinned: true });
+
+      const all = chats.listAll();
+      const ids = all.map((c) => c.id);
+      expect(ids.indexOf(c1.id)).toBeLessThan(ids.indexOf(c2.id));
+    });
   });
 
   describe('mentions', () => {

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -2,6 +2,14 @@ import type Database from 'better-sqlite3';
 import type { Chat, SessionMention, SkillFileEntry, TodoItem } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 
+/** Raw shape returned by SQLite before boolean/JSON coercion. */
+type RawChatRow = Omit<Chat, 'pinned' | 'mentions' | 'modifiedFiles' | 'todos'> & {
+  mentions: string;
+  modifiedFiles: string;
+  todos: string;
+  pinned: number;
+};
+
 function parseJsonColumn<T>(value: string | null | undefined, fallback: T): T {
   if (!value) return fallback;
   try {
@@ -25,12 +33,12 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos
+        process_state as processState, todos, pinned
       FROM chats
       WHERE project_id = ? AND status != 'archived'
-      ORDER BY updated_at DESC
+      ORDER BY pinned DESC, updated_at DESC
     `);
-    const rows = stmt.all(projectId) as (Chat & { mentions: string; modifiedFiles: string; todos: string })[];
+    const rows = stmt.all(projectId) as RawChatRow[];
     return rows.map((row) => ({
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
@@ -39,6 +47,7 @@ export class ChatsRepository {
       branchName: row.branchName || undefined,
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
+      pinned: Boolean(row.pinned),
     }));
   }
 
@@ -53,12 +62,12 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos
+        process_state as processState, todos, pinned
       FROM chats
       WHERE status != 'archived'
-      ORDER BY updated_at DESC, rowid DESC
+      ORDER BY pinned DESC, updated_at DESC, rowid DESC
     `);
-    const rows = stmt.all() as (Chat & { mentions: string; modifiedFiles: string; todos: string })[];
+    const rows = stmt.all() as RawChatRow[];
     return rows.map((row) => ({
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
@@ -67,6 +76,7 @@ export class ChatsRepository {
       branchName: row.branchName || undefined,
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
+      pinned: Boolean(row.pinned),
     }));
   }
 
@@ -81,10 +91,10 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos
+        process_state as processState, todos, pinned
       FROM chats WHERE id = ?
     `);
-    const row = stmt.get(id) as (Chat & { mentions: string; modifiedFiles: string; todos: string }) | null;
+    const row = stmt.get(id) as RawChatRow | null;
     if (!row) return null;
     return {
       ...row,
@@ -94,6 +104,7 @@ export class ChatsRepository {
       branchName: row.branchName || undefined,
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
+      pinned: Boolean(row.pinned),
     };
   }
 
@@ -140,6 +151,7 @@ export class ChatsRepository {
     processState: { column: 'process_state' },
     createdAt: { column: 'created_at' },
     updatedAt: { column: 'updated_at' },
+    pinned: { column: 'pinned', transform: (v) => (v ? 1 : 0) },
   };
 
   update(id: string, updates: Partial<Chat>): void {
@@ -243,12 +255,10 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos
+        process_state as processState, todos, pinned
       FROM chats WHERE claude_session_id = ? AND project_id = ?
     `);
-    const row = stmt.get(sessionId, projectId) as
-      | (Chat & { mentions: string; modifiedFiles: string; todos: string })
-      | null;
+    const row = stmt.get(sessionId, projectId) as RawChatRow | null;
     if (!row) return null;
     return {
       ...row,
@@ -258,6 +268,7 @@ export class ChatsRepository {
       branchName: row.branchName || undefined,
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
+      pinned: Boolean(row.pinned),
     };
   }
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -88,6 +88,9 @@ export function initializeSchema(db: Database.Database): void {
   if (!cols.some((c) => c.name === 'todos')) {
     db.exec('ALTER TABLE chats ADD COLUMN todos TEXT');
   }
+  if (!cols.some((c) => c.name === 'pinned')) {
+    db.exec('ALTER TABLE chats ADD COLUMN pinned INTEGER DEFAULT 0');
+  }
 
   const projectCols = db.pragma('table_info(projects)') as { name: string }[];
   if (!projectCols.some((c) => c.name === 'parent_project_id')) {

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import type { RouteContext } from './types.js';
 import { param } from './types.js';
 import { asyncHandler } from './async-handler.js';
@@ -76,6 +77,29 @@ export function chatRoutes(ctx: RouteContext): Router {
       res.json({ success: true, data: chat });
     } catch (err) {
       logger.warn({ err, chatId }, 'Failed to rename chat');
+      res.status(500).json({ success: false, error: 'Operation failed' });
+    }
+  });
+
+  const pinSchema = z.object({ pinned: z.boolean() });
+
+  router.patch('/api/chats/:id/pinned', (req: Request, res: Response) => {
+    const chatId = param(req, 'id');
+    const parsed = pinSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: 'pinned (boolean) is required' });
+      return;
+    }
+    try {
+      ctx.db.chats.update(chatId, { pinned: parsed.data.pinned });
+      const chat = ctx.db.chats.get(chatId);
+      if (!chat) {
+        res.status(404).json({ success: false, error: 'Chat not found' });
+        return;
+      }
+      res.json({ success: true, data: chat });
+    } catch (err) {
+      logger.warn({ err, chatId }, 'Failed to update pinned state');
       res.status(500).json({ success: false, error: 'Operation failed' });
     }
   });

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { DirectoryPickerModal } from '../DirectoryPickerModal';
 import { daemonClient } from '../../lib/client';
 import { getDefaultModelForAdapter } from '../../lib/adapters';
+import { pinChat } from '../../lib/api';
 import { ProjectGroup } from './ProjectGroup';
 import { FlatSessionRow } from './FlatSessionRow';
 import { ImportSessionsPopover } from './ImportSessionsPopover';
@@ -249,7 +250,12 @@ export function ChatsPanel(): React.ReactElement {
   const groups = useMemo(() => buildGroups(projects, chats), [projects, chats]);
   const projectMap = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects]);
   const flatChats = useMemo(
-    () => [...chats].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    () =>
+      [...chats].sort((a, b) => {
+        if (a.pinned && !b.pinned) return -1;
+        if (!a.pinned && b.pinned) return 1;
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      }),
     [chats],
   );
 
@@ -305,37 +311,51 @@ export function ChatsPanel(): React.ReactElement {
     renameCallbacks.current.delete(chatId);
   }, []);
 
-  const handleContextMenu = useCallback((e: React.MouseEvent, sessionId: string | undefined, chatId?: string) => {
-    e.preventDefault();
-    setContextMenu({
-      x: e.clientX,
-      y: e.clientY,
-      items: [
-        ...(chatId
-          ? [
-              {
-                label: 'Rename',
-                onClick: () => {
-                  renameCallbacks.current.get(chatId)?.();
+  const updateChat = useChatsStore((s) => s.updateChat);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, sessionId: string | undefined, chatId?: string) => {
+      e.preventDefault();
+      const chat = chatId ? chats.find((c) => c.id === chatId) : undefined;
+      setContextMenu({
+        x: e.clientX,
+        y: e.clientY,
+        items: [
+          ...(chat
+            ? [
+                {
+                  label: 'Rename',
+                  onClick: () => {
+                    renameCallbacks.current.get(chat.id)?.();
+                  },
                 },
-              },
-            ]
-          : []),
-        ...(sessionId
-          ? [
-              {
-                label: 'Copy Session ID',
-                onClick: () => {
-                  navigator.clipboard.writeText(sessionId).catch((err) => {
-                    log.warn('failed to copy session id', { err: String(err) });
-                  });
+                {
+                  label: chat.pinned ? 'Unpin' : 'Pin',
+                  onClick: () => {
+                    const newPinned = !chat.pinned;
+                    updateChat({ ...chat, pinned: newPinned });
+                    pinChat(chat.id, newPinned).catch((err) => log.warn('pin failed', { err: String(err) }));
+                  },
                 },
-              },
-            ]
-          : []),
-      ],
-    });
-  }, []);
+              ]
+            : []),
+          ...(sessionId
+            ? [
+                {
+                  label: 'Copy Session ID',
+                  onClick: () => {
+                    navigator.clipboard.writeText(sessionId).catch((err) => {
+                      log.warn('failed to copy session id', { err: String(err) });
+                    });
+                  },
+                },
+              ]
+            : []),
+        ],
+      });
+    },
+    [chats, updateChat],
+  );
 
   const handleAddProject = useCallback(
     async (path: string) => {

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Archive, FolderOpen, GitBranch, Clock, Loader2, Pencil } from 'lucide-react';
+import { Archive, FolderOpen, GitBranch, Clock, Loader2, Pencil, Pin } from 'lucide-react';
 import type { Chat } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
@@ -171,14 +171,17 @@ export function FlatSessionRow({
                 className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
               />
             ) : (
-              <div
-                className={cn(
-                  'text-mf-small truncate',
-                  isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                  isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                )}
-              >
-                {chat.title || 'Untitled session'}
+              <div className="flex items-center gap-1 min-w-0">
+                {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
+                <div
+                  className={cn(
+                    'text-mf-small truncate',
+                    isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                    isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+                  )}
+                >
+                  {chat.title || 'Untitled session'}
+                </div>
               </div>
             )}
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -150,6 +150,24 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
         isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',
       )}
     >
+      {createdPrUrl && !editing && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(createdPrUrl, '_blank');
+              }}
+              className="w-5 h-5 shrink-0 ml-2 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
+              aria-label="Open PR"
+            >
+              <GitPullRequest size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Open PR</TooltipContent>
+        </Tooltip>
+      )}
       <button type="button" onClick={handleSelect} className="flex-1 min-w-0 px-3 py-1.5 text-left">
         <div className="flex items-center gap-2">
           <div className="w-3 h-3 shrink-0 flex items-center justify-center">
@@ -165,24 +183,6 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1">
-              {createdPrUrl && !editing && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        window.open(createdPrUrl, '_blank');
-                      }}
-                      className="w-5 h-5 shrink-0 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
-                      aria-label="Open PR"
-                    >
-                      <GitPullRequest size={13} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Open PR</TooltipContent>
-                </Tooltip>
-              )}
               {editing ? (
                 <input
                   ref={inputRef}

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Plus, Archive, Pencil, ChevronDown, ChevronRight, Bot, GitBranch, Clock, Loader2 } from 'lucide-react';
+import { Plus, Archive, Pencil, ChevronDown, ChevronRight, Bot, GitBranch, Clock, Loader2, Pin } from 'lucide-react';
 import type { Project, Chat } from '@qlan-ro/mainframe-types';
 import type { SessionStatus } from '../../store/chats';
 import { useChatsStore } from '../../store';
@@ -155,21 +155,24 @@ function ChatRow({
                 className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
               />
             ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className={cn(
-                      'text-mf-small truncate',
-                      isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                      isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                    )}
-                    tabIndex={0}
-                  >
-                    {chat.title || 'Untitled session'}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
-              </Tooltip>
+              <div className="flex items-center gap-1 min-w-0">
+                {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        'text-mf-small truncate',
+                        isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                        isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+                      )}
+                      tabIndex={0}
+                    >
+                      {chat.title || 'Untitled session'}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
+                </Tooltip>
+              </div>
             )}
             <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">
               <Bot size={10} className="shrink-0" />

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -148,6 +148,24 @@ function ChatRow({
         isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',
       )}
     >
+      {createdPrUrl && !editing && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(createdPrUrl, '_blank');
+              }}
+              className="w-5 h-5 shrink-0 ml-2 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
+              aria-label="Open PR"
+            >
+              <GitPullRequest size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Open PR</TooltipContent>
+        </Tooltip>
+      )}
       <button
         type="button"
         onClick={() => onSelect(chat.id, chat.title)}
@@ -161,24 +179,6 @@ function ChatRow({
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1">
-              {createdPrUrl && !editing && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        window.open(createdPrUrl, '_blank');
-                      }}
-                      className="w-5 h-5 shrink-0 rounded flex items-center justify-center text-[#1a7f37] hover:bg-mf-hover transition-colors"
-                      aria-label="Open PR"
-                    >
-                      <GitPullRequest size={13} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Open PR</TooltipContent>
-                </Tooltip>
-              )}
               {editing ? (
                 <input
                   ref={inputRef}

--- a/packages/desktop/src/renderer/lib/api/index.ts
+++ b/packages/desktop/src/renderer/lib/api/index.ts
@@ -8,6 +8,7 @@ export {
   getAllChats,
   renameChat,
   archiveChat,
+  pinChat,
   getChatMessages,
   getAdapters,
 } from './projects-api';

--- a/packages/desktop/src/renderer/lib/api/projects-api.ts
+++ b/packages/desktop/src/renderer/lib/api/projects-api.ts
@@ -52,6 +52,15 @@ export async function renameChat(chatId: string, title: string): Promise<void> {
   });
 }
 
+export async function pinChat(chatId: string, pinned: boolean): Promise<void> {
+  log.info('pinChat', { chatId, pinned });
+  await fetch(`${API_BASE}/api/chats/${chatId}/pinned`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pinned }),
+  });
+}
+
 export async function archiveChat(chatId: string, deleteWorktree = true): Promise<void> {
   log.info('archiveChat', { chatId, deleteWorktree });
   const params = deleteWorktree ? '' : '?deleteWorktree=false';

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -143,7 +143,7 @@ export const useChatsStore = create<ChatsState>((set) => ({
   },
   addChat: (chat) =>
     set((state) => {
-      const sorted = sortChats([...state.chats, chat]);
+      const sorted = sortChats([chat, ...state.chats]);
       return { chats: sorted };
     }),
   updateChat: (chat) =>

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -53,6 +53,14 @@ interface ChatsState {
   setTodos: (chatId: string, todos: TodoItem[]) => void;
 }
 
+function sortChats(chats: Chat[]): Chat[] {
+  return chats.sort((a, b) => {
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+    return new Date(b.updatedAt ?? b.createdAt).getTime() - new Date(a.updatedAt ?? a.createdAt).getTime();
+  });
+}
+
 export const useChatsStore = create<ChatsState>((set) => ({
   chats: [],
   activeChatId: null,
@@ -108,21 +116,17 @@ export const useChatsStore = create<ChatsState>((set) => ({
   },
   addChat: (chat) =>
     set((state) => {
-      const chatTime = new Date(chat.updatedAt ?? chat.createdAt).getTime();
-      const idx = state.chats.findIndex((c) => new Date(c.updatedAt ?? c.createdAt).getTime() <= chatTime);
-      if (idx === -1) return { chats: [...state.chats, chat] };
-      const next = [...state.chats];
-      next.splice(idx, 0, chat);
-      return { chats: next };
+      const sorted = sortChats([...state.chats, chat]);
+      return { chats: sorted };
     }),
   updateChat: (chat) =>
     set((state) => {
       const idx = state.chats.findIndex((c) => c.id === chat.id);
-      if (idx === -1) return { chats: [chat, ...state.chats] };
+      if (idx === -1) return { chats: sortChats([chat, ...state.chats]) };
       const prev = state.chats[idx]!;
-      // Only move to top when updatedAt actually changed (real content update)
-      if (chat.updatedAt !== prev.updatedAt) {
-        return { chats: [chat, ...state.chats.filter((c) => c.id !== chat.id)] };
+      // Only re-sort when updatedAt or pinned changed
+      if (chat.updatedAt !== prev.updatedAt || chat.pinned !== prev.pinned) {
+        return { chats: sortChats([chat, ...state.chats.filter((c) => c.id !== chat.id)]) };
       }
       // Otherwise update in-place to preserve list order
       const updated = [...state.chats];

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -31,6 +31,7 @@ export interface Chat {
   isRunning?: boolean;
   worktreeMissing?: boolean;
   todos?: TodoItem[];
+  pinned?: boolean;
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary
- **#84** Add session pinning:
  - `pinned` field on `Chat` type + SQLite migration
  - `PATCH /api/chats/:id/pinned` endpoint with Zod validation
  - Sort pinned sessions first in both grouped and flat views
  - Pin/Unpin context menu action with optimistic update
  - Small pin icon indicator on pinned sessions
  - 4 new DB tests for pin/unpin and ordering

## Test plan
- [x] Right-click session → Pin — session moves to top with pin icon
- [x] Right-click pinned session → Unpin — session returns to normal sort
- [x] Pin persists across app restarts
- [x] Multiple pinned sessions sort by `updatedAt` among themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)