### PR TITLE
fix(desktop): re-wire file editor into center panel split

### DIFF
--- a/.changeset/floppy-tires-worry.md
+++ b/.changeset/floppy-tires-worry.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Re-wire file editor into center panel split after zone-based layout rewrite

--- a/packages/desktop/src/renderer/components/Layout.tsx
+++ b/packages/desktop/src/renderer/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Panel, Group, Separator } from 'react-resizable-panels';
 import { usePluginLayoutStore } from '../store';
 import { useLayoutStore } from '../store/layout';
+import { useTabsStore } from '../store/tabs';
 import { TitleBar } from './TitleBar';
 import { LeftRail } from './LeftRail';
 import { RightRail } from './RightRail';
@@ -10,6 +11,8 @@ import { PluginView } from './plugins/PluginView';
 import { Zone } from './zone/Zone';
 import { BottomResizeHandle } from './zone/BottomResizeHandle';
 import { DragProvider } from './zone/DragOverlay';
+import { FileViewHeader } from './panels/FileViewHeader';
+import { FileViewContent } from './panels/FileViewContent';
 
 const BOTTOM_HEIGHT_MIN = 120;
 const BOTTOM_HEIGHT_DEFAULT = 200;
@@ -24,6 +27,33 @@ function HorizontalResizeHandle(): React.ReactElement {
 
 function VerticalResizeHandle(): React.ReactElement {
   return <Separator className="h-mf-gap bg-mf-app-bg hover:bg-mf-divider transition-colors" />;
+}
+
+function CenterSplit({ centerPanel }: { centerPanel: React.ReactNode }): React.ReactElement {
+  const fileView = useTabsStore((s) => s.fileView);
+  const fileViewCollapsed = useTabsStore((s) => s.fileViewCollapsed);
+  const showFileView = fileView != null && !fileViewCollapsed;
+
+  if (!showFileView) {
+    return <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">{centerPanel}</div>;
+  }
+
+  return (
+    <Group orientation="horizontal">
+      <Panel id="center-chat" defaultSize="50%" minSize="30%">
+        <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">{centerPanel}</div>
+      </Panel>
+      <HorizontalResizeHandle />
+      <Panel id="center-file" defaultSize="50%" minSize="20%">
+        <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden flex flex-col">
+          <FileViewHeader />
+          <div className="flex-1 overflow-hidden">
+            <FileViewContent />
+          </div>
+        </div>
+      </Panel>
+    </Group>
+  );
 }
 
 export function Layout({ centerPanel }: LayoutProps): React.ReactElement {
@@ -92,7 +122,7 @@ export function Layout({ centerPanel }: LayoutProps): React.ReactElement {
                   )}
 
                   <Panel id="center">
-                    <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">{centerPanel}</div>
+                    <CenterSplit centerPanel={centerPanel} />
                   </Panel>
 
                   {hasRight && (

--- a/packages/desktop/src/renderer/store/tabs.ts
+++ b/packages/desktop/src/renderer/store/tabs.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { getEditorViewStateForNav, getCursorPositionForNav } from '../components/editor/editor-state';
-import { useLayoutStore } from './layout';
 import { useChatsStore } from './chats';
 
 export type ChatTab = { type: 'chat'; id: string; chatId: string; label: string };
@@ -94,13 +93,6 @@ function currentEditorNavEntry(fv: FileView & { type: 'editor' }): NavEntry {
   };
 }
 
-function expandRightPanel(): void {
-  const layout = useLayoutStore.getState();
-  if (layout.collapsed.right) {
-    layout.toggleSide('right');
-  }
-}
-
 export const useTabsStore = create<TabsState>((set, get) => ({
   tabs: [],
   activePrimaryTabId: null,
@@ -158,19 +150,19 @@ export const useTabsStore = create<TabsState>((set, get) => ({
         navForwardStack.length = 0;
       }
     }
-    expandRightPanel();
+
     set({ fileView: { type: 'editor', filePath, label, content, line, column }, fileViewCollapsed: false });
   },
 
   openDiffTab: (filePath, source, chatId, oldPath, base) => {
     const label = `${filePath.split('/').pop() || filePath} (diff)`;
-    expandRightPanel();
+
     set({ fileView: { type: 'diff', filePath, label, source, chatId, oldPath, base }, fileViewCollapsed: false });
   },
 
   openInlineDiffTab: (filePath, original, modified, startLine) => {
     const label = `${filePath.split('/').pop() || filePath} (diff)`;
-    expandRightPanel();
+
     set({
       fileView: { type: 'diff', filePath, label, source: 'inline', original, modified, startLine },
       fileViewCollapsed: false,
@@ -178,7 +170,6 @@ export const useTabsStore = create<TabsState>((set, get) => ({
   },
 
   openSkillEditorTab: (skillId, adapterId, label) => {
-    expandRightPanel();
     set({ fileView: { type: 'skill-editor', skillId, adapterId, label }, fileViewCollapsed: false });
   },
 


### PR DESCRIPTION
## Summary
- Re-wires orphaned `FileViewHeader` and `FileViewContent` components into the layout after PR #191 deleted `RightPanel.tsx` without reconnecting them
- Adds a `CenterSplit` component in `Layout.tsx` that renders a resizable horizontal split (chat + file editor) inside the center panel, matching the [design spec](docs/superpowers/specs/2026-04-08-intellij-sidepanels-design.md)
- Removes the now-unnecessary `expandRightPanel()` calls from the tabs store since the file view no longer lives in the right column

## Test plan
- [x] Click a file in the file tree → editor opens in a 50/50 split next to the chat
- [x] Click the collapse button → file view hides, chat takes full width
- [x] Click another file → editor updates to new file
- [x] All 384 desktop unit tests pass
- [x] Build succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)