### PR TITLE
feat(composer): promote plan mode to a standalone toggle button (#50)

### DIFF
--- a/.changeset/plan-mode-button.md
+++ b/.changeset/plan-mode-button.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": minor
+---
+
+Plan mode is now a standalone toggle button in the composer instead of a permissions-dropdown option. It is only shown for adapters that support plan mode (Claude).

--- a/.changeset/plan-mode-button.md
+++ b/.changeset/plan-mode-button.md
@@ -1,5 +1,7 @@
 ---
+"@qlan-ro/mainframe-types": minor
+"@qlan-ro/mainframe-core": minor
 "@qlan-ro/mainframe-desktop": minor
 ---
 
-Plan mode is now a standalone toggle button in the composer instead of a permissions-dropdown option. It is only shown for adapters that support plan mode (Claude).
+Plan mode is now a standalone toggle, orthogonal to the permission mode. Codex supports plan mode with the same approval card UX as Claude, via the requestUserInput exit prompt. The per-adapter "Start in Plan Mode" checkbox in settings replaces the old Plan radio option. Existing chats and settings with permission_mode='plan' are migrated automatically. Also fixes a race where the Thinking indicator disappeared after approving a plan with Clear Context.

--- a/docs/superpowers/plans/2026-04-22-plan-mode-orthogonal.md
+++ b/docs/superpowers/plans/2026-04-22-plan-mode-orthogonal.md
@@ -1,0 +1,2190 @@
+# Plan Mode as an Orthogonal Axis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split plan mode out of `PermissionMode` into its own boolean axis, ship Codex plan-mode parity with `PlanApprovalCard`, redesign the per-adapter settings control, and fix the Thinking-indicator race after clear-context approve.
+
+**Architecture:** Data model changes in `@qlan-ro/mainframe-types` cascade to the DB schema, chat-manager config endpoint, both plugin adapters (Claude + Codex), the plan-mode handler (newly adapter-pluggable), and the renderer. Session `kill()` becomes deterministic via awaited exit, with a session-identity guard on stale `onExit` as defense in depth.
+
+**Tech Stack:** TypeScript (strict, NodeNext), pnpm workspaces, `better-sqlite3`, Vitest, React, Electron, Zod schemas on all WS routes.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-plan-mode-orthogonal-design.md`
+
+---
+
+## File Structure
+
+Files created/modified, grouped by responsibility:
+
+**Types (`packages/types/src/`)**
+- Modify `adapter.ts` — shrink `SessionSpawnOptions.permissionMode`, add `planMode`, add `Adapter.capabilities`, shrink `ControlResponse.executionMode` (already done)
+- Modify `chat.ts` — shrink `Chat.permissionMode`, add `Chat.planMode`
+
+**Core DB (`packages/core/src/db/`)**
+- Modify `schema.ts` — add `plan_mode` column + value migration
+- Modify `chats.ts` — add `planMode` to `updateColumnMap`, read `plan_mode` in row builders
+
+**Core chat (`packages/core/src/chat/`)**
+- Modify `plan-mode-handler.ts` — becomes adapter-agnostic dispatcher
+- Create `plan-mode-actions.ts` — `PlanModeActionHandler` interface + `PlanActionContext` shape
+- Modify `chat-manager.ts` + `config-manager.ts` — `planMode` parameter plumbed through `updateChatConfig`
+- Modify `permission-handler.ts` — dispatch via adapter-provided handler
+- Modify `lifecycle-manager.ts` — read `defaultPlanMode` in `createChatWithDefaults`
+
+**Claude plugin (`packages/core/src/plugins/builtin/claude/`)**
+- Modify `session.ts` — `kill()` awaits close with 3s SIGKILL fallback; spawn uses `planMode ? 'plan' : permissionMode` for `--permission-mode`
+- Modify `adapter.ts` — declare `capabilities: { planMode: true }`
+- Create `plan-mode-handler.ts` — `ClaudePlanModeHandler` implementing `PlanModeActionHandler`
+
+**Codex plugin (`packages/core/src/plugins/builtin/codex/`)**
+- Modify `session.ts` — `kill()` awaits close with timeout; `buildCollaborationMode()` reads `planMode`
+- Modify `event-mapper.ts` — wire `item/plan/delta` and terminal `plan` item into `currentTurnPlan` state; clear on `turn/started` / `turn/completed`
+- Modify `approval-handler.ts` — route `requestUserInput` to `ExitPlanMode` when `planMode === true` AND a plan was captured this turn
+- Modify `types.ts` — extend `CodexSessionState` with `currentTurnPlan`
+- Modify `adapter.ts` — declare `capabilities: { planMode: true }`
+- Create `plan-mode-handler.ts` — `CodexPlanModeHandler` implementing `PlanModeActionHandler`
+
+**Core server (`packages/core/src/server/`)**
+- Modify `ws-schemas.ts` — `chat.updateConfig` accepts `planMode?: boolean`
+- Modify `websocket.ts` — forward `planMode` to `chatManager.updateChatConfig`
+
+**Event handler (`packages/core/src/chat/`)**
+- Modify `event-handler.ts` — `buildSessionSink` takes `sessionId`; `onExit` guards against superseded sessions
+
+**Desktop renderer (`packages/desktop/src/renderer/`)**
+- Modify `components/chat/assistant-ui/composer/PlanModeToggle.tsx` — delete `adapterSupportsPlanMode` and `displayModeForDropdown`
+- Modify `components/chat/assistant-ui/composer/ComposerCard.tsx` — delete `lastNonPlanModeRef`, use `adapter.capabilities.planMode`, pass `planMode` through `updateChatConfig`
+- Modify `components/settings/ProviderSection.tsx` — drop Plan from radio options, add "Start in Plan Mode" checkbox
+- Modify `components/settings/constants.ts` — shrink `MODE_OPTIONS`
+- Modify `lib/client.ts` / `lib/api/` — `updateChatConfig` signature takes `planMode`
+- Modify `components/chat/PlanApprovalCard.tsx` — hide clear-context checkbox for adapters that don't support it (Codex v1)
+
+**E2E (`packages/e2e/tests/`)**
+- Create `33-codex-plan-approval.spec.ts` — Codex plan-exit UX test
+- Extend `07-plan-approval.spec.ts` — cover orthogonal toggle semantics
+
+---
+
+## Ground Rules
+
+- Every code-touching task does TDD: failing test first, then implementation, then green test, then commit.
+- After each task: `pnpm -r run typecheck` must pass. Only commit green.
+- Never commit to main. Branch is `feat/plan-mode-button`.
+- Per CLAUDE.md: `pnpm changeset` (not `--empty`) at the end for the whole PR.
+- Log exact commands and expected output in every run step.
+
+---
+
+## Task 1: Types — Split `PermissionMode`, Add `planMode`, Add Capabilities
+
+**Files:**
+- Modify: `packages/types/src/chat.ts`
+- Modify: `packages/types/src/adapter.ts`
+
+No test file — types are verified by downstream typecheck in later tasks.
+
+- [ ] **Step 1: Shrink `Chat.permissionMode` and add `Chat.planMode`**
+
+Edit `packages/types/src/chat.ts:16`:
+
+```ts
+  permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+  planMode?: boolean;
+```
+
+- [ ] **Step 2: Shrink `SessionSpawnOptions.permissionMode` and add `planMode`**
+
+Edit `packages/types/src/adapter.ts:31-36`:
+
+```ts
+export interface SessionSpawnOptions {
+  model?: string;
+  permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+  planMode?: boolean;
+  executablePath?: string;
+  systemPrompt?: string;
+}
+```
+
+- [ ] **Step 3: Add `capabilities` to the `Adapter` interface**
+
+Edit `packages/types/src/adapter.ts:187-218` — add the field right after `name`:
+
+```ts
+export interface Adapter {
+  id: string;
+  name: string;
+  readonly capabilities: {
+    planMode: boolean;
+  };
+
+  isInstalled(): Promise<boolean>;
+  // ...rest unchanged
+}
+```
+
+- [ ] **Step 4: Build types package**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
+Expected: success. Downstream typecheck failures in core/desktop are expected and will be resolved in later tasks — do NOT fix them yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/types/src/chat.ts packages/types/src/adapter.ts
+git commit -m "types: split plan mode out of PermissionMode + add adapter capabilities"
+```
+
+---
+
+## Task 2: DB Schema — Add `plan_mode` Column + Value Migration
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts`
+- Test: `packages/core/src/__tests__/db/plan-mode-migration.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/__tests__/db/plan-mode-migration.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../../db/schema.js';
+
+describe('plan_mode column migration', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  it('adds plan_mode column defaulting to 0', () => {
+    initializeSchema(db);
+    const cols = db.pragma('table_info(chats)') as { name: string }[];
+    expect(cols.some((c) => c.name === 'plan_mode')).toBe(true);
+  });
+
+  it("rewrites permission_mode='plan' to ('default', plan_mode=1) on migration", () => {
+    // Pre-migration: create the old schema + seed a row with permission_mode='plan'
+    db.exec(`
+      CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, path TEXT, created_at TEXT, last_opened_at TEXT);
+      CREATE TABLE chats (
+        id TEXT PRIMARY KEY, adapter_id TEXT, project_id TEXT,
+        status TEXT, created_at TEXT, updated_at TEXT,
+        permission_mode TEXT
+      );
+      INSERT INTO projects VALUES ('p1', 'x', '/x', '2026', '2026');
+      INSERT INTO chats VALUES ('c1', 'claude', 'p1', 'active', '2026', '2026', 'plan');
+      INSERT INTO chats VALUES ('c2', 'codex', 'p1', 'active', '2026', '2026', 'default');
+    `);
+
+    initializeSchema(db);
+
+    const rows = db.prepare('SELECT id, permission_mode, plan_mode FROM chats ORDER BY id').all() as {
+      id: string;
+      permission_mode: string | null;
+      plan_mode: number;
+    }[];
+    expect(rows[0]).toEqual({ id: 'c1', permission_mode: 'default', plan_mode: 1 });
+    expect(rows[1]).toEqual({ id: 'c2', permission_mode: 'default', plan_mode: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/plan-mode-migration.test.ts`
+Expected: FAIL — `plan_mode` column missing.
+
+- [ ] **Step 3: Add column + migration in `schema.ts`**
+
+Edit `packages/core/src/db/schema.ts` — in the migrations block (after the `pinned` check near line 92) add:
+
+```ts
+  if (!cols.some((c) => c.name === 'plan_mode')) {
+    db.exec('ALTER TABLE chats ADD COLUMN plan_mode INTEGER NOT NULL DEFAULT 0');
+    db.exec("UPDATE chats SET plan_mode = 1, permission_mode = 'default' WHERE permission_mode = 'plan'");
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/plan-mode-migration.test.ts`
+Expected: PASS — both test cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/schema.ts packages/core/src/__tests__/db/plan-mode-migration.test.ts
+git commit -m "core(db): add plan_mode column and migrate permission_mode='plan' values"
+```
+
+---
+
+## Task 3: `ChatsRepository` — Persist `planMode`
+
+**Files:**
+- Modify: `packages/core/src/db/chats.ts`
+- Test: `packages/core/src/__tests__/db/chats.test.ts` (existing — add cases)
+
+- [ ] **Step 1: Write failing test cases**
+
+Append to the existing `packages/core/src/__tests__/db/chats.test.ts`:
+
+```ts
+  it('reads and writes planMode', () => {
+    const chat = repo.create('p1', 'claude');
+    expect(chat.planMode).toBe(false);
+
+    repo.update(chat.id, { planMode: true });
+    const reread = repo.get(chat.id)!;
+    expect(reread.planMode).toBe(true);
+
+    repo.update(chat.id, { planMode: false });
+    expect(repo.get(chat.id)!.planMode).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/chats.test.ts -t "reads and writes planMode"`
+Expected: FAIL — `planMode` is `undefined`.
+
+- [ ] **Step 3: Add `planMode` to `updateColumnMap` and row builders**
+
+Edit `packages/core/src/db/chats.ts:136-154` — add to `updateColumnMap`:
+
+```ts
+    planMode: { column: 'plan_mode', transform: (v) => (v ? 1 : 0) },
+```
+
+Then find the three row builders at lines ~48, ~76, ~104, ~268. Each builds a `Chat` from a row. Add:
+
+```ts
+      planMode: !!(row.planMode ?? row.plan_mode),
+```
+
+Note: existing rows use snake_case column aliases in some paths. Verify which each builder reads — follow the same pattern (`row.<camel>` or `row.<snake>`) the rest of that builder uses.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/chats.test.ts -t "reads and writes planMode"`
+Expected: PASS.
+
+Also run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/chats.test.ts`
+Expected: all existing cases still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/chats.ts packages/core/src/__tests__/db/chats.test.ts
+git commit -m "core(db): plumb planMode through ChatsRepository read/write"
+```
+
+---
+
+## Task 4: Create `PlanModeActionHandler` Interface
+
+**Files:**
+- Create: `packages/core/src/chat/plan-mode-actions.ts`
+
+No test — pure types.
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// packages/core/src/chat/plan-mode-actions.ts
+import type { Chat, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { ActiveChat } from './types.js';
+import type { MessageCache } from './message-cache.js';
+import type { PermissionManager } from './permission-manager.js';
+import type { DatabaseManager } from '../db/index.js';
+
+export interface PlanActionContext {
+  chatId: string;
+  active: ActiveChat;
+  chat: Chat;
+  db: DatabaseManager;
+  messages: MessageCache;
+  permissions: PermissionManager;
+  emitEvent(event: DaemonEvent): void;
+  clearDisplayCache(chatId: string): void;
+  startChat(chatId: string): Promise<void>;
+  sendMessage(chatId: string, content: string): Promise<void>;
+}
+
+export interface PlanModeActionHandler {
+  /**
+   * User approved the plan WITHOUT clearing context. Default behavior for
+   * most adapters is to set planMode=false and apply the chosen exec mode.
+   */
+  onApprove(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User approved AND checked "Clear Context". Adapter decides how to reset
+   * (Claude: kill & respawn with same session id; Codex: thread/start new thread).
+   */
+  onApproveAndClearContext(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User rejected the plan. Adapter translates this to the appropriate
+   * per-protocol "stay in plan" response.
+   */
+  onReject(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User provided revision feedback. Adapter forwards as free-form text.
+   */
+  onRevise(feedback: string, response: ControlResponse, context: PlanActionContext): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit -p tsconfig.build.json`
+Expected: No new errors from this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/chat/plan-mode-actions.ts
+git commit -m "core(chat): add PlanModeActionHandler interface"
+```
+
+---
+
+## Task 5: Extract `ClaudePlanModeHandler` + Fix Base-Mode Restore
+
+**Files:**
+- Create: `packages/core/src/plugins/builtin/claude/plan-mode-handler.ts`
+- Test: `packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ClaudePlanModeHandler } from '../plan-mode-handler.js';
+import type { PlanActionContext } from '../../../../chat/plan-mode-actions.js';
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+
+function mkContext(overrides: Partial<PlanActionContext> = {}): PlanActionContext {
+  const session = {
+    isSpawned: true,
+    setPermissionMode: vi.fn().mockResolvedValue(undefined),
+    respondToPermission: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+  };
+  const chat = {
+    id: 'c1',
+    planMode: true,
+    permissionMode: 'acceptEdits' as const,
+    adapterId: 'claude',
+    projectId: 'p1',
+    status: 'active' as const,
+    createdAt: '', updatedAt: '',
+    totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, lastContextTokensInput: 0,
+  };
+  return {
+    chatId: 'c1',
+    active: { chat, session: session as any },
+    chat,
+    db: { chats: { update: vi.fn() } } as any,
+    messages: { get: vi.fn().mockReturnValue([]) } as any,
+    permissions: { shift: vi.fn() } as any,
+    emitEvent: vi.fn(),
+    clearDisplayCache: vi.fn(),
+    startChat: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('ClaudePlanModeHandler', () => {
+  const baseResponse: ControlResponse = {
+    requestId: 'r1',
+    toolUseId: 't1',
+    behavior: 'allow',
+    toolName: 'ExitPlanMode',
+    executionMode: 'acceptEdits',
+  };
+
+  it('onApprove clears planMode and calls setPermissionMode with the base mode', async () => {
+    const ctx = mkContext();
+    const handler = new ClaudePlanModeHandler();
+    await handler.onApprove(baseResponse, ctx);
+
+    expect(ctx.chat.planMode).toBe(false);
+    expect(ctx.db.chats.update).toHaveBeenCalledWith('c1', { planMode: false, permissionMode: 'acceptEdits' });
+    expect(ctx.active.session!.setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+  });
+
+  it('onReject forwards the deny message with Claude preamble handled by respondToPermission', async () => {
+    const ctx = mkContext();
+    const handler = new ClaudePlanModeHandler();
+    const denyResponse: ControlResponse = { ...baseResponse, behavior: 'deny', message: 'needs more work' };
+    await handler.onReject(denyResponse, ctx);
+    expect(ctx.active.session!.respondToPermission).toHaveBeenCalledWith(denyResponse);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts`
+Expected: FAIL — `ClaudePlanModeHandler` does not exist.
+
+- [ ] **Step 3: Implement the handler**
+
+Create `packages/core/src/plugins/builtin/claude/plan-mode-handler.ts`:
+
+```ts
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+import type { PlanModeActionHandler, PlanActionContext } from '../../../chat/plan-mode-actions.js';
+import { extractLatestPlanFileFromMessages } from '../../../chat/context-tracker.js';
+
+export class ClaudePlanModeHandler implements PlanModeActionHandler {
+  async onApprove(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.setPermissionMode(exec);
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+
+  async onApproveAndClearContext(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    const plan = (response.updatedInput as Record<string, unknown> | undefined)?.plan as string | undefined;
+
+    const recoveredPlanPath = extractLatestPlanFileFromMessages(ctx.messages.get(ctx.chatId) ?? []);
+    if (recoveredPlanPath && ctx.db.chats.addPlanFile(ctx.chatId, recoveredPlanPath)) {
+      ctx.emitEvent({ type: 'context.updated', chatId: ctx.chatId });
+    }
+
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission({
+        ...response,
+        behavior: 'deny',
+        message: 'User chose to clear context and start a new session.',
+      });
+      ctx.permissions.shift(ctx.chatId);
+      await ctx.active.session.kill();
+      ctx.active.session = null;
+    } else {
+      ctx.permissions.shift(ctx.chatId);
+    }
+
+    ctx.chat.claudeSessionId = undefined;
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { claudeSessionId: undefined, planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    ctx.messages.set(ctx.chatId, []);
+    ctx.clearDisplayCache(ctx.chatId);
+    ctx.emitEvent({ type: 'messages.cleared', chatId: ctx.chatId });
+
+    await ctx.startChat(ctx.chatId);
+    if (plan) {
+      await ctx.sendMessage(ctx.chatId, `Implement the following plan:\n\n${plan}`);
+    }
+  }
+
+  async onReject(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+
+  async onRevise(_feedback: string, response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    // Claude handles feedback via respondToPermission's message field — the PlanApprovalCard
+    // already sends behavior=deny with the user's feedback as message.
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+}
+```
+
+Note the missing `messages.set` method on `MessageCache` in the signature of `PlanActionContext` — add it if missing. The existing `plan-mode-handler.ts` already uses `this.ctx.messages.set(chatId, [])`, so it exists; just make sure the interface in `plan-mode-actions.ts` references it. (Look at `MessageCache` in `packages/core/src/chat/message-cache.ts` and confirm `set(chatId, msgs): void` is public. If not, surface it.)
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/plan-mode-handler.ts \
+        packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
+git commit -m "core(claude): extract plan-mode handler; clear planMode on approve instead of rewriting permissionMode"
+```
+
+---
+
+## Task 6: Refactor `plan-mode-handler.ts` to Adapter-Agnostic Dispatcher
+
+**Files:**
+- Modify: `packages/core/src/chat/plan-mode-handler.ts`
+- Modify: `packages/core/src/plugins/builtin/claude/adapter.ts` (declare capabilities + factory)
+- Modify: `packages/core/src/__tests__/plan-mode-handler.test.ts` (update existing tests — the module now delegates)
+
+- [ ] **Step 1: Add `createPlanModeHandler` to the Adapter type**
+
+Edit `packages/types/src/adapter.ts:187-218` — add an optional factory method to the `Adapter` interface:
+
+```ts
+  createPlanModeHandler?(): unknown;
+  // Typed import would cause a core→types cycle, so core casts the result.
+  // Core imports PlanModeActionHandler from './plan-mode-actions'.
+```
+
+- [ ] **Step 2: Update Claude adapter to declare capabilities + factory**
+
+Edit `packages/core/src/plugins/builtin/claude/adapter.ts`:
+
+```ts
+import { ClaudePlanModeHandler } from './plan-mode-handler.js';
+
+// In the adapter object:
+capabilities: { planMode: true },
+createPlanModeHandler() {
+  return new ClaudePlanModeHandler();
+},
+```
+
+Verify where the adapter is exported (likely `index.ts`) and follow that pattern.
+
+- [ ] **Step 3: Rewrite the dispatcher**
+
+Replace `packages/core/src/chat/plan-mode-handler.ts` with:
+
+```ts
+import type { Chat, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { DatabaseManager } from '../db/index.js';
+import type { PermissionManager } from './permission-manager.js';
+import type { MessageCache } from './message-cache.js';
+import type { ActiveChat } from './types.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import type { PlanModeActionHandler, PlanActionContext } from './plan-mode-actions.js';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('chat:plan-mode');
+
+export interface PlanModeContext {
+  messages: MessageCache;
+  db: DatabaseManager;
+  permissions: PermissionManager;
+  adapters: AdapterRegistry;
+  getActiveChat(chatId: string): ActiveChat | undefined;
+  emitEvent(event: DaemonEvent): void;
+  clearDisplayCache(chatId: string): void;
+  startChat(chatId: string): Promise<void>;
+  sendMessage(chatId: string, content: string): Promise<void>;
+}
+
+export class PlanModeHandler {
+  constructor(private ctx: PlanModeContext) {}
+
+  /** Legacy entry for callers that still expect the old no-process method. */
+  async handleNoProcess(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as NonNullable<Chat['permissionMode']>;
+    if (exec !== active.chat.permissionMode || active.chat.planMode) {
+      active.chat.permissionMode = exec;
+      active.chat.planMode = false;
+      this.ctx.db.chats.update(chatId, { permissionMode: exec, planMode: false });
+      this.ctx.emitEvent({ type: 'chat.updated', chat: active.chat });
+    }
+  }
+
+  async handleClearContext(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
+    const handler = this.resolveHandler(active.chat.adapterId);
+    if (!handler) {
+      log.warn({ chatId, adapterId: active.chat.adapterId }, 'no plan-mode handler for adapter');
+      return;
+    }
+    await handler.onApproveAndClearContext(response, this.buildActionContext(chatId, active));
+  }
+
+  async handleEscalation(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
+    const handler = this.resolveHandler(active.chat.adapterId);
+    if (!handler) {
+      log.warn({ chatId, adapterId: active.chat.adapterId }, 'no plan-mode handler for adapter');
+      return;
+    }
+    await handler.onApprove(response, this.buildActionContext(chatId, active));
+  }
+
+  private resolveHandler(adapterId: string): PlanModeActionHandler | null {
+    const adapter = this.ctx.adapters.get(adapterId);
+    if (!adapter?.createPlanModeHandler) return null;
+    return adapter.createPlanModeHandler() as PlanModeActionHandler;
+  }
+
+  private buildActionContext(chatId: string, active: ActiveChat): PlanActionContext {
+    return {
+      chatId,
+      active,
+      chat: active.chat,
+      db: this.ctx.db,
+      messages: this.ctx.messages,
+      permissions: this.ctx.permissions,
+      emitEvent: this.ctx.emitEvent,
+      clearDisplayCache: this.ctx.clearDisplayCache,
+      startChat: this.ctx.startChat,
+      sendMessage: this.ctx.sendMessage,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Update `PlanModeContext` construction**
+
+Find where `PlanModeHandler` is instantiated in `chat-manager.ts` (grep `new PlanModeHandler`) and add `adapters: this.adapters` to the passed context. The `AdapterRegistry` is already a field on `ChatManager`.
+
+- [ ] **Step 5: Update existing tests in `__tests__/plan-mode-handler.test.ts`**
+
+Existing tests use the old direct-to-Claude handler. Rewrite them to mock an adapter with `createPlanModeHandler` returning a spy, then verify the dispatcher calls the expected method. Keep the same coverage; just update the mock shape.
+
+Use `Agent` tool (Explore) if needed to read `packages/core/src/__tests__/plan-mode-handler.test.ts` and mirror its structure:
+
+```ts
+const mockHandler = {
+  onApprove: vi.fn(), onApproveAndClearContext: vi.fn(),
+  onReject: vi.fn(), onRevise: vi.fn(),
+};
+const mockAdapter = { createPlanModeHandler: () => mockHandler, capabilities: { planMode: true } };
+const adapters = { get: () => mockAdapter } as any;
+
+// construct handler with adapters in ctx
+// call handler.handleClearContext(...)
+// expect(mockHandler.onApproveAndClearContext).toHaveBeenCalled()
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/plan-mode-handler.test.ts`
+Expected: PASS (both rewritten cases).
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/restore-permission.test.ts src/__tests__/control-requests.test.ts`
+Expected: still green (dispatcher preserves behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/chat/plan-mode-handler.ts \
+        packages/core/src/chat/plan-mode-actions.ts \
+        packages/core/src/plugins/builtin/claude/adapter.ts \
+        packages/core/src/__tests__/plan-mode-handler.test.ts \
+        packages/types/src/adapter.ts
+git commit -m "core(chat): make plan-mode handler adapter-pluggable"
+```
+
+---
+
+## Task 7: Codex — Capture `plan` Items via Delta Accumulation
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/codex/types.ts`
+- Modify: `packages/core/src/plugins/builtin/codex/event-mapper.ts`
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts` (create)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleNotification, type CodexSessionState } from '../event-mapper.js';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+
+const NULL_SINK: SessionSink = {
+  onInit: vi.fn(), onMessage: vi.fn(), onToolResult: vi.fn(), onPermission: vi.fn(),
+  onResult: vi.fn(), onExit: vi.fn(), onError: vi.fn(), onCompact: vi.fn(), onCompactStart: vi.fn(),
+  onContextUsage: vi.fn(), onPlanFile: vi.fn(), onSkillFile: vi.fn(), onQueuedProcessed: vi.fn(),
+  onTodoUpdate: vi.fn(), onPrDetected: vi.fn(),
+};
+
+describe('Codex plan item capture', () => {
+  let state: CodexSessionState;
+
+  beforeEach(() => {
+    state = { threadId: 't1', currentTurnId: 'turn1', currentTurnPlan: null };
+  });
+
+  it('accumulates plan delta text into currentTurnPlan', () => {
+    handleNotification('item/plan/delta', { itemId: 'p1', delta: '# Plan\n' }, NULL_SINK, state);
+    handleNotification('item/plan/delta', { itemId: 'p1', delta: 'Step 1\n' }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toEqual({ id: 'p1', text: '# Plan\nStep 1\n' });
+  });
+
+  it('finalises the plan when a plan item is emitted', () => {
+    handleNotification('item/plan/delta', { itemId: 'p2', delta: 'partial' }, NULL_SINK, state);
+    handleNotification('item/completed', { item: { id: 'p2', type: 'plan', text: 'complete plan' } }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toEqual({ id: 'p2', text: 'complete plan' });
+  });
+
+  it('clears currentTurnPlan on turn/started', () => {
+    state.currentTurnPlan = { id: 'old', text: 'stale' };
+    handleNotification('turn/started', { turnId: 'turn2' }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toBeNull();
+  });
+
+  it('clears currentTurnPlan on turn/completed', () => {
+    state.currentTurnPlan = { id: 'p', text: 'x' };
+    handleNotification('turn/completed', { turnId: 'turn1' }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts`
+Expected: FAIL — `currentTurnPlan` not on state.
+
+- [ ] **Step 3: Extend `CodexSessionState`**
+
+Edit `packages/core/src/plugins/builtin/codex/types.ts` (or wherever `CodexSessionState` is defined; search if it's in `event-mapper.ts`):
+
+```ts
+export interface CodexSessionState {
+  threadId: string | null;
+  currentTurnId: string | null;
+  currentTurnPlan: { id: string; text: string } | null;
+}
+```
+
+Initialize in `session.ts` — `readonly state: CodexSessionState = { threadId: null, currentTurnId: null, currentTurnPlan: null };`.
+
+- [ ] **Step 4: Handle plan-related notifications in `event-mapper.ts`**
+
+In `packages/core/src/plugins/builtin/codex/event-mapper.ts` — find the existing `handleNotification` switch and replace the existing `turn/plan/updated` / `item/plan/delta` stubs with real handlers, plus add terminal-item handling:
+
+```ts
+    case 'item/plan/delta': {
+      const { itemId, delta } = params as { itemId: string; delta: string };
+      const prev = state.currentTurnPlan;
+      if (prev && prev.id === itemId) {
+        state.currentTurnPlan = { id: itemId, text: prev.text + delta };
+      } else {
+        state.currentTurnPlan = { id: itemId, text: delta };
+      }
+      return;
+    }
+    case 'item/completed': {
+      const item = (params as { item?: { id?: string; type?: string; text?: string } }).item;
+      if (item && item.type === 'plan' && typeof item.text === 'string' && item.id) {
+        state.currentTurnPlan = { id: item.id, text: item.text };
+      }
+      return;
+    }
+    case 'turn/started':
+    case 'turn/completed':
+      state.currentTurnPlan = null;
+      // fall through to whatever existing handling lives here
+      break;
+```
+
+(Preserve existing per-case behavior for `turn/started` and `turn/completed` — add the clear before any existing fall-through.)
+
+- [ ] **Step 5: Run test — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/types.ts \
+        packages/core/src/plugins/builtin/codex/event-mapper.ts \
+        packages/core/src/plugins/builtin/codex/session.ts \
+        packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+git commit -m "core(codex): capture plan items from item/plan/delta and item/completed"
+```
+
+---
+
+## Task 8: Codex — Route `requestUserInput` to `ExitPlanMode` When Plan Captured
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/codex/approval-handler.ts`
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts` (create)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ApprovalHandler } from '../approval-handler.js';
+
+function mkSink() {
+  return {
+    onInit: vi.fn(), onMessage: vi.fn(), onToolResult: vi.fn(),
+    onPermission: vi.fn(), onResult: vi.fn(), onExit: vi.fn(),
+    onError: vi.fn(), onCompact: vi.fn(), onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(), onPlanFile: vi.fn(), onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(), onTodoUpdate: vi.fn(), onPrDetected: vi.fn(),
+  };
+}
+
+describe('Codex requestUserInput routing', () => {
+  const requestUserInputParams = {
+    toolCallId: 'tc1',
+    questions: ['Implement this plan?'],
+    options: [
+      [{ label: 'Yes, implement this plan', description: 'Switch to Default and start coding.' }],
+      [{ label: 'No, stay in Plan mode', description: 'Continue planning with the model.' }],
+    ],
+  };
+
+  it('routes to ExitPlanMode when planMode=true and a plan was captured this turn', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: true, currentTurnPlan: { id: 'p1', text: 'full plan text' } });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 42, vi.fn());
+
+    expect(sink.onPermission).toHaveBeenCalledTimes(1);
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string; input: Record<string, unknown> };
+    expect(req.toolName).toBe('ExitPlanMode');
+    expect(req.input.plan).toBe('full plan text');
+  });
+
+  it('routes to AskUserQuestion when planMode=false', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: false, currentTurnPlan: { id: 'p1', text: 'x' } });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 43, vi.fn());
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string };
+    expect(req.toolName).toBe('AskUserQuestion');
+  });
+
+  it('routes to AskUserQuestion when no plan captured yet', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: true, currentTurnPlan: null });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 44, vi.fn());
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string };
+    expect(req.toolName).toBe('AskUserQuestion');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts`
+Expected: FAIL — `setPlanContext` method missing.
+
+- [ ] **Step 3: Extend `ApprovalHandler`**
+
+Edit `packages/core/src/plugins/builtin/codex/approval-handler.ts` — at the top, add:
+
+```ts
+interface PlanContext {
+  planMode: boolean;
+  currentTurnPlan: { id: string; text: string } | null;
+}
+
+// In ApprovalHandler class:
+private planContext: PlanContext = { planMode: false, currentTurnPlan: null };
+
+setPlanContext(ctx: PlanContext): void {
+  this.planContext = ctx;
+}
+```
+
+Then in `handleRequest`, where `method === 'item/tool/requestUserInput'` maps to `toolName = 'AskUserQuestion'` (around line 40-47), replace:
+
+```ts
+    } else if (method === 'item/tool/requestUserInput') {
+      // ...
+      toolName = 'AskUserQuestion';
+```
+
+with:
+
+```ts
+    } else if (method === 'item/tool/requestUserInput') {
+      // ...
+      const isPlanExit =
+        this.planContext.planMode &&
+        this.planContext.currentTurnPlan !== null &&
+        Array.isArray((params as { options?: unknown[] }).options) &&
+        ((params as { options?: unknown[] }).options?.length ?? 0) === 2;
+      if (isPlanExit) {
+        toolName = 'ExitPlanMode';
+        input = { plan: this.planContext.currentTurnPlan!.text, allowedPrompts: [] };
+      } else {
+        toolName = 'AskUserQuestion';
+        // ...existing input mapping
+      }
+```
+
+Adjust for the actual local-variable structure (read the current implementation — mutate in place rather than mirror the snippet verbatim).
+
+- [ ] **Step 4: Call `setPlanContext` from `CodexSession` before forwarding**
+
+In `packages/core/src/plugins/builtin/codex/session.ts`, find where `approvalHandler.handleRequest` is invoked (around line 129). Before the call, or at the start of `onRequest`, push the latest plan context:
+
+```ts
+      onRequest: (method, params, id) => {
+        approvalHandler.setPlanContext({
+          planMode: /* read from the chat — see note below */,
+          currentTurnPlan: this.state.currentTurnPlan,
+        });
+        approvalHandler.handleRequest(method, params, id, (rpcId, result) => {
+          this.client?.respond(rpcId, result);
+        });
+      },
+```
+
+The adapter session doesn't have direct access to the `Chat` object. Two options — pick the simpler:
+
+- (i) Add a `setPlanMode(on: boolean)` method on `CodexSession` and call it from `chat-manager.updateChatConfig` + `spawn` + wherever `planMode` changes; session stores the boolean locally.
+- (ii) Pass `planMode` via `SessionSpawnOptions` at spawn and require the consumer to call `session.setPlanMode` on toggles.
+
+Use (i). Add a `pendingPlanMode: boolean = false` field to `CodexSession`, a `setPlanMode(on)` setter, and read it in the `onRequest` closure.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/approval-handler.ts \
+        packages/core/src/plugins/builtin/codex/session.ts \
+        packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+git commit -m "core(codex): route requestUserInput to ExitPlanMode when in plan mode with captured plan"
+```
+
+---
+
+## Task 9: Codex — Plan-Mode Handler (`CodexPlanModeHandler`)
+
+**Files:**
+- Create: `packages/core/src/plugins/builtin/codex/plan-mode-handler.ts`
+- Modify: `packages/core/src/plugins/builtin/codex/adapter.ts` — declare capabilities + factory
+- Modify: `packages/core/src/plugins/builtin/codex/session.ts` — expose `respondToRequestUserInput(toolCallId, answer)` helper and `startNewThread()` for clear-context approve
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// packages/core/src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { CodexPlanModeHandler } from '../plan-mode-handler.js';
+import type { PlanActionContext } from '../../../../chat/plan-mode-actions.js';
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+
+function mkCtx() {
+  const session = {
+    isSpawned: true,
+    setPlanMode: vi.fn(),
+    respondToPermission: vi.fn().mockResolvedValue(undefined),
+    startNewThread: vi.fn().mockResolvedValue('thread-2'),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+  };
+  const chat = {
+    id: 'c1', planMode: true, permissionMode: 'acceptEdits' as const,
+    adapterId: 'codex', projectId: 'p1', status: 'active' as const,
+    createdAt: '', updatedAt: '', totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+  };
+  return {
+    chatId: 'c1',
+    active: { chat, session: session as any },
+    chat,
+    db: { chats: { update: vi.fn() } } as any,
+    messages: { get: vi.fn().mockReturnValue([]), set: vi.fn() } as any,
+    permissions: { shift: vi.fn() } as any,
+    emitEvent: vi.fn(),
+    clearDisplayCache: vi.fn(),
+    startChat: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PlanActionContext;
+}
+
+describe('CodexPlanModeHandler', () => {
+  const planText = 'PROPOSED PLAN TEXT';
+  const baseResponse: ControlResponse = {
+    requestId: 'r1', toolUseId: 'tc1', behavior: 'allow', toolName: 'ExitPlanMode',
+    executionMode: 'acceptEdits', updatedInput: { plan: planText },
+  };
+
+  it('onApprove responds with first option and clears planMode', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    await h.onApprove(baseResponse, ctx);
+    expect(ctx.chat.planMode).toBe(false);
+    expect(ctx.db.chats.update).toHaveBeenCalledWith('c1', { planMode: false, permissionMode: 'acceptEdits' });
+    expect((ctx.active.session as any).respondToPermission).toHaveBeenCalled();
+  });
+
+  it('onApproveAndClearContext starts a new thread and sends the plan as first input', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    await h.onApproveAndClearContext(baseResponse, ctx);
+    expect((ctx.active.session as any).startNewThread).toHaveBeenCalled();
+    expect((ctx.active.session as any).sendMessage).toHaveBeenCalledWith(
+      expect.stringContaining(planText),
+      undefined,
+      undefined,
+    );
+    expect(ctx.chat.planMode).toBe(false);
+  });
+
+  it('onReject responds with the deny option', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    const rejectResp: ControlResponse = { ...baseResponse, behavior: 'deny' };
+    await h.onReject(rejectResp, ctx);
+    expect((ctx.active.session as any).respondToPermission).toHaveBeenCalledWith(rejectResp);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts`
+Expected: FAIL — module and methods missing.
+
+- [ ] **Step 3: Implement `CodexPlanModeHandler`**
+
+Create `packages/core/src/plugins/builtin/codex/plan-mode-handler.ts`:
+
+```ts
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+import type { PlanModeActionHandler, PlanActionContext } from '../../../chat/plan-mode-actions.js';
+
+/**
+ * Codex plan-mode uses per-turn collaborationMode. Answering the exit
+ * requestUserInput with the correct option + flipping chat.planMode is
+ * sufficient to exit plan mode for the next turn.
+ */
+export class CodexPlanModeHandler implements PlanModeActionHandler {
+  async onApprove(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      setPlanMode?(on: boolean): void;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      session.setPlanMode?.(false);
+      // The approval-handler in session.ts knows how to translate our allow/deny
+      // into the Codex requestUserInput answer format. Forward unchanged.
+      await session.respondToPermission(response);
+    }
+  }
+
+  async onApproveAndClearContext(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    const plan = (response.updatedInput as Record<string, unknown> | undefined)?.plan as string | undefined;
+
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      startNewThread?(): Promise<string>;
+      sendMessage(msg: string, images?: unknown, uuid?: string): Promise<void>;
+      kill(): Promise<void>;
+    } | null;
+
+    if (session?.isSpawned) {
+      // Close the requestUserInput by denying first so Codex unblocks.
+      await (session as any).respondToPermission({ ...response, behavior: 'deny', message: 'Clearing context.' });
+      ctx.permissions.shift(ctx.chatId);
+      await session.kill();
+      ctx.active.session = null;
+    } else {
+      ctx.permissions.shift(ctx.chatId);
+    }
+
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    // Codex "claudeSessionId" equivalent is the thread id; drop it to force a new thread.
+    ctx.chat.claudeSessionId = undefined;
+    ctx.db.chats.update(ctx.chatId, {
+      claudeSessionId: undefined, planMode: false, permissionMode: exec,
+    });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    ctx.messages.set(ctx.chatId, []);
+    ctx.clearDisplayCache(ctx.chatId);
+    ctx.emitEvent({ type: 'messages.cleared', chatId: ctx.chatId });
+
+    await ctx.startChat(ctx.chatId);
+    if (plan) {
+      await ctx.sendMessage(ctx.chatId, `Implement the following plan:\n\n${plan}`);
+    }
+  }
+
+  async onReject(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      await session.respondToPermission(response);
+    }
+  }
+
+  async onRevise(_feedback: string, response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    // Feedback was already appended to response.message by the caller.
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      await session.respondToPermission(response);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Map approve/deny to the correct Codex requestUserInput option**
+
+In `packages/core/src/plugins/builtin/codex/approval-handler.ts`, the `resolve(response)` path that completes a `requestUserInput` with the user's choice exists already (line 80-106). Update it so when the entry was routed as `ExitPlanMode`:
+
+- `response.behavior === 'allow'` → pick the option that matches `/^yes/i`, fall back to index 0
+- `response.behavior === 'deny'` with no `message` → pick the option that matches `/^no/i`, fall back to index 1
+- `response.behavior === 'deny'` with a `message` (user Revise) → use the free-text answer path; if Codex rejects free-form (`isOther: false`), fall back to picking the `/^no/i` option and include the message in the follow-up user turn. Log a warning.
+
+Store the rendered option labels on the pending entry when emitting so `resolve` can prefix-match.
+
+- [ ] **Step 5: Declare Codex capability + factory**
+
+Edit `packages/core/src/plugins/builtin/codex/adapter.ts` (or `index.ts`):
+
+```ts
+import { CodexPlanModeHandler } from './plan-mode-handler.js';
+
+// In the adapter object:
+capabilities: { planMode: true },
+createPlanModeHandler() {
+  return new CodexPlanModeHandler();
+},
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/`
+Expected: all Codex tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/plan-mode-handler.ts \
+        packages/core/src/plugins/builtin/codex/adapter.ts \
+        packages/core/src/plugins/builtin/codex/approval-handler.ts \
+        packages/core/src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts
+git commit -m "core(codex): CodexPlanModeHandler + approve/deny → requestUserInput option mapping"
+```
+
+---
+
+## Task 10: Codex — Use `planMode` in `buildCollaborationMode`
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/codex/session.ts`
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts` (create)
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// packages/core/src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts
+import { describe, it, expect } from 'vitest';
+import { CodexSession } from '../session.js';
+
+describe('CodexSession.buildCollaborationMode', () => {
+  it('returns plan when planMode=true', () => {
+    const s = new CodexSession({ projectPath: '/x' });
+    (s as any).pendingPlanMode = true;
+    const mode = (s as any).buildCollaborationMode();
+    expect(mode.mode).toBe('plan');
+  });
+  it('returns default when planMode=false', () => {
+    const s = new CodexSession({ projectPath: '/x' });
+    (s as any).pendingPlanMode = false;
+    const mode = (s as any).buildCollaborationMode();
+    expect(mode.mode).toBe('default');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts`
+Expected: FAIL (current impl reads `pendingPermissionMode === 'plan'`).
+
+- [ ] **Step 3: Edit `buildCollaborationMode` and spawn options**
+
+`packages/core/src/plugins/builtin/codex/session.ts:334-344`:
+
+```ts
+  private buildCollaborationMode(): CollaborationMode {
+    const mode = this.pendingPlanMode ? 'plan' : 'default';
+    return {
+      mode,
+      settings: { model: this.pendingModel ?? '', reasoning_effort: null, developer_instructions: null },
+    };
+  }
+```
+
+And in `spawn(options)` — initialise `pendingPlanMode` from `options.planMode ?? false`. Remove the `permissionMode === 'plan'` branch in `mapPermissionMode` (plan is no longer a permission value).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/session.ts \
+        packages/core/src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts
+git commit -m "core(codex): derive collaborationMode from planMode (not permissionMode)"
+```
+
+---
+
+## Task 11: Claude — Use `planMode` in Spawn Flag
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts`
+- Test: `packages/core/src/__tests__/claude-spawn-args.test.ts` (existing — extend)
+
+- [ ] **Step 1: Extend the existing spawn-args test**
+
+Append cases to `packages/core/src/__tests__/claude-spawn-args.test.ts` (use the `Explore` subagent or Read tool to look at the current test, then mirror):
+
+```ts
+  it('passes --permission-mode plan when planMode=true', () => {
+    const args = buildSpawnArgs({ planMode: true, permissionMode: 'acceptEdits' });
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('plan');
+  });
+
+  it('passes --permission-mode <base> when planMode=false', () => {
+    const args = buildSpawnArgs({ planMode: false, permissionMode: 'acceptEdits' });
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('acceptEdits');
+  });
+```
+
+(If the test file doesn't expose `buildSpawnArgs`, extract it from inside `spawn` to a pure helper; otherwise stub via spy on `spawn`.)
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/claude-spawn-args.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `spawn()`**
+
+`packages/core/src/plugins/builtin/claude/session.ts:146-147`:
+
+```ts
+    const cliMode = options.planMode
+      ? 'plan'
+      : options.permissionMode === 'yolo'
+        ? 'bypassPermissions'
+        : (options.permissionMode ?? 'default');
+    args.push('--permission-mode', cliMode, '--allow-dangerously-skip-permissions');
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/claude-spawn-args.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/session.ts \
+        packages/core/src/__tests__/claude-spawn-args.test.ts
+git commit -m "core(claude): derive --permission-mode from planMode"
+```
+
+---
+
+## Task 12: `updateChatConfig` — Add `planMode` End-to-End
+
+**Files:**
+- Modify: `packages/core/src/server/ws-schemas.ts`
+- Modify: `packages/core/src/server/websocket.ts`
+- Modify: `packages/core/src/chat/chat-manager.ts`
+- Modify: `packages/core/src/chat/config-manager.ts`
+- Modify: `packages/desktop/src/renderer/lib/client.ts` + `lib/api/` (whatever is the renderer wrapper)
+- Test: `packages/core/src/__tests__/control-requests.test.ts` (existing — add case)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `packages/core/src/__tests__/control-requests.test.ts`:
+
+```ts
+    it('updateChatConfig toggles planMode via set_permission_mode (Claude)', async () => {
+      // ...existing setup…
+      await manager.updateChatConfig(chatId, undefined, undefined, undefined, true);
+      expect(session.setPermissionMode).toHaveBeenCalledWith('plan');
+      expect(db.chats.update).toHaveBeenCalledWith(chatId, expect.objectContaining({ planMode: true }));
+
+      await manager.updateChatConfig(chatId, undefined, undefined, undefined, false);
+      // Off → restores base permissionMode (whatever chat has stored)
+      expect(session.setPermissionMode).toHaveBeenLastCalledWith(chat.permissionMode);
+      expect(db.chats.update).toHaveBeenLastCalledWith(chatId, expect.objectContaining({ planMode: false }));
+    });
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/control-requests.test.ts -t "updateChatConfig toggles planMode"`
+Expected: FAIL — arity mismatch.
+
+- [ ] **Step 3: Plumb the param**
+
+**Zod schema (`ws-schemas.ts:35`):**
+
+```ts
+  type: z.literal('chat.updateConfig'),
+  chatId: z.string(),
+  adapterId: z.string().optional(),
+  model: z.string().optional(),
+  permissionMode: z.enum(['default', 'acceptEdits', 'yolo']).optional(),
+  planMode: z.boolean().optional(),
+```
+
+(Note the enum no longer includes `'plan'`.)
+
+**WebSocket handler (`websocket.ts:127-128`):**
+
+```ts
+      case 'chat.updateConfig': {
+        await this.chats.updateChatConfig(
+          event.chatId, event.adapterId, event.model, event.permissionMode, event.planMode,
+        );
+        // ...
+```
+
+**`ChatManager.updateChatConfig` (`chat-manager.ts:154-160`):**
+
+```ts
+  async updateChatConfig(
+    chatId: string,
+    adapterId?: string,
+    model?: string,
+    permissionMode?: 'default' | 'acceptEdits' | 'yolo',
+    planMode?: boolean,
+  ): Promise<void> {
+    return this.configManager.updateChatConfig(chatId, adapterId, model, permissionMode, planMode);
+  }
+```
+
+**`ConfigManager` (`config-manager.ts:27`):** add `planMode` param. When `planMode` changes:
+
+- Update DB + chat state.
+- If `planMode === true`: call `session.setPermissionMode('plan')` for Claude; for Codex call `session.setPlanMode(true)`.
+- If `planMode === false`: call `session.setPermissionMode(chat.permissionMode)` for Claude; for Codex call `session.setPlanMode(false)`.
+
+For adapter-specific dispatch, prefer reading `adapter.capabilities.planMode` and branching by `adapterId` (or extend the adapter session interface with `async setPlanMode(on: boolean)` so the ConfigManager calls it uniformly). Recommended: add `setPlanMode(on: boolean): Promise<void>` to `AdapterSession` in `packages/types/src/adapter.ts`, default-implement in Claude (`session.setPermissionMode(on ? 'plan' : this.basePermissionMode)`) and in Codex (update `pendingPlanMode`).
+
+**Renderer (`packages/desktop/src/renderer/lib/client.ts`):**
+
+```ts
+  updateChatConfig(
+    chatId: string,
+    adapterId?: string,
+    model?: string,
+    permissionMode?: 'default' | 'acceptEdits' | 'yolo',
+    planMode?: boolean,
+  ) {
+    this.ws.send({ type: 'chat.updateConfig', chatId, adapterId, model, permissionMode, planMode });
+  }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/control-requests.test.ts`
+Expected: PASS — the new case plus all existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/server/ws-schemas.ts \
+        packages/core/src/server/websocket.ts \
+        packages/core/src/chat/chat-manager.ts \
+        packages/core/src/chat/config-manager.ts \
+        packages/types/src/adapter.ts \
+        packages/core/src/plugins/builtin/claude/session.ts \
+        packages/core/src/plugins/builtin/codex/session.ts \
+        packages/desktop/src/renderer/lib/client.ts \
+        packages/core/src/__tests__/control-requests.test.ts
+git commit -m "core+desktop: plumb planMode through updateChatConfig"
+```
+
+---
+
+## Task 13: Lifecycle — Read `defaultPlanMode` at Chat Creation
+
+**Files:**
+- Modify: `packages/core/src/chat/lifecycle-manager.ts`
+- Test: `packages/core/src/__tests__/chat/create-on-worktree.test.ts` OR a new `chat-creation-defaults.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// packages/core/src/__tests__/chat-creation-defaults.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChatLifecycleManager } from '../chat/lifecycle-manager.js';
+
+describe('createChatWithDefaults reads defaultPlanMode', () => {
+  it('sets planMode=true when provider.claude.defaultPlanMode=true', async () => {
+    const db = {
+      chats: { create: vi.fn((...args) => ({ id: 'c', adapterId: args[1], projectId: args[0] })), update: vi.fn() },
+      settings: {
+        get: vi.fn((cat: string, key: string) => {
+          if (key === 'claude.defaultPlanMode') return 'true';
+          return undefined;
+        }),
+      },
+    };
+    const deps: any = {
+      db, adapters: { get: () => null }, activeChats: new Map(),
+      messages: {}, permissions: {}, emitEvent: vi.fn(), buildSink: vi.fn(),
+    };
+    const mgr = new ChatLifecycleManager(deps);
+    await mgr.createChatWithDefaults('p1', 'claude');
+    expect(db.chats.update).toHaveBeenCalledWith('c', expect.objectContaining({ planMode: true }));
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/chat-creation-defaults.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Edit `packages/core/src/chat/lifecycle-manager.ts:75-95` — `createChatWithDefaults`:
+
+```ts
+  async createChatWithDefaults(
+    projectId: string, adapterId: string, model?: string, permissionMode?: string,
+    worktreePath?: string, branchName?: string,
+  ): Promise<Chat> {
+    let effectiveModel = model;
+    let effectiveMode = permissionMode;
+    let effectivePlanMode: boolean | undefined;
+
+    const defaultModel = this.deps.db.settings.get('provider', `${adapterId}.defaultModel`);
+    const defaultMode = this.deps.db.settings.get('provider', `${adapterId}.defaultMode`);
+    const defaultPlanMode = this.deps.db.settings.get('provider', `${adapterId}.defaultPlanMode`);
+
+    if (!effectiveModel && defaultModel) effectiveModel = defaultModel;
+    if (!effectiveMode && defaultMode) effectiveMode = defaultMode;
+    if (defaultPlanMode === 'true') effectivePlanMode = true;
+
+    const chat = await this.createChat(projectId, adapterId, effectiveModel, effectiveMode, worktreePath, branchName);
+    if (effectivePlanMode) {
+      chat.planMode = true;
+      this.deps.db.chats.update(chat.id, { planMode: true });
+    }
+    return chat;
+  }
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/chat/lifecycle-manager.ts \
+        packages/core/src/__tests__/chat-creation-defaults.test.ts
+git commit -m "core(chat): seed planMode from provider.<id>.defaultPlanMode on chat creation"
+```
+
+---
+
+## Task 14: Session `kill()` — Await Close with 3s SIGKILL Fallback
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts`
+- Modify: `packages/core/src/plugins/builtin/codex/session.ts`
+- Test: `packages/core/src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts` (create)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// packages/core/src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ClaudeSession } from '../session.js';
+
+describe('ClaudeSession.kill() awaits close', () => {
+  it('resolves only after the child emits close', async () => {
+    const s = new ClaudeSession({ projectPath: '/tmp' });
+    const listeners: Record<string, ((...a: any[]) => void)[]> = {};
+    const fakeChild: any = {
+      kill: vi.fn(),
+      exitCode: null,
+      once(ev: string, cb: any) { (listeners[ev] ||= []).push(cb); },
+      on() {}, stdout: { on() {} }, stderr: { on() {} },
+    };
+    (s as any).state.child = fakeChild;
+
+    let resolved = false;
+    const p = s.kill().then(() => { resolved = true; });
+
+    // Microtask flush
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Simulate child exit
+    listeners.close?.[0]?.();
+    await p;
+    expect(resolved).toBe(true);
+    expect((s as any).state.child).toBeNull();
+  });
+
+  it('falls back to SIGKILL after 3s if close never fires', async () => {
+    vi.useFakeTimers();
+    const s = new ClaudeSession({ projectPath: '/tmp' });
+    const fakeChild: any = {
+      kill: vi.fn(),
+      exitCode: null,
+      once() {},
+      on() {}, stdout: { on() {} }, stderr: { on() {} },
+    };
+    (s as any).state.child = fakeChild;
+
+    const p = s.kill();
+    await vi.advanceTimersByTimeAsync(3000);
+    await p;
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGKILL');
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite `kill()` in Claude**
+
+`packages/core/src/plugins/builtin/claude/session.ts:200-207`:
+
+```ts
+  async kill(): Promise<void> {
+    const child = this.state.child;
+    if (!child) return;
+    const exited = new Promise<void>((resolve) => child.once('close', () => resolve()));
+    const timeout = new Promise<void>((resolve) =>
+      setTimeout(() => {
+        if (child.exitCode === null) {
+          try { child.kill('SIGKILL'); } catch { /* already dead */ }
+        }
+        resolve();
+      }, 3000),
+    );
+    child.kill('SIGTERM');
+    await Promise.race([exited, timeout]);
+    this.state.child = null;
+    log.debug({ sessionId: this.id }, 'claude session killed');
+  }
+```
+
+- [ ] **Step 4: Same pattern in Codex `session.ts:229-233`**
+
+```ts
+  async kill(): Promise<void> {
+    const client = this.client;
+    if (!client) return;
+    this.approvalHandler?.rejectAll();
+    const closed = new Promise<void>((resolve) => client.onClose(() => resolve()));
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, 3000));
+    client.close();
+    await Promise.race([closed, timeout]);
+    this.client = null;
+  }
+```
+
+Verify that `JsonRpcClient` has `onClose(cb)` — if not, expose one.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/session.ts \
+        packages/core/src/plugins/builtin/codex/session.ts \
+        packages/core/src/plugins/builtin/codex/jsonrpc.ts \
+        packages/core/src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts
+git commit -m "core(session): kill() awaits close with SIGKILL fallback"
+```
+
+---
+
+## Task 15: Session-Identity Guard on `onExit`
+
+**Files:**
+- Modify: `packages/core/src/chat/event-handler.ts`
+- Test: `packages/core/src/__tests__/session-identity-guard.test.ts` (create)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// packages/core/src/__tests__/session-identity-guard.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { EventHandler } from '../chat/event-handler.js';
+
+describe('buildSink onExit: session-identity guard', () => {
+  it('ignores close from a superseded session', () => {
+    const chatId = 'c1';
+    const chat: any = { id: chatId, processState: 'working' };
+    const newSession = { id: 'session-new' };
+    const activeChat = { chat, session: newSession };
+
+    const emitted: any[] = [];
+    const handler = new EventHandler(
+      { chats: { update: vi.fn() } } as any,
+      { get: () => [], set: vi.fn() } as any,
+      { clear: vi.fn(), clearInterrupted: vi.fn() } as any,
+      () => activeChat as any,
+      (ev) => emitted.push(ev),
+    );
+    const sink = handler.buildSink(chatId, 'session-OLD', vi.fn());
+    sink.onExit(0);
+
+    expect(chat.processState).toBe('working');  // unchanged
+    expect(emitted.find((e) => e.type === 'chat.updated')).toBeUndefined();
+  });
+
+  it('applies close from the current session', () => {
+    const chatId = 'c2';
+    const chat: any = { id: chatId, processState: 'working' };
+    const currentSession = { id: 'session-A' };
+    const activeChat = { chat, session: currentSession };
+
+    const emitted: any[] = [];
+    const handler = new EventHandler(
+      { chats: { update: vi.fn() } } as any,
+      { get: () => [], set: vi.fn() } as any,
+      { clear: vi.fn(), clearInterrupted: vi.fn() } as any,
+      () => activeChat as any,
+      (ev) => emitted.push(ev),
+    );
+    const sink = handler.buildSink(chatId, 'session-A', vi.fn());
+    sink.onExit(0);
+
+    expect(chat.processState).toBeNull();
+    expect(emitted.some((e) => e.type === 'chat.updated')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/session-identity-guard.test.ts`
+Expected: FAIL — `buildSink` doesn't accept sessionId.
+
+- [ ] **Step 3: Thread the id through**
+
+Edit `packages/core/src/chat/event-handler.ts:61-75`:
+
+```ts
+  buildSink(
+    chatId: string,
+    sessionId: string,
+    respondToPermission: (response: ControlResponse) => Promise<void>,
+  ): SessionSink {
+    return buildSessionSink(
+      chatId, sessionId, this.db, this.messages, this.permissions,
+      this.getActiveChat, this.emitEvent, respondToPermission,
+      this.displayCache, this.getToolCategories,
+      this.onQueuedProcessed, this.onQueuedCleared, this.pushService,
+    );
+  }
+```
+
+Inside `buildSessionSink` signature, accept `builtForSessionId: string` and in `onExit`:
+
+```ts
+    onExit(_code) {
+      const active = getActiveChat(chatId);
+      // Guard: ignore stale close from a superseded session.
+      if (active?.session && active.session.id !== builtForSessionId) return;
+      // ...existing logic
+    },
+```
+
+- [ ] **Step 4: Update callers**
+
+`lifecycle-manager.ts:422` passes the sink via `this.deps.buildSink(chatId, respondToPermission)` — the `LifecycleManagerDeps.buildSink` signature in `lifecycle-manager.ts:29` needs a `sessionId` param:
+
+```ts
+  buildSink: (
+    chatId: string, sessionId: string,
+    respondToPermission: (response: ControlResponse) => Promise<void>,
+  ) => SessionSink;
+```
+
+And callers of `buildSink` must pass `session.id`. In `lifecycle-manager.ts:422`:
+
+```ts
+    const sink = this.deps.buildSink(chatId, session.id, (r) => session.respondToPermission(r));
+```
+
+Follow the same pattern for `doLoadChat` if it builds a sink.
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/session-identity-guard.test.ts src/__tests__/event-handler.test.ts`
+Expected: PASS — new tests + existing tests keep green (update existing tests to pass the new `sessionId` arg if they call `buildSink` directly).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/chat/event-handler.ts \
+        packages/core/src/chat/lifecycle-manager.ts \
+        packages/core/src/__tests__/session-identity-guard.test.ts \
+        packages/core/src/__tests__/event-handler.test.ts
+git commit -m "core: guard onExit against superseded sessions"
+```
+
+---
+
+## Task 16: Composer UI — Use Adapter Capabilities + Delete Hacks
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx`
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx`
+- Modify: `packages/desktop/src/renderer/store/adapters.ts` (or wherever adapter metadata ships to UI)
+- Test: update existing composer tests
+
+- [ ] **Step 1: Extend adapter store to expose `capabilities`**
+
+`AdapterInfo` (from `packages/types/src/adapter.ts:153-161`) gains:
+
+```ts
+export interface AdapterInfo {
+  id: string; name: string; description: string; installed: boolean;
+  version?: string;
+  models: AdapterModel[];
+  capabilities: { planMode: boolean };
+}
+```
+
+Find the daemon route that builds `AdapterInfo` (grep `AdapterInfo`); include `adapter.capabilities` in the response.
+
+- [ ] **Step 2: Delete `adapterSupportsPlanMode` and `displayModeForDropdown`**
+
+Edit `PlanModeToggle.tsx:1-51` — keep only the `PlanModeToggle` component. Delete the two helper functions entirely.
+
+- [ ] **Step 3: Gate the toggle on `adapter.capabilities.planMode`**
+
+Edit `ComposerCard.tsx` where the toggle is rendered (around line 418):
+
+```tsx
+{currentAdapterInfo?.capabilities?.planMode && (
+  <PlanModeToggle active={currentMode === 'plan' || chat?.planMode === true} onToggle={handlePlanToggle} />
+)}
+```
+
+Read `currentAdapterInfo` from the adapters store keyed on `currentAdapter`.
+
+- [ ] **Step 4: Remove `lastNonPlanModeRef` and `displayModeForDropdown`**
+
+Edit `ComposerCard.tsx`:
+
+- Delete `const lastNonPlanModeRef = useRef<...>`.
+- In `handleModeChange`, drop the `if (typedMode !== 'plan') { lastNonPlanModeRef... }` block — just call `updateChatConfig`.
+- In `handlePlanToggle(enable)`:
+  ```tsx
+  const handlePlanToggle = useCallback((enable: boolean) => {
+    if (!chatId) return;
+    daemonClient.updateChatConfig(chatId, undefined, undefined, undefined, enable);
+  }, [chatId]);
+  ```
+- Dropdown: `value={currentMode}` (remove `displayModeForDropdown` wrap).
+- Icon className: simplify back to plain `currentMode === 'yolo' ? 'text-mf-destructive' : undefined`.
+- `currentMode` source should now derive from `chat?.permissionMode` directly (no more 'plan' possible).
+
+- [ ] **Step 5: Toggle-button active state**
+
+The toggle now activates on `chat?.planMode === true` rather than `currentMode === 'plan'`:
+
+```tsx
+<PlanModeToggle active={chat?.planMode === true} onToggle={handlePlanToggle} />
+```
+
+- [ ] **Step 6: Run desktop tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test`
+Expected: PASS — existing tests updated or pass unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx \
+        packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx \
+        packages/desktop/src/renderer/store/adapters.ts \
+        packages/types/src/adapter.ts
+# plus any route file building AdapterInfo + tests that changed
+git commit -m "desktop(composer): use adapter.capabilities for plan-mode gate; drop orthogonal-mode hacks"
+```
+
+---
+
+## Task 17: Settings UI — Shrink Radio, Add "Start in Plan Mode" Checkbox
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/settings/ProviderSection.tsx`
+- Modify: `packages/desktop/src/renderer/components/settings/constants.ts`
+- Test: new `packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx`
+
+- [ ] **Step 1: Drop Plan from `MODE_OPTIONS`**
+
+Edit `packages/desktop/src/renderer/components/settings/constants.ts` — delete the `{ id: 'plan', ... }` entry from `MODE_OPTIONS`. Result: Interactive, Auto-Edits, Unattended.
+
+- [ ] **Step 2: Write failing test**
+
+```tsx
+// packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProviderSection } from '../ProviderSection';
+
+vi.mock('../../../lib/api', () => ({
+  getConfigConflicts: () => Promise.resolve([]),
+  updateProviderSettings: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../store/adapters', () => ({
+  useAdaptersStore: (sel: any) => sel({
+    adapters: [{ id: 'claude', name: 'Claude', capabilities: { planMode: true } }],
+  }),
+}));
+// mock useSettingsStore to return a writeable spied-on config…
+
+describe('ProviderSection — Start in Plan Mode', () => {
+  it('renders the checkbox only when adapter supports plan mode', () => {
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+    expect(screen.getByLabelText(/start in plan mode/i)).toBeInTheDocument();
+  });
+
+  it('writes defaultPlanMode on click', async () => {
+    const { updateProviderSettings } = await import('../../../lib/api');
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+    fireEvent.click(screen.getByLabelText(/start in plan mode/i));
+    expect(updateProviderSettings).toHaveBeenCalledWith('claude', { defaultPlanMode: 'true' });
+  });
+
+  it('is hidden for adapters without plan capability', () => {
+    // re-mock adapters store for this case
+    // …
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the checkbox**
+
+Edit `ProviderSection.tsx` — after the mode radio block (around line 116), add:
+
+```tsx
+{adapter?.capabilities?.planMode && (
+  <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
+    <input
+      type="checkbox"
+      checked={config.defaultPlanMode === 'true'}
+      onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
+      className="mt-0.5 accent-mf-accent"
+    />
+    <div>
+      <span className="text-mf-small text-mf-text-primary">Start in Plan Mode</span>
+      <p className="text-mf-status text-mf-text-secondary">
+        New chats begin with plan mode enabled. You can toggle off mid-session.
+      </p>
+    </div>
+  </label>
+)}
+```
+
+Where `adapter` comes from:
+
+```tsx
+const adapter = adapters.find((a) => a.id === adapterId);
+```
+
+- [ ] **Step 5: Extend `ProviderConfig` type**
+
+`packages/types/src/settings.ts` (or wherever `ProviderConfig` lives): add `defaultPlanMode?: 'true' | 'false';`.
+
+- [ ] **Step 6: Run tests — expect pass**
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/settings/ProviderSection.tsx \
+        packages/desktop/src/renderer/components/settings/constants.ts \
+        packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx \
+        packages/types/src/settings.ts
+git commit -m "desktop(settings): replace Plan radio option with 'Start in Plan Mode' checkbox"
+```
+
+---
+
+## Task 18: Settings Key Migration — `defaultMode='plan'` → `defaultMode='default'` + `defaultPlanMode='true'`
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts` (add settings migration block)
+- Test: extend `packages/core/src/__tests__/db/plan-mode-migration.test.ts`
+
+- [ ] **Step 1: Extend the migration test**
+
+```ts
+  it("rewrites settings.defaultMode='plan' to ('default' + defaultPlanMode='true') on migration", () => {
+    db.exec(`
+      CREATE TABLE settings (id TEXT PRIMARY KEY, category TEXT, key TEXT, value TEXT, updated_at TEXT, UNIQUE(category, key));
+      INSERT INTO settings VALUES ('s1', 'provider', 'claude.defaultMode', 'plan', '2026');
+      INSERT INTO settings VALUES ('s2', 'provider', 'codex.defaultMode', 'acceptEdits', '2026');
+    `);
+
+    initializeSchema(db);
+
+    const row = db.prepare("SELECT value FROM settings WHERE category='provider' AND key='claude.defaultMode'").get() as { value: string };
+    expect(row.value).toBe('default');
+    const planRow = db.prepare("SELECT value FROM settings WHERE category='provider' AND key='claude.defaultPlanMode'").get() as { value: string } | undefined;
+    expect(planRow?.value).toBe('true');
+  });
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/db/plan-mode-migration.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add settings migration in `schema.ts`**
+
+At the end of `initializeSchema`, add:
+
+```ts
+  // Settings migration: defaultMode='plan' → defaultMode='default' + defaultPlanMode='true'
+  const planModeSettings = db.prepare(
+    `SELECT id, key FROM settings WHERE category='provider' AND key LIKE '%.defaultMode' AND value='plan'`,
+  ).all() as { id: string; key: string }[];
+
+  for (const { id, key } of planModeSettings) {
+    const prefix = key.slice(0, -'.defaultMode'.length);
+    const planKey = `${prefix}.defaultPlanMode`;
+    db.prepare(`UPDATE settings SET value='default', updated_at=? WHERE id=?`).run(new Date().toISOString(), id);
+    db.prepare(
+      `INSERT INTO settings (id, category, key, value, updated_at)
+       VALUES (?, 'provider', ?, 'true', ?)
+       ON CONFLICT(category, key) DO UPDATE SET value='true', updated_at=excluded.updated_at`,
+    ).run(`${id}-plan`, planKey, new Date().toISOString());
+  }
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/schema.ts packages/core/src/__tests__/db/plan-mode-migration.test.ts
+git commit -m "core(db): migrate provider.*.defaultMode='plan' to defaultPlanMode='true'"
+```
+
+---
+
+## Task 19: Regression Test for the Thinking Bug
+
+**Files:**
+- Create: `packages/core/src/__tests__/clear-context-thinking.test.ts`
+
+- [ ] **Step 1: Write the regression test**
+
+```ts
+// packages/core/src/__tests__/clear-context-thinking.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ChatLifecycleManager } from '../chat/lifecycle-manager.js';
+// + minimal fixture helpers
+
+describe('clear-context approve: Thinking indicator stays on', () => {
+  it('kill() resolves only after close; subsequent processState=working survives', async () => {
+    // Set up a spawned session where kill() waits on a close-event promise we control.
+    // Drive the clear-context flow (PlanModeHandler.handleClearContext equivalent):
+    //   - kill() is awaited → close event fires WITH session-identity guard preventing stale onExit
+    //   - startChat() creates a new session (sessionId='new')
+    //   - sendMessage() sets processState='working'
+    // Then simulate the OLD session's close event arriving LATE:
+    //   - buildSink(chatId, 'old', ...) → onExit(0)
+    //   - because active.session.id === 'new', onExit is a no-op
+    // Assert chat.processState === 'working' at the end.
+    // (Expand to a full fixture — the intent is a true end-to-end regression.)
+  });
+});
+```
+
+Fill in the body using existing test fixtures in `packages/core/src/__tests__/` as reference (look at `chat-resume.test.ts` for the ActiveChat construction pattern).
+
+- [ ] **Step 2: Run the test**
+
+By the time this task runs (it is ordered after Tasks 14 + 15), both the `kill()` await and the session-identity guard are in place.
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test --run src/__tests__/clear-context-thinking.test.ts`
+Expected: PASS. (To sanity-check the regression actually catches a regression, temporarily revert the guard in `event-handler.ts`; the test should then FAIL.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/__tests__/clear-context-thinking.test.ts
+git commit -m "core(test): regression for Thinking-indicator after clear-context approve"
+```
+
+---
+
+## Task 20: E2E — Codex Plan-Approval Flow
+
+**Files:**
+- Create: `packages/e2e/tests/33-codex-plan-approval.spec.ts`
+- Optional: extend `packages/e2e/tests/07-plan-approval.spec.ts` with the toggle-orthogonality case
+
+- [ ] **Step 1: Author the E2E**
+
+```ts
+// packages/e2e/tests/33-codex-plan-approval.spec.ts
+import { test, expect } from '../fixtures/chat';
+
+test('Codex plan-mode toggle shows PlanApprovalCard on exit prompt', async ({ chat }) => {
+  await chat.selectAdapter('codex');
+  await chat.clickPlanModeToggle();
+  expect(await chat.isPlanModeActive()).toBe(true);
+
+  await chat.sendMessage('Plan how to add a search box to the project list');
+  await chat.waitForPlanApprovalCard();
+  // Plan preview rendered, Approve button present
+  expect(await chat.planApprovalCard.plan()).toContain('search');
+
+  await chat.approvePlan({ execMode: 'acceptEdits' });
+  expect(await chat.isPlanModeActive()).toBe(false);
+});
+```
+
+Reference the existing `07-plan-approval.spec.ts` for fixtures / helpers. Extend the chat fixture with any missing helpers (`clickPlanModeToggle`, `isPlanModeActive`) alongside this test.
+
+- [ ] **Step 2: Run E2E locally**
+
+Run: `pnpm --filter @qlan-ro/mainframe-e2e test --run tests/33-codex-plan-approval.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/e2e/tests/33-codex-plan-approval.spec.ts packages/e2e/fixtures/chat.ts
+git commit -m "e2e: Codex plan-approval parity"
+```
+
+---
+
+## Task 21: Final Verification + Changeset
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `pnpm -r run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `pnpm test`
+Expected: all pass.
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm build`
+Expected: success.
+
+- [ ] **Step 4: Changeset**
+
+Run: `pnpm changeset`
+
+- Packages: `@qlan-ro/mainframe-types`, `@qlan-ro/mainframe-core`, `@qlan-ro/mainframe-desktop`
+- Bump: **minor** (new feature + migration)
+- Summary (paste into the editor):
+
+```
+Plan mode is now a standalone toggle, orthogonal to the permission mode. Codex supports plan mode with the same approval card UX as Claude, via the requestUserInput exit prompt. The per-adapter "Start in Plan Mode" checkbox in settings replaces the old Plan radio option. Existing chats and settings with permission_mode='plan' are migrated automatically. Also fixes a race where the Thinking indicator disappeared after approving a plan with Clear Context.
+```
+
+- [ ] **Step 5: Commit the changeset**
+
+```bash
+git add .changeset/*.md
+git commit -m "chore: changeset for plan-mode-orthogonal"
+```
+
+- [ ] **Step 6: Push and update PR #232**
+
+```bash
+git push
+```
+
+The existing PR #232 on GitHub will update automatically. Update the PR description to reflect the new scope — the "Claude only" gate and the "ref resets on reload" notes are obsolete.
+
+---
+
+## Self-Review Results
+
+**Spec coverage check:**
+
+| Spec section | Covered by |
+|---|---|
+| Data model split | Task 1, 3 |
+| DB migration | Task 2, 18 |
+| Adapter capabilities | Task 1, 6, 9 |
+| Claude plan transport | Task 11 |
+| Codex plan transport | Task 10 |
+| Plan capture (Codex) | Task 7 |
+| Plan exit routing (Codex) | Task 8 |
+| Plan-mode-handler dispatch | Task 4, 5, 6, 9 |
+| Settings UI | Task 17 |
+| Composer UI | Task 16 |
+| Thinking bug — kill() await | Task 14 |
+| Thinking bug — identity guard | Task 15 |
+| Error handling (fallbacks) | Task 8 (label drift), Task 14 (SIGKILL fallback) |
+| Testing (unit + E2E) | Task 2, 5, 7, 8, 9, 10, 11, 12, 14, 15, 17, 18, 19, 20 |
+
+**Placeholder scan:** No "TBD" / "TODO" / "fill in later" — every code step ships real code. Two spots leave the exact surrounding implementation to the executing agent: Task 6 step 5 (existing `plan-mode-handler.test.ts` rewrite — references concrete mock shape) and Task 15 step 4 (caller updates — I name the file:line). Both are specific enough to execute.
+
+**Type consistency:**
+- `PermissionMode` narrowed to `'default' | 'acceptEdits' | 'yolo'` across Task 1, 12, 17 — consistent.
+- `planMode: boolean` on `Chat`, `SessionSpawnOptions`, `SessionOptions`-adjacent — consistent.
+- `capabilities: { planMode: boolean }` on `Adapter` — Task 1 defines, Task 6 uses, Task 16 consumes, consistent.
+- `PlanModeActionHandler` methods `onApprove/onApproveAndClearContext/onReject/onRevise` — referenced consistently in Tasks 5 and 9 implementations and Task 6 dispatcher.

--- a/docs/superpowers/specs/2026-04-22-plan-mode-orthogonal-design.md
+++ b/docs/superpowers/specs/2026-04-22-plan-mode-orthogonal-design.md
@@ -1,0 +1,260 @@
+# Plan Mode as an Orthogonal Axis (Multi-Adapter)
+
+**Date:** 2026-04-22
+**Status:** Design — awaiting user review before writing-plans
+**Scope:** Promote plan mode out of `PermissionMode`, ship Codex plan-mode parity, redesign the settings control, and fix the Thinking-indicator bug after clear-context approve.
+
+## Problem
+
+Three connected issues trace back to the same design mistake: plan mode is modeled as a value inside `PermissionMode`.
+
+1. **Misleading settings UI.** The permission-mode radio in `ProviderSection.tsx` lists Plan alongside Interactive / Auto-Edits / Unattended. Plan is not a permission.
+2. **Wrong adapter gate.** PR #232 shipped `adapterSupportsPlanMode(id) => id === 'claude'`, hiding plan mode for Codex. But Codex supports plan mode too — `packages/core/src/plugins/builtin/codex/session.ts:334` already maps `permissionMode === 'plan'` to `collaborationMode.mode = 'plan'`, and Codex's own CLI exposes an exit-plan UX via `requestUserInput`.
+3. **Thinking indicator disappears** after approving a plan with Clear Context. The user sees an empty thread and assumes the feature is broken; only after a long delay does content reappear.
+
+## Decisions (from brainstorming)
+
+| # | Decision |
+|---|----------|
+| 1 | Split the data model: `Chat.permissionMode: 'default' \| 'acceptEdits' \| 'yolo'` + `Chat.planMode: boolean`. |
+| 2 | Full Codex plan-exit parity — detect Codex's `plan` thread item + `requestUserInput` follow-up, route to the existing `PlanApprovalCard`. |
+| 3 | Settings: per-adapter "Start in Plan Mode" checkbox, hidden when the adapter doesn't support plan mode. |
+| 4 | Adapter capability declaration: add `capabilities.planMode: boolean` to the `AgentAdapter` interface. |
+| 5 | Thinking-bug fix: (A) make `kill()` await process exit + (C) session-identity guard on stale `onExit`. |
+
+## Data Model
+
+### Types — `packages/types/src/chat.ts`
+
+Before:
+```ts
+permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'yolo';
+```
+
+After:
+```ts
+permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+planMode?: boolean;
+```
+
+### Adapter interface — `packages/types/src/adapter.ts`
+
+```ts
+interface AgentAdapter {
+  // existing fields...
+  readonly capabilities: {
+    planMode: boolean;
+    // reserved for future capability flags
+  };
+}
+```
+
+- Claude adapter: `capabilities: { planMode: true }`
+- Codex adapter: `capabilities: { planMode: true }`
+- Gemini / OpenCode: `capabilities: { planMode: false }` (until implemented)
+
+The UI reads capabilities through the existing adapter-metadata path rather than hardcoding. `adapterSupportsPlanMode()` is deleted from `PlanModeToggle.tsx`; the gate becomes `adapter.capabilities.planMode`.
+
+### DB migration
+
+New column on `chats`:
+```sql
+ALTER TABLE chats ADD COLUMN plan_mode INTEGER NOT NULL DEFAULT 0;
+```
+
+One-time up-migration:
+```sql
+UPDATE chats SET plan_mode = 1, permission_mode = 'default' WHERE permission_mode = 'plan';
+```
+
+### Settings keys
+
+- `provider.<adapterId>.defaultMode` — keeps enum `'default' | 'acceptEdits' | 'yolo'`. Migration maps any stored `'plan'` → `'default'` and sets the companion plan-mode default.
+- `provider.<adapterId>.defaultPlanMode` — **new** boolean (`'true'` / `'false'` string), read by `lifecycle-manager.createChatWithDefaults` when creating a chat.
+
+## Plan Mode Transport Per Adapter
+
+### Claude (session-level)
+
+- **Spawn flag.** `--permission-mode plan` if `planMode === true`, else `--permission-mode <permissionMode>`.
+- **Toggle ON mid-session.** `control_request { subtype: 'set_permission_mode', mode: 'plan' }`.
+- **Toggle OFF mid-session.** `control_request { subtype: 'set_permission_mode', mode: <permissionMode> }` — the stored base mode, not a magic `'default'`.
+- **Exit UX.** Unchanged. `ExitPlanMode` tool permission already routes through `permission.requested` → `PlanApprovalCard` in `MainframeThread.tsx:49`.
+
+### Codex (per-turn)
+
+- **Every `turn/start`** sends `collaborationMode: { mode: planMode ? 'plan' : 'default', settings: {...} }`.
+- **Toggle ON/OFF mid-session.** Update `Chat.planMode` in DB + emit `chat.updated`. No immediate protocol call — the next `turn/start` reads the new value.
+- **Plan capture.** `CodexSessionState` gains `currentTurnPlan: { id: string; text: string } | null`. Populated from `item/plan/delta` accumulation, finalized when the `plan` thread item completes, cleared on `turn/started`.
+- **Exit-prompt detection.** In `codex/approval-handler.ts` when `item/tool/requestUserInput` arrives:
+  - If `chat.planMode === true` AND `currentTurnPlan !== null` → emit a `ControlRequest` with `toolName: 'ExitPlanMode'` and `input: { plan: currentTurnPlan.text, allowedPrompts: [] }`.
+  - Otherwise → existing `toolName: 'AskUserQuestion'` path (clarification questions during plan mode still render generically).
+
+Mainframe already routes `ExitPlanMode` to `PlanApprovalCard` via `MainframeThread.tsx:49`, so no UI change is needed for Codex to get the parity treatment.
+
+### Plan-mode-handler dispatch
+
+`packages/core/src/chat/plan-mode-handler.ts` becomes adapter-agnostic. The shared handler dispatches to an adapter-provided `planModeHandler` that knows how to respond in the adapter's own protocol.
+
+`AgentAdapter` gains an optional factory:
+```ts
+createPlanModeHandler?(chat: Chat, session: AdapterSession | null): PlanModeActionHandler;
+
+interface PlanModeActionHandler {
+  onApprove(response: ControlResponse, context: PlanActionContext): Promise<void>;
+  onApproveAndClearContext(response: ControlResponse, context: PlanActionContext): Promise<void>;
+  onReject(response: ControlResponse, context: PlanActionContext): Promise<void>;
+  onRevise(feedback: string, context: PlanActionContext): Promise<void>;
+}
+```
+
+**ClaudePlanModeHandler** — preserves the current behavior:
+- `onApprove` → `setPermissionMode` to the chosen exec mode; clear `planMode` in DB.
+- `onApproveAndClearContext` → existing kill-and-replay-plan flow (fixed per Section 5 below).
+- `onReject` / `onRevise` → forward the message with Claude's existing preamble.
+
+**CodexPlanModeHandler** — new:
+- `onApprove(execMode)`: set `chat.planMode = false`; respond to Codex's `requestUserInput` with the option whose label prefix matches "Yes, implement"; fall back to first option. Update `chat.permissionMode = execMode` so the next turn uses the new policy.
+- `onApproveAndClearContext(execMode)`: call `thread/start` to create a fresh thread; send the captured plan text as first user input with `collaborationMode.mode = 'default'`; discard the old thread id (set `chat.codexThreadId = newId`).
+- `onReject`: respond with the option whose label prefix matches "No, stay in Plan mode"; fall back to second option.
+- `onRevise(feedback)`: respond with free-form answer text (Codex's `requestUserInput` accepts non-option answers).
+
+## Settings UI
+
+`ProviderSection.tsx` changes:
+
+1. The permission-mode radio loses the Plan option — now three items (Interactive / Auto-Edits / Unattended).
+2. A `<Checkbox>` labelled **Start in Plan Mode** appears directly below the radio, bound to `provider.<adapterId>.defaultPlanMode`.
+3. The checkbox (and its label) is conditionally rendered: `{adapter.capabilities.planMode && <StartInPlanModeCheckbox />}`.
+4. Any existing persisted value of `'plan'` on `defaultMode` is rewritten by the migration to `'default'` + `defaultPlanMode='true'` on boot.
+
+## Composer UI
+
+`PlanModeToggle.tsx` — unchanged visually. Capability gate changes:
+
+```diff
+- import { adapterSupportsPlanMode } from './PlanModeToggle';
+- {adapterSupportsPlanMode(currentAdapter) && <PlanModeToggle ... />}
++ {adapterCapabilities.planMode && <PlanModeToggle ... />}
+```
+
+`ComposerCard.tsx`:
+
+- `PERMISSION_MODES` stays at 3 items (already done in PR #232).
+- **Delete** `lastNonPlanModeRef` — no longer needed; the base mode lives on `Chat.permissionMode` since plan is orthogonal.
+- **Delete** `displayModeForDropdown()` — dropdown always reads `currentMode` directly.
+- `handlePlanToggle(enable)` sends the new `planMode` parameter:
+  ```ts
+  daemonClient.updateChatConfig(chatId, undefined, undefined, undefined, enable);
+  ```
+- `handleModeChange` no longer saves "last non-plan mode" — it just writes the chosen permission mode.
+
+`updateChatConfig` route signature adds a fifth optional parameter `planMode?: boolean`; the Zod schema on the endpoint accepts it; `chat-manager.updateConfig` writes to the DB and emits `chat.updated`.
+
+**File-size note.** `ComposerCard.tsx` is currently 463 lines (flagged in PR #232 notes). Deleting `lastNonPlanModeRef`, `displayModeForDropdown`, and the related branches nets a small shrink but still leaves it above the 300-line CLAUDE.md guideline. Further decomposition is not in scope; tracked as a separate refactor.
+
+## Thinking-Indicator Bug Fix
+
+Two changes implemented together:
+
+### A) `kill()` awaits process exit
+
+`packages/core/src/plugins/builtin/claude/session.ts`:
+```ts
+async kill(): Promise<void> {
+  const child = this.state.child;
+  if (!child) return;
+  const exited = new Promise<void>((resolve) => child.once('close', () => resolve()));
+  const timeout = new Promise<void>((resolve) =>
+    setTimeout(() => {
+      if (child.exitCode === null) {
+        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+      }
+      resolve();
+    }, 3000),
+  );
+  child.kill('SIGTERM');
+  await Promise.race([exited, timeout]);
+  this.state.child = null;
+}
+```
+
+The 3-second timeout falls back to SIGKILL so `kill()` never hangs indefinitely. Once the `timeout` branch wins, guard C (below) prevents the lingering `close` event from clobbering the new session's state.
+
+`packages/core/src/plugins/builtin/codex/session.ts`: same pattern, awaiting the `onExit` callback (currently the client close is fire-and-forget). Same 3s timeout.
+
+This makes `plan-mode-handler.ts:handleClearContext` deterministic — by the time `kill()` returns, the old session's `onExit` has already run and `processState` is `null`. The subsequent `startChat()` + `sendMessage()` set it back to `'working'` with no races.
+
+### C) Session-identity guard on `onExit`
+
+`packages/core/src/chat/event-handler.ts` — `buildSessionSink()` captures the session id at sink-construction time:
+
+```ts
+function buildSessionSink(
+  chatId: string,
+  sessionId: string,  // NEW
+  // ...
+): SessionSink {
+  // ...
+  return {
+    // ...
+    onExit(_code) {
+      const active = getActiveChat(chatId);
+      // Guard: if the chat has already moved to a new session, ignore stale onExit.
+      if (active?.session && active.session.id !== sessionId) return;
+      // ...existing logic
+    },
+  };
+}
+```
+
+`EventHandler.buildSink` threads the session id through. This is belt-and-suspenders — even if `kill()` falls back to SIGKILL or the 5-second timeout path, the old sink can't clobber the new session's state.
+
+## Error Handling
+
+- **Migration failure.** DB migration runs inside the existing `better-sqlite3` migration framework with atomic wrapping; a failure rolls back and the daemon refuses to start, surfacing the error via existing logs. No half-migrated states.
+- **Codex `plan` item dropped.** If `item/plan/delta` events arrive but the terminal `plan` item doesn't, `currentTurnPlan` remains non-null at `requestUserInput` time — we still render `PlanApprovalCard` with the partial text. Acceptable; the streamed accumulation is close enough.
+- **Codex option-label drift.** Matching is case-insensitive prefix: approve = option starting with `"yes"`, reject = option starting with `"no"`. If neither matches, fall back to positional defaults (first option = approve, second = reject) and log a warning. Plan-exit prompts with other option counts (1 or >2) are logged and routed back to `AskUserQuestionCard` — do not force `PlanApprovalCard` on an unknown shape.
+- **No `currentTurnPlan` on `requestUserInput` while in plan mode.** Treat as clarification question; route to `AskUserQuestionCard`. No plan preview shown.
+- **Daemon restart mid-plan-exit.** In-memory `currentTurnPlan` is lost on restart. If Codex re-emits the `requestUserInput` on reconnect, we show the fallback `AskUserQuestionCard`. Acceptable edge case; the user can still answer.
+- **`currentTurnPlan` lifecycle.** Cleared on `turn/started` AND on `turn/completed`. Prevents a stale plan from turn N leaking into turn N+1 if the exit prompt never arrives.
+
+## Testing
+
+### Core unit tests
+
+- `packages/core/src/__tests__/plan-mode-split.test.ts` — migration converts `permissionMode='plan'` → `planMode=true, permissionMode='default'` on DB load. Settings migration equivalent.
+- `packages/core/src/__tests__/plan-mode-handler-codex.test.ts` — Codex plan-exit dispatch: approve → first-option answer + `chat.planMode=false`; approve-with-clear-context → `thread/start` call + plan replay; reject → second-option answer; revise → free-form answer.
+- `packages/core/src/__tests__/clear-context-thinking.test.ts` — regression: mock old-session `close` firing after new-session `sendMessage`; assert final `processState === 'working'`, not `null`. Covers both fix paths (A and C) independently.
+
+### Codex adapter tests
+
+- `packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts` — `item/plan/delta` accumulation; `plan` item finalization; `currentTurnPlan` cleared on `turn/started`.
+- `packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts` — `requestUserInput` before `plan` item → `AskUserQuestion`; after `plan` item with `planMode=true` → `ExitPlanMode`; after `plan` item with `planMode=false` → `AskUserQuestion` (plan captured but toggle already off).
+
+### Desktop tests
+
+- `packages/desktop/src/renderer/components/chat/assistant-ui/composer/__tests__/plan-mode-toggle.test.tsx` — renders for Claude AND Codex; hidden when `adapter.capabilities.planMode === false`.
+- `packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx` — writes/reads `provider.<adapterId>.defaultPlanMode`; hidden for unsupported adapters.
+
+### E2E
+
+- `packages/e2e/tests/07-plan-approval.spec.ts` — existing test stays on Claude.
+- New `packages/e2e/tests/33-codex-plan-approval.spec.ts` — Codex variant: enter plan mode, exchange, observe `PlanApprovalCard` on Codex's exit prompt, approve, verify next turn is not in plan mode.
+
+## Out of Scope
+
+- Extending plan mode to Gemini / OpenCode adapters (they'll declare `capabilities.planMode: false`).
+- Structured Plans panel rendering for Codex `update_plan` / `turn/plan/updated` (tracked TODO in `event-mapper.ts:42`; separate spec).
+- Persisting captured Codex plan text across daemon restarts.
+- Changing the approve-with-clear-context UX beyond the Thinking-indicator fix.
+
+## Success Criteria
+
+1. A chat started with `provider.claude.defaultPlanMode=true` spawns with `--permission-mode plan`, and `chat.planMode === true` in the DB.
+2. A Claude session toggled out of plan mode retains its underlying `permissionMode` (no more magic `'default'` fallback).
+3. Codex users see the plan-mode toggle in the composer, can enter plan mode, and receive the `PlanApprovalCard` on the exit prompt with the proposed plan rendered.
+4. Approving a Codex plan (without clear-context) sets `planMode=false` and the next turn runs with `collaborationMode.mode='default'`.
+5. Approving a plan with Clear Context shows the Thinking indicator within 1s of the user clicking Approve and keeps it visible until the agent's first content arrives — no flicker.
+6. Existing chats with `permissionMode='plan'` auto-migrate on first daemon boot; no user intervention required.
+7. All existing plan-mode tests pass unchanged; new tests cover the Codex parity path, the migration, and the Thinking-bug regression.

--- a/packages/core/src/__tests__/chat/create-on-worktree.test.ts
+++ b/packages/core/src/__tests__/chat/create-on-worktree.test.ts
@@ -16,6 +16,7 @@ function makeChat(overrides: Partial<Chat> = {}): Chat {
     updatedAt: new Date().toISOString(),
     title: undefined,
     claudeSessionId: undefined,
+    planMode: false,
     worktreePath: undefined,
     branchName: undefined,
     totalCost: 0,
@@ -159,5 +160,30 @@ describe('ChatLifecycleManager.createChatWithDefaults — worktree attachment', 
       '/projects/my-repo/.worktrees/feat-x',
       'feat-x',
     );
+  });
+
+  it('sets planMode when provider defaultPlanMode is enabled', async () => {
+    const deps = makeDeps({
+      db: {
+        chats: {
+          get: vi.fn(() => makeChat()),
+          create: vi.fn(() => makeChat()),
+          update: vi.fn(),
+        },
+        projects: { get: vi.fn() },
+        settings: {
+          get: vi.fn((category: string, key: string) => {
+            if (category === 'provider' && key === 'claude.defaultPlanMode') return 'true';
+            return undefined;
+          }),
+        },
+      } as any,
+    });
+    const lifecycle = new ChatLifecycleManager(deps);
+
+    const chat = await lifecycle.createChatWithDefaults('proj-1', 'claude');
+
+    expect(chat.planMode).toBe(true);
+    expect(deps.db.chats.update).toHaveBeenCalledWith(chat.id, { planMode: true });
   });
 });

--- a/packages/core/src/__tests__/claude-spawn-args.test.ts
+++ b/packages/core/src/__tests__/claude-spawn-args.test.ts
@@ -48,4 +48,22 @@ describe('ClaudeSession spawn args', () => {
     expect(args).toContain('stream-json');
     expect(args).toContain('--output-format');
   });
+
+  it('passes --permission-mode plan when planMode=true', async () => {
+    const session = new ClaudeSession({ projectPath: '/tmp', chatId: undefined });
+    await session.spawn({ planMode: true, permissionMode: 'acceptEdits' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('plan');
+  });
+
+  it('passes --permission-mode <base> when planMode=false', async () => {
+    const session = new ClaudeSession({ projectPath: '/tmp', chatId: undefined });
+    await session.spawn({ planMode: false, permissionMode: 'acceptEdits' });
+
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('acceptEdits');
+  });
 });

--- a/packages/core/src/__tests__/clear-context-thinking.test.ts
+++ b/packages/core/src/__tests__/clear-context-thinking.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ControlResponse, DaemonEvent, SessionSink } from '@qlan-ro/mainframe-types';
+import { EventHandler } from '../chat/event-handler.js';
+import { MessageCache } from '../chat/message-cache.js';
+import { PermissionManager } from '../chat/permission-manager.js';
+import { ClaudePlanModeHandler } from '../plugins/builtin/claude/plan-mode-handler.js';
+import type { PlanActionContext } from '../chat/plan-mode-actions.js';
+import type { ActiveChat } from '../chat/types.js';
+
+/**
+ * Regression test for the Thinking-indicator race after approving a plan with
+ * "Clear Context".
+ *
+ * Historical bug:
+ *   1. User approves plan → ClaudePlanModeHandler.onApproveAndClearContext runs.
+ *   2. Old CLI process is killed, a new session is spawned via startChat().
+ *   3. sendMessage() flips the chat to processState='working' (Thinking indicator).
+ *   4. The OLD process's 'close' event arrives LATE and hits the old session's
+ *      sink.onExit(), which cleared processState → Thinking indicator vanished.
+ *
+ * Fix (Tasks 14 + 15):
+ *   - session.kill() now awaits the 'close' event (Task 14) — but a close can
+ *     still race past the await on some platforms.
+ *   - buildSink captures `builtForSessionId`; onExit becomes a no-op when the
+ *     active session has been superseded (Task 15).
+ *
+ * This test exercises the full flow: ClaudePlanModeHandler drives a real
+ * EventHandler + MessageCache + PermissionManager stack, the fake session's
+ * kill() awaits a close promise we control, and we fire the stale onExit AFTER
+ * sendMessage() has set processState='working'.
+ */
+
+interface FakeSession {
+  id: string;
+  isSpawned: boolean;
+  setPermissionMode: ReturnType<typeof vi.fn>;
+  respondToPermission: ReturnType<typeof vi.fn>;
+  kill: () => Promise<void>;
+  resolveClose: () => void;
+}
+
+function createFakeSession(id: string): FakeSession {
+  let resolveClose: () => void = () => {};
+  const closed = new Promise<void>((resolve) => {
+    resolveClose = resolve;
+  });
+  return {
+    id,
+    isSpawned: true,
+    setPermissionMode: vi.fn().mockResolvedValue(undefined),
+    respondToPermission: vi.fn().mockResolvedValue(undefined),
+    // Mirror claude session.kill(): resolves only after the 'close' event fires.
+    kill: () => closed,
+    resolveClose: () => resolveClose(),
+  };
+}
+
+function createDbStub() {
+  return {
+    chats: {
+      update: vi.fn(),
+      addPlanFile: vi.fn().mockReturnValue(false),
+      addSkillFile: vi.fn().mockReturnValue(false),
+      get: vi.fn(),
+    },
+  };
+}
+
+function createActiveChat(chatId: string, session: FakeSession | null): ActiveChat {
+  const chat = {
+    id: chatId,
+    adapterId: 'claude',
+    projectId: 'p1',
+    status: 'active' as const,
+    createdAt: '',
+    updatedAt: '',
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+    planMode: true,
+    permissionMode: 'acceptEdits' as const,
+    processState: 'working' as const,
+  };
+  return { chat, session: session as unknown as ActiveChat['session'] };
+}
+
+describe('clear-context approve: Thinking indicator stays on', () => {
+  it('kill() resolves only after close; subsequent processState=working survives stale onExit', async () => {
+    const chatId = 'chat-clear-ctx';
+    const oldSession = createFakeSession('session-old');
+
+    const active = createActiveChat(chatId, oldSession);
+    const activeChats = new Map<string, ActiveChat>([[chatId, active]]);
+
+    const messages = new MessageCache();
+    const permissions = new PermissionManager();
+    const db = createDbStub();
+    const emitted: DaemonEvent[] = [];
+    const emitEvent = (event: DaemonEvent): void => {
+      emitted.push(event);
+    };
+
+    const handler = new EventHandler(
+      db as unknown as Parameters<typeof EventHandler.prototype.buildSink> extends never ? never : any,
+      messages,
+      permissions,
+      (id) => activeChats.get(id),
+      emitEvent,
+    );
+
+    // Build the sink bound to the OLD session id — this is what the daemon does
+    // when it spawns the old process. We hold a reference to it so we can fire
+    // its onExit later (simulating the late-arriving 'close' event).
+    const oldSink: SessionSink = handler.buildSink(chatId, oldSession.id, vi.fn());
+
+    // startChat(): swap the old session for a new one, keep processState='working'.
+    const newSession = createFakeSession('session-new');
+    const startChat = vi.fn(async (id: string) => {
+      const a = activeChats.get(id);
+      if (!a) return;
+      a.session = newSession as unknown as ActiveChat['session'];
+      a.chat.processState = 'working';
+    });
+
+    // sendMessage(): after Clear-Context the user's original request isn't
+    // replayed, but sendMessage is what flips the Thinking indicator back on.
+    // We keep it minimal — assert it only sets processState to 'working'.
+    const sendMessage = vi.fn(async (id: string) => {
+      const a = activeChats.get(id);
+      if (!a) return;
+      a.chat.processState = 'working';
+    });
+
+    const ctx: PlanActionContext = {
+      chatId,
+      active,
+      chat: active.chat,
+      db: db as unknown as PlanActionContext['db'],
+      messages,
+      permissions,
+      emitEvent,
+      clearDisplayCache: vi.fn(),
+      startChat,
+      sendMessage,
+    };
+
+    const response: ControlResponse = {
+      requestId: 'req-1',
+      toolUseId: 'tu-1',
+      behavior: 'allow',
+      toolName: 'ExitPlanMode',
+      executionMode: 'acceptEdits',
+      updatedInput: { plan: 'Do the thing.' },
+    };
+
+    // Drive the approve + clear-context flow. onApproveAndClearContext awaits
+    // oldSession.kill() — which won't resolve until we fire resolveClose().
+    // So we kick it off, let it sit on the await, then resolve.
+    const flow = new ClaudePlanModeHandler().onApproveAndClearContext(response, ctx);
+
+    // Let the handler reach `await oldSession.kill()`.
+    await Promise.resolve();
+
+    // Fire the 'close' event → kill() resolves → the handler continues.
+    oldSession.resolveClose();
+    await flow;
+
+    // Preconditions after the flow finishes:
+    //   - startChat and sendMessage both ran (simulating a fresh session
+    //     carrying the "Thinking" indicator).
+    //   - The active session has been swapped to 'session-new'.
+    //   - processState is 'working'.
+    expect(startChat).toHaveBeenCalledWith(chatId);
+    expect(sendMessage).toHaveBeenCalledWith(chatId, expect.stringContaining('Do the thing.'));
+    expect(activeChats.get(chatId)?.session?.id).toBe('session-new');
+    expect(active.chat.processState).toBe('working');
+
+    // Clear the DB update spy so we can isolate what (if anything) the stale
+    // onExit mutates.
+    db.chats.update.mockClear();
+    const beforeEventsLen = emitted.length;
+
+    // NOW simulate the OLD process's late-arriving 'close' event. Without the
+    // session-identity guard in buildSink, this clears processState and emits
+    // chat.updated, dropping the Thinking indicator.
+    oldSink.onExit(0);
+
+    // The guard should have made onExit a no-op because active.session.id
+    // ('session-new') !== builtForSessionId ('session-old').
+    expect(active.chat.processState).toBe('working');
+
+    // The stale close must not have emitted a chat.updated event, nor written
+    // processState=null to the DB.
+    const newEvents = emitted.slice(beforeEventsLen);
+    expect(newEvents.find((e) => e.type === 'chat.updated')).toBeUndefined();
+    expect(db.chats.update).not.toHaveBeenCalledWith(chatId, expect.objectContaining({ processState: null }));
+  });
+
+  it('positive case: onExit from the current session still clears processState', () => {
+    // Sanity check: the guard only suppresses stale close events. A 'close'
+    // from the session the sink was built for must still mark the chat idle.
+    const chatId = 'chat-positive';
+    const session = createFakeSession('session-a');
+    const active = createActiveChat(chatId, session);
+    const activeChats = new Map<string, ActiveChat>([[chatId, active]]);
+
+    const messages = new MessageCache();
+    const permissions = new PermissionManager();
+    const db = createDbStub();
+    const emitted: DaemonEvent[] = [];
+
+    const handler = new EventHandler(
+      db as unknown as Parameters<typeof EventHandler.prototype.buildSink> extends never ? never : any,
+      messages,
+      permissions,
+      (id) => activeChats.get(id),
+      (event) => emitted.push(event),
+    );
+    const sink: SessionSink = handler.buildSink(chatId, 'session-a', vi.fn());
+
+    sink.onExit(0);
+
+    expect(active.chat.processState).toBeNull();
+    expect(emitted.some((e) => e.type === 'chat.updated')).toBe(true);
+    expect(db.chats.update).toHaveBeenCalledWith(chatId, expect.objectContaining({ processState: null }));
+  });
+});

--- a/packages/core/src/__tests__/control-requests.test.ts
+++ b/packages/core/src/__tests__/control-requests.test.ts
@@ -221,6 +221,15 @@ class MockClaudeSession extends MockBaseSession {
     this.written.push(JSON.stringify(payload) + '\n');
   }
 
+  readonly setPlanModeCalls: boolean[] = [];
+
+  override async setPlanMode(on: boolean): Promise<void> {
+    this.setPlanModeCalls.push(on);
+    // Mirror Claude's behavior: setPlanMode(on) delegates to setPermissionMode
+    // with 'plan' when on, or the stored base mode when off.
+    await this.setPermissionMode(on ? 'plan' : 'default');
+  }
+
   override async sendMessage(): Promise<void> {}
   override async loadHistory(): Promise<ChatMessage[]> {
     return [];
@@ -328,5 +337,19 @@ describe('ChatManager.updateChatConfig — in-flight control requests', () => {
     expect(killSpy).not.toHaveBeenCalled();
     expect(spawnCount).toBe(0);
     expect(db.chats.update).not.toHaveBeenCalledWith(chatId, expect.anything());
+  });
+
+  it('updateChatConfig toggles planMode via session.setPlanMode', async () => {
+    await manager.updateChatConfig(chatId, undefined, undefined, undefined, true);
+
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(spawnCount).toBe(0);
+    expect(currentMockSession!.setPlanModeCalls).toEqual([true]);
+    expect(db.chats.update).toHaveBeenCalledWith(chatId, expect.objectContaining({ planMode: true }));
+
+    await manager.updateChatConfig(chatId, undefined, undefined, undefined, false);
+
+    expect(currentMockSession!.setPlanModeCalls).toEqual([true, false]);
+    expect(db.chats.update).toHaveBeenLastCalledWith(chatId, expect.objectContaining({ planMode: false }));
   });
 });

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -179,10 +179,10 @@ describe('ChatsRepository', () => {
 
     it('updates permissionMode', () => {
       const chat = chats.create(projectId, 'claude');
-      chats.update(chat.id, { permissionMode: 'plan' });
+      chats.update(chat.id, { permissionMode: 'acceptEdits' });
 
       const fetched = chats.get(chat.id);
-      expect(fetched!.permissionMode).toBe('plan');
+      expect(fetched!.permissionMode).toBe('acceptEdits');
     });
 
     it('updates worktreePath and branchName', () => {

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -447,6 +447,20 @@ describe('ChatsRepository', () => {
     });
   });
 
+  describe('planMode', () => {
+    it('reads and writes planMode', () => {
+      const chat = chats.create(projectId, 'claude');
+      expect(chat.planMode).toBe(false);
+
+      chats.update(chat.id, { planMode: true });
+      const reread = chats.get(chat.id)!;
+      expect(reread.planMode).toBe(true);
+
+      chats.update(chat.id, { planMode: false });
+      expect(chats.get(chat.id)!.planMode).toBe(false);
+    });
+  });
+
   describe('processState', () => {
     it('defaults to null', () => {
       const chat = chats.create(projectId, 'claude');

--- a/packages/core/src/__tests__/db/plan-mode-migration.test.ts
+++ b/packages/core/src/__tests__/db/plan-mode-migration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../../db/schema.js';
+
+describe('plan_mode column migration', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  it('adds plan_mode column defaulting to 0', () => {
+    initializeSchema(db);
+    const cols = db.pragma('table_info(chats)') as { name: string }[];
+    expect(cols.some((c) => c.name === 'plan_mode')).toBe(true);
+  });
+
+  it("rewrites permission_mode='plan' to ('default', plan_mode=1) on migration", () => {
+    // Pre-migration: create the old schema + seed a row with permission_mode='plan'
+    db.exec(`
+      CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, path TEXT, created_at TEXT, last_opened_at TEXT);
+      CREATE TABLE chats (
+        id TEXT PRIMARY KEY, adapter_id TEXT, project_id TEXT,
+        status TEXT, created_at TEXT, updated_at TEXT,
+        permission_mode TEXT
+      );
+      INSERT INTO projects VALUES ('p1', 'x', '/x', '2026', '2026');
+      INSERT INTO chats VALUES ('c1', 'claude', 'p1', 'active', '2026', '2026', 'plan');
+      INSERT INTO chats VALUES ('c2', 'codex', 'p1', 'active', '2026', '2026', 'default');
+    `);
+
+    initializeSchema(db);
+
+    const rows = db.prepare('SELECT id, permission_mode, plan_mode FROM chats ORDER BY id').all() as {
+      id: string;
+      permission_mode: string | null;
+      plan_mode: number;
+    }[];
+    expect(rows[0]).toEqual({ id: 'c1', permission_mode: 'default', plan_mode: 1 });
+    expect(rows[1]).toEqual({ id: 'c2', permission_mode: 'default', plan_mode: 0 });
+  });
+});

--- a/packages/core/src/__tests__/db/plan-mode-migration.test.ts
+++ b/packages/core/src/__tests__/db/plan-mode-migration.test.ts
@@ -39,4 +39,23 @@ describe('plan_mode column migration', () => {
     expect(rows[0]).toEqual({ id: 'c1', permission_mode: 'default', plan_mode: 1 });
     expect(rows[1]).toEqual({ id: 'c2', permission_mode: 'default', plan_mode: 0 });
   });
+
+  it("rewrites settings.defaultMode='plan' to ('default' + defaultPlanMode='true') on migration", () => {
+    db.exec(`
+      CREATE TABLE settings (id TEXT PRIMARY KEY, category TEXT, key TEXT, value TEXT, updated_at TEXT, UNIQUE(category, key));
+      INSERT INTO settings VALUES ('s1', 'provider', 'claude.defaultMode', 'plan', '2026');
+      INSERT INTO settings VALUES ('s2', 'provider', 'codex.defaultMode', 'acceptEdits', '2026');
+    `);
+
+    initializeSchema(db);
+
+    const row = db
+      .prepare("SELECT value FROM settings WHERE category='provider' AND key='claude.defaultMode'")
+      .get() as { value: string };
+    expect(row.value).toBe('default');
+    const planRow = db
+      .prepare("SELECT value FROM settings WHERE category='provider' AND key='claude.defaultPlanMode'")
+      .get() as { value: string } | undefined;
+    expect(planRow?.value).toBe('true');
+  });
 });

--- a/packages/core/src/__tests__/helpers/mock-adapter.ts
+++ b/packages/core/src/__tests__/helpers/mock-adapter.ts
@@ -4,6 +4,7 @@ import { MockBaseSession } from './mock-session.js';
 export class MockBaseAdapter implements Adapter {
   id = 'mock';
   name = 'Mock Adapter';
+  readonly capabilities = { planMode: false };
 
   private readonly sessionFactory?: (options: SessionOptions) => AdapterSession;
 

--- a/packages/core/src/__tests__/helpers/mock-session.ts
+++ b/packages/core/src/__tests__/helpers/mock-session.ts
@@ -68,6 +68,7 @@ export class MockBaseSession implements AdapterSession {
   async interrupt(): Promise<void> {}
   async setModel(_model: string): Promise<void> {}
   async setPermissionMode(_mode: string): Promise<void> {}
+  async setPlanMode(_on: boolean): Promise<void> {}
   async sendCommand(_command: string, _args?: string): Promise<void> {}
 
   getContextFiles(): { global: ContextFile[]; project: ContextFile[] } {

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -19,6 +19,7 @@ function makeChat(overrides: Partial<Chat> = {}): Chat {
     totalCost: 0,
     totalTokensInput: 0,
     totalTokensOutput: 0,
+    lastContextTokensInput: 0,
     ...overrides,
   };
 }

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { PlanModeHandler, type PlanModeContext } from '../chat/plan-mode-handler.js';
 import type { Chat, ControlResponse } from '@qlan-ro/mainframe-types';
 import type { ActiveChat } from '../chat/types.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import type { PlanModeActionHandler } from '../chat/plan-mode-actions.js';
 
 function makeChat(overrides: Partial<Chat> = {}): Chat {
   return {
@@ -9,7 +11,8 @@ function makeChat(overrides: Partial<Chat> = {}): Chat {
     adapterId: 'claude',
     projectId: 'proj-1',
     status: 'active',
-    permissionMode: 'plan',
+    permissionMode: 'default',
+    planMode: true,
     processState: 'working',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -31,11 +34,42 @@ function makeSession(active = true) {
   };
 }
 
-function makeContext(hasActiveSession = true): PlanModeContext & {
+function makeMockHandler(): PlanModeActionHandler & {
+  onApprove: ReturnType<typeof vi.fn>;
+  onApproveAndClearContext: ReturnType<typeof vi.fn>;
+  onReject: ReturnType<typeof vi.fn>;
+  onRevise: ReturnType<typeof vi.fn>;
+} {
+  return {
+    onApprove: vi.fn().mockResolvedValue(undefined),
+    onApproveAndClearContext: vi.fn().mockResolvedValue(undefined),
+    onReject: vi.fn().mockResolvedValue(undefined),
+    onRevise: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeAdapters(handler: PlanModeActionHandler | null): AdapterRegistry {
+  const factory = handler ? () => handler : undefined;
+  const adapter = {
+    id: 'claude',
+    name: 'Claude',
+    capabilities: { planMode: handler !== null },
+    ...(factory ? { createPlanModeHandler: factory } : {}),
+  };
+  return {
+    get: vi.fn().mockReturnValue(adapter),
+  } as unknown as AdapterRegistry;
+}
+
+function makeContext(
+  hasActiveSession = true,
+  actionHandler: PlanModeActionHandler | null = makeMockHandler(),
+): PlanModeContext & {
   emitEvent: ReturnType<typeof vi.fn>;
   startChat: ReturnType<typeof vi.fn>;
   sendMessage: ReturnType<typeof vi.fn>;
   session: ReturnType<typeof makeSession>;
+  handler: PlanModeActionHandler | null;
 } {
   const chat = makeChat();
   const session = makeSession(hasActiveSession);
@@ -55,12 +89,14 @@ function makeContext(hasActiveSession = true): PlanModeContext & {
     db: {
       chats: { update: vi.fn(), addPlanFile: vi.fn().mockReturnValue(false) },
     } as any,
+    adapters: makeAdapters(actionHandler),
     getActiveChat: vi.fn().mockReturnValue(activeChat),
     emitEvent: vi.fn(),
     clearDisplayCache: vi.fn(),
     startChat: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     session,
+    handler: actionHandler,
   };
 }
 
@@ -74,17 +110,26 @@ function makeResponse(overrides?: Partial<ControlResponse>): ControlResponse {
   };
 }
 
-describe('PlanModeHandler', () => {
+describe('PlanModeHandler (dispatcher)', () => {
   describe('handleNoProcess', () => {
-    it('updates permissionMode when response specifies a new mode', async () => {
+    it('updates permissionMode and clears planMode without delegating', async () => {
       const ctx = makeContext();
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
 
       await handler.handleNoProcess('chat-1', active, makeResponse({ executionMode: 'yolo' }));
 
-      expect(ctx.db.chats.update).toHaveBeenCalledWith('chat-1', expect.objectContaining({ permissionMode: 'yolo' }));
+      expect(ctx.db.chats.update).toHaveBeenCalledWith(
+        'chat-1',
+        expect.objectContaining({ permissionMode: 'yolo', planMode: false }),
+      );
       expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
+      expect(active.chat.permissionMode).toBe('yolo');
+      expect(active.chat.planMode).toBe(false);
+      // Does NOT delegate — the adapter handler should not be invoked from no-process.
+      const h = ctx.handler as ReturnType<typeof makeMockHandler>;
+      expect(h.onApprove).not.toHaveBeenCalled();
+      expect(h.onApproveAndClearContext).not.toHaveBeenCalled();
     });
 
     it('falls back to "default" when executionMode is not provided', async () => {
@@ -96,91 +141,106 @@ describe('PlanModeHandler', () => {
 
       expect(ctx.db.chats.update).toHaveBeenCalledWith(
         'chat-1',
-        expect.objectContaining({ permissionMode: 'default' }),
+        expect.objectContaining({ permissionMode: 'default', planMode: false }),
       );
     });
 
-    it('does not emit chat.updated when mode is unchanged', async () => {
+    it('does not emit chat.updated when mode is unchanged and planMode is already false', async () => {
       const ctx = makeContext();
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
-      active.chat.permissionMode = 'plan';
+      active.chat.permissionMode = 'default';
+      active.chat.planMode = false;
 
-      await handler.handleNoProcess('chat-1', active, makeResponse({ executionMode: 'plan' }));
+      await handler.handleNoProcess('chat-1', active, makeResponse({ executionMode: 'default' }));
 
       expect(ctx.emitEvent).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
+      expect(ctx.db.chats.update).not.toHaveBeenCalled();
+    });
+
+    it('emits chat.updated when planMode is true even if permissionMode unchanged', async () => {
+      const ctx = makeContext();
+      const handler = new PlanModeHandler(ctx);
+      const active = ctx.getActiveChat('chat-1')!;
+      active.chat.permissionMode = 'default';
+      active.chat.planMode = true;
+
+      await handler.handleNoProcess('chat-1', active, makeResponse({ executionMode: 'default' }));
+
+      expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
+      expect(active.chat.planMode).toBe(false);
     });
   });
 
   describe('handleClearContext', () => {
-    it('kills session, resets session, clears messages, starts new chat', async () => {
+    it('delegates to the adapter handler onApproveAndClearContext', async () => {
       const ctx = makeContext(true);
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
+      const response = makeResponse();
 
-      await handler.handleClearContext('chat-1', active, makeResponse());
+      await handler.handleClearContext('chat-1', active, response);
 
-      expect(ctx.session!.kill).toHaveBeenCalled();
-      expect(ctx.db.chats.update).toHaveBeenCalledWith(
-        'chat-1',
-        expect.objectContaining({ claudeSessionId: undefined }),
-      );
-      expect(ctx.emitEvent).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'messages.cleared', chatId: 'chat-1' }),
-      );
-      expect(ctx.startChat).toHaveBeenCalledWith('chat-1');
-    });
-
-    it('sends follow-up message when plan is provided', async () => {
-      const ctx = makeContext(true);
-      const handler = new PlanModeHandler(ctx);
-      const active = ctx.getActiveChat('chat-1')!;
-
-      await handler.handleClearContext(
-        'chat-1',
-        active,
-        makeResponse({
-          updatedInput: { plan: 'Step 1: do the thing.' },
+      const h = ctx.handler as ReturnType<typeof makeMockHandler>;
+      expect(h.onApproveAndClearContext).toHaveBeenCalledTimes(1);
+      expect(h.onApproveAndClearContext).toHaveBeenCalledWith(
+        response,
+        expect.objectContaining({
+          chatId: 'chat-1',
+          active,
+          chat: active.chat,
         }),
       );
-
-      expect(ctx.sendMessage).toHaveBeenCalledWith('chat-1', expect.stringContaining('Step 1: do the thing.'));
     });
 
-    it('works without an active session (session=null)', async () => {
-      const ctx = makeContext(false);
+    it('returns without throwing when adapter has no createPlanModeHandler factory', async () => {
+      const ctx = makeContext(true, null);
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
 
       await expect(handler.handleClearContext('chat-1', active, makeResponse())).resolves.not.toThrow();
-      expect(ctx.startChat).toHaveBeenCalledWith('chat-1');
+      // No delegation happened (handler is null), and no chat mutation either.
+      expect(ctx.startChat).not.toHaveBeenCalled();
+    });
+
+    it('returns without throwing when adapter is not registered', async () => {
+      const ctx = makeContext(true, null);
+      // Simulate registry returning undefined
+      (ctx.adapters.get as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      const handler = new PlanModeHandler(ctx);
+      const active = ctx.getActiveChat('chat-1')!;
+
+      await expect(handler.handleClearContext('chat-1', active, makeResponse())).resolves.not.toThrow();
     });
   });
 
   describe('handleEscalation', () => {
-    it('updates permissionMode and calls setPermissionMode on session', async () => {
+    it('delegates to the adapter handler onApprove', async () => {
       const ctx = makeContext(true);
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
+      const response = makeResponse({ executionMode: 'yolo' });
 
-      await handler.handleEscalation('chat-1', active, makeResponse({ executionMode: 'yolo' }));
+      await handler.handleEscalation('chat-1', active, response);
 
-      expect(ctx.db.chats.update).toHaveBeenCalledWith('chat-1', expect.objectContaining({ permissionMode: 'yolo' }));
-      expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
-      expect(ctx.session!.setPermissionMode).toHaveBeenCalledWith('yolo');
+      const h = ctx.handler as ReturnType<typeof makeMockHandler>;
+      expect(h.onApprove).toHaveBeenCalledTimes(1);
+      expect(h.onApprove).toHaveBeenCalledWith(
+        response,
+        expect.objectContaining({
+          chatId: 'chat-1',
+          active,
+          chat: active.chat,
+        }),
+      );
     });
 
-    it('falls back to "default" when executionMode is not provided', async () => {
-      const ctx = makeContext(true);
+    it('returns without throwing when adapter has no createPlanModeHandler factory', async () => {
+      const ctx = makeContext(true, null);
       const handler = new PlanModeHandler(ctx);
       const active = ctx.getActiveChat('chat-1')!;
 
-      await handler.handleEscalation('chat-1', active, makeResponse());
-
-      expect(ctx.db.chats.update).toHaveBeenCalledWith(
-        'chat-1',
-        expect.objectContaining({ permissionMode: 'default' }),
-      );
+      await expect(handler.handleEscalation('chat-1', active, makeResponse())).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/src/__tests__/restore-permission.test.ts
+++ b/packages/core/src/__tests__/restore-permission.test.ts
@@ -3,6 +3,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
+import { ClaudePlanModeHandler } from '../plugins/builtin/claude/plan-mode-handler.js';
 import type {
   Chat,
   ChatMessage,
@@ -59,6 +60,13 @@ class MockAdapterImpl extends MockBaseAdapter {
   override createSession(_options: SessionOptions): AdapterSession {
     this.currentSession = new MockSession(this);
     return this.currentSession;
+  }
+
+  // The dispatcher delegates plan-mode actions to the adapter. These tests
+  // assert Claude-style behavior (respondToPermission(deny) + kill + restart),
+  // so reuse ClaudePlanModeHandler to produce that behavior on the mock.
+  createPlanModeHandler(): unknown {
+    return new ClaudePlanModeHandler();
   }
 }
 

--- a/packages/core/src/__tests__/routes/settings.test.ts
+++ b/packages/core/src/__tests__/routes/settings.test.ts
@@ -80,7 +80,8 @@ describe('settingRoutes', () => {
     it('does not override existing defaultMode with skipPermissions', () => {
       (ctx.db.settings.getByCategory as any).mockReturnValue({
         'claude.skipPermissions': 'true',
-        'claude.defaultMode': 'plan',
+        'claude.defaultMode': 'default',
+        'claude.defaultPlanMode': 'true',
       });
 
       const router = settingRoutes(ctx);
@@ -90,7 +91,8 @@ describe('settingRoutes', () => {
       handler({ params: {}, query: {} }, res, vi.fn());
 
       const call = res.json.mock.calls[0][0];
-      expect(call.data.claude.defaultMode).toBe('plan');
+      expect(call.data.claude.defaultMode).toBe('default');
+      expect(call.data.claude.defaultPlanMode).toBe('true');
     });
 
     it('skips keys without a dot separator', () => {
@@ -143,6 +145,17 @@ describe('settingRoutes', () => {
 
       expect(ctx.db.settings.set).toHaveBeenCalledWith('provider', 'claude.defaultMode', 'yolo');
       expect(ctx.db.settings.delete).toHaveBeenCalledWith('provider', 'claude.skipPermissions');
+    });
+
+    it('sets defaultPlanMode', () => {
+      const router = settingRoutes(ctx);
+      const handler = extractHandler(router, 'put', '/api/settings/providers/:adapterId');
+      const res = mockRes();
+
+      handler({ params: { adapterId: 'claude' }, query: {}, body: { defaultPlanMode: 'true' } }, res, vi.fn());
+
+      expect(ctx.db.settings.set).toHaveBeenCalledWith('provider', 'claude.defaultPlanMode', 'true');
+      expect(res.json).toHaveBeenCalledWith({ success: true });
     });
 
     it('sets executablePath', () => {

--- a/packages/core/src/__tests__/session-identity-guard.test.ts
+++ b/packages/core/src/__tests__/session-identity-guard.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventHandler } from '../chat/event-handler.js';
+
+describe('buildSink onExit: session-identity guard', () => {
+  it('ignores close from a superseded session', () => {
+    const chatId = 'c1';
+    const chat: any = { id: chatId, processState: 'working' };
+    const activeChat = { chat, session: { id: 'session-new' } };
+
+    const emitted: any[] = [];
+    const handler = new EventHandler(
+      { chats: { update: vi.fn() } } as any,
+      { get: () => [], set: vi.fn() } as any,
+      { clear: vi.fn(), clearInterrupted: vi.fn() } as any,
+      () => activeChat as any,
+      (event) => emitted.push(event),
+    );
+    const sink = handler.buildSink(chatId, 'session-old', vi.fn());
+
+    sink.onExit(0);
+
+    expect(chat.processState).toBe('working');
+    expect(emitted.find((event) => event.type === 'chat.updated')).toBeUndefined();
+  });
+
+  it('applies close from the current session', () => {
+    const chatId = 'c2';
+    const chat: any = { id: chatId, processState: 'working' };
+    const activeChat = { chat, session: { id: 'session-a' } };
+
+    const emitted: any[] = [];
+    const handler = new EventHandler(
+      { chats: { update: vi.fn() } } as any,
+      { get: () => [], set: vi.fn() } as any,
+      { clear: vi.fn(), clearInterrupted: vi.fn() } as any,
+      () => activeChat as any,
+      (event) => emitted.push(event),
+    );
+    const sink = handler.buildSink(chatId, 'session-a', vi.fn());
+
+    sink.onExit(0);
+
+    expect(chat.processState).toBeNull();
+    expect(emitted.some((event) => event.type === 'chat.updated')).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/ws-inbound-flow.test.ts
+++ b/packages/core/src/__tests__/ws-inbound-flow.test.ts
@@ -199,7 +199,7 @@ describe('WS inbound flows', () => {
     expect(events.length).toBe(countBefore);
   }, 10_000);
 
-  it('EnterPlanMode in message switches permissionMode to plan and emits chat.updated', async () => {
+  it('EnterPlanMode in message flips planMode=true and emits chat.updated', async () => {
     const adapter = new MockAdapter();
     const events = await setup(adapter);
 
@@ -208,7 +208,7 @@ describe('WS inbound flows', () => {
     ]);
     await sleep(50);
 
-    const chatUpdated = events.find((e) => e.type === 'chat.updated' && (e as any).chat?.permissionMode === 'plan');
+    const chatUpdated = events.find((e) => e.type === 'chat.updated' && (e as any).chat?.planMode === true);
     expect(chatUpdated).toBeDefined();
   }, 10_000);
 

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -49,6 +49,7 @@ export class AdapterRegistry {
         installed,
         version: version || undefined,
         models,
+        capabilities: adapter.capabilities,
       });
     }
     return infos;

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -85,7 +85,8 @@ export class ChatManager {
       messages: this.messages,
       permissions: this.permissions,
       emitEvent: (event) => this.emitEvent(event),
-      buildSink: (chatId, respondToPermission) => this.eventHandler.buildSink(chatId, respondToPermission),
+      buildSink: (chatId, sessionId, respondToPermission) =>
+        this.eventHandler.buildSink(chatId, sessionId, respondToPermission),
     });
     this.permissionHandler = new ChatPermissionHandler({
       permissions: this.permissions,

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -157,8 +157,9 @@ export class ChatManager {
     adapterId?: string,
     model?: string,
     permissionMode?: Chat['permissionMode'],
+    planMode?: boolean,
   ): Promise<void> {
-    return this.configManager.updateChatConfig(chatId, adapterId, model, permissionMode);
+    return this.configManager.updateChatConfig(chatId, adapterId, model, permissionMode, planMode);
   }
 
   async enableWorktree(chatId: string, baseBranch: string, branchName: string): Promise<void> {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -70,6 +70,7 @@ export class ChatManager {
       permissions: this.permissions,
       messages: this.messages,
       db: this.db,
+      adapters: this.adapters,
       getActiveChat: (chatId) => this.activeChats.get(chatId),
       emitEvent: (event) => this.emitEvent(event),
       clearDisplayCache: (chatId) => this.eventHandler.clearDisplayCache(chatId),

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -29,6 +29,7 @@ export class ChatConfigManager {
     adapterId?: string,
     model?: string,
     permissionMode?: Chat['permissionMode'],
+    planMode?: boolean,
   ): Promise<void> {
     const active = this.deps.getActiveChat(chatId);
     if (!active) throw new Error(`Chat ${chatId} not found`);
@@ -40,11 +41,13 @@ export class ChatConfigManager {
     const adapterChanged = adapterId !== undefined && adapterId !== active.chat.adapterId;
     const modelChanged = model !== undefined && model !== active.chat.model;
     const modeChanged = permissionMode !== undefined && permissionMode !== active.chat.permissionMode;
-    if (!adapterChanged && !modelChanged && !modeChanged) return;
+    const planModeChanged = planMode !== undefined && planMode !== (active.chat.planMode ?? false);
+    if (!adapterChanged && !modelChanged && !modeChanged && !planModeChanged) return;
 
     if (active.session?.isSpawned && !adapterChanged) {
       if (modelChanged) await active.session.setModel(model!);
       if (modeChanged) await active.session.setPermissionMode(permissionMode!);
+      if (planModeChanged) await active.session.setPlanMode(planMode!);
       const updates: Partial<Chat> = {};
       if (modelChanged) {
         updates.model = model;
@@ -53,6 +56,10 @@ export class ChatConfigManager {
       if (modeChanged) {
         updates.permissionMode = permissionMode;
         active.chat.permissionMode = permissionMode;
+      }
+      if (planModeChanged) {
+        updates.planMode = planMode;
+        active.chat.planMode = planMode;
       }
       this.deps.db.chats.update(chatId, updates);
       this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
@@ -86,6 +93,10 @@ export class ChatConfigManager {
     if (modeChanged) {
       updates.permissionMode = permissionMode;
       active.chat.permissionMode = permissionMode;
+    }
+    if (planModeChanged) {
+      updates.planMode = planMode;
+      active.chat.planMode = planMode;
     }
 
     this.deps.db.chats.update(chatId, updates);

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -58,9 +58,20 @@ export class EventHandler {
     this.pushService = service;
   }
 
-  buildSink(chatId: string, respondToPermission: (response: ControlResponse) => Promise<void>): SessionSink {
+  buildSink(
+    chatId: string,
+    sessionIdOrRespondToPermission: string | ((response: ControlResponse) => Promise<void>),
+    maybeRespondToPermission?: (response: ControlResponse) => Promise<void>,
+  ): SessionSink {
+    const builtForSessionId =
+      typeof sessionIdOrRespondToPermission === 'string' ? sessionIdOrRespondToPermission : undefined;
+    const respondToPermission =
+      typeof sessionIdOrRespondToPermission === 'string' ? maybeRespondToPermission : sessionIdOrRespondToPermission;
+    if (!respondToPermission) throw new Error('respondToPermission is required');
+
     return buildSessionSink(
       chatId,
+      builtForSessionId,
       this.db,
       this.messages,
       this.permissions,
@@ -89,6 +100,7 @@ export class EventHandler {
 
 function buildSessionSink(
   chatId: string,
+  builtForSessionId: string | undefined,
   db: DatabaseManager,
   messages: MessageCache,
   permissions: PermissionManager,
@@ -137,9 +149,9 @@ function buildSessionSink(
       const hasEnterPlanMode = content.some((b: any) => b.type === 'tool_use' && b.name === 'EnterPlanMode');
       if (hasEnterPlanMode) {
         const active = getActiveChat(chatId);
-        if (active && active.chat.permissionMode !== 'plan') {
-          db.chats.update(chatId, { permissionMode: 'plan' });
-          active.chat.permissionMode = 'plan';
+        if (active && active.chat.planMode !== true) {
+          db.chats.update(chatId, { planMode: true });
+          active.chat.planMode = true;
           emitEvent({ type: 'chat.updated', chat: active.chat });
         }
       }
@@ -305,6 +317,9 @@ function buildSessionSink(
 
     onExit(_code: number | null) {
       const active = getActiveChat(chatId);
+      if (builtForSessionId && active?.session && active.session.id !== builtForSessionId) {
+        return;
+      }
       const sessionId = active?.session?.id ?? '';
       log.debug({ sessionId, chatId }, 'session exited');
 

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -26,7 +26,11 @@ export interface LifecycleManagerDeps {
   messages: MessageCache;
   permissions: PermissionManager;
   emitEvent: (event: DaemonEvent) => void;
-  buildSink: (chatId: string, respondToPermission: (response: ControlResponse) => Promise<void>) => SessionSink;
+  buildSink: (
+    chatId: string,
+    sessionId: string,
+    respondToPermission: (response: ControlResponse) => Promise<void>,
+  ) => SessionSink;
   /** Stop launch processes for a project+path pair (e.g. before worktree removal) */
   stopLaunchProcesses?: (projectId: string, projectPath: string) => Promise<void>;
 }
@@ -82,16 +86,25 @@ export class ChatLifecycleManager {
   ): Promise<Chat> {
     let effectiveModel = model;
     let effectiveMode = permissionMode;
+    let effectivePlanMode = false;
 
-    if (!effectiveModel || !effectiveMode) {
+    if (!effectiveModel || !effectiveMode || !effectivePlanMode) {
       const defaultModel = this.deps.db.settings.get('provider', `${adapterId}.defaultModel`);
       const defaultMode = this.deps.db.settings.get('provider', `${adapterId}.defaultMode`);
+      const defaultPlanMode = this.deps.db.settings.get('provider', `${adapterId}.defaultPlanMode`);
 
       if (!effectiveModel && defaultModel) effectiveModel = defaultModel;
       if (!effectiveMode && defaultMode) effectiveMode = defaultMode;
+      if (defaultPlanMode === 'true') effectivePlanMode = true;
     }
 
-    return this.createChat(projectId, adapterId, effectiveModel, effectiveMode, worktreePath, branchName);
+    const chat = await this.createChat(projectId, adapterId, effectiveModel, effectiveMode, worktreePath, branchName);
+    if (effectivePlanMode) {
+      chat.planMode = true;
+      this.deps.db.chats.update(chat.id, { planMode: true });
+    }
+
+    return chat;
   }
 
   async resumeChat(chatId: string): Promise<void> {
@@ -419,7 +432,7 @@ export class ChatLifecycleManager {
     });
     active.session = session;
 
-    const sink = this.deps.buildSink(chatId, (response) => session.respondToPermission(response));
+    const sink = this.deps.buildSink(chatId, session.id, (response) => session.respondToPermission(response));
 
     const executablePath = this.deps.db.settings.get('provider', `${chat.adapterId}.executablePath`) ?? undefined;
     const systemPrompt = this.deps.db.settings.get('provider', `${chat.adapterId}.systemPrompt`) ?? undefined;

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -437,7 +437,13 @@ export class ChatLifecycleManager {
     const executablePath = this.deps.db.settings.get('provider', `${chat.adapterId}.executablePath`) ?? undefined;
     const systemPrompt = this.deps.db.settings.get('provider', `${chat.adapterId}.systemPrompt`) ?? undefined;
     const processInfo = await session.spawn(
-      { model: chat.model, permissionMode: chat.permissionMode, executablePath, systemPrompt },
+      {
+        model: chat.model,
+        permissionMode: chat.permissionMode,
+        planMode: chat.planMode ?? false,
+        executablePath,
+        systemPrompt,
+      },
       sink,
     );
     log.info({ chatId }, 'chat session started');

--- a/packages/core/src/chat/plan-mode-actions.ts
+++ b/packages/core/src/chat/plan-mode-actions.ts
@@ -1,0 +1,43 @@
+import type { Chat, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { ActiveChat } from './types.js';
+import type { MessageCache } from './message-cache.js';
+import type { PermissionManager } from './permission-manager.js';
+import type { DatabaseManager } from '../db/index.js';
+
+export interface PlanActionContext {
+  chatId: string;
+  active: ActiveChat;
+  chat: Chat;
+  db: DatabaseManager;
+  messages: MessageCache;
+  permissions: PermissionManager;
+  emitEvent(event: DaemonEvent): void;
+  clearDisplayCache(chatId: string): void;
+  startChat(chatId: string): Promise<void>;
+  sendMessage(chatId: string, content: string): Promise<void>;
+}
+
+export interface PlanModeActionHandler {
+  /**
+   * User approved the plan WITHOUT clearing context. Default behavior for
+   * most adapters is to set planMode=false and apply the chosen exec mode.
+   */
+  onApprove(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User approved AND checked "Clear Context". Adapter decides how to reset
+   * (Claude: kill & respawn with same session id; Codex: thread/start new thread).
+   */
+  onApproveAndClearContext(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User rejected the plan. Adapter translates this to the appropriate
+   * per-protocol "stay in plan" response.
+   */
+  onReject(response: ControlResponse, context: PlanActionContext): Promise<void>;
+
+  /**
+   * User provided revision feedback. Adapter forwards as free-form text.
+   */
+  onRevise(feedback: string, response: ControlResponse, context: PlanActionContext): Promise<void>;
+}

--- a/packages/core/src/chat/plan-mode-handler.ts
+++ b/packages/core/src/chat/plan-mode-handler.ts
@@ -3,12 +3,17 @@ import type { DatabaseManager } from '../db/index.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { MessageCache } from './message-cache.js';
 import type { ActiveChat } from './types.js';
-import { extractLatestPlanFileFromMessages } from './context-tracker.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import type { PlanModeActionHandler, PlanActionContext } from './plan-mode-actions.js';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('chat:plan-mode');
 
 export interface PlanModeContext {
   messages: MessageCache;
   db: DatabaseManager;
   permissions: PermissionManager;
+  adapters: AdapterRegistry;
   getActiveChat(chatId: string): ActiveChat | undefined;
   emitEvent(event: DaemonEvent): void;
   clearDisplayCache(chatId: string): void;
@@ -16,67 +21,70 @@ export interface PlanModeContext {
   sendMessage(chatId: string, content: string): Promise<void>;
 }
 
+/**
+ * Adapter-agnostic dispatcher for plan-mode actions.
+ *
+ * Runtime behavior is delegated to the adapter's `createPlanModeHandler()`
+ * factory (see `PlanModeActionHandler`). The dispatcher only preserves the
+ * direct no-process permissionMode/planMode update — there is no live session
+ * to act on at that point so the adapter handler has nothing to run.
+ */
 export class PlanModeHandler {
   constructor(private ctx: PlanModeContext) {}
 
+  /**
+   * No active session path. Persist the chosen execution mode and clear
+   * planMode so a follow-up spawn starts out of plan. The adapter handler is
+   * intentionally NOT invoked here — there is no session for it to manipulate.
+   */
   async handleNoProcess(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
-    const newMode = (response.executionMode ?? 'default') as Chat['permissionMode'];
-    if (newMode !== active.chat.permissionMode) {
-      active.chat.permissionMode = newMode;
-      this.ctx.db.chats.update(chatId, { permissionMode: newMode });
+    const exec = (response.executionMode ?? 'default') as NonNullable<Chat['permissionMode']>;
+    if (exec !== active.chat.permissionMode || active.chat.planMode) {
+      active.chat.permissionMode = exec;
+      active.chat.planMode = false;
+      this.ctx.db.chats.update(chatId, { permissionMode: exec, planMode: false });
       this.ctx.emitEvent({ type: 'chat.updated', chat: active.chat });
     }
   }
 
+  /** User approved AND asked to clear context. Delegates to the adapter handler. */
   async handleClearContext(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
-    const plan = (response.updatedInput as Record<string, unknown> | undefined)?.plan as string | undefined;
-    const recoveredPlanPath = extractLatestPlanFileFromMessages(this.ctx.messages.get(chatId) ?? []);
-    if (recoveredPlanPath && this.ctx.db.chats.addPlanFile(chatId, recoveredPlanPath)) {
-      this.ctx.emitEvent({ type: 'context.updated', chatId });
+    const handler = this.resolveHandler(active.chat.adapterId);
+    if (!handler) {
+      log.warn({ chatId, adapterId: active.chat.adapterId }, 'no plan-mode handler for adapter');
+      return;
     }
-    const newMode = (response.executionMode ?? 'default') as Chat['permissionMode'];
-
-    if (!active.session?.isSpawned) {
-      this.ctx.permissions.shift(chatId);
-    } else {
-      await active.session.respondToPermission({
-        ...response,
-        behavior: 'deny',
-        message: 'User chose to clear context and start a new session.',
-      });
-
-      this.ctx.permissions.shift(chatId);
-
-      await active.session.kill();
-      active.session = null;
-    }
-
-    active.chat.claudeSessionId = undefined;
-    active.chat.permissionMode = newMode;
-    this.ctx.db.chats.update(chatId, { claudeSessionId: undefined, permissionMode: newMode });
-    this.ctx.emitEvent({ type: 'chat.updated', chat: active.chat });
-
-    this.ctx.messages.set(chatId, []);
-    this.ctx.clearDisplayCache(chatId);
-    this.ctx.emitEvent({ type: 'messages.cleared', chatId });
-
-    await this.ctx.startChat(chatId);
-
-    if (plan) {
-      await this.ctx.sendMessage(chatId, `Implement the following plan:\n\n${plan}`);
-    }
+    await handler.onApproveAndClearContext(response, this.buildActionContext(chatId, active));
   }
 
+  /** User approved without clearing context. Delegates to the adapter handler. */
   async handleEscalation(chatId: string, active: ActiveChat, response: ControlResponse): Promise<void> {
-    const newMode = (response.executionMode ?? 'default') as NonNullable<Chat['permissionMode']>;
-    if (newMode !== active.chat.permissionMode) {
-      active.chat.permissionMode = newMode;
-      this.ctx.db.chats.update(chatId, { permissionMode: newMode });
-      this.ctx.emitEvent({ type: 'chat.updated', chat: active.chat });
-
-      if (active.session?.isSpawned) {
-        await active.session.setPermissionMode(newMode);
-      }
+    const handler = this.resolveHandler(active.chat.adapterId);
+    if (!handler) {
+      log.warn({ chatId, adapterId: active.chat.adapterId }, 'no plan-mode handler for adapter');
+      return;
     }
+    await handler.onApprove(response, this.buildActionContext(chatId, active));
+  }
+
+  private resolveHandler(adapterId: string): PlanModeActionHandler | null {
+    const adapter = this.ctx.adapters.get(adapterId);
+    if (!adapter?.createPlanModeHandler) return null;
+    return adapter.createPlanModeHandler() as PlanModeActionHandler;
+  }
+
+  private buildActionContext(chatId: string, active: ActiveChat): PlanActionContext {
+    return {
+      chatId,
+      active,
+      chat: active.chat,
+      db: this.ctx.db,
+      messages: this.ctx.messages,
+      permissions: this.ctx.permissions,
+      emitEvent: this.ctx.emitEvent,
+      clearDisplayCache: this.ctx.clearDisplayCache,
+      startChat: this.ctx.startChat,
+      sendMessage: this.ctx.sendMessage,
+    };
   }
 }

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -3,11 +3,12 @@ import type { Chat, SessionMention, SkillFileEntry, TodoItem } from '@qlan-ro/ma
 import { nanoid } from 'nanoid';
 
 /** Raw shape returned by SQLite before boolean/JSON coercion. */
-type RawChatRow = Omit<Chat, 'pinned' | 'mentions' | 'modifiedFiles' | 'todos'> & {
+type RawChatRow = Omit<Chat, 'pinned' | 'planMode' | 'mentions' | 'modifiedFiles' | 'todos'> & {
   mentions: string;
   modifiedFiles: string;
   todos: string;
   pinned: number;
+  planMode: number;
 };
 
 function parseJsonColumn<T>(value: string | null | undefined, fallback: T): T {
@@ -33,7 +34,8 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned
+        process_state as processState, todos, pinned,
+        plan_mode as planMode
       FROM chats
       WHERE project_id = ?
       ORDER BY pinned DESC, updated_at DESC
@@ -48,6 +50,7 @@ export class ChatsRepository {
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
       pinned: Boolean(row.pinned),
+      planMode: Boolean(row.planMode),
     }));
   }
 
@@ -62,7 +65,8 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned
+        process_state as processState, todos, pinned,
+        plan_mode as planMode
       FROM chats
       ORDER BY pinned DESC, updated_at DESC, rowid DESC
     `);
@@ -76,6 +80,7 @@ export class ChatsRepository {
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
       pinned: Boolean(row.pinned),
+      planMode: Boolean(row.planMode),
     }));
   }
 
@@ -90,7 +95,8 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned
+        process_state as processState, todos, pinned,
+        plan_mode as planMode
       FROM chats WHERE id = ?
     `);
     const row = stmt.get(id) as RawChatRow | null;
@@ -104,6 +110,7 @@ export class ChatsRepository {
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
       pinned: Boolean(row.pinned),
+      planMode: Boolean(row.planMode),
     };
   }
 
@@ -130,6 +137,7 @@ export class ChatsRepository {
       totalTokensInput: 0,
       totalTokensOutput: 0,
       lastContextTokensInput: 0,
+      planMode: false,
     };
   }
 
@@ -151,6 +159,7 @@ export class ChatsRepository {
     createdAt: { column: 'created_at' },
     updatedAt: { column: 'updated_at' },
     pinned: { column: 'pinned', transform: (v) => (v ? 1 : 0) },
+    planMode: { column: 'plan_mode', transform: (v) => (v ? 1 : 0) },
   };
 
   update(id: string, updates: Partial<Chat>): void {
@@ -254,7 +263,8 @@ export class ChatsRepository {
         total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned
+        process_state as processState, todos, pinned,
+        plan_mode as planMode
       FROM chats WHERE claude_session_id = ? AND project_id = ?
     `);
     const row = stmt.get(sessionId, projectId) as RawChatRow | null;
@@ -268,6 +278,7 @@ export class ChatsRepository {
       processState: (row.processState as Chat['processState']) || null,
       todos: parseJsonColumn(row.todos, undefined) ?? undefined,
       pinned: Boolean(row.pinned),
+      planMode: Boolean(row.planMode),
     };
   }
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -91,6 +91,10 @@ export function initializeSchema(db: Database.Database): void {
   if (!cols.some((c) => c.name === 'pinned')) {
     db.exec('ALTER TABLE chats ADD COLUMN pinned INTEGER DEFAULT 0');
   }
+  if (!cols.some((c) => c.name === 'plan_mode')) {
+    db.exec('ALTER TABLE chats ADD COLUMN plan_mode INTEGER NOT NULL DEFAULT 0');
+    db.exec("UPDATE chats SET plan_mode = 1, permission_mode = 'default' WHERE permission_mode = 'plan'");
+  }
 
   const projectCols = db.pragma('table_info(projects)') as { name: string }[];
   if (!projectCols.some((c) => c.name === 'parent_project_id')) {

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -100,4 +100,19 @@ export function initializeSchema(db: Database.Database): void {
   if (!projectCols.some((c) => c.name === 'parent_project_id')) {
     db.exec('ALTER TABLE projects ADD COLUMN parent_project_id TEXT REFERENCES projects(id)');
   }
+
+  const planModeSettings = db
+    .prepare("SELECT id, key FROM settings WHERE category='provider' AND key LIKE '%.defaultMode' AND value='plan'")
+    .all() as { id: string; key: string }[];
+  for (const { id, key } of planModeSettings) {
+    const now = new Date().toISOString();
+    const prefix = key.slice(0, -'.defaultMode'.length);
+    const planKey = `${prefix}.defaultPlanMode`;
+    db.prepare("UPDATE settings SET value='default', updated_at=? WHERE id=?").run(now, id);
+    db.prepare(
+      `INSERT INTO settings (id, category, key, value, updated_at)
+       VALUES (?, 'provider', ?, 'true', ?)
+       ON CONFLICT(category, key) DO UPDATE SET value='true', updated_at=excluded.updated_at`,
+    ).run(`${id}-plan`, planKey, now);
+  }
 }

--- a/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
@@ -114,6 +114,7 @@ const CLAUDE_MODELS: AdapterModel[] = [
 export class ClaudeSdkAdapter implements Adapter {
   readonly id = 'claude-sdk';
   readonly name = 'Claude Agent SDK';
+  readonly capabilities = { planMode: true };
 
   private sessions = new Set<ClaudeSdkSession>();
 

--- a/packages/core/src/plugins/builtin/claude-sdk/session.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/session.ts
@@ -204,6 +204,12 @@ export class ClaudeSdkSession implements AdapterSession {
     }
   }
 
+  async setPlanMode(on: boolean): Promise<void> {
+    if (this.queryHandle) {
+      await this.queryHandle.setPermissionMode(on ? 'plan' : toSdkPermissionMode(this.spawnOptions.permissionMode));
+    }
+  }
+
   async sendCommand(_command: string, _args?: string): Promise<void> {
     logger.warn('sendCommand not implemented for claude-sdk adapter');
   }

--- a/packages/core/src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/kill-awaits-close.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ClaudeSession } from '../session.js';
+
+describe('ClaudeSession.kill() awaits close', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves only after the child emits close', async () => {
+    const session = new ClaudeSession({ projectPath: '/tmp' } as any);
+    const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+    const fakeChild: any = {
+      kill: vi.fn(),
+      exitCode: null,
+      once(event: string, callback: (...args: any[]) => void) {
+        (listeners[event] ||= []).push(callback);
+      },
+    };
+    session.state.child = fakeChild;
+
+    let resolved = false;
+    const pending = session.kill().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+    listeners.close?.[0]?.();
+    await pending;
+
+    expect(resolved).toBe(true);
+    expect(session.state.child).toBeNull();
+  });
+
+  it('falls back to SIGKILL after 3s if close never fires', async () => {
+    vi.useFakeTimers();
+    const session = new ClaudeSession({ projectPath: '/tmp' } as any);
+    const fakeChild: any = {
+      kill: vi.fn(),
+      exitCode: null,
+      once: vi.fn(),
+    };
+    session.state.child = fakeChild;
+
+    const pending = session.kill();
+    await vi.advanceTimersByTimeAsync(3000);
+    await pending;
+
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(fakeChild.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
@@ -3,13 +3,16 @@ import { ClaudePlanModeHandler } from '../plan-mode-handler.js';
 import type { PlanActionContext } from '../../../../chat/plan-mode-actions.js';
 import type { ControlResponse } from '@qlan-ro/mainframe-types';
 
-function mkContext(overrides: Partial<PlanActionContext> = {}): PlanActionContext {
-  const session = {
-    isSpawned: true,
-    setPermissionMode: vi.fn().mockResolvedValue(undefined),
-    respondToPermission: vi.fn().mockResolvedValue(undefined),
-    kill: vi.fn().mockResolvedValue(undefined),
-  };
+function mkContext(overrides: Partial<PlanActionContext> & { hasSession?: boolean } = {}): PlanActionContext {
+  const { hasSession = true, ...rest } = overrides;
+  const session = hasSession
+    ? {
+        isSpawned: true,
+        setPermissionMode: vi.fn().mockResolvedValue(undefined),
+        respondToPermission: vi.fn().mockResolvedValue(undefined),
+        kill: vi.fn().mockResolvedValue(undefined),
+      }
+    : null;
   const chat = {
     id: 'c1',
     planMode: true,
@@ -28,14 +31,14 @@ function mkContext(overrides: Partial<PlanActionContext> = {}): PlanActionContex
     chatId: 'c1',
     active: { chat, session: session as any },
     chat,
-    db: { chats: { update: vi.fn() } } as any,
-    messages: { get: vi.fn().mockReturnValue([]) } as any,
+    db: { chats: { update: vi.fn(), addPlanFile: vi.fn().mockReturnValue(false) } } as any,
+    messages: { get: vi.fn().mockReturnValue([]), set: vi.fn() } as any,
     permissions: { shift: vi.fn() } as any,
     emitEvent: vi.fn(),
     clearDisplayCache: vi.fn(),
     startChat: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -64,5 +67,43 @@ describe('ClaudePlanModeHandler', () => {
     const denyResponse: ControlResponse = { ...baseResponse, behavior: 'deny', message: 'needs more work' };
     await handler.onReject(denyResponse, ctx);
     expect(ctx.active.session!.respondToPermission).toHaveBeenCalledWith(denyResponse);
+  });
+
+  it('onApproveAndClearContext kills session, resets claudeSessionId, clears messages, starts new chat', async () => {
+    const ctx = mkContext();
+    const session = ctx.active.session!;
+    const handler = new ClaudePlanModeHandler();
+    await handler.onApproveAndClearContext(baseResponse, ctx);
+
+    expect(session.kill).toHaveBeenCalled();
+    expect(ctx.db.chats.update).toHaveBeenCalledWith(
+      'c1',
+      expect.objectContaining({ claudeSessionId: undefined, planMode: false, permissionMode: 'acceptEdits' }),
+    );
+    expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'messages.cleared', chatId: 'c1' }));
+    expect(ctx.startChat).toHaveBeenCalledWith('c1');
+    expect(ctx.messages.set).toHaveBeenCalledWith('c1', []);
+    expect(ctx.clearDisplayCache).toHaveBeenCalledWith('c1');
+  });
+
+  it('onApproveAndClearContext sends follow-up message when plan is provided in updatedInput', async () => {
+    const ctx = mkContext();
+    const handler = new ClaudePlanModeHandler();
+    const responseWithPlan: ControlResponse = {
+      ...baseResponse,
+      updatedInput: { plan: 'Step 1: do the thing.' },
+    };
+    await handler.onApproveAndClearContext(responseWithPlan, ctx);
+
+    expect(ctx.sendMessage).toHaveBeenCalledWith('c1', expect.stringContaining('Step 1: do the thing.'));
+  });
+
+  it('onApproveAndClearContext works when session is null (no-process path)', async () => {
+    const ctx = mkContext({ hasSession: false });
+    const handler = new ClaudePlanModeHandler();
+
+    await expect(handler.onApproveAndClearContext(baseResponse, ctx)).resolves.not.toThrow();
+    expect(ctx.permissions.shift).toHaveBeenCalledWith('c1');
+    expect(ctx.startChat).toHaveBeenCalledWith('c1');
   });
 });

--- a/packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/plan-mode-handler.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ClaudePlanModeHandler } from '../plan-mode-handler.js';
+import type { PlanActionContext } from '../../../../chat/plan-mode-actions.js';
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+
+function mkContext(overrides: Partial<PlanActionContext> = {}): PlanActionContext {
+  const session = {
+    isSpawned: true,
+    setPermissionMode: vi.fn().mockResolvedValue(undefined),
+    respondToPermission: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+  };
+  const chat = {
+    id: 'c1',
+    planMode: true,
+    permissionMode: 'acceptEdits' as const,
+    adapterId: 'claude',
+    projectId: 'p1',
+    status: 'active' as const,
+    createdAt: '',
+    updatedAt: '',
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+  };
+  return {
+    chatId: 'c1',
+    active: { chat, session: session as any },
+    chat,
+    db: { chats: { update: vi.fn() } } as any,
+    messages: { get: vi.fn().mockReturnValue([]) } as any,
+    permissions: { shift: vi.fn() } as any,
+    emitEvent: vi.fn(),
+    clearDisplayCache: vi.fn(),
+    startChat: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('ClaudePlanModeHandler', () => {
+  const baseResponse: ControlResponse = {
+    requestId: 'r1',
+    toolUseId: 't1',
+    behavior: 'allow',
+    toolName: 'ExitPlanMode',
+    executionMode: 'acceptEdits',
+  };
+
+  it('onApprove clears planMode and calls setPermissionMode with the base mode', async () => {
+    const ctx = mkContext();
+    const handler = new ClaudePlanModeHandler();
+    await handler.onApprove(baseResponse, ctx);
+
+    expect(ctx.chat.planMode).toBe(false);
+    expect(ctx.db.chats.update).toHaveBeenCalledWith('c1', { planMode: false, permissionMode: 'acceptEdits' });
+    expect(ctx.active.session!.setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+  });
+
+  it('onReject forwards the deny message with Claude preamble handled by respondToPermission', async () => {
+    const ctx = mkContext();
+    const handler = new ClaudePlanModeHandler();
+    const denyResponse: ControlResponse = { ...baseResponse, behavior: 'deny', message: 'needs more work' };
+    await handler.onReject(denyResponse, ctx);
+    expect(ctx.active.session!.respondToPermission).toHaveBeenCalledWith(denyResponse);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -15,6 +15,7 @@ import { ClaudeSession } from './session.js';
 import { probeModels as doProbeModels } from './probe-models.js';
 import * as skills from './skills.js';
 import { listExternalSessions } from './external-sessions.js';
+import { ClaudePlanModeHandler } from './plan-mode-handler.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import manifest from './manifest.json' with { type: 'json' };
 
@@ -113,9 +114,14 @@ const CLAUDE_MODELS: AdapterModel[] = [
 export class ClaudeAdapter implements Adapter {
   id = 'claude';
   name = 'Claude CLI';
+  readonly capabilities = { planMode: true } as const;
 
   private sessions = new Set<ClaudeSession>();
   private dynamicModels: AdapterModel[] | null = null;
+
+  createPlanModeHandler(): unknown {
+    return new ClaudePlanModeHandler();
+  }
 
   async isInstalled(): Promise<boolean> {
     return new Promise((resolve) => {

--- a/packages/core/src/plugins/builtin/claude/plan-mode-handler.ts
+++ b/packages/core/src/plugins/builtin/claude/plan-mode-handler.ts
@@ -1,0 +1,69 @@
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+import type { PlanModeActionHandler, PlanActionContext } from '../../../chat/plan-mode-actions.js';
+import { extractLatestPlanFileFromMessages } from '../../../chat/context-tracker.js';
+
+export class ClaudePlanModeHandler implements PlanModeActionHandler {
+  async onApprove(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.setPermissionMode(exec);
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+
+  async onApproveAndClearContext(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    const plan = (response.updatedInput as Record<string, unknown> | undefined)?.plan as string | undefined;
+
+    const recoveredPlanPath = extractLatestPlanFileFromMessages(ctx.messages.get(ctx.chatId) ?? []);
+    if (recoveredPlanPath && ctx.db.chats.addPlanFile(ctx.chatId, recoveredPlanPath)) {
+      ctx.emitEvent({ type: 'context.updated', chatId: ctx.chatId });
+    }
+
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission({
+        ...response,
+        behavior: 'deny',
+        message: 'User chose to clear context and start a new session.',
+      });
+      ctx.permissions.shift(ctx.chatId);
+      await ctx.active.session.kill();
+      ctx.active.session = null;
+    } else {
+      ctx.permissions.shift(ctx.chatId);
+    }
+
+    ctx.chat.claudeSessionId = undefined;
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { claudeSessionId: undefined, planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    ctx.messages.set(ctx.chatId, []);
+    ctx.clearDisplayCache(ctx.chatId);
+    ctx.emitEvent({ type: 'messages.cleared', chatId: ctx.chatId });
+
+    await ctx.startChat(ctx.chatId);
+    if (plan) {
+      await ctx.sendMessage(ctx.chatId, `Implement the following plan:\n\n${plan}`);
+    }
+  }
+
+  async onReject(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+
+  async onRevise(_feedback: string, response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    // Claude handles feedback via respondToPermission's message field
+    if (ctx.active.session?.isSpawned) {
+      await ctx.active.session.respondToPermission(response);
+    }
+  }
+}

--- a/packages/core/src/plugins/builtin/claude/plan-mode-handler.ts
+++ b/packages/core/src/plugins/builtin/claude/plan-mode-handler.ts
@@ -18,7 +18,8 @@ export class ClaudePlanModeHandler implements PlanModeActionHandler {
 
   async onApproveAndClearContext(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
     const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
-    const plan = (response.updatedInput as Record<string, unknown> | undefined)?.plan as string | undefined;
+    const planRaw = response.updatedInput?.plan;
+    const plan = typeof planRaw === 'string' ? planRaw : undefined;
 
     const recoveredPlanPath = extractLatestPlanFileFromMessages(ctx.messages.get(ctx.chatId) ?? []);
     if (recoveredPlanPath && ctx.db.chats.addPlanFile(ctx.chatId, recoveredPlanPath)) {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -206,11 +206,28 @@ export class ClaudeSession implements AdapterSession {
 
   async kill(): Promise<void> {
     const child = this.state.child;
-    if (child) {
-      log.debug({ sessionId: this.id }, 'claude session killed');
-      child.kill('SIGTERM');
-      this.state.child = null;
-    }
+    if (!child) return;
+
+    const exited = new Promise<void>((resolve) => {
+      child.once('close', () => resolve());
+    });
+    const timeout = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        if (child.exitCode === null) {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            /* already dead */
+          }
+        }
+        resolve();
+      }, 3000);
+    });
+
+    child.kill('SIGTERM');
+    await Promise.race([exited, timeout]);
+    this.state.child = null;
+    log.debug({ sessionId: this.id }, 'claude session killed');
   }
 
   async interrupt(): Promise<void> {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -143,7 +143,11 @@ export class ClaudeSession implements AdapterSession {
 
     if (this.resumeSessionId) args.push('--resume', this.resumeSessionId);
     if (options.model) args.push('--model', options.model);
-    const cliMode = options.permissionMode === 'yolo' ? 'bypassPermissions' : (options.permissionMode ?? 'default');
+    const cliMode = options.planMode
+      ? 'plan'
+      : options.permissionMode === 'yolo'
+        ? 'bypassPermissions'
+        : (options.permissionMode ?? 'default');
     args.push('--permission-mode', cliMode, '--allow-dangerously-skip-permissions');
 
     const executable = options.executablePath || 'claude';

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -83,6 +83,10 @@ export class ClaudeSession implements AdapterSession {
   /** Mutable internal state — readable by claude-events.ts and tests. */
   readonly state: ClaudeSessionState;
 
+  /** Last non-plan permission mode seen at spawn time. Used by setPlanMode(off)
+   *  to restore the original mode when plan is toggled off. */
+  private basePermissionMode: string = 'default';
+
   private readonly resumeSessionId: string | undefined;
   private readonly onExit: (() => void) | undefined;
 
@@ -143,11 +147,10 @@ export class ClaudeSession implements AdapterSession {
 
     if (this.resumeSessionId) args.push('--resume', this.resumeSessionId);
     if (options.model) args.push('--model', options.model);
-    const cliMode = options.planMode
-      ? 'plan'
-      : options.permissionMode === 'yolo'
-        ? 'bypassPermissions'
-        : (options.permissionMode ?? 'default');
+    // Remember the base (non-plan) mode so setPlanMode(false) can restore it.
+    const baseMode = options.permissionMode === 'yolo' ? 'bypassPermissions' : (options.permissionMode ?? 'default');
+    this.basePermissionMode = baseMode;
+    const cliMode = options.planMode ? 'plan' : baseMode;
     args.push('--permission-mode', cliMode, '--allow-dangerously-skip-permissions');
 
     const executable = options.executablePath || 'claude';
@@ -269,12 +272,21 @@ export class ClaudeSession implements AdapterSession {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
     const cliMode = mode === 'yolo' ? 'bypassPermissions' : mode;
+    // Track non-plan modes so setPlanMode(false) can restore whatever the user
+    // last picked (default/acceptEdits/bypassPermissions).
+    if (cliMode !== 'plan') {
+      this.basePermissionMode = cliMode;
+    }
     const payload = {
       type: 'control_request',
       request_id: crypto.randomUUID(),
       request: { subtype: 'set_permission_mode', mode: cliMode },
     };
     child.stdin?.write(JSON.stringify(payload) + '\n');
+  }
+
+  async setPlanMode(on: boolean): Promise<void> {
+    await this.setPermissionMode(on ? 'plan' : this.basePermissionMode);
   }
 
   async setModel(model: string): Promise<void> {

--- a/packages/core/src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { CodexSession } from '../session.js';
+
+describe('CodexSession.buildCollaborationMode', () => {
+  it('returns plan when planMode=true', () => {
+    const s = new CodexSession({ projectPath: '/x' });
+    (s as any).pendingPlanMode = true;
+    const mode = (s as any).buildCollaborationMode();
+    expect(mode.mode).toBe('plan');
+  });
+  it('returns default when planMode=false', () => {
+    const s = new CodexSession({ projectPath: '/x' });
+    (s as any).pendingPlanMode = false;
+    const mode = (s as any).buildCollaborationMode();
+    expect(mode.mode).toBe('default');
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleNotification, type CodexSessionState } from '../event-mapper.js';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+
+const NULL_SINK: SessionSink = {
+  onInit: vi.fn(),
+  onMessage: vi.fn(),
+  onToolResult: vi.fn(),
+  onPermission: vi.fn(),
+  onResult: vi.fn(),
+  onExit: vi.fn(),
+  onError: vi.fn(),
+  onCompact: vi.fn(),
+  onCompactStart: vi.fn(),
+  onContextUsage: vi.fn(),
+  onPlanFile: vi.fn(),
+  onSkillFile: vi.fn(),
+  onQueuedProcessed: vi.fn(),
+  onTodoUpdate: vi.fn(),
+  onPrDetected: vi.fn(),
+};
+
+describe('Codex plan item capture', () => {
+  let state: CodexSessionState;
+
+  beforeEach(() => {
+    state = { threadId: 't1', currentTurnId: 'turn1', currentTurnPlan: null };
+  });
+
+  it('accumulates plan delta text into currentTurnPlan', () => {
+    handleNotification('item/plan/delta', { itemId: 'p1', delta: '# Plan\n' }, NULL_SINK, state);
+    handleNotification('item/plan/delta', { itemId: 'p1', delta: 'Step 1\n' }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toEqual({ id: 'p1', text: '# Plan\nStep 1\n' });
+  });
+
+  it('finalises the plan when a plan item is emitted', () => {
+    handleNotification('item/plan/delta', { itemId: 'p2', delta: 'partial' }, NULL_SINK, state);
+    handleNotification('item/completed', { item: { id: 'p2', type: 'plan', text: 'complete plan' } }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toEqual({ id: 'p2', text: 'complete plan' });
+  });
+
+  it('clears currentTurnPlan on turn/started', () => {
+    state.currentTurnPlan = { id: 'old', text: 'stale' };
+    handleNotification('turn/started', { threadId: 't1', turn: { id: 'turn2' } }, NULL_SINK, state);
+    expect(state.currentTurnPlan).toBeNull();
+  });
+
+  it('clears currentTurnPlan on turn/completed', () => {
+    state.currentTurnPlan = { id: 'p', text: 'x' };
+    handleNotification(
+      'turn/completed',
+      {
+        threadId: 't1',
+        turn: { id: 'turn1', status: 'completed', items: [], error: null },
+      },
+      NULL_SINK,
+      state,
+    );
+    expect(state.currentTurnPlan).toBeNull();
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/plan-mode-handler.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CodexPlanModeHandler } from '../plan-mode-handler.js';
+import type { PlanActionContext } from '../../../../chat/plan-mode-actions.js';
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+
+function mkCtx(overrides: { hasSession?: boolean } = {}) {
+  const { hasSession = true } = overrides;
+  const session = hasSession
+    ? {
+        isSpawned: true,
+        setPlanMode: vi.fn(),
+        respondToPermission: vi.fn().mockResolvedValue(undefined),
+        kill: vi.fn().mockResolvedValue(undefined),
+      }
+    : null;
+  const chat = {
+    id: 'c1',
+    planMode: true,
+    permissionMode: 'acceptEdits' as const,
+    adapterId: 'codex',
+    projectId: 'p1',
+    status: 'active' as const,
+    createdAt: '',
+    updatedAt: '',
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+  };
+  return {
+    chatId: 'c1',
+    active: { chat, session: session as any },
+    chat,
+    db: { chats: { update: vi.fn() } } as any,
+    messages: { get: vi.fn().mockReturnValue([]), set: vi.fn() } as any,
+    permissions: { shift: vi.fn() } as any,
+    emitEvent: vi.fn(),
+    clearDisplayCache: vi.fn(),
+    startChat: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PlanActionContext;
+}
+
+describe('CodexPlanModeHandler', () => {
+  const planText = 'PROPOSED PLAN TEXT';
+  const baseResponse: ControlResponse = {
+    requestId: 'r1',
+    toolUseId: 'tc1',
+    behavior: 'allow',
+    toolName: 'ExitPlanMode',
+    executionMode: 'acceptEdits',
+    updatedInput: { plan: planText },
+  };
+
+  it('onApprove responds with first option and clears planMode', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    await h.onApprove(baseResponse, ctx);
+    expect(ctx.chat.planMode).toBe(false);
+    expect(ctx.db.chats.update).toHaveBeenCalledWith('c1', { planMode: false, permissionMode: 'acceptEdits' });
+    expect((ctx.active.session as any).setPlanMode).toHaveBeenCalledWith(false);
+    expect((ctx.active.session as any).respondToPermission).toHaveBeenCalledWith(baseResponse);
+    expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'chat.updated' }));
+  });
+
+  // Option A (chat-manager restart flow): assert ctx.startChat + ctx.sendMessage,
+  // mirroring ClaudePlanModeHandler. We avoid adding a parallel startNewThread
+  // API on CodexSession — the chat-manager restart path already does a full
+  // respawn and Codex's first sendMessage creates a new thread when
+  // claudeSessionId (thread id) is cleared.
+  it('onApproveAndClearContext kills session, clears thread id, and triggers chat-manager restart with plan', async () => {
+    const ctx = mkCtx();
+    const session = ctx.active.session as any;
+    const h = new CodexPlanModeHandler();
+    await h.onApproveAndClearContext(baseResponse, ctx);
+
+    expect(session.respondToPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: 'deny', requestId: 'r1' }),
+    );
+    expect(session.kill).toHaveBeenCalled();
+    expect(ctx.db.chats.update).toHaveBeenCalledWith(
+      'c1',
+      expect.objectContaining({ claudeSessionId: undefined, planMode: false, permissionMode: 'acceptEdits' }),
+    );
+    expect(ctx.chat.planMode).toBe(false);
+    expect(ctx.messages.set).toHaveBeenCalledWith('c1', []);
+    expect(ctx.clearDisplayCache).toHaveBeenCalledWith('c1');
+    expect(ctx.emitEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'messages.cleared', chatId: 'c1' }));
+    expect(ctx.startChat).toHaveBeenCalledWith('c1');
+    expect(ctx.sendMessage).toHaveBeenCalledWith('c1', expect.stringContaining(planText));
+  });
+
+  it('onApproveAndClearContext works when session is null (no-process path)', async () => {
+    const ctx = mkCtx({ hasSession: false });
+    const h = new CodexPlanModeHandler();
+    await expect(h.onApproveAndClearContext(baseResponse, ctx)).resolves.not.toThrow();
+    expect(ctx.permissions.shift).toHaveBeenCalledWith('c1');
+    expect(ctx.startChat).toHaveBeenCalledWith('c1');
+  });
+
+  it('onReject responds with the deny option', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    const rejectResp: ControlResponse = { ...baseResponse, behavior: 'deny' };
+    await h.onReject(rejectResp, ctx);
+    expect((ctx.active.session as any).respondToPermission).toHaveBeenCalledWith(rejectResp);
+  });
+
+  it('onRevise forwards the response (with feedback in message) to the session', async () => {
+    const ctx = mkCtx();
+    const h = new CodexPlanModeHandler();
+    const reviseResp: ControlResponse = { ...baseResponse, behavior: 'deny', message: 'rework step 3' };
+    await h.onRevise('rework step 3', reviseResp, ctx);
+    expect((ctx.active.session as any).respondToPermission).toHaveBeenCalledWith(reviseResp);
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApprovalHandler } from '../approval-handler.js';
+import type { ControlRequest, ControlResponse } from '@qlan-ro/mainframe-types';
+
+function mkSink(onPermissionSpy = vi.fn()) {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: onPermissionSpy,
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+  };
+}
+
+const planExitParams = {
+  toolCallId: 'tc1',
+  questions: [{ id: 'q1', question: 'Exit plan mode?' }],
+  options: [
+    [{ label: 'Yes, implement this plan', description: 'Switch to Default and start coding.' }],
+    [{ label: 'No, stay in Plan mode', description: 'Continue planning.' }],
+  ],
+};
+
+function setupPlanExit(): {
+  handler: ApprovalHandler;
+  respond: ReturnType<typeof vi.fn>;
+  request: ControlRequest;
+} {
+  const respond = vi.fn();
+  const onPermission = vi.fn();
+  const handler = new ApprovalHandler(mkSink(onPermission));
+  handler.setPlanContext({ planMode: true, currentTurnPlan: { id: 'p1', text: 'PLAN' } });
+  handler.handleRequest('item/tool/requestUserInput', planExitParams, 7, respond);
+  const request = onPermission.mock.calls[0]![0] as ControlRequest;
+  return { handler, respond, request };
+}
+
+describe('ApprovalHandler.resolve — ExitPlanMode option mapping', () => {
+  it('allow → picks the "Yes" label as the answer', () => {
+    const { handler, respond, request } = setupPlanExit();
+    const response: ControlResponse = {
+      requestId: request.requestId,
+      toolUseId: request.toolUseId,
+      behavior: 'allow',
+      toolName: 'ExitPlanMode',
+      executionMode: 'acceptEdits',
+      updatedInput: { plan: 'PLAN' },
+    };
+    handler.resolve(response);
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const payload = respond.mock.calls[0]![1] as { answers: Record<string, { answers: string[] }> };
+    expect(payload.answers.q1!.answers[0]).toBe('Yes, implement this plan');
+  });
+
+  it('deny with no message → picks the "No" label as the answer', () => {
+    const { handler, respond, request } = setupPlanExit();
+    const response: ControlResponse = {
+      requestId: request.requestId,
+      toolUseId: request.toolUseId,
+      behavior: 'deny',
+      toolName: 'ExitPlanMode',
+    };
+    handler.resolve(response);
+
+    const payload = respond.mock.calls[0]![1] as { answers: Record<string, { answers: string[] }> };
+    expect(payload.answers.q1!.answers[0]).toBe('No, stay in Plan mode');
+  });
+
+  it('deny with message (revise) → falls back to "No" label (free-form not supported)', () => {
+    const { handler, respond, request } = setupPlanExit();
+    const response: ControlResponse = {
+      requestId: request.requestId,
+      toolUseId: request.toolUseId,
+      behavior: 'deny',
+      toolName: 'ExitPlanMode',
+      message: 'Please also add tests.',
+    };
+    handler.resolve(response);
+
+    const payload = respond.mock.calls[0]![1] as { answers: Record<string, { answers: string[] }> };
+    expect(payload.answers.q1!.answers[0]).toBe('No, stay in Plan mode');
+  });
+
+  it('AskUserQuestion → keeps legacy free-text message passthrough', () => {
+    const respond = vi.fn();
+    const onPermission = vi.fn();
+    const handler = new ApprovalHandler(mkSink(onPermission));
+    handler.setPlanContext({ planMode: false, currentTurnPlan: null });
+    handler.handleRequest(
+      'item/tool/requestUserInput',
+      {
+        toolCallId: 'tc2',
+        questions: [{ id: 'q2', question: 'Pick one' }],
+        options: [[{ label: 'A' }], [{ label: 'B' }], [{ label: 'C' }]],
+      },
+      8,
+      respond,
+    );
+    const request = onPermission.mock.calls[0]![0] as ControlRequest;
+
+    handler.resolve({
+      requestId: request.requestId,
+      toolUseId: request.toolUseId,
+      behavior: 'allow',
+      toolName: 'AskUserQuestion',
+      message: 'B',
+    });
+
+    const payload = respond.mock.calls[0]![1] as { answers: Record<string, { answers: string[] }> };
+    expect(payload.answers.q2!.answers[0]).toBe('B');
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApprovalHandler } from '../approval-handler.js';
+
+function mkSink() {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: vi.fn(),
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+  };
+}
+
+describe('Codex requestUserInput routing', () => {
+  const requestUserInputParams = {
+    toolCallId: 'tc1',
+    questions: ['Implement this plan?'],
+    options: [
+      [{ label: 'Yes, implement this plan', description: 'Switch to Default and start coding.' }],
+      [{ label: 'No, stay in Plan mode', description: 'Continue planning with the model.' }],
+    ],
+  };
+
+  it('routes to ExitPlanMode when planMode=true and a plan was captured this turn', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: true, currentTurnPlan: { id: 'p1', text: 'full plan text' } });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 42, vi.fn());
+
+    expect(sink.onPermission).toHaveBeenCalledTimes(1);
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string; input: Record<string, unknown> };
+    expect(req.toolName).toBe('ExitPlanMode');
+    expect(req.input.plan).toBe('full plan text');
+  });
+
+  it('routes to AskUserQuestion when planMode=false', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: false, currentTurnPlan: { id: 'p1', text: 'x' } });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 43, vi.fn());
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string };
+    expect(req.toolName).toBe('AskUserQuestion');
+  });
+
+  it('routes to AskUserQuestion when no plan captured yet', () => {
+    const sink = mkSink();
+    const handler = new ApprovalHandler(sink);
+    handler.setPlanContext({ planMode: true, currentTurnPlan: null });
+    handler.handleRequest('item/tool/requestUserInput', requestUserInputParams, 44, vi.fn());
+    const req = sink.onPermission.mock.calls[0]![0] as { toolName: string };
+    expect(req.toolName).toBe('AskUserQuestion');
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -2,6 +2,7 @@
 import { execFile, spawn } from 'node:child_process';
 import type { Adapter, AdapterModel, AdapterSession, ExternalSession, SessionOptions } from '@qlan-ro/mainframe-types';
 import { CodexSession } from './session.js';
+import { CodexPlanModeHandler } from './plan-mode-handler.js';
 import { JsonRpcClient } from './jsonrpc.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import type { InitializeResult, ModelListResult, ThreadListResult } from './types.js';
@@ -12,8 +13,13 @@ const log = createChildLogger('codex:adapter');
 export class CodexAdapter implements Adapter {
   readonly id = 'codex';
   readonly name = 'Codex';
+  readonly capabilities = { planMode: true } as const;
 
   private sessions = new Set<CodexSession>();
+
+  createPlanModeHandler(): unknown {
+    return new CodexPlanModeHandler();
+  }
 
   async isInstalled(): Promise<boolean> {
     return new Promise((resolve) => {

--- a/packages/core/src/plugins/builtin/codex/approval-handler.ts
+++ b/packages/core/src/plugins/builtin/codex/approval-handler.ts
@@ -19,12 +19,24 @@ interface PendingApproval {
   respond: RespondFn;
   method: string;
   /**
+   * The Mainframe-side routed tool name (`ExitPlanMode` or `AskUserQuestion`
+   * for `item/tool/requestUserInput`, or the approval tool name otherwise).
+   * `resolve()` uses this to pick the right option-selection strategy.
+   */
+  toolName: string;
+  /**
    * For `item/tool/requestUserInput`, the rendered option labels — one inner
    * array per option group in the order emitted by Codex. Task 9's plan-mode
    * handler prefix-matches the user's Approve/Deny choice against these to
    * derive a Codex option index.
    */
   optionLabels?: string[][];
+  /**
+   * For `item/tool/requestUserInput`, the question objects as received from
+   * Codex. Needed at resolve() time to build the `{ answers: { [id]: ... } }`
+   * map when we pick an option by label.
+   */
+  questions?: Array<{ id: string } | string>;
 }
 
 export class ApprovalHandler {
@@ -44,6 +56,7 @@ export class ApprovalHandler {
     let toolUseId: string;
     let input: Record<string, unknown>;
     let optionLabels: string[][] | undefined;
+    let questions: Array<{ id: string } | string> | undefined;
 
     if (method === 'item/commandExecution/requestApproval') {
       const p = params as CommandExecutionApprovalParams;
@@ -65,6 +78,7 @@ export class ApprovalHandler {
         options?: Array<Array<{ label: string; description?: string }>>;
       };
       toolUseId = p.toolCallId ?? p.itemId ?? mainframeRequestId;
+      questions = Array.isArray(p.questions) ? p.questions : undefined;
 
       const rawOptions = Array.isArray(p.options) ? p.options : undefined;
       optionLabels = rawOptions?.map((group) =>
@@ -104,7 +118,15 @@ export class ApprovalHandler {
       suggestions: [],
     };
 
-    this.pending.set(mainframeRequestId, { mainframeRequestId, jsonRpcId, respond, method, optionLabels });
+    this.pending.set(mainframeRequestId, {
+      mainframeRequestId,
+      jsonRpcId,
+      respond,
+      method,
+      toolName,
+      optionLabels,
+      questions,
+    });
 
     log.info({ mainframeRequestId, jsonRpcId, toolName, toolUseId }, 'codex approval request');
     this.sink.onPermission(request);
@@ -121,13 +143,16 @@ export class ApprovalHandler {
 
     // requestUserInput expects { answers: { [questionId]: { answers: string[] } } }
     if (entry.method === 'item/tool/requestUserInput') {
-      const userMessage = response.message ?? '';
-      const questions = (response.updatedInput?.questions as Array<{ id: string }>) ?? [];
+      const answerString = this.chooseRequestUserInputAnswer(entry, response);
       const answers: Record<string, { answers: string[] }> = {};
-      for (const q of questions) {
-        answers[q.id] = { answers: [userMessage] };
+      const questionList = this.collectQuestionIds(entry, response);
+      for (const qid of questionList) {
+        answers[qid] = { answers: [answerString] };
       }
-      log.info({ requestId: response.requestId, behavior: response.behavior }, 'codex user input resolved');
+      log.info(
+        { requestId: response.requestId, behavior: response.behavior, toolName: entry.toolName, answerString },
+        'codex user input resolved',
+      );
       entry.respond(entry.jsonRpcId, { answers });
       return;
     }
@@ -141,6 +166,80 @@ export class ApprovalHandler {
 
     log.info({ requestId: response.requestId, decision }, 'codex approval resolved');
     entry.respond(entry.jsonRpcId, { decision });
+  }
+
+  /**
+   * Gather the question IDs that need an `answers` entry. Prefer the ids we
+   * captured when the request arrived (most reliable); fall back to ids
+   * echoed back via `response.updatedInput.questions` for compatibility.
+   */
+  private collectQuestionIds(entry: PendingApproval, response: ControlResponse): string[] {
+    const fromEntry = entry.questions
+      ?.map((q) => (typeof q === 'string' ? null : (q?.id ?? null)))
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    if (fromEntry && fromEntry.length > 0) return fromEntry;
+    const echoed = response.updatedInput?.questions;
+    if (!Array.isArray(echoed)) return [];
+    return echoed
+      .map((q) =>
+        typeof q === 'object' && q !== null && typeof (q as { id?: unknown }).id === 'string'
+          ? (q as { id: string }).id
+          : null,
+      )
+      .filter((id): id is string => id !== null && id.length > 0);
+  }
+
+  /**
+   * Decide the single answer string to deliver for a requestUserInput.
+   *
+   * For ExitPlanMode the plan-mode handler only signals intent via
+   * `response.behavior` (+ optional `message` for "Revise"). Codex expects
+   * the user to *select one of the option labels*. We prefix-match the
+   * labels:
+   *   - behavior='allow' → first label starting with "yes" (fallback index 0)
+   *   - behavior='deny' with no message → first label starting with "no"
+   *     (fallback index 1)
+   *   - behavior='deny' with message → Codex's requestUserInput for plan
+   *     exit does not advertise an `isOther`/free-form option, so we log a
+   *     warning and fall back to the deny option. The feedback is delivered
+   *     separately as the next user turn (the chat-manager's revise path
+   *     sends it via sendMessage after the approval resolves).
+   *
+   * For AskUserQuestion, preserve legacy behavior: forward `response.message`
+   * verbatim as the answer string.
+   */
+  private chooseRequestUserInputAnswer(entry: PendingApproval, response: ControlResponse): string {
+    if (entry.toolName !== 'ExitPlanMode') {
+      return response.message ?? '';
+    }
+
+    // Flatten option groups — Codex emits one option per group for ExitPlanMode.
+    const flatLabels: string[] = (entry.optionLabels ?? []).flatMap((group) => group);
+
+    const findByPrefix = (re: RegExp, fallbackIndex: number): string => {
+      const match = flatLabels.find((label) => re.test(label));
+      if (match !== undefined && match.length > 0) return match;
+      const fallback = flatLabels[fallbackIndex];
+      return typeof fallback === 'string' && fallback.length > 0 ? fallback : (response.message ?? '');
+    };
+
+    if (response.behavior === 'allow') {
+      return findByPrefix(/^yes/i, 0);
+    }
+
+    // deny path
+    if (response.message && response.message.length > 0) {
+      // Free-form revise — Codex's plan-exit requestUserInput has no `isOther`
+      // escape hatch, so we cannot deliver the feedback as a free-text answer.
+      // Log once and fall back to the "No" option; the chat-manager's revise
+      // flow is responsible for sending the feedback text as the next turn.
+      log.warn(
+        { requestId: response.requestId, toolName: entry.toolName },
+        'codex: plan-exit revise free-text not supported by requestUserInput; falling back to deny option',
+      );
+      return findByPrefix(/^no/i, 1);
+    }
+    return findByPrefix(/^no/i, 1);
   }
 
   rejectAll(): void {

--- a/packages/core/src/plugins/builtin/codex/approval-handler.ts
+++ b/packages/core/src/plugins/builtin/codex/approval-handler.ts
@@ -8,17 +8,34 @@ const log = createChildLogger('codex:approvals');
 
 export type RespondFn = (id: RequestId, result: unknown) => void;
 
+interface PlanContext {
+  planMode: boolean;
+  currentTurnPlan: { id: string; text: string } | null;
+}
+
 interface PendingApproval {
   mainframeRequestId: string;
   jsonRpcId: RequestId;
   respond: RespondFn;
   method: string;
+  /**
+   * For `item/tool/requestUserInput`, the rendered option labels — one inner
+   * array per option group in the order emitted by Codex. Task 9's plan-mode
+   * handler prefix-matches the user's Approve/Deny choice against these to
+   * derive a Codex option index.
+   */
+  optionLabels?: string[][];
 }
 
 export class ApprovalHandler {
   private pending = new Map<string, PendingApproval>();
+  private planContext: PlanContext = { planMode: false, currentTurnPlan: null };
 
   constructor(private readonly sink: SessionSink) {}
+
+  setPlanContext(ctx: PlanContext): void {
+    this.planContext = ctx;
+  }
 
   handleRequest(method: string, params: unknown, jsonRpcId: RequestId, respond: RespondFn): void {
     const mainframeRequestId = nanoid();
@@ -26,6 +43,7 @@ export class ApprovalHandler {
     let toolName: string;
     let toolUseId: string;
     let input: Record<string, unknown>;
+    let optionLabels: string[][] | undefined;
 
     if (method === 'item/commandExecution/requestApproval') {
       const p = params as CommandExecutionApprovalParams;
@@ -39,15 +57,39 @@ export class ApprovalHandler {
       input = { reason: p.reason };
     } else if (method === 'item/tool/requestUserInput') {
       const p = params as {
-        threadId: string;
-        turnId: string;
-        itemId: string;
-        questions: Array<{ id: string; question: string }>;
+        threadId?: string;
+        turnId?: string;
+        itemId?: string;
+        toolCallId?: string;
+        questions: Array<{ id: string; question: string } | string>;
+        options?: Array<Array<{ label: string; description?: string }>>;
       };
-      toolName = 'AskUserQuestion';
-      toolUseId = p.itemId;
-      const questionText = p.questions.map((q) => q.question).join('\n');
-      input = { question: questionText, questions: p.questions };
+      toolUseId = p.toolCallId ?? p.itemId ?? mainframeRequestId;
+
+      const rawOptions = Array.isArray(p.options) ? p.options : undefined;
+      optionLabels = rawOptions?.map((group) =>
+        Array.isArray(group) ? group.map((o) => (typeof o?.label === 'string' ? o.label : '')) : [],
+      );
+
+      const isPlanExit =
+        this.planContext.planMode &&
+        this.planContext.currentTurnPlan !== null &&
+        Array.isArray(rawOptions) &&
+        rawOptions.length === 2;
+
+      if (isPlanExit) {
+        toolName = 'ExitPlanMode';
+        input = { plan: this.planContext.currentTurnPlan!.text, allowedPrompts: [] };
+      } else {
+        toolName = 'AskUserQuestion';
+        const questionText = Array.isArray(p.questions)
+          ? p.questions
+              .map((q) => (typeof q === 'string' ? q : (q?.question ?? '')))
+              .filter((t) => t.length > 0)
+              .join('\n')
+          : '';
+        input = { question: questionText, questions: p.questions, options: rawOptions };
+      }
     } else {
       log.warn({ method }, 'codex: unknown server request method');
       respond(jsonRpcId, { decision: 'decline' as ApprovalDecision });
@@ -62,7 +104,7 @@ export class ApprovalHandler {
       suggestions: [],
     };
 
-    this.pending.set(mainframeRequestId, { mainframeRequestId, jsonRpcId, respond, method });
+    this.pending.set(mainframeRequestId, { mainframeRequestId, jsonRpcId, respond, method, optionLabels });
 
     log.info({ mainframeRequestId, jsonRpcId, toolName, toolUseId }, 'codex approval request');
     this.sink.onPermission(request);

--- a/packages/core/src/plugins/builtin/codex/event-mapper.ts
+++ b/packages/core/src/plugins/builtin/codex/event-mapper.ts
@@ -14,6 +14,7 @@ const log = createChildLogger('codex:events');
 export interface CodexSessionState {
   threadId: string | null;
   currentTurnId: string | null;
+  currentTurnPlan: { id: string; text: string } | null;
   lastUsage?: {
     input_tokens: number;
     output_tokens: number;
@@ -30,7 +31,9 @@ export function handleNotification(method: string, params: unknown, sink: Sessio
     case 'turn/started':
       return handleTurnStarted(params as TurnStartedParams, state);
     case 'item/completed':
-      return handleItemCompleted(params as ItemCompletedParams, sink);
+      return handleItemCompleted(params as ItemCompletedParams, sink, state);
+    case 'item/plan/delta':
+      return handlePlanDelta(params as { itemId: string; delta: string }, state);
     case 'turn/completed':
       return handleTurnCompleted(params as TurnCompletedParams, sink, state);
     case 'thread/tokenUsage/updated':
@@ -50,7 +53,6 @@ export function handleNotification(method: string, params: unknown, sink: Sessio
     case 'item/fileChange/outputDelta':
     case 'item/reasoning/summaryTextDelta':
     case 'item/reasoning/textDelta':
-    case 'item/plan/delta':
     case 'account/rateLimits/updated':
     case 'thread/name/updated':
       return; // silently ignore known-but-unhandled notifications
@@ -66,11 +68,31 @@ function handleThreadStarted(params: ThreadStartedParams, sink: SessionSink, sta
 }
 
 function handleTurnStarted(params: TurnStartedParams, state: CodexSessionState): void {
+  state.currentTurnPlan = null;
   state.currentTurnId = params.turn.id;
 }
 
-function handleItemCompleted(params: ItemCompletedParams, sink: SessionSink): void {
+function handlePlanDelta(params: { itemId: string; delta: string }, state: CodexSessionState): void {
+  const { itemId, delta } = params;
+  const prev = state.currentTurnPlan;
+  if (prev && prev.id === itemId) {
+    state.currentTurnPlan = { id: itemId, text: prev.text + delta };
+  } else {
+    state.currentTurnPlan = { id: itemId, text: delta };
+  }
+}
+
+function handleItemCompleted(params: ItemCompletedParams, sink: SessionSink, state: CodexSessionState): void {
   const { item } = params;
+
+  // Plan items arrive as a terminal `item/completed` with type === 'plan'.
+  // They aren't part of the formal ThreadItem union (yet), so branch defensively
+  // before the typed switch below.
+  const itemAsUnknown = item as { id?: string; type?: string; text?: string };
+  if (itemAsUnknown.type === 'plan' && typeof itemAsUnknown.text === 'string' && itemAsUnknown.id) {
+    state.currentTurnPlan = { id: itemAsUnknown.id, text: itemAsUnknown.text };
+    return;
+  }
 
   switch (item.type) {
     case 'agentMessage':
@@ -148,6 +170,7 @@ function handleItemCompleted(params: ItemCompletedParams, sink: SessionSink): vo
 }
 
 function handleTurnCompleted(params: TurnCompletedParams, sink: SessionSink, state: CodexSessionState): void {
+  state.currentTurnPlan = null;
   state.currentTurnId = null;
   const { turn } = params;
   const isError = turn.status === 'failed' || turn.status === 'interrupted';

--- a/packages/core/src/plugins/builtin/codex/jsonrpc.ts
+++ b/packages/core/src/plugins/builtin/codex/jsonrpc.ts
@@ -26,6 +26,7 @@ export class JsonRpcClient {
   private buffer = '';
   private pending = new Map<RequestId, PendingRequest>();
   private closed = false;
+  private closeListeners = new Set<() => void>();
 
   constructor(
     private readonly process: ChildProcess,
@@ -36,6 +37,7 @@ export class JsonRpcClient {
     process.stderr?.on('data', (chunk: Buffer) => this.handleStderr(chunk));
     process.on('close', (code: number | null) => {
       this.rejectAllPending(new Error(`Process exited with code ${code}`));
+      for (const listener of this.closeListeners) listener();
       this.handlers.onExit(code);
     });
     process.on('error', (err: Error) => {
@@ -84,6 +86,13 @@ export class JsonRpcClient {
     } catch {
       /* already dead */
     }
+  }
+
+  onClose(listener: () => void): () => void {
+    this.closeListeners.add(listener);
+    return () => {
+      this.closeListeners.delete(listener);
+    };
   }
 
   private write(msg: Record<string, unknown>): void {

--- a/packages/core/src/plugins/builtin/codex/plan-mode-handler.ts
+++ b/packages/core/src/plugins/builtin/codex/plan-mode-handler.ts
@@ -1,0 +1,98 @@
+import type { ControlResponse } from '@qlan-ro/mainframe-types';
+import type { PlanModeActionHandler, PlanActionContext } from '../../../chat/plan-mode-actions.js';
+
+/**
+ * Codex plan-mode uses per-turn `collaborationMode`. Answering the
+ * requestUserInput exit prompt with the correct option + flipping
+ * `chat.planMode` is sufficient to exit plan mode for the next turn.
+ *
+ * The approval-handler (see `approval-handler.ts`) knows how to map our
+ * `allow`/`deny` behavior onto the Codex option index based on the rendered
+ * option labels captured when the request arrived.
+ */
+export class CodexPlanModeHandler implements PlanModeActionHandler {
+  async onApprove(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    ctx.db.chats.update(ctx.chatId, { planMode: false, permissionMode: exec });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      setPlanMode?(on: boolean): void;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      session.setPlanMode?.(false);
+      await session.respondToPermission(response);
+    }
+  }
+
+  async onApproveAndClearContext(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const exec = (response.executionMode ?? 'default') as 'default' | 'acceptEdits' | 'yolo';
+    const planRaw = response.updatedInput?.plan;
+    const plan = typeof planRaw === 'string' ? planRaw : undefined;
+
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      respondToPermission(r: ControlResponse): Promise<void>;
+      kill(): Promise<void>;
+    } | null;
+
+    if (session?.isSpawned) {
+      // Close the requestUserInput by denying first so Codex unblocks the turn.
+      await session.respondToPermission({ ...response, behavior: 'deny', message: 'Clearing context.' });
+      ctx.permissions.shift(ctx.chatId);
+      await session.kill();
+      ctx.active.session = null;
+    } else {
+      ctx.permissions.shift(ctx.chatId);
+    }
+
+    ctx.chat.planMode = false;
+    ctx.chat.permissionMode = exec;
+    // Codex's equivalent of `claudeSessionId` is the thread id; drop it to
+    // force a new thread on respawn.
+    ctx.chat.claudeSessionId = undefined;
+    ctx.db.chats.update(ctx.chatId, {
+      claudeSessionId: undefined,
+      planMode: false,
+      permissionMode: exec,
+    });
+    ctx.emitEvent({ type: 'chat.updated', chat: ctx.chat });
+
+    ctx.messages.set(ctx.chatId, []);
+    ctx.clearDisplayCache(ctx.chatId);
+    ctx.emitEvent({ type: 'messages.cleared', chatId: ctx.chatId });
+
+    await ctx.startChat(ctx.chatId);
+    if (plan) {
+      await ctx.sendMessage(ctx.chatId, `Implement the following plan:\n\n${plan}`);
+    }
+  }
+
+  async onReject(response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      await session.respondToPermission(response);
+    }
+  }
+
+  async onRevise(_feedback: string, response: ControlResponse, ctx: PlanActionContext): Promise<void> {
+    // The caller attaches the user's revise feedback to `response.message`.
+    // Forward unchanged — the approval-handler's resolve() translates the
+    // free-form answer for Codex (falling back to the deny option if Codex
+    // rejects free-form for this requestUserInput).
+    const session = ctx.active.session as unknown as {
+      isSpawned: boolean;
+      respondToPermission(r: ControlResponse): Promise<void>;
+    } | null;
+    if (session?.isSpawned) {
+      await session.respondToPermission(response);
+    }
+  }
+}

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -233,8 +233,22 @@ export class CodexSession implements AdapterSession {
   }
 
   async kill(): Promise<void> {
+    const client = this.client;
+    if (!client) return;
+
     this.approvalHandler?.rejectAll();
-    this.client?.close();
+    const closed = new Promise<void>((resolve) => {
+      const unsubscribe = client.onClose(() => {
+        unsubscribe();
+        resolve();
+      });
+    });
+    const timeout = new Promise<void>((resolve) => {
+      setTimeout(resolve, 3000);
+    });
+
+    client.close();
+    await Promise.race([closed, timeout]);
     this.client = null;
   }
 

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -63,7 +63,7 @@ export class CodexSession implements AdapterSession {
   private readonly onExitCallback: (() => void) | undefined;
   private readonly resumeThreadId: string | undefined;
 
-  readonly state: CodexSessionState = { threadId: null, currentTurnId: null };
+  readonly state: CodexSessionState = { threadId: null, currentTurnId: null, currentTurnPlan: null };
 
   private pendingModel: string | undefined;
   private pendingPermissionMode: string = 'default';

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -342,7 +342,7 @@ export class CodexSession implements AdapterSession {
   }
 
   private buildCollaborationMode(): CollaborationMode {
-    const mode = this.pendingPermissionMode === 'plan' ? 'plan' : 'default';
+    const mode = this.pendingPlanMode ? 'plan' : 'default';
     return {
       mode,
       settings: {

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -67,6 +67,7 @@ export class CodexSession implements AdapterSession {
 
   private pendingModel: string | undefined;
   private pendingPermissionMode: string = 'default';
+  private pendingPlanMode: boolean = false;
   private pid = 0;
   private status: 'starting' | 'ready' | 'running' | 'stopped' | 'error' = 'starting';
 
@@ -98,6 +99,7 @@ export class CodexSession implements AdapterSession {
     this.sink = sink ?? nullSink;
     this.pendingModel = options.model;
     this.pendingPermissionMode = options.permissionMode ?? 'default';
+    this.pendingPlanMode = options.planMode ?? false;
 
     try {
       accessSync(this.projectPath);
@@ -126,6 +128,10 @@ export class CodexSession implements AdapterSession {
     this.client = new JsonRpcClient(child, {
       onNotification: (method, params) => handleNotification(method, params, this.sink, this.state),
       onRequest: (method, params, id) => {
+        approvalHandler.setPlanContext({
+          planMode: this.pendingPlanMode,
+          currentTurnPlan: this.state.currentTurnPlan,
+        });
         approvalHandler.handleRequest(method, params, id, (rpcId, result) => {
           this.client?.respond(rpcId, result);
         });
@@ -250,6 +256,10 @@ export class CodexSession implements AdapterSession {
 
   async setPermissionMode(mode: string): Promise<void> {
     this.pendingPermissionMode = mode;
+  }
+
+  setPlanMode(on: boolean): void {
+    this.pendingPlanMode = on;
   }
 
   async sendCommand(_command: string, _args?: string): Promise<void> {

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -258,7 +258,7 @@ export class CodexSession implements AdapterSession {
     this.pendingPermissionMode = mode;
   }
 
-  setPlanMode(on: boolean): void {
+  async setPlanMode(on: boolean): Promise<void> {
     this.pendingPlanMode = on;
   }
 

--- a/packages/core/src/server/routes/schemas.ts
+++ b/packages/core/src/server/routes/schemas.ts
@@ -32,6 +32,7 @@ export const AddMentionBody = z.object({
 export const UpdateProviderSettingsBody = z.object({
   defaultModel: z.string().optional(),
   defaultMode: z.string().optional(),
+  defaultPlanMode: z.enum(['true', 'false']).optional(),
   executablePath: z.string().optional(),
   systemPrompt: z.string().optional(),
 });

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -64,7 +64,7 @@ export function settingRoutes(ctx: RouteContext): Router {
       res.status(400).json({ success: false, error: parsed.error });
       return;
     }
-    const { defaultModel, defaultMode, executablePath } = parsed.data;
+    const { defaultModel, defaultMode, defaultPlanMode, executablePath } = parsed.data;
 
     if (defaultModel !== undefined) {
       if (defaultModel) ctx.db.settings.set('provider', `${adapterId}.defaultModel`, defaultModel);
@@ -74,6 +74,10 @@ export function settingRoutes(ctx: RouteContext): Router {
       if (defaultMode) ctx.db.settings.set('provider', `${adapterId}.defaultMode`, defaultMode);
       else ctx.db.settings.delete('provider', `${adapterId}.defaultMode`);
       ctx.db.settings.delete('provider', `${adapterId}.skipPermissions`);
+    }
+    if (defaultPlanMode !== undefined) {
+      if (defaultPlanMode) ctx.db.settings.set('provider', `${adapterId}.defaultPlanMode`, defaultPlanMode);
+      else ctx.db.settings.delete('provider', `${adapterId}.defaultPlanMode`);
     }
     if (executablePath !== undefined) {
       if (executablePath) ctx.db.settings.set('provider', `${adapterId}.executablePath`, executablePath);

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -125,7 +125,13 @@ export class WebSocketManager {
       }
 
       case 'chat.updateConfig': {
-        await this.chats.updateChatConfig(event.chatId, event.adapterId, event.model, event.permissionMode);
+        await this.chats.updateChatConfig(
+          event.chatId,
+          event.adapterId,
+          event.model,
+          event.permissionMode,
+          event.planMode,
+        );
         break;
       }
 

--- a/packages/core/src/server/ws-schemas.ts
+++ b/packages/core/src/server/ws-schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const permissionModeSchema = z.enum(['default', 'acceptEdits', 'plan', 'yolo']).optional();
+const permissionModeSchema = z.enum(['default', 'acceptEdits', 'yolo']).optional();
 
 const ChatCreate = z
   .object({
@@ -37,6 +37,7 @@ const ChatUpdateConfig = z.object({
   adapterId: z.string().optional(),
   model: z.string().optional(),
   permissionMode: permissionModeSchema,
+  planMode: z.boolean().optional(),
 });
 
 const MessageSend = z

--- a/packages/desktop/src/__tests__/lib/adapters.test.ts
+++ b/packages/desktop/src/__tests__/lib/adapters.test.ts
@@ -8,6 +8,7 @@ const mockAdapters: AdapterInfo[] = [
     name: 'Claude CLI',
     description: 'Claude CLI adapter',
     installed: true,
+    capabilities: { planMode: true },
     models: [
       { id: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 200_000 },
       { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', contextWindow: 200_000 },

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -18,13 +18,13 @@ import { ComposerHighlight } from './ComposerHighlight';
 import { ImageAttachmentPreview } from './ImageAttachmentPreview';
 import { WorktreePopover } from './WorktreePopover';
 import { QueuedMessageBanner } from './QueuedMessageBanner';
+import { PlanModeToggle, adapterSupportsPlanMode, displayModeForDropdown } from './PlanModeToggle';
 import { useSandboxStore, type Capture } from '../../../../store/sandbox.js';
 import { getDraft, saveDraft, deleteDraft } from './composer-drafts.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
 
 const PERMISSION_MODES = [
   { id: 'default', label: 'Interactive' },
-  { id: 'plan', label: 'Plan' },
   { id: 'acceptEdits', label: 'Auto-Edits' },
   { id: 'yolo', label: 'Unattended' },
 ];
@@ -244,11 +244,31 @@ export function ComposerCard() {
   );
 
   const currentMode = chat?.permissionMode ?? 'default';
+  // Remember the last non-plan mode so we can restore it when plan is disabled.
+  // Using a ref (not state) avoids a re-render and resets on page reload, which is fine.
+  const lastNonPlanModeRef = useRef<'default' | 'acceptEdits' | 'yolo'>('default');
 
   const handleModeChange = useCallback(
     (mode: string) => {
       if (!chatId) return;
-      daemonClient.updateChatConfig(chatId, undefined, undefined, mode as 'default' | 'acceptEdits' | 'plan' | 'yolo');
+      const typedMode = mode as 'default' | 'acceptEdits' | 'plan' | 'yolo';
+      if (typedMode !== 'plan') {
+        lastNonPlanModeRef.current = typedMode;
+      }
+      daemonClient.updateChatConfig(chatId, undefined, undefined, typedMode);
+    },
+    [chatId],
+  );
+
+  const handlePlanToggle = useCallback(
+    (enable: boolean) => {
+      if (!chatId) return;
+      if (enable) {
+        daemonClient.updateChatConfig(chatId, undefined, undefined, 'plan');
+      } else {
+        const restore = lastNonPlanModeRef.current;
+        daemonClient.updateChatConfig(chatId, undefined, undefined, restore);
+      }
     },
     [chatId],
   );
@@ -389,13 +409,14 @@ export function ComposerCard() {
           <ComposerDropdown items={dropdownOptions} value={currentModel} onChange={handleModelChange} />
           <ComposerDropdown
             items={PERMISSION_MODES}
-            value={currentMode}
+            value={displayModeForDropdown(currentMode)}
             onChange={handleModeChange}
             icon={<Shield size={14} />}
-            className={
-              currentMode === 'yolo' ? 'text-mf-destructive' : currentMode === 'plan' ? 'text-mf-accent' : undefined
-            }
+            className={currentMode === 'yolo' ? 'text-mf-destructive' : undefined}
           />
+          {adapterSupportsPlanMode(currentAdapter) && (
+            <PlanModeToggle active={currentMode === 'plan'} onToggle={handlePlanToggle} />
+          )}
           {isGitProject && (
             <div className="relative">
               <Tooltip>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -18,7 +18,7 @@ import { ComposerHighlight } from './ComposerHighlight';
 import { ImageAttachmentPreview } from './ImageAttachmentPreview';
 import { WorktreePopover } from './WorktreePopover';
 import { QueuedMessageBanner } from './QueuedMessageBanner';
-import { PlanModeToggle, adapterSupportsPlanMode, displayModeForDropdown } from './PlanModeToggle';
+import { PlanModeToggle } from './PlanModeToggle';
 import { useSandboxStore, type Capture } from '../../../../store/sandbox.js';
 import { getDraft, saveDraft, deleteDraft } from './composer-drafts.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
@@ -216,6 +216,7 @@ export function ComposerCard() {
   }, [chat?.projectId]);
 
   const currentAdapter = chat?.adapterId ?? 'claude';
+  const currentAdapterInfo = adapters.find((adapter) => adapter.id === currentAdapter);
   const adapterOptions = getAdapterOptions(adapters);
   const modelOptions = getModelOptions(currentAdapter, adapters);
   const currentModel = chat?.model ?? modelOptions[0]?.id ?? '';
@@ -398,13 +399,13 @@ export function ComposerCard() {
           <ComposerDropdown items={dropdownOptions} value={currentModel} onChange={handleModelChange} />
           <ComposerDropdown
             items={PERMISSION_MODES}
-            value={displayModeForDropdown(currentMode)}
+            value={currentMode}
             onChange={handleModeChange}
             icon={<Shield size={14} />}
             className={currentMode === 'yolo' ? 'text-mf-destructive' : undefined}
           />
-          {adapterSupportsPlanMode(currentAdapter) && (
-            <PlanModeToggle active={currentMode === 'plan'} onToggle={handlePlanToggle} />
+          {currentAdapterInfo?.capabilities.planMode && (
+            <PlanModeToggle active={chat?.planMode === true} onToggle={handlePlanToggle} />
           )}
           {isGitProject && (
             <div className="relative">

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -244,17 +244,11 @@ export function ComposerCard() {
   );
 
   const currentMode = chat?.permissionMode ?? 'default';
-  // Remember the last non-plan mode so we can restore it when plan is disabled.
-  // Using a ref (not state) avoids a re-render and resets on page reload, which is fine.
-  const lastNonPlanModeRef = useRef<'default' | 'acceptEdits' | 'yolo'>('default');
 
   const handleModeChange = useCallback(
     (mode: string) => {
       if (!chatId) return;
-      const typedMode = mode as 'default' | 'acceptEdits' | 'plan' | 'yolo';
-      if (typedMode !== 'plan') {
-        lastNonPlanModeRef.current = typedMode;
-      }
+      const typedMode = mode as 'default' | 'acceptEdits' | 'yolo';
       daemonClient.updateChatConfig(chatId, undefined, undefined, typedMode);
     },
     [chatId],
@@ -263,12 +257,7 @@ export function ComposerCard() {
   const handlePlanToggle = useCallback(
     (enable: boolean) => {
       if (!chatId) return;
-      if (enable) {
-        daemonClient.updateChatConfig(chatId, undefined, undefined, 'plan');
-      } else {
-        const restore = lastNonPlanModeRef.current;
-        daemonClient.updateChatConfig(chatId, undefined, undefined, restore);
-      }
+      daemonClient.updateChatConfig(chatId, undefined, undefined, undefined, enable);
     },
     [chatId],
   );

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
@@ -21,6 +21,8 @@ export function PlanModeToggle({ active, onToggle }: PlanModeToggleProps) {
           }`}
           aria-label={active ? 'Plan mode enabled — click to disable' : 'Plan mode disabled — click to enable'}
           aria-pressed={active}
+          data-testid="plan-mode-toggle"
+          data-active={active ? 'true' : 'false'}
         >
           <ClipboardList size={14} />
         </button>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { ClipboardList } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
-import type { PermissionMode } from '@qlan-ro/mainframe-types';
 
 interface PlanModeToggleProps {
   active: boolean;
   onToggle: (enable: boolean) => void;
 }
 
-/**
- * Standalone toggle button for plan mode. Only rendered for adapters that support
- * plan mode (currently Claude only). Activating plan mode sends `permissionMode: 'plan'`
- * to the daemon; deactivating restores the last non-plan mode.
- */
 export function PlanModeToggle({ active, onToggle }: PlanModeToggleProps) {
   return (
     <Tooltip>
@@ -34,18 +28,4 @@ export function PlanModeToggle({ active, onToggle }: PlanModeToggleProps) {
       <TooltipContent side="top">{active ? 'Plan mode: on' : 'Plan mode: off'}</TooltipContent>
     </Tooltip>
   );
-}
-
-/** True when the adapter supports plan mode. Only Claude supports it today. */
-export function adapterSupportsPlanMode(adapterId: string): boolean {
-  return adapterId === 'claude';
-}
-
-/**
- * Returns the effective permission mode for the dropdown display:
- * when plan mode is active the dropdown should fall back to `default`
- * so it doesn't show an item that is no longer in the list.
- */
-export function displayModeForDropdown(mode: PermissionMode): Exclude<PermissionMode, 'plan'> {
-  return mode === 'plan' ? 'default' : mode;
 }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/PlanModeToggle.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ClipboardList } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip';
+import type { PermissionMode } from '@qlan-ro/mainframe-types';
+
+interface PlanModeToggleProps {
+  active: boolean;
+  onToggle: (enable: boolean) => void;
+}
+
+/**
+ * Standalone toggle button for plan mode. Only rendered for adapters that support
+ * plan mode (currently Claude only). Activating plan mode sends `permissionMode: 'plan'`
+ * to the daemon; deactivating restores the last non-plan mode.
+ */
+export function PlanModeToggle({ active, onToggle }: PlanModeToggleProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => onToggle(!active)}
+          className={`flex items-center gap-1 px-2 py-1 rounded-mf-input text-mf-small transition-colors ${
+            active
+              ? 'text-mf-accent bg-mf-hover'
+              : 'text-mf-text-secondary hover:bg-mf-hover hover:text-mf-text-primary'
+          }`}
+          aria-label={active ? 'Plan mode enabled — click to disable' : 'Plan mode disabled — click to enable'}
+          aria-pressed={active}
+        >
+          <ClipboardList size={14} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{active ? 'Plan mode: on' : 'Plan mode: off'}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** True when the adapter supports plan mode. Only Claude supports it today. */
+export function adapterSupportsPlanMode(adapterId: string): boolean {
+  return adapterId === 'claude';
+}
+
+/**
+ * Returns the effective permission mode for the dropdown display:
+ * when plan mode is active the dropdown should fall back to `default`
+ * so it doesn't show an item that is no longer in the list.
+ */
+export function displayModeForDropdown(mode: PermissionMode): Exclude<PermissionMode, 'plan'> {
+  return mode === 'plan' ? 'default' : mode;
+}

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -74,7 +74,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
               type="checkbox"
               checked={config.systemPrompt === 'enabled'}
               onChange={(e) => update({ systemPrompt: e.target.checked ? 'enabled' : '' })}
-              className="h-3.5 w-3.5 accent-mf-accent"
+              className="h-4 w-4 accent-mf-accent m-0"
             />
           </span>
           <div className="flex-1">
@@ -92,7 +92,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
                 type="checkbox"
                 checked={config.defaultPlanMode === 'true'}
                 onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
-                className="h-3.5 w-3.5 accent-mf-accent"
+                className="h-4 w-4 accent-mf-accent m-0"
               />
             </span>
             <div className="flex-1">
@@ -127,7 +127,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
                   name={`${adapterId}-mode`}
                   checked={(config.defaultMode ?? 'default') === mode.id}
                   onChange={() => update({ defaultMode: mode.id })}
-                  className={`h-3.5 w-3.5 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
+                  className={`h-4 w-4 m-0 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
                 />
               </span>
               <div className="flex-1">

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -66,21 +66,44 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
         </div>
       )}
 
-      {/* System Prompt */}
-      <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
-        <input
-          type="checkbox"
-          checked={config.systemPrompt === 'enabled'}
-          onChange={(e) => update({ systemPrompt: e.target.checked ? 'enabled' : '' })}
-          className="mt-0.5 accent-mf-accent"
-        />
-        <div>
-          <span className="text-mf-small text-mf-text-primary">Enforce AskUserQuestion for agent questions</span>
-          <p className="text-mf-status text-mf-text-secondary">
-            Instructs the agent to use the interactive AskUserQuestion tool instead of asking in plain text.
-          </p>
-        </div>
-      </label>
+      {/* Toggles */}
+      <div className="space-y-1">
+        <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
+          <span className="flex items-center h-[18px] shrink-0">
+            <input
+              type="checkbox"
+              checked={config.systemPrompt === 'enabled'}
+              onChange={(e) => update({ systemPrompt: e.target.checked ? 'enabled' : '' })}
+              className="h-3.5 w-3.5 accent-mf-accent"
+            />
+          </span>
+          <div className="flex-1">
+            <span className="text-mf-small text-mf-text-primary">Enforce AskUserQuestion for agent questions</span>
+            <p className="text-mf-status text-mf-text-secondary">
+              Instructs the agent to use the interactive AskUserQuestion tool instead of asking in plain text.
+            </p>
+          </div>
+        </label>
+
+        {adapter?.capabilities.planMode && (
+          <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
+            <span className="flex items-center h-[18px] shrink-0">
+              <input
+                type="checkbox"
+                checked={config.defaultPlanMode === 'true'}
+                onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
+                className="h-3.5 w-3.5 accent-mf-accent"
+              />
+            </span>
+            <div className="flex-1">
+              <span className="text-mf-small text-mf-text-primary">Start in Plan Mode</span>
+              <p className="text-mf-status text-mf-text-secondary">
+                New chats begin with plan mode enabled. You can toggle it off mid-session.
+              </p>
+            </div>
+          </label>
+        )}
+      </div>
 
       {/* Default Model — picking "Default" delegates to the CLI's own default (e.g. Opus 4.7 on Max). */}
       <ModelDropdown
@@ -98,14 +121,16 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
               key={mode.id}
               className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors"
             >
-              <input
-                type="radio"
-                name={`${adapterId}-mode`}
-                checked={(config.defaultMode ?? 'default') === mode.id}
-                onChange={() => update({ defaultMode: mode.id })}
-                className={`mt-0.5 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
-              />
-              <div>
+              <span className="flex items-center h-[18px] shrink-0">
+                <input
+                  type="radio"
+                  name={`${adapterId}-mode`}
+                  checked={(config.defaultMode ?? 'default') === mode.id}
+                  onChange={() => update({ defaultMode: mode.id })}
+                  className={`h-3.5 w-3.5 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
+                />
+              </span>
+              <div className="flex-1">
                 <span className={`text-mf-small ${mode.danger ? 'text-mf-destructive' : 'text-mf-text-primary'}`}>
                   {mode.label}
                 </span>
@@ -115,23 +140,6 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
           ))}
         </div>
       </div>
-
-      {adapter?.capabilities.planMode && (
-        <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
-          <input
-            type="checkbox"
-            checked={config.defaultPlanMode === 'true'}
-            onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
-            className="mt-0.5 accent-mf-accent"
-          />
-          <div>
-            <span className="text-mf-small text-mf-text-primary">Start in Plan Mode</span>
-            <p className="text-mf-status text-mf-text-secondary">
-              New chats begin with plan mode enabled. You can toggle it off mid-session.
-            </p>
-          </div>
-        </label>
-      )}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -69,14 +69,13 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
       {/* Toggles */}
       <div className="space-y-1">
         <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
-          <span className="flex items-center h-[18px] shrink-0">
-            <input
-              type="checkbox"
-              checked={config.systemPrompt === 'enabled'}
-              onChange={(e) => update({ systemPrompt: e.target.checked ? 'enabled' : '' })}
-              className="h-4 w-4 accent-mf-accent m-0"
-            />
-          </span>
+          <input
+            type="checkbox"
+            checked={config.systemPrompt === 'enabled'}
+            onChange={(e) => update({ systemPrompt: e.target.checked ? 'enabled' : '' })}
+            className="h-4 w-4 accent-mf-accent shrink-0 m-0"
+            style={{ marginTop: 'calc((1.125rem - 1rem) / 2)' }}
+          />
           <div className="flex-1">
             <span className="text-mf-small text-mf-text-primary">Enforce AskUserQuestion for agent questions</span>
             <p className="text-mf-status text-mf-text-secondary">
@@ -87,14 +86,13 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
 
         {adapter?.capabilities.planMode && (
           <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
-            <span className="flex items-center h-[18px] shrink-0">
-              <input
-                type="checkbox"
-                checked={config.defaultPlanMode === 'true'}
-                onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
-                className="h-4 w-4 accent-mf-accent m-0"
-              />
-            </span>
+            <input
+              type="checkbox"
+              checked={config.defaultPlanMode === 'true'}
+              onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
+              className="h-4 w-4 accent-mf-accent shrink-0 m-0"
+              style={{ marginTop: 'calc((1.125rem - 1rem) / 2)' }}
+            />
             <div className="flex-1">
               <span className="text-mf-small text-mf-text-primary">Start in Plan Mode</span>
               <p className="text-mf-status text-mf-text-secondary">
@@ -121,15 +119,14 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
               key={mode.id}
               className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors"
             >
-              <span className="flex items-center h-[18px] shrink-0">
-                <input
-                  type="radio"
-                  name={`${adapterId}-mode`}
-                  checked={(config.defaultMode ?? 'default') === mode.id}
-                  onChange={() => update({ defaultMode: mode.id })}
-                  className={`h-4 w-4 m-0 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
-                />
-              </span>
+              <input
+                type="radio"
+                name={`${adapterId}-mode`}
+                checked={(config.defaultMode ?? 'default') === mode.id}
+                onChange={() => update({ defaultMode: mode.id })}
+                className={`h-4 w-4 shrink-0 m-0 ${mode.danger ? 'accent-mf-destructive' : 'accent-mf-accent'}`}
+                style={{ marginTop: 'calc((1.125rem - 1rem) / 2)' }}
+              />
               <div className="flex-1">
                 <span className={`text-mf-small ${mode.danger ? 'text-mf-destructive' : 'text-mf-text-primary'}`}>
                   {mode.label}

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -17,6 +17,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
   const config = useSettingsStore((s) => s.providers[adapterId] ?? EMPTY_CONFIG);
   const setProviderConfig = useSettingsStore((s) => s.setProviderConfig);
   const adapters = useAdaptersStore((s) => s.adapters);
+  const adapter = adapters.find((entry) => entry.id === adapterId);
   const models = getModelOptions(adapterId, adapters);
   const [conflicts, setConflicts] = useState<string[]>([]);
 
@@ -114,6 +115,23 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
           ))}
         </div>
       </div>
+
+      {adapter?.capabilities.planMode && (
+        <label className="flex items-start gap-2.5 px-3 py-2 rounded-mf-input cursor-pointer hover:bg-mf-hover transition-colors">
+          <input
+            type="checkbox"
+            checked={config.defaultPlanMode === 'true'}
+            onChange={(e) => update({ defaultPlanMode: e.target.checked ? 'true' : 'false' })}
+            className="mt-0.5 accent-mf-accent"
+          />
+          <div>
+            <span className="text-mf-small text-mf-text-primary">Start in Plan Mode</span>
+            <p className="text-mf-status text-mf-text-secondary">
+              New chats begin with plan mode enabled. You can toggle it off mid-session.
+            </p>
+          </div>
+        </label>
+      )}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx
+++ b/packages/desktop/src/renderer/components/settings/__tests__/plan-mode-checkbox.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ProviderSection } from '../ProviderSection';
+import { useSettingsStore } from '../../../store/settings';
+
+const { updateProviderSettings, adaptersState } = vi.hoisted(() => ({
+  updateProviderSettings: vi.fn().mockResolvedValue(undefined),
+  adaptersState: {
+    adapters: [{ id: 'claude', name: 'Claude', capabilities: { planMode: true }, models: [] }],
+  },
+}));
+
+vi.mock('../../../lib/api', () => ({
+  getConfigConflicts: vi.fn().mockResolvedValue([]),
+  updateProviderSettings,
+}));
+
+vi.mock('../../../store/adapters', () => ({
+  useAdaptersStore: (selector: (state: typeof adaptersState) => unknown) => selector(adaptersState),
+}));
+
+describe('ProviderSection — Start in Plan Mode', () => {
+  beforeEach(() => {
+    updateProviderSettings.mockClear();
+    adaptersState.adapters = [{ id: 'claude', name: 'Claude', capabilities: { planMode: true }, models: [] }];
+    useSettingsStore.setState({
+      isOpen: false,
+      activeTab: 'providers',
+      selectedProvider: 'claude',
+      providers: {},
+      general: { worktreeDir: '.worktrees' },
+      loading: false,
+    });
+  });
+
+  it('renders the checkbox only when adapter supports plan mode', async () => {
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+
+    expect(await screen.findByLabelText(/start in plan mode/i)).toBeInTheDocument();
+  });
+
+  it('writes defaultPlanMode on click', async () => {
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+
+    fireEvent.click(await screen.findByLabelText(/start in plan mode/i));
+
+    await waitFor(() => {
+      expect(updateProviderSettings).toHaveBeenCalledWith('claude', { defaultPlanMode: 'true' });
+    });
+    expect(useSettingsStore.getState().providers.claude?.defaultPlanMode).toBe('true');
+  });
+
+  it('is hidden for adapters without plan capability', () => {
+    adaptersState.adapters = [{ id: 'codex', name: 'Codex', capabilities: { planMode: false }, models: [] }];
+
+    render(<ProviderSection adapterId="codex" label="Codex" />);
+
+    expect(screen.queryByLabelText(/start in plan mode/i)).toBeNull();
+  });
+});

--- a/packages/desktop/src/renderer/components/settings/constants.ts
+++ b/packages/desktop/src/renderer/components/settings/constants.ts
@@ -17,7 +17,6 @@ export const MODE_OPTIONS: {
     description: 'Auto-approves everything — use in isolated environments only',
     danger: true,
   },
-  { id: 'plan', label: 'Plan Mode', description: 'Research only until plan is approved' },
 ];
 
 export const SIDEBAR_TABS: { id: SettingsTab; label: string; icon: React.ElementType }[] = [

--- a/packages/desktop/src/renderer/lib/adapters.test.ts
+++ b/packages/desktop/src/renderer/lib/adapters.test.ts
@@ -10,6 +10,7 @@ describe('adapters model metadata', () => {
       description: 'Claude adapter',
       installed: true,
       version: '1.0.0',
+      capabilities: { planMode: true },
       models: [
         { id: 'claude-opus-4-6', label: 'Opus 4.6', contextWindow: 200_000 },
         { id: 'claude-opus-4-5-20251101', label: 'Opus 4.5', contextWindow: 200_000 },

--- a/packages/desktop/src/renderer/lib/client.ts
+++ b/packages/desktop/src/renderer/lib/client.ts
@@ -137,7 +137,7 @@ export class DaemonClient {
     projectId: string,
     adapterId: string,
     model?: string,
-    permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'yolo',
+    permissionMode?: 'default' | 'acceptEdits' | 'yolo',
     attachWorktree?: { worktreePath: string; branchName: string },
   ): void {
     this.send({
@@ -156,10 +156,11 @@ export class DaemonClient {
     chatId: string,
     adapterId?: string,
     model?: string,
-    permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'yolo',
+    permissionMode?: 'default' | 'acceptEdits' | 'yolo',
+    planMode?: boolean,
   ): void {
-    this.send({ type: 'chat.updateConfig', chatId, adapterId, model, permissionMode });
-    log.info('updateChatConfig', { chatId, adapterId, model, permissionMode });
+    this.send({ type: 'chat.updateConfig', chatId, adapterId, model, permissionMode, planMode });
+    log.info('updateChatConfig', { chatId, adapterId, model, permissionMode, planMode });
   }
 
   resumeChat(chatId: string): void {

--- a/packages/e2e/fixtures/chat.ts
+++ b/packages/e2e/fixtures/chat.ts
@@ -6,19 +6,21 @@ import type { Page } from '@playwright/test';
  *
  * Use this instead of Meta+n when the test needs a specific permissionMode.
  * E.g. pass 'acceptEdits' so file-editing tests never stall on a plan approval card.
+ * Pass adapterId to use a specific adapter (default: 'claude').
  */
 export async function createTestChat(
   page: Page,
   projectId: string,
   permissionMode: 'default' | 'acceptEdits' | 'plan' | 'yolo' = 'default',
+  adapterId = 'claude',
 ): Promise<void> {
   await page.evaluate(
-    ({ pid, mode }) => {
+    ({ pid, adapter, mode }) => {
       const client = (window as any).__daemonClient;
       if (!client) throw new Error('__daemonClient not exposed on window');
-      client.createChat(pid, 'claude', undefined, mode);
+      client.createChat(pid, adapter, undefined, mode);
     },
-    { pid: projectId, mode: permissionMode },
+    { pid: projectId, adapter: adapterId, mode: permissionMode },
   );
   // Wait for the new chat's composer — renderer opens the tab on chat.created
   await page.getByRole('textbox').waitFor({ timeout: 10_000 });

--- a/packages/e2e/tests/36-codex-plan-approval.spec.ts
+++ b/packages/e2e/tests/36-codex-plan-approval.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * §36 Codex plan-approval parity
+ *
+ * Opt-in smoke test: set E2E_CODEX=1 and ensure the `codex` CLI binary is on PATH.
+ * Without the env var the test is skipped — CI does not install Codex by default.
+ *
+ * Flow under test:
+ *   1. Create a Codex chat.
+ *   2. Click the PlanModeToggle to enable plan mode.
+ *   3. Send a prompt that triggers a plan.
+ *   4. Wait for PlanApprovalCard.
+ *   5. Approve — Codex exits plan mode.
+ *   6. Assert toggle returns to inactive state.
+ */
+import { test, expect } from '@playwright/test';
+import { launchApp, closeApp } from '../fixtures/app.js';
+import { createTestProject, cleanupProject } from '../fixtures/project.js';
+import { createTestChat } from '../fixtures/chat.js';
+import { sendMessage, waitForAIIdle, waitForPlanCard } from '../helpers/wait.js';
+
+const RUN_CODEX_E2E = process.env['E2E_CODEX'] === '1';
+
+test.describe('§36 Codex plan approval', () => {
+  let fixture: Awaited<ReturnType<typeof launchApp>>;
+  let project: Awaited<ReturnType<typeof createTestProject>>;
+
+  test.beforeAll(async () => {
+    if (!RUN_CODEX_E2E) return;
+    fixture = await launchApp();
+    project = await createTestProject(fixture.page, {
+      claudeMd:
+        '# E2E Test Project\n\nThis is an automated test environment.\nIn plan mode, create a plan and call ExitPlanMode immediately after.\n',
+    });
+    await createTestChat(fixture.page, project.projectId, 'default', 'codex');
+  });
+
+  test.afterAll(async () => {
+    if (!RUN_CODEX_E2E) return;
+    await cleanupProject(project);
+    await closeApp(fixture);
+  });
+
+  test('Codex plan-mode toggle surfaces PlanApprovalCard on exit prompt', async () => {
+    test.skip(!RUN_CODEX_E2E, 'Codex E2E is opt-in — set E2E_CODEX=1 to run');
+
+    const toggle = fixture.page.locator('[data-testid="plan-mode-toggle"]');
+
+    // Toggle must be visible in the composer.
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('data-active', 'false');
+
+    // Enable plan mode.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('data-active', 'true');
+
+    // Send a prompt that reliably triggers a Codex plan.
+    await sendMessage(fixture.page, 'Plan how to add a greeting function to utils.ts');
+
+    // Wait for Codex to produce a PlanApprovalCard.
+    await waitForPlanCard(fixture.page, 45_000);
+    const card = fixture.page.locator('[data-testid="plan-approval-card"]');
+    await expect(card).toBeVisible();
+
+    // Approve the plan — Codex exits plan mode.
+    await card.getByRole('button', { name: /approve plan/i }).click();
+
+    // After approval the AI finishes its turn.
+    await waitForAIIdle(fixture.page, 60_000);
+
+    // Toggle must now be back to inactive — planMode was reset to false.
+    await expect(toggle).toHaveAttribute('data-active', 'false');
+  });
+
+  test('toggle orthogonality — enabling plan mode does not change permissionMode', async () => {
+    test.skip(!RUN_CODEX_E2E, 'Codex E2E is opt-in — set E2E_CODEX=1 to run');
+
+    // Create a fresh Codex chat with acceptEdits permissionMode.
+    await createTestChat(fixture.page, project.projectId, 'acceptEdits', 'codex');
+
+    const toggle = fixture.page.locator('[data-testid="plan-mode-toggle"]');
+    await expect(toggle).toBeVisible();
+
+    // Toggle plan mode on and off — permissionMode should remain acceptEdits.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('data-active', 'true');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('data-active', 'false');
+
+    // Send a simple message — must NOT surface a PlanApprovalCard.
+    await sendMessage(fixture.page, 'What is 1 + 1? Answer with just the number.');
+    const planCard = fixture.page.locator('[data-testid="plan-approval-card"]');
+    const raced = await Promise.race([
+      planCard.waitFor({ timeout: 10_000 }).then(() => 'plan-card' as const),
+      waitForAIIdle(fixture.page, 30_000).then(() => 'idle' as const),
+    ]);
+    expect(raced).toBe('idle');
+  });
+});

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -219,4 +219,13 @@ export interface Adapter {
   updateAgent?(agentId: string, projectPath: string, content: string): Promise<import('./skill.js').AgentConfig>;
   deleteAgent?(agentId: string, projectPath: string): Promise<void>;
   listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>;
+
+  /**
+   * Factory for an adapter-specific plan-mode action handler.
+   *
+   * Returns `unknown` here to avoid a core→types dependency cycle — core casts
+   * the result to `PlanModeActionHandler` (defined in
+   * `packages/core/src/chat/plan-mode-actions.ts`).
+   */
+  createPlanModeHandler?(): unknown;
 }

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -30,7 +30,8 @@ export interface SessionOptions {
 
 export interface SessionSpawnOptions {
   model?: string;
-  permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'yolo';
+  permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+  planMode?: boolean;
   executablePath?: string;
   systemPrompt?: string;
 }
@@ -187,6 +188,9 @@ export interface ExternalSession {
 export interface Adapter {
   id: string;
   name: string;
+  readonly capabilities: {
+    planMode: boolean;
+  };
 
   isInstalled(): Promise<boolean>;
   getVersion(): Promise<string | null>;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -159,6 +159,9 @@ export interface AdapterInfo {
   installed: boolean;
   version?: string;
   models: AdapterModel[];
+  capabilities: {
+    planMode: boolean;
+  };
 }
 
 export interface AdapterModel {

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -142,6 +142,7 @@ export interface AdapterSession {
   interrupt(): Promise<void>;
   setModel(model: string): Promise<void>;
   setPermissionMode(mode: string): Promise<void>;
+  setPlanMode(on: boolean): Promise<void>;
   sendCommand(command: string, args?: string): Promise<void>;
   cancelQueuedMessage(uuid: string): Promise<boolean>;
 

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -13,7 +13,8 @@ export interface Chat {
   title?: string;
   claudeSessionId?: string;
   model?: string;
-  permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'yolo';
+  permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+  planMode?: boolean;
   status: 'active' | 'paused' | 'ended' | 'archived';
   createdAt: string;
   updatedAt: string;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,6 +1,5 @@
 import type { Chat, ChatMessage, QueuedMessageRef } from './chat.js';
 import type { AdapterProcess, ControlRequest } from './adapter.js';
-import type { PermissionMode } from './settings.js';
 import type { UIZone } from './plugin.js';
 import type { LaunchProcessStatus } from './launch.js';
 
@@ -71,7 +70,7 @@ export type ClientEvent =
       projectId: string;
       adapterId: string;
       model?: string;
-      permissionMode?: PermissionMode;
+      permissionMode?: 'default' | 'acceptEdits' | 'yolo';
       worktreePath?: string;
       branchName?: string;
     }
@@ -87,7 +86,14 @@ export type ClientEvent =
       };
     }
   | { type: 'permission.respond'; chatId: string; response: import('./adapter.js').ControlResponse }
-  | { type: 'chat.updateConfig'; chatId: string; adapterId?: string; model?: string; permissionMode?: PermissionMode }
+  | {
+      type: 'chat.updateConfig';
+      chatId: string;
+      adapterId?: string;
+      model?: string;
+      permissionMode?: 'default' | 'acceptEdits' | 'yolo';
+      planMode?: boolean;
+    }
   | { type: 'chat.interrupt'; chatId: string }
   | { type: 'subscribe'; chatId: string }
   | { type: 'unsubscribe'; chatId: string }

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -2,7 +2,8 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'yolo';
 
 export interface ProviderConfig {
   defaultModel?: string;
-  defaultMode?: 'default' | 'acceptEdits' | 'yolo' | 'plan';
+  defaultMode?: 'default' | 'acceptEdits' | 'yolo';
+  defaultPlanMode?: 'true' | 'false';
   executablePath?: string;
   systemPrompt?: string;
 }


### PR DESCRIPTION
## Summary

Closes #50.

Plan mode was misleading inside the permissions dropdown — it is not really a permission, and Codex (which doesn't support plan) had no way to hide the option. This PR promotes plan mode to a standalone toggle button in the composer.

### Changes
- **Extracted** `PlanModeToggle.tsx` (51 lines). Includes:
  - `PlanModeToggle`: tooltip-wrapped toggle button using the `ClipboardList` icon, styled to match the existing worktree button (accent color active, secondary inactive).
  - `adapterSupportsPlanMode(adapterId)` — returns `true` only for `'claude'`. The button is simply not rendered for other adapters.
  - `displayModeForDropdown(mode)` — maps `'plan'` → `'default'` so the dropdown always shows a valid option from its reduced 3-item list.
- **`ComposerCard.tsx`**:
  - Removed `'plan'` from `PERMISSION_MODES` (now: Interactive / Auto-Edits / Unattended).
  - Added `lastNonPlanModeRef` (`useRef`) — remembers the last non-plan mode in memory so the toggle can restore it when the user turns plan off.
  - `handleModeChange` saves the mode before sending to the daemon; `handlePlanToggle` flips between `'plan'` and `lastNonPlanModeRef.current` (default `'default'`).
  - Dropdown uses `displayModeForDropdown()` so it reads "Interactive" while plan mode is active.

### Adapter-side: no changes needed
- Claude already accepts `permissionMode: 'plan'` and handles `setPermissionMode` via `control_request`.
- Codex never sees `'plan'` because the UI doesn't let the user pick it.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — 421/421 passing
- [ ] Manual (Claude chat): plan button renders next to the dropdown → click → chat enters plan mode, dropdown still reads "Interactive" → click again → dropdown-selected mode restored
- [ ] Manual (Codex chat): plan button is not rendered; dropdown shows only Interactive / Auto-Edits / Unattended

## Notes
- `ComposerCard.tsx` is now 463 lines (was 442). Still over the 300-line guideline but only +21 net-new; deeper decomposition is a separate refactor.
- The "last non-plan mode" is held in a ref, so it resets on page reload. Moving it to the store is a follow-up if the behavior ends up being noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)