### PR TITLE
fix: notification improvements and push dedup

### DIFF
--- a/.changeset/desktop-active-push-suppression.md
+++ b/.changeset/desktop-active-push-suppression.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Suppress mobile push notifications when desktop app is active

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -261,24 +261,21 @@ function buildSessionSink(
           emitEvent({ type: 'message.added', chatId, message });
           emitDisplay();
 
+          const notification = { title: 'Session Error', body: 'A session ended unexpectedly' };
+          emitEvent({ type: 'chat.notification', chatId, ...notification, level: 'error' });
           pushService
-            ?.sendPush({
-              title: 'Session Error',
-              body: 'A session ended unexpectedly',
-              data: { chatId, type: 'error' },
-              priority: 'high',
-            })
+            ?.sendPush({ ...notification, data: { chatId, type: 'error' }, priority: 'high' })
             .catch((err) => log.warn({ err }, 'push notification failed'));
         }
       } else {
         const lastText = getLastAssistantText(messages.get(chatId));
+        const notification = {
+          title: 'Task Complete',
+          body: lastText || `Session finished (cost: $${cost.toFixed(4)})`,
+        };
+        emitEvent({ type: 'chat.notification', chatId, ...notification, level: 'success' });
         pushService
-          ?.sendPush({
-            title: 'Task Complete',
-            body: lastText || `Session finished (cost: $${cost.toFixed(4)})`,
-            data: { chatId, type: 'task_complete' },
-            priority: 'default',
-          })
+          ?.sendPush({ ...notification, data: { chatId, type: 'task_complete' }, priority: 'default' })
           .catch((err) => log.warn({ err }, 'push notification failed'));
       }
 

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -20,6 +20,25 @@ import { createChildLogger } from '../logger.js';
 
 const log = createChildLogger('chat:events');
 
