### PR TITLE
docs(plugins): note builtin UI is rendered from a hardcoded map

### DIFF
--- a/.changeset/plugin-ui-builtins-note.md
+++ b/.changeset/plugin-ui-builtins-note.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document that builtin plugin UI is currently rendered from a hardcoded `BUILTIN_GLOBAL_COMPONENTS` map in the desktop shell, and that the backend already emits `plugin.panel.*`, `plugin.action.*`, and `plugin.notification` events that a future external-plugin loader will consume.

--- a/docs/PLUGIN-DEVELOPER-GUIDE.md
+++ b/docs/PLUGIN-DEVELOPER-GUIDE.md
@@ -488,6 +488,18 @@ ctx.router.get('/ui', (_req, res) => {
 });
 ```
 
+### Builtin UI rendering (current state)
+
+Per the [2026-02-22 plugin design](./plans/completed/2026-02-22-plugin-system-design.md), builtin plugins colocate their React components inside the desktop package (e.g. `QuickTodoDialog` for the `todos` plugin), and the desktop shell renders them from a hardcoded map — `BUILTIN_GLOBAL_COMPONENTS` in `packages/desktop/src/renderer/components/plugins/PluginGlobalComponents.tsx`. This is deliberate: external plugin packaging and loading are not implemented yet, so there is nowhere else for that UI to live.
+
+The backend already emits the events that a future loader would consume:
+
+- `plugin.panel.registered` / `plugin.panel.unregistered` — emitted by `ctx.ui.addPanel` / `removePanel`
+- `plugin.action.registered` / `plugin.action.unregistered` — emitted by `ctx.ui.addAction` / `removeAction`
+- `plugin.notification` — emitted by `ctx.ui.notify`
+
+Once a plugin-packaging / external-plugin loading mechanism lands, the renderer will subscribe to those events and mount any plugin's UI dynamically (same `ctx.ui.*` API, just sourced from a real plugin bundle instead of a hardcoded map). Until then, adding UI for a new builtin plugin means editing `BUILTIN_GLOBAL_COMPONENTS` — and that's the expected seam, not a bug.
+
 ---
 
 ## Event Bus


### PR DESCRIPTION
## Summary

- Add a "Builtin UI rendering (current state)" subsection to `docs/PLUGIN-DEVELOPER-GUIDE.md` explaining that builtin plugin UI lives inside the desktop package and is mounted from the `BUILTIN_GLOBAL_COMPONENTS` map in `PluginGlobalComponents.tsx`.
- Document the `plugin.panel.*`, `plugin.action.*`, and `plugin.notification` events the backend already emits via `ctx.ui.*`, which a future external-plugin loader will consume.
- Links back to `docs/plans/completed/2026-02-22-plugin-system-design.md` for the full rationale.

Motivated by a discussion around the todos plugin's QuickTodoDialog living in the desktop package — wanted to codify that this is expected, not tech debt, until external plugin packaging is built.

## Test plan

- [x] Markdown renders cleanly on GitHub.
- [x] Links (`plans/completed/...`) resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)