### PR TITLE
fix(desktop): ship macOS zip for auto-update + radix tooltip polish

### DIFF
--- a/.changeset/auto-updater-macos-zip.md
+++ b/.changeset/auto-updater-macos-zip.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(updater): publish macOS zip artifact so electron-updater can apply updates
+
+Squirrel.Mac auto-updates require a `.zip` of the app bundle; the release previously shipped only `.dmg`, causing the updater to fail with "ZIP file not provided" when applying an update. Also replaces native `title` attributes on the status-bar update indicator and the composer worktree button with Radix tooltips so hovercards render with the app's own styling, re-enables hoverable content on the chat link-preview tooltip so the Copy button can be reached, and adds a right-click context menu to chat links with Copy link / Open link actions.

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -151,7 +151,8 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/packages/desktop/src/renderer/components/StatusBar.tsx
+++ b/packages/desktop/src/renderer/components/StatusBar.tsx
@@ -11,6 +11,7 @@ import { getGitBranch, getGitStatus } from '../lib/api';
 import { isConflictStatus } from '../lib/git-utils';
 import { cn } from '../lib/utils';
 import { BranchPopover } from './git/BranchPopover';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
 const GIT_POLL_INTERVAL = 60_000;
 
@@ -23,20 +24,24 @@ function UpdateIndicator(): React.ReactElement | null {
 
   if (status.state === 'available') {
     return (
-      <button
-        className="flex items-center gap-1 text-mf-accent hover:text-mf-text-primary transition-colors"
-        onClick={() => {
-          try {
-            window.mainframe.updates.download();
-          } catch (err) {
-            console.warn('[UpdateIndicator] download failed', err);
-          }
-        }}
-        title={`Download update v${status.version}`}
-      >
-        <Download size={12} />
-        <span>Update v{status.version}</span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="flex items-center gap-1 text-mf-accent hover:text-mf-text-primary transition-colors"
+            onClick={() => {
+              try {
+                window.mainframe.updates.download();
+              } catch (err) {
+                console.warn('[UpdateIndicator] download failed', err);
+              }
+            }}
+          >
+            <Download size={12} />
+            <span>Update v{status.version}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Download update v{status.version}</TooltipContent>
+      </Tooltip>
     );
   }
 
@@ -51,29 +56,40 @@ function UpdateIndicator(): React.ReactElement | null {
 
   if (status.state === 'downloaded') {
     return (
-      <button
-        className="flex items-center gap-1 text-mf-success hover:text-mf-text-primary transition-colors"
-        onClick={() => {
-          try {
-            window.mainframe.updates.install();
-          } catch (err) {
-            console.warn('[UpdateIndicator] install failed', err);
-          }
-        }}
-        title={`Restart to install v${status.version}`}
-      >
-        <RotateCcw size={12} />
-        <span>Restart to update</span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="flex items-center gap-1 text-mf-success hover:text-mf-text-primary transition-colors"
+            onClick={() => {
+              try {
+                window.mainframe.updates.install();
+              } catch (err) {
+                console.warn('[UpdateIndicator] install failed', err);
+              }
+            }}
+          >
+            <RotateCcw size={12} />
+            <span>Restart to update</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Restart to install v{status.version}</TooltipContent>
+      </Tooltip>
     );
   }
 
   if (status.state === 'error') {
     return (
-      <span className="flex items-center gap-1 text-mf-destructive" title={status.message}>
-        <AlertTriangle size={12} />
-        <span>Update error</span>
-      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex items-center gap-1 text-mf-destructive cursor-default">
+            <AlertTriangle size={12} />
+            <span>Update error</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-sm whitespace-pre-wrap break-words">
+          {status.message}
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -20,6 +20,7 @@ import { WorktreePopover } from './WorktreePopover';
 import { QueuedMessageBanner } from './QueuedMessageBanner';
 import { useSandboxStore, type Capture } from '../../../../store/sandbox.js';
 import { getDraft, saveDraft, deleteDraft } from './composer-drafts.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
 
 const PERMISSION_MODES = [
   { id: 'default', label: 'Interactive' },
@@ -397,19 +398,25 @@ export function ComposerCard() {
           />
           {isGitProject && (
             <div className="relative">
-              <button
-                type="button"
-                onClick={() => setWorktreePopoverOpen((o) => !o)}
-                className={`flex items-center gap-1 px-2 py-1 rounded-mf-input text-mf-small transition-colors ${
-                  chat?.worktreePath
-                    ? 'text-mf-accent bg-mf-hover'
-                    : 'text-mf-text-secondary hover:bg-mf-hover hover:text-mf-text-primary'
-                }`}
-                title={chat?.worktreePath ? `Branch: ${chat.branchName}` : 'Worktree isolation'}
-                aria-label={chat?.worktreePath ? `Worktree on branch ${chat.branchName}` : 'Worktree isolation'}
-              >
-                {chat?.worktreePath ? <FolderGit size={14} /> : <GitBranch size={14} />}
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => setWorktreePopoverOpen((o) => !o)}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-mf-input text-mf-small transition-colors ${
+                      chat?.worktreePath
+                        ? 'text-mf-accent bg-mf-hover'
+                        : 'text-mf-text-secondary hover:bg-mf-hover hover:text-mf-text-primary'
+                    }`}
+                    aria-label={chat?.worktreePath ? `Worktree on branch ${chat.branchName}` : 'Worktree isolation'}
+                  >
+                    {chat?.worktreePath ? <FolderGit size={14} /> : <GitBranch size={14} />}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {chat?.worktreePath ? `Branch: ${chat.branchName}` : 'Worktree isolation'}
+                </TooltipContent>
+              </Tooltip>
               {worktreePopoverOpen && chatId && (
                 <WorktreePopover
                   chatId={chatId}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
@@ -9,6 +9,7 @@ import remarkGfm from 'remark-gfm';
 import { cn } from '../../../../lib/utils';
 import { urlTransform as markdownUrlTransform, remarkAppLinks } from '../../../../lib/markdown-url-transform';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../ui/tooltip';
+import { ContextMenu, type ContextMenuItem } from '../../../ui/context-menu';
 import { CodeHeader } from './CodeHeader';
 import { SyntaxHighlightedCode } from './SyntaxHighlightedCode';
 
@@ -89,44 +90,64 @@ function LinkWithPreview({
   ...props
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>): React.ReactElement {
   const [copied, setCopied] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
-  const copyUrl = (e: React.MouseEvent): void => {
-    e.preventDefault();
-    e.stopPropagation();
+  const copyHref = (): void => {
     if (!href) return;
     navigator.clipboard.writeText(href);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
 
+  const copyUrl = (e: React.MouseEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    copyHref();
+  };
+
+  const handleContextMenu = (e: React.MouseEvent): void => {
+    if (!href) return;
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY });
+  };
+
   if (!href) {
     return <a className={cn('aui-md-a', className)} href={href} {...props} />;
   }
 
+  const menuItems: ContextMenuItem[] = [
+    { label: 'Copy link', onClick: copyHref },
+    { label: 'Open link', onClick: () => window.mainframe.openExternal(href) },
+  ];
+
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <a
-          className={cn('aui-md-a', className)}
-          href={href}
-          onClick={(e) => {
-            e.preventDefault();
-            window.mainframe.openExternal(href);
-          }}
-          {...props}
-        />
-      </TooltipTrigger>
-      <TooltipContent className="flex items-center gap-1.5 max-w-[400px]">
-        <span className="truncate min-w-0">{href}</span>
-        <button
-          type="button"
-          onClick={copyUrl}
-          className="shrink-0 px-1.5 py-0.5 rounded bg-mf-hover hover:bg-mf-border text-mf-text-secondary hover:text-mf-text-primary transition-colors text-[10px]"
-        >
-          {copied ? 'Copied' : 'Copy'}
-        </button>
-      </TooltipContent>
-    </Tooltip>
+    <>
+      <Tooltip disableHoverableContent={false}>
+        <TooltipTrigger asChild>
+          <a
+            className={cn('aui-md-a', className)}
+            href={href}
+            onClick={(e) => {
+              e.preventDefault();
+              window.mainframe.openExternal(href);
+            }}
+            onContextMenu={handleContextMenu}
+            {...props}
+          />
+        </TooltipTrigger>
+        <TooltipContent className="flex items-center gap-1.5 max-w-[400px]">
+          <span className="truncate min-w-0">{href}</span>
+          <button
+            type="button"
+            onClick={copyUrl}
+            className="shrink-0 px-1.5 py-0.5 rounded bg-mf-hover hover:bg-mf-border text-mf-text-secondary hover:text-mf-text-primary transition-colors text-[10px]"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </TooltipContent>
+      </Tooltip>
+      {menu && <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `zip` to the electron-builder macOS target so `latest-mac.yml` lists a zipped `.app` bundle. Squirrel.Mac (the engine electron-updater drives on macOS) can't apply an update from a `.dmg` — it needs the zip — which is why the currently-installed v0.11.0 fails with `ZIP file not provided`.
- Replace native `title="..."` tooltips on the status-bar update indicator and the composer worktree button with the shared Radix `<Tooltip>` wrapper so hovercards pick up the app's own styling.
- Override `disableHoverableContent={false}` on the chat link-preview tooltip so the cursor can reach the Copy button without the tooltip closing first.
- Right-clicking a chat link now opens the app's existing `ContextMenu` with **Copy link** / **Open link** items.

## Caveats

This fix only helps **future** releases. v0.11.0 is already published without a zip asset, so users currently on v0.10.3 still have to install v0.11.0 manually from the DMG. Every release after this lands will auto-update cleanly.

## Test plan

- [ ] Cut a test release tag, confirm `latest-mac.yml` lists both the dmg and zip, and that `Mainframe-*-mac.zip` lands in the release assets.
- [ ] Install v0.11.0 manually, publish the next version, confirm the status-bar update indicator progresses through `available → downloading → downloaded` without the `ZIP file not provided` error.
- [ ] Hover the update indicator (available/downloaded/error states) — Radix tooltip renders with app styling.
- [ ] Hover the composer worktree button — Radix tooltip, not system tooltip.
- [ ] Hover a URL in chat, then move the mouse to the Copy button — tooltip stays open and Copy works.
- [ ] Right-click a URL in chat — context menu shows Copy link / Open link.