### PR TITLE
fix(todos): include task title in "Task created" toast

### DIFF
--- a/.changeset/todo-toast-title.md
+++ b/.changeset/todo-toast-title.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Include task title in the "Task created" toast so it matches the notification body removed in the earlier dedup fix.

--- a/packages/desktop/src/renderer/components/todos/QuickTodoDialog.tsx
+++ b/packages/desktop/src/renderer/components/todos/QuickTodoDialog.tsx
@@ -176,7 +176,7 @@ export function QuickTodoDialog() {
         );
       }
 
-      toast.success(`Task #${todo.number} created`);
+      toast.success(`Task #${todo.number} created: ${todo.title}`);
       window.dispatchEvent(new CustomEvent('todos:changed'));
       setOpen(false);
     } catch {


### PR DESCRIPTION
## Summary

- Earlier dedup (commit 4b063b15) removed the `ctx.ui.notify` call in the todos plugin that had richer body content (`#${number} ${title}`) and kept the frontend `toast.success` which showed only `Task #${number} created` — no title.
- Restore the title in the remaining toast so users can see which task was just created without opening the todos panel.

Closes #86

## Test plan

- [x] Open the Quick Todo dialog (Cmd+Shift+T), create a task, verify the toast reads `Task #N created: <title>`.
- [x] Confirm no duplicate OS notification appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)