### PR TITLE
fix: downgrade launch and auto-updater errors to warn

### DIFF
--- a/.changeset/launch-updater-log-noise.md
+++ b/.changeset/launch-updater-log-noise.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Downgrade launch spawn failures and auto-updater network errors to `warn` and drop stack traces. These are expected user-config / connectivity conditions, not application errors.

--- a/packages/core/src/launch/launch-manager.ts
+++ b/packages/core/src/launch/launch-manager.ts
@@ -190,8 +190,17 @@ export class LaunchManager {
         );
         resolve();
       });
-      child.once('error', (err) => {
-        log.error({ err, name: config.name }, 'process error');
+      child.once('error', (err: NodeJS.ErrnoException) => {
+        log.warn(
+          {
+            name: config.name,
+            code: err.code,
+            syscall: err.syscall,
+            path: err.path,
+            message: err.message,
+          },
+          'process error',
+        );
         managed.status = 'failed';
         this.processes.delete(config.name);
         this.emit({

--- a/packages/core/src/server/routes/launch.ts
+++ b/packages/core/src/server/routes/launch.ts
@@ -133,7 +133,16 @@ export function launchRoutes(ctx: RouteContext): Router {
         await manager.start(config);
         res.json({ success: true });
       } catch (err) {
-        logger.error({ err, projectId: resolved.projectId, name }, 'failed to start launch process');
+        const errno = err as NodeJS.ErrnoException;
+        logger.warn(
+          {
+            projectId: resolved.projectId,
+            name,
+            code: errno.code,
+            message: errno.message,
+          },
+          'failed to start launch process',
+        );
         res.status(500).json({ success: false, error: 'Failed to start process' });
       }
     }),

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -43,7 +43,7 @@ function registerListeners(mainWindow: BrowserWindow): void {
   });
 
   autoUpdater.on('error', (err) => {
-    log.error({ err }, 'update error');
+    log.warn({ message: err.message }, 'update error');
     send(mainWindow, { state: 'error', message: err.message });
   });
 }


### PR DESCRIPTION
## Summary
- Launch spawn failures (e.g. `ENOENT` on user-configured `mvnw`/`docker compose`) and `electron:auto-updater` network errors are expected operational conditions, not app bugs. They were logged at `ERROR` with full stack traces, creating noise that drowns out real crashes when scanning logs.
- `launch-manager` and `routes/launch`: log at `warn` with structured fields (`code`, `syscall`, `path`, `message`) instead of the full `Error` object.
- `electron:auto-updater`: log just `err.message` at `warn` on `error` events.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core build` — clean
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` — clean
- [x] `vitest run src/__tests__/launch-manager.test.ts src/__tests__/routes/launch.test.ts` — 16/16 passing
- [ ] Manual: trigger a launch with a bogus command (e.g. rename `mvnw`) — verify log line is `warn` level with `code: "ENOENT"` and no stack
- [ ] Manual: disconnect network, wait for the 4h auto-updater tick (or call `update:check`) — verify log line is `warn` with just `message`, no stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)