### PR TITLE
feat(projects): delete project from sidebar (#106)

### DIFF
--- a/.changeset/delete-project-sidebar.md
+++ b/.changeset/delete-project-sidebar.md
@@ -2,4 +2,9 @@
 "@qlan-ro/mainframe-desktop": minor
 ---
 
-Added the ability to delete a project from the sidebar. A trash icon appears on hover next to the "New Session" button on each project header. Confirming the prompt stops all running CLI sessions in that project, removes all its chats from the database in a transaction, and resets any active filter or selected chat that belonged to the deleted project. Files on disk are not affected.
+Added the ability to delete a project from the sidebar. Two discoverable entry points route through the same confirm-and-cleanup flow:
+
+- Hover the project group header (in the "All" view) → trash icon fades in next to "New Session".
+- When filtered to a specific project, the active filter pill shows a chevron — clicking it opens a menu with "Delete Project".
+
+Confirming stops all running CLI sessions in that project, removes all its chats from the database in a transaction, and resets any active filter or selected chat that belonged to the deleted project. Files on disk are not affected.

--- a/.changeset/delete-project-sidebar.md
+++ b/.changeset/delete-project-sidebar.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": minor
+---
+
+Added the ability to delete a project from the sidebar. A trash icon appears on hover next to the "New Session" button on each project header. Confirming the prompt stops all running CLI sessions in that project, removes all its chats from the database in a transaction, and resets any active filter or selected chat that belonged to the deleted project. Files on disk are not affected.

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FolderPlus, Plus, Download } from 'lucide-react';
+import { FolderPlus, Plus, Download, ChevronDown } from 'lucide-react';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:panels');
@@ -7,6 +7,7 @@ import { useChatsStore, useProjectsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { createProject } from '../../lib/api';
+import { deleteProjectWithCleanup } from '../../lib/delete-project';
 import { ContextMenu } from '../ui/context-menu';
 import type { ContextMenuItem } from '../ui/context-menu';
 import { cn } from '../../lib/utils';
@@ -93,29 +94,46 @@ function FilterPillBadge({
   onClick,
   label,
   truncate: shouldTruncate,
+  onDropdownClick,
 }: {
   count: number;
   isActive: boolean;
   onClick: () => void;
   label: string;
   truncate?: boolean;
+  onDropdownClick?: (e: React.MouseEvent) => void;
 }) {
+  const showCaret = isActive && onDropdownClick !== undefined;
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div
       className={cn(
-        'shrink-0 px-2.5 py-1 rounded-full text-mf-status transition-colors inline-flex items-center gap-1.5',
+        'shrink-0 rounded-full text-mf-status inline-flex items-center transition-colors',
         isActive ? 'bg-mf-accent text-white' : 'bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary',
       )}
     >
-      {shouldTruncate ? <span className="truncate max-w-[140px]">{label}</span> : label}
-      {count > 0 && (
-        <span className={cn(BADGE_BASE, isActive ? 'bg-mf-hover text-mf-text-secondary' : 'bg-mf-accent text-white')}>
-          {count}
-        </span>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn('inline-flex items-center gap-1.5 py-1 rounded-full', showCaret ? 'pl-2.5 pr-1' : 'px-2.5')}
+      >
+        {shouldTruncate ? <span className="truncate max-w-[140px]">{label}</span> : label}
+        {count > 0 && (
+          <span className={cn(BADGE_BASE, isActive ? 'bg-mf-hover text-mf-text-secondary' : 'bg-mf-accent text-white')}>
+            {count}
+          </span>
+        )}
+      </button>
+      {showCaret && (
+        <button
+          type="button"
+          onClick={onDropdownClick}
+          aria-label={`Options for ${label}`}
+          className="p-1 mr-1 rounded-full hover:bg-mf-hover text-white/80 hover:text-white transition-colors"
+        >
+          <ChevronDown size={12} />
+        </button>
       )}
-    </button>
+    </div>
   );
 }
 
@@ -351,6 +369,28 @@ export function ChatsPanel(): React.ReactElement {
     [chats, updateChat],
   );
 
+  const handleProjectContextMenu = useCallback(
+    (e: React.MouseEvent, projectId: string) => {
+      e.preventDefault();
+      const proj = projectMap.get(projectId);
+      if (!proj) return;
+      setContextMenu({
+        x: e.clientX,
+        y: e.clientY,
+        items: [
+          {
+            label: `Delete Project "${proj.name}"`,
+            destructive: true,
+            onClick: () => {
+              void deleteProjectWithCleanup(proj);
+            },
+          },
+        ],
+      });
+    },
+    [projectMap],
+  );
+
   const handleAddProject = useCallback(
     async (path: string) => {
       setShowDirPicker(false);
@@ -462,6 +502,10 @@ export function ChatsPanel(): React.ReactElement {
                     onClick={() => handleFilterSelect(filterProjectId === p.id ? null : p.id)}
                     label={p.name}
                     truncate
+                    onDropdownClick={(e) => {
+                      e.stopPropagation();
+                      handleProjectContextMenu(e, p.id);
+                    }}
                   />
                 </TooltipTrigger>
                 <TooltipContent>{p.name}</TooltipContent>

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -11,15 +11,17 @@ import {
   Clock,
   Loader2,
   Pin,
+  Trash2,
 } from 'lucide-react';
 import type { Project, Chat } from '@qlan-ro/mainframe-types';
 import type { SessionStatus } from '../../store/chats';
-import { useChatsStore } from '../../store';
+import { useChatsStore, useProjectsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
 import { useAdaptersStore } from '../../store/adapters';
+import { useToastStore } from '../../store/toasts';
 import { daemonClient } from '../../lib/client';
 import { getDefaultModelForAdapter } from '../../lib/adapters';
-import { archiveChat, renameChat } from '../../lib/api';
+import { archiveChat, renameChat, removeProject } from '../../lib/api';
 import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
@@ -359,6 +361,44 @@ export const ProjectGroup = React.memo(function ProjectGroup({
     [project.id],
   );
 
+  const addToast = useToastStore((s) => s.add);
+  const removeProjectFromStore = useProjectsStore((s) => s.removeProject);
+  const setFilterProjectId = useChatsStore((s) => s.setFilterProjectId);
+
+  const handleDeleteProject = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const confirmed = window.confirm(
+        `Delete project "${project.name}"?\n\nThis will stop all its sessions and remove the project from the database. Files on disk are NOT affected.\n\nThis cannot be undone.`,
+      );
+      if (!confirmed) return;
+
+      try {
+        await removeProject(project.id);
+        // Clean up client-side state
+        const { filterProjectId, activeChatId, chats: allChats, setActiveChat } = useChatsStore.getState();
+        const projectChatIds = new Set(allChats.filter((c) => c.projectId === project.id).map((c) => c.id));
+        for (const chatId of projectChatIds) {
+          useChatsStore.getState().removeChat(chatId);
+          deleteDraft(chatId);
+          useTabsStore.getState().closeTab(`chat:${chatId}`);
+        }
+        if (filterProjectId === project.id) {
+          setFilterProjectId(null);
+        }
+        if (activeChatId && projectChatIds.has(activeChatId)) {
+          setActiveChat(null);
+        }
+        removeProjectFromStore(project.id);
+        addToast('success', 'Project deleted', project.name);
+      } catch (err) {
+        log.warn('delete project failed', { err: String(err) });
+        addToast('error', 'Failed to delete project', String(err));
+      }
+    },
+    [project.id, project.name, removeProjectFromStore, setFilterProjectId, addToast],
+  );
+
   return (
     <div data-testid={`project-group-${project.id}`}>
       {/* Group header */}
@@ -372,7 +412,7 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             onToggleCollapse();
           }
         }}
-        className="w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label hover:bg-mf-hover/50 transition-colors cursor-pointer"
+        className="group w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label hover:bg-mf-hover/50 transition-colors cursor-pointer"
       >
         {collapsed ? <ChevronRight size={12} className="shrink-0" /> : <ChevronDown size={12} className="shrink-0" />}
         <div className="flex-1 min-w-0 text-left">
@@ -399,6 +439,19 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             </button>
           </TooltipTrigger>
           <TooltipContent>New Session</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleDeleteProject}
+              className="w-6 h-6 rounded-mf-input flex items-center justify-center text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors shrink-0 opacity-0 group-hover:opacity-100"
+              aria-label={`Delete project ${project.name}`}
+            >
+              <Trash2 size={12} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete Project</TooltipContent>
         </Tooltip>
       </div>
 

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -15,14 +15,14 @@ import {
 } from 'lucide-react';
 import type { Project, Chat } from '@qlan-ro/mainframe-types';
 import type { SessionStatus } from '../../store/chats';
-import { useChatsStore, useProjectsStore } from '../../store';
+import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
 import { useAdaptersStore } from '../../store/adapters';
-import { useToastStore } from '../../store/toasts';
 import { daemonClient } from '../../lib/client';
 import { getDefaultModelForAdapter } from '../../lib/adapters';
-import { archiveChat, renameChat, removeProject } from '../../lib/api';
+import { archiveChat, renameChat } from '../../lib/api';
 import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
+import { deleteProjectWithCleanup } from '../../lib/delete-project';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { getAdapterLabel } from '../../lib/adapters';
@@ -361,42 +361,12 @@ export const ProjectGroup = React.memo(function ProjectGroup({
     [project.id],
   );
 
-  const addToast = useToastStore((s) => s.add);
-  const removeProjectFromStore = useProjectsStore((s) => s.removeProject);
-  const setFilterProjectId = useChatsStore((s) => s.setFilterProjectId);
-
   const handleDeleteProject = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation();
-      const confirmed = window.confirm(
-        `Delete project "${project.name}"?\n\nThis will stop all its sessions and remove the project from the database. Files on disk are NOT affected.\n\nThis cannot be undone.`,
-      );
-      if (!confirmed) return;
-
-      try {
-        await removeProject(project.id);
-        // Clean up client-side state
-        const { filterProjectId, activeChatId, chats: allChats, setActiveChat } = useChatsStore.getState();
-        const projectChatIds = new Set(allChats.filter((c) => c.projectId === project.id).map((c) => c.id));
-        for (const chatId of projectChatIds) {
-          useChatsStore.getState().removeChat(chatId);
-          deleteDraft(chatId);
-          useTabsStore.getState().closeTab(`chat:${chatId}`);
-        }
-        if (filterProjectId === project.id) {
-          setFilterProjectId(null);
-        }
-        if (activeChatId && projectChatIds.has(activeChatId)) {
-          setActiveChat(null);
-        }
-        removeProjectFromStore(project.id);
-        addToast('success', 'Project deleted', project.name);
-      } catch (err) {
-        log.warn('delete project failed', { err: String(err) });
-        addToast('error', 'Failed to delete project', String(err));
-      }
+      await deleteProjectWithCleanup(project);
     },
-    [project.id, project.name, removeProjectFromStore, setFilterProjectId, addToast],
+    [project],
   );
 
   return (
@@ -445,7 +415,7 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             <button
               type="button"
               onClick={handleDeleteProject}
-              className="w-6 h-6 rounded-mf-input flex items-center justify-center text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors shrink-0 opacity-0 group-hover:opacity-100"
+              className="w-6 h-6 rounded-mf-input flex items-center justify-center text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
               aria-label={`Delete project ${project.name}`}
             >
               <Trash2 size={12} />

--- a/packages/desktop/src/renderer/components/ui/context-menu.tsx
+++ b/packages/desktop/src/renderer/components/ui/context-menu.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils';
 export interface ContextMenuItem {
   label: string;
   onClick: () => void;
+  destructive?: boolean;
 }
 
 interface ContextMenuProps {
@@ -47,7 +48,10 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps): React.R
             item.onClick();
             onClose();
           }}
-          className="w-full text-left px-3 py-1.5 text-mf-small text-mf-text-primary hover:bg-mf-hover transition-colors"
+          className={cn(
+            'w-full text-left px-3 py-1.5 text-mf-small hover:bg-mf-hover transition-colors',
+            item.destructive ? 'text-mf-destructive' : 'text-mf-text-primary',
+          )}
         >
           {item.label}
         </button>

--- a/packages/desktop/src/renderer/lib/delete-project.test.ts
+++ b/packages/desktop/src/renderer/lib/delete-project.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Project, Chat } from '@qlan-ro/mainframe-types';
+
+vi.mock('./api', () => ({
+  removeProject: vi.fn(),
+}));
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../components/chat/assistant-ui/composer/composer-drafts.js', () => ({
+  deleteDraft: vi.fn(),
+}));
+
+vi.mock('../store', () => ({
+  useChatsStore: { getState: vi.fn() },
+  useProjectsStore: { getState: vi.fn() },
+}));
+
+vi.mock('../store/tabs', () => ({
+  useTabsStore: { getState: vi.fn() },
+}));
+
+vi.mock('../store/toasts', () => ({
+  useToastStore: { getState: vi.fn() },
+}));
+
+import { removeProject } from './api';
+import { deleteDraft } from '../components/chat/assistant-ui/composer/composer-drafts.js';
+import { useChatsStore, useProjectsStore } from '../store';
+import { useTabsStore } from '../store/tabs';
+import { useToastStore } from '../store/toasts';
+import { deleteProjectWithCleanup } from './delete-project';
+
+const project: Project = {
+  id: 'p1',
+  name: 'My Project',
+  path: '/tmp/p1',
+  createdAt: '2026-04-21T00:00:00Z',
+  lastOpenedAt: '2026-04-21T00:00:00Z',
+};
+
+function makeChat(id: string, projectId: string): Chat {
+  return {
+    id,
+    adapterId: 'claude',
+    projectId,
+    status: 'active',
+    createdAt: '2026-04-21T00:00:00Z',
+    updatedAt: '2026-04-21T00:00:00Z',
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+  };
+}
+
+describe('deleteProjectWithCleanup', () => {
+  const removeChat = vi.fn();
+  const setActiveChat = vi.fn();
+  const setFilterProjectId = vi.fn();
+  const removeProjectFromStore = vi.fn();
+  const closeTab = vi.fn();
+  const addToast = vi.fn();
+  const confirmSpy = vi.spyOn(window, 'confirm');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(removeProject).mockResolvedValue(undefined as never);
+    vi.mocked(useToastStore.getState).mockReturnValue({ add: addToast } as never);
+    vi.mocked(useProjectsStore.getState).mockReturnValue({ removeProject: removeProjectFromStore } as never);
+    vi.mocked(useTabsStore.getState).mockReturnValue({ closeTab } as never);
+    vi.mocked(useChatsStore.getState).mockReturnValue({
+      filterProjectId: null,
+      activeChatId: null,
+      chats: [makeChat('c1', 'p1'), makeChat('c2', 'p1'), makeChat('c3', 'other')],
+      removeChat,
+      setActiveChat,
+      setFilterProjectId,
+    } as never);
+  });
+
+  it('does nothing when user cancels confirm', async () => {
+    confirmSpy.mockReturnValue(false);
+    await deleteProjectWithCleanup(project);
+    expect(removeProject).not.toHaveBeenCalled();
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('calls API, removes project chats, deletes drafts, closes tabs, shows success toast', async () => {
+    confirmSpy.mockReturnValue(true);
+    await deleteProjectWithCleanup(project);
+
+    expect(removeProject).toHaveBeenCalledWith('p1');
+    expect(removeChat).toHaveBeenCalledWith('c1');
+    expect(removeChat).toHaveBeenCalledWith('c2');
+    expect(removeChat).not.toHaveBeenCalledWith('c3');
+    expect(deleteDraft).toHaveBeenCalledWith('c1');
+    expect(deleteDraft).toHaveBeenCalledWith('c2');
+    expect(closeTab).toHaveBeenCalledWith('chat:c1');
+    expect(closeTab).toHaveBeenCalledWith('chat:c2');
+    expect(removeProjectFromStore).toHaveBeenCalledWith('p1');
+    expect(addToast).toHaveBeenCalledWith('success', 'Project deleted', 'My Project');
+  });
+
+  it('resets filterProjectId when it pointed at deleted project', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(useChatsStore.getState).mockReturnValue({
+      filterProjectId: 'p1',
+      activeChatId: null,
+      chats: [makeChat('c1', 'p1')],
+      removeChat,
+      setActiveChat,
+      setFilterProjectId,
+    } as never);
+
+    await deleteProjectWithCleanup(project);
+    expect(setFilterProjectId).toHaveBeenCalledWith(null);
+  });
+
+  it('leaves filterProjectId alone when it points elsewhere', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(useChatsStore.getState).mockReturnValue({
+      filterProjectId: 'other-project',
+      activeChatId: null,
+      chats: [makeChat('c1', 'p1')],
+      removeChat,
+      setActiveChat,
+      setFilterProjectId,
+    } as never);
+
+    await deleteProjectWithCleanup(project);
+    expect(setFilterProjectId).not.toHaveBeenCalled();
+  });
+
+  it('clears activeChatId when the active chat belonged to the deleted project', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(useChatsStore.getState).mockReturnValue({
+      filterProjectId: null,
+      activeChatId: 'c1',
+      chats: [makeChat('c1', 'p1'), makeChat('c3', 'other')],
+      removeChat,
+      setActiveChat,
+      setFilterProjectId,
+    } as never);
+
+    await deleteProjectWithCleanup(project);
+    expect(setActiveChat).toHaveBeenCalledWith(null);
+  });
+
+  it('leaves activeChatId when the active chat belongs to another project', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(useChatsStore.getState).mockReturnValue({
+      filterProjectId: null,
+      activeChatId: 'c3',
+      chats: [makeChat('c1', 'p1'), makeChat('c3', 'other')],
+      removeChat,
+      setActiveChat,
+      setFilterProjectId,
+    } as never);
+
+    await deleteProjectWithCleanup(project);
+    expect(setActiveChat).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when API call fails', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(removeProject).mockRejectedValue(new Error('server boom'));
+
+    await deleteProjectWithCleanup(project);
+
+    expect(addToast).toHaveBeenCalledWith('error', 'Failed to delete project', expect.stringContaining('server boom'));
+    expect(removeProjectFromStore).not.toHaveBeenCalled();
+    expect(removeChat).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/renderer/lib/delete-project.ts
+++ b/packages/desktop/src/renderer/lib/delete-project.ts
@@ -1,0 +1,41 @@
+import type { Project } from '@qlan-ro/mainframe-types';
+import { removeProject } from './api';
+import { useChatsStore, useProjectsStore } from '../store';
+import { useTabsStore } from '../store/tabs';
+import { useToastStore } from '../store/toasts';
+import { deleteDraft } from '../components/chat/assistant-ui/composer/composer-drafts.js';
+import { createLogger } from './logger';
+
+const log = createLogger('renderer:delete-project');
+
+export async function deleteProjectWithCleanup(project: Project): Promise<void> {
+  const confirmed = window.confirm(
+    `Delete project "${project.name}"?\n\nThis will stop all its sessions and remove the project from the database. Files on disk are NOT affected.\n\nThis cannot be undone.`,
+  );
+  if (!confirmed) return;
+
+  const { add: addToast } = useToastStore.getState();
+
+  try {
+    await removeProject(project.id);
+    const { filterProjectId, activeChatId, chats, removeChat, setActiveChat, setFilterProjectId } =
+      useChatsStore.getState();
+    const projectChatIds = new Set(chats.filter((c) => c.projectId === project.id).map((c) => c.id));
+    for (const chatId of projectChatIds) {
+      removeChat(chatId);
+      deleteDraft(chatId);
+      useTabsStore.getState().closeTab(`chat:${chatId}`);
+    }
+    if (filterProjectId === project.id) {
+      setFilterProjectId(null);
+    }
+    if (activeChatId && projectChatIds.has(activeChatId)) {
+      setActiveChat(null);
+    }
+    useProjectsStore.getState().removeProject(project.id);
+    addToast('success', 'Project deleted', project.name);
+  } catch (err) {
+    log.warn('delete project failed', { err: String(err) });
+    addToast('error', 'Failed to delete project', String(err));
+  }
+}


### PR DESCRIPTION
## Summary

Closes #106 — users can now delete a project from the sidebar.

- New trash icon button on each project group header. Hidden by default, fades in on hover (`group-hover:opacity-100`), turns red on hover. Not shown on the "All" pseudo-project.
- `window.confirm()` warns that sessions are stopped and the project is removed from the DB, but files on disk are untouched.
- Backend chain already existed: `DELETE /api/projects/:id` → `chat-manager.removeProject()` kills active CLI processes, clears in-memory caches, then cascades via `db.projects.removeWithChats()` in a transaction.
- Client-side cleanup after successful delete:
  - Removes all chats belonging to the project from the chats store (which drops their messages, permissions, process entries).
  - Clears drafts and open tabs for those chats.
  - Resets `filterProjectId` to null if it pointed at the deleted project.
  - Clears `activeChatId` if the active chat belonged to the deleted project.
  - Removes the project from the projects store.
  - Success toast.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — 421/421 passing
- [ ] Manual: create a project with a few chats, hover the project header → trash icon appears → click → confirm → project, chats, and active sessions disappear from the sidebar
- [ ] Manual: delete the project you were actively viewing → activeChatId resets cleanly, sidebar stays usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)