### PR TITLE
fix(desktop): contain TurnFooter crash and log renderer-gone events

### DIFF
--- a/.changeset/turn-footer-crash.md
+++ b/.changeset/turn-footer-crash.md
@@ -1,0 +1,8 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Prevent `TurnFooter` crashes from bringing down the whole chat turn, and log renderer-process crashes so blank-screen bugs leave a trace.
+
+- `TurnFooter`: local error boundary. `assistant-ui`'s `tapClientLookup` can throw `"Index N out of bounds (length: N)"` during concurrent renders when the external messages array shrinks between a parent capturing its index and a descendant hook reading it. The boundary scopes the failure to the footer and auto-resets on the next render; the rest of the turn keeps rendering.
+- `main`: listen for `render-process-gone` and log `{ reason, exitCode }`. Renderer crashes (OOM, GPU, killed) previously left no trace because React `ErrorBoundary` only catches render errors, not process-level failures.

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -219,6 +219,13 @@ function createWindow(): void {
     }
   });
 
+  // Capture renderer crashes (blank-screen bugs leave no other trace — the React
+  // ErrorBoundary only catches render errors, not process-level crashes like OOM
+  // or GPU-killed). Log the reason so we can diagnose recurring cases.
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    log.error({ reason: details.reason, exitCode: details.exitCode }, 'renderer process gone');
+  });
+
   if (process.env.NODE_ENV !== 'development') {
     mainWindow.webContents.on('devtools-opened', () => {
       mainWindow?.webContents.closeDevTools();

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/TurnFooter.tsx
@@ -3,8 +3,37 @@ import { useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import type { DisplayMessage } from '@qlan-ro/mainframe-types';
 import { formatTurnDuration } from '../message-parsing';
+import { createLogger } from '../../../../lib/logger';
 
-export function TurnFooter() {
+const log = createLogger('renderer:turn-footer');
+
+// Why a boundary here: assistant-ui's tapClientLookup can throw
+// "Index N out of bounds (length: N)" during concurrent renders when the
+// external messages array shrinks between a parent's captured index and a
+// descendant hook's read. Without isolation, the whole turn (and up to the
+// root ErrorBoundary) fails to render. Scoping the failure to the footer
+// keeps the turn visible; React recovers on the next stable render.
+class TurnFooterBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    log.warn('turn footer render failed', { message: error.message });
+  }
+
+  componentDidUpdate(_prev: { children: React.ReactNode }): void {
+    if (this.state.hasError) this.setState({ hasError: false });
+  }
+
+  render(): React.ReactNode {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+function TurnFooterInner() {
   const message = useMessage();
   const [original] = getExternalStoreMessages<DisplayMessage>(message);
   if (!original?.timestamp) return null;
@@ -17,5 +46,13 @@ export function TurnFooter() {
     >
       {durationMs !== null ? `${time} · ${formatTurnDuration(durationMs)}` : time}
     </span>
+  );
+}
+
+export function TurnFooter() {
+  return (
+    <TurnFooterBoundary>
+      <TurnFooterInner />
+    </TurnFooterBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- **TurnFooter containment.** `assistant-ui`'s `tapClientLookup` throws `"Index N out of bounds (length: N)"` during concurrent renders when the external messages array shrinks between a parent capturing its index and a descendant hook reading it. Observed in prod (`~/.mainframe/logs/desktop-app.2026-04-14.log:830`). Without isolation the whole turn (up to the root `ErrorBoundary`) fails and the user sees the "Something went wrong" fallback instead of their chat. Wrapping `TurnFooter` in a local boundary that auto-resets on the next render keeps the turn visible; the worst case is a footer that blinks once.
- **Renderer crash telemetry.** Renderer-process crashes (OOM, GPU, killed) leave no trace today because React's `ErrorBoundary` only catches render errors, not process-level failures. Users have reported blank-screen events that required CMD+R to recover, with nothing in the logs to diagnose. Added `render-process-gone` handler on the main `BrowserWindow` to log `{ reason, exitCode }`.

## Why not fix the root cause of the `tapClientLookup` race?
It's an internal race in `@assistant-ui/store`'s `tapClientLookup` (see `node_modules/.pnpm/@assistant-ui+store@0.2.3/.../tapClientLookup.ts:66`). Fixing it upstream would require either a message-id-based lookup throughout the render tree or careful coordination of external-store updates. The local boundary is a minimal, well-scoped defense that keeps blast radius tiny. The footer isn't load-bearing — hiding it for one render is invisible to users.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` — clean
- [x] `vitest run src/renderer/components/chat/assistant-ui` — 36/36 passing
- [ ] Manual: open a chat with many messages, stream a long response — verify no `renderer:app` render error entries for `TurnFooter`
- [ ] Manual: force a renderer crash (`kill -9` on the renderer PID, or navigate to `chrome://crash`) — verify `electron` logger emits `"renderer process gone"` with a reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)