+const PUSH_BODY_MAX_LENGTH = 200;
+
+function getLastAssistantText(msgs: import('@qlan-ro/mainframe-types').ChatMessage[] | undefined): string {
+  if (!msgs) return '';
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const msg = msgs[i]!;
+    if (msg.type !== 'assistant') continue;
+    for (let j = msg.content.length - 1; j >= 0; j--) {
+      const block = msg.content[j]!;
+      if (block.type === 'text' && block.text.trim()) {
+        const text = block.text.trim();
+        if (text.length <= PUSH_BODY_MAX_LENGTH) return text;
+        return text.slice(0, PUSH_BODY_MAX_LENGTH - 1) + '…';
+      }
+    }
+  }
+  return '';
+}
+
 export class EventHandler {
   private displayCache = new Map<string, DisplayMessage[]>();
   private pushService?: PushService;
@@ -252,10 +271,11 @@ function buildSessionSink(
             .catch((err) => log.warn({ err }, 'push notification failed'));
         }
       } else {
+        const lastText = getLastAssistantText(messages.get(chatId));
         pushService
           ?.sendPush({
             title: 'Task Complete',
-            body: `Session finished (cost: $${cost.toFixed(4)})`,
+            body: lastText || `Session finished (cost: $${cost.toFixed(4)})`,
             data: { chatId, type: 'task_complete' },
             priority: 'default',
           })

--- a/packages/core/src/push/__tests__/push-service.test.ts
+++ b/packages/core/src/push/__tests__/push-service.test.ts
@@ -97,6 +97,23 @@ describe('PushService', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('deduplicates tokens when multiple deviceIds share the same push token', async () => {
+    service.registerDevice('device-1', 'ExponentPushToken[aaa]');
+    service.registerDevice('device-2', 'ExponentPushToken[aaa]');
+
+    await service.sendPush({
+      title: 'Test',
+      body: 'Test',
+      data: {},
+      priority: 'default',
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![1].body);
+    expect(body).toHaveLength(1);
+    expect(body[0].to).toBe('ExponentPushToken[aaa]');
+  });
+
   it('expires desktop-active state after staleness timeout', async () => {
     vi.useFakeTimers();
     service.registerDevice('device-1', 'ExponentPushToken[aaa]');

--- a/packages/core/src/push/push-service.ts
+++ b/packages/core/src/push/push-service.ts
@@ -77,9 +77,13 @@ export class PushService {
       return;
     }
 
-    const disconnectedTokens = Array.from(this.devices.values())
-      .filter((d) => !d.connected)
-      .map((d) => d.pushToken);
+    const disconnectedTokens = [
+      ...new Set(
+        Array.from(this.devices.values())
+          .filter((d) => !d.connected)
+          .map((d) => d.pushToken),
+      ),
+    ];
 
     if (disconnectedTokens.length === 0) return;
 

--- a/packages/desktop/src/main/idle-reporter.ts
+++ b/packages/desktop/src/main/idle-reporter.ts
@@ -9,10 +9,14 @@ const DAEMON_HOST = process.env['DAEMON_HOST'] ?? '127.0.0.1';
 const DAEMON_PORT = process.env['DAEMON_PORT'] ?? '31415';
 const DAEMON_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}`;
 
+const KEEPALIVE_INTERVAL_MS = 4 * 60 * 1000; // 4 minutes — must be shorter than daemon's 6-min staleness timer
+
 let currentState: 'active' | 'idle' = 'active';
 let pollTimer: ReturnType<typeof setInterval> | null = null;
+let lastReportedAt = 0;
 
 async function reportState(state: 'active' | 'idle'): Promise<void> {
+  lastReportedAt = Date.now();
   try {
     await fetch(`${DAEMON_URL}/api/device/activity`, {
       method: 'POST',
@@ -32,6 +36,8 @@ function checkIdle(): void {
     currentState = newState;
     log.info({ state: currentState, idleSeconds }, 'desktop state transition');
     reportState(currentState);
+  } else if (newState === 'active' && Date.now() - lastReportedAt >= KEEPALIVE_INTERVAL_MS) {
+    reportState('active');
   }
 }
 

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -1,4 +1,4 @@
-import type { DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { DaemonEvent, DisplayMessage } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../store/chats';
 import { useTabsStore } from '../store/tabs';
 import { useProjectsStore } from '../store/projects';
@@ -10,6 +10,23 @@ import { buildLaunchScope } from './launch-scope.js';
 import { notify } from './notify';
 
 const log = createLogger('renderer:ws');
+
+function getLastAssistantText(msgs: DisplayMessage[] | undefined): string {
+  if (!msgs) return '';
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const msg = msgs[i]!;
+    if (msg.type !== 'assistant') continue;
+    for (let j = msg.content.length - 1; j >= 0; j--) {
+      const block = msg.content[j]!;
+      if (block.type === 'text' && block.text.trim()) {
+        const text = block.text.trim();
+        if (text.length <= 200) return text;
+        return text.slice(0, 199) + '…';
+      }
+    }
+  }
+  return '';
+}
 
 export function routeEvent(event: DaemonEvent): void {
   const chats = useChatsStore.getState();
@@ -32,10 +49,11 @@ export function routeEvent(event: DaemonEvent): void {
       }
 
       if (event.reason === 'completed') {
+        const lastText = getLastAssistantText(chats.messages.get(event.chat.id));
         notify({
           type: 'success',
           title: event.chat.title ?? 'Session',
-          body: 'Agent responded',
+          body: lastText || 'Agent responded',
           chatId: event.chat.id,
         });
       } else if (event.reason === 'error') {

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -1,4 +1,4 @@
-import type { DaemonEvent, DisplayMessage } from '@qlan-ro/mainframe-types';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../store/chats';
 import { useTabsStore } from '../store/tabs';
 import { useProjectsStore } from '../store/projects';
@@ -10,23 +10,6 @@ import { buildLaunchScope } from './launch-scope.js';
 import { notify } from './notify';
 
 const log = createLogger('renderer:ws');
-
-function getLastAssistantText(msgs: DisplayMessage[] | undefined): string {
-  if (!msgs) return '';
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    const msg = msgs[i]!;
-    if (msg.type !== 'assistant') continue;
-    for (let j = msg.content.length - 1; j >= 0; j--) {
-      const block = msg.content[j]!;
-      if (block.type === 'text' && block.text.trim()) {
-        const text = block.text.trim();
-        if (text.length <= 200) return text;
-        return text.slice(0, 199) + '…';
-      }
-    }
-  }
-  return '';
-}
 
 export function routeEvent(event: DaemonEvent): void {
   const chats = useChatsStore.getState();
@@ -48,22 +31,16 @@ export function routeEvent(event: DaemonEvent): void {
         tabs.updateTabLabel(`chat:${event.chat.id}`, event.chat.title);
       }
 
-      if (event.reason === 'completed') {
-        const lastText = getLastAssistantText(chats.messages.get(event.chat.id));
-        notify({
-          type: 'success',
-          title: event.chat.title ?? 'Session',
-          body: lastText || 'Agent responded',
-          chatId: event.chat.id,
-        });
-      } else if (event.reason === 'error') {
-        notify({
-          type: 'error',
-          title: event.chat.title ?? 'Session',
-          body: 'Agent error',
-          chatId: event.chat.id,
-        });
-      }
+      break;
+    }
+    case 'chat.notification': {
+      const chat = chats.chats.find((c) => c.id === event.chatId);
+      notify({
+        type: event.level,
+        title: chat?.title ?? event.title,
+        body: event.body,
+        chatId: event.chatId,
+      });
       break;
     }
     case 'chat.ended':

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -56,6 +56,7 @@ export type DaemonEvent =
   | { type: 'message.queued.cancelled'; chatId: string; uuid: string }
   | { type: 'message.queued.cancel_failed'; chatId: string; uuid: string }
   | { type: 'message.queued.cleared'; chatId: string }
+  | { type: 'chat.notification'; chatId: string; title: string; body: string; level: 'success' | 'error' }
   | { type: 'chat.compacting'; chatId: string }
   | { type: 'chat.compactDone'; chatId: string }
   | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number }


### PR DESCRIPTION
## Summary

- **Fix duplicate push notifications**: deduplicate Expo push tokens in `sendPush()` — multiple deviceIds sharing the same token no longer cause double notifications
- **Fix push suppression expiring while desktop active**: idle reporter now re-pings the daemon every 4 minutes to keep the staleness timer alive
- **Show agent response in notifications**: both desktop and mobile notifications display the last assistant text instead of generic "Agent responded" / "Session finished"
- **Unify notification source**: new `chat.notification` WS event — daemon builds notification content once, desktop renderer consumes it instead of building its own

## Test plan

- [x] 10 unit tests for PushService (including token dedup test)
- [ ] Verify no duplicate mobile notifications after re-pairing
- [ ] Verify push suppression holds while desktop is active for >6 minutes
- [ ] Verify desktop + mobile notifications show last agent text

🤖 Generated with [Claude Code](https://claude.com/claude-code)