### PR TITLE
fix: queued messages not clearing from composer (#116)

### DIFF
--- a/.changeset/queued-message-cleanup.md
+++ b/.changeset/queued-message-cleanup.md
@@ -1,0 +1,15 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix queued messages not clearing from the composer (#116).
+
+The Claude CLI only emits `isReplay: true` acks for queued uuids when spawned with `--replay-user-messages`; without the flag, queued cleanup fell back to a cache-scan on turn completion that mis-fired when the cache was reloaded from JSONL or when the CLI exited without a final `result`. Fixes:
+
+- Pass `--replay-user-messages` to the Claude spawn so the CLI emits a per-uuid ack the daemon can match.
+- Route `onQueuedProcessed` back into `ChatManager.handleQueuedProcessed` so `queuedRefs` is pruned in lockstep with the composer banner.
+- Clear queued metadata and emit `message.queued.cleared` on abnormal CLI exit.
+- Drop the premature bulk-clear in `onResult` that was stripping metadata from messages the CLI hadn't dequeued yet.
+- Emit `message.queued.snapshot` to subscribing clients so the renderer's Zustand state rehydrates after a WS reconnect.

--- a/packages/core/src/__tests__/claude-spawn-args.test.ts
+++ b/packages/core/src/__tests__/claude-spawn-args.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+const spawnSpy = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnSpy(...args),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+  };
+});
+
+// Import AFTER the mocks above so they take effect.
+const { ClaudeSession } = await import('../plugins/builtin/claude/session.js');
+
+function fakeChildProcess(): ChildProcess {
+  const ee = new EventEmitter() as unknown as ChildProcess;
+  (ee as unknown as { stdout: EventEmitter }).stdout = new EventEmitter();
+  (ee as unknown as { stderr: EventEmitter }).stderr = new EventEmitter();
+  (ee as unknown as { stdin: { write: (s: string) => void; destroyed: boolean } }).stdin = {
+    write: () => {},
+    destroyed: false,
+  };
+  (ee as unknown as { pid: number }).pid = 42;
+  return ee;
+}
+
+describe('ClaudeSession spawn args', () => {
+  beforeEach(() => {
+    spawnSpy.mockReset();
+    spawnSpy.mockImplementation(() => fakeChildProcess());
+  });
+
+  it('passes --replay-user-messages so the CLI emits isReplay acks for queued uuids', async () => {
+    const session = new ClaudeSession({ projectPath: '/tmp', chatId: undefined });
+    await session.spawn();
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toContain('--replay-user-messages');
+    // Sanity check: still uses stream-json mode (the flag's prerequisite)
+    expect(args).toContain('--input-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--output-format');
+  });
+});

--- a/packages/core/src/__tests__/queued-message-lifecycle.test.ts
+++ b/packages/core/src/__tests__/queued-message-lifecycle.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventHandler } from '../chat/event-handler.js';
+import { MessageCache } from '../chat/message-cache.js';
+import { PermissionManager } from '../chat/permission-manager.js';
+import { handleStdout } from '../plugins/builtin/claude/events.js';
+import type { ClaudeSession, ClaudeSessionState } from '../plugins/builtin/claude/session.js';
+import type { DaemonEvent, SessionSink } from '@qlan-ro/mainframe-types';
+
+/**
+ * Bug #116: Queued messages not clearing from composer.
+ *
+ * These tests specify the correct lifecycle semantics for queued messages
+ * under stream-json mode with `--replay-user-messages`.
+ */
+
+function makeSink(
+  activeChats: Map<string, any>,
+  chatId: string,
+  emitEvent: (event: DaemonEvent) => void,
+  callbacks?: {
+    onQueuedProcessed?: (chatId: string, uuid: string) => void;
+    onQueuedCleared?: (chatId: string) => void;
+  },
+) {
+  const db: any = {
+    chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+    projects: { get: vi.fn() },
+    settings: { get: vi.fn() },
+  };
+  const messages = new MessageCache();
+  const permissions = new PermissionManager();
+  const handler = new EventHandler(
+    db,
+    messages,
+    permissions,
+    (id) => activeChats.get(id),
+    emitEvent,
+    () => undefined,
+    callbacks?.onQueuedProcessed,
+    callbacks?.onQueuedCleared,
+  );
+  const sink: SessionSink = handler.buildSink(chatId, vi.fn().mockResolvedValue(undefined));
+  return { sink, messages, handler, db };
+}
+
+function makeActiveChat(chatId: string): Map<string, any> {
+  const map = new Map();
+  map.set(chatId, {
+    chat: {
+      id: chatId,
+      totalCost: 0,
+      totalTokensInput: 0,
+      totalTokensOutput: 0,
+      processState: 'working',
+    },
+    session: { id: 'session-1', adapterId: 'claude' },
+  });
+  return map;
+}
+
+describe('Queued message cleanup — onQueuedProcessed via isReplay', () => {
+  const chatId = 'chat-q2';
+  let activeChats: Map<string, any>;
+  let emitEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    activeChats = makeActiveChat(chatId);
+    emitEvent = vi.fn();
+  });
+
+  function makeSessionState(): ClaudeSessionState {
+    return {
+      chatId,
+      buffer: '',
+      child: null,
+      status: 'ready',
+      pid: 123,
+      activeTasks: new Map(),
+      interruptTimer: null,
+      pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
+    };
+  }
+
+  it('isReplay=true triggers onQueuedProcessed and emits message.queued.processed', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink, messages } = makeSink(activeChats, chatId, emit);
+    const queuedMsg = messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'queued B' }], {
+      queued: true,
+      uuid: 'uuid-B',
+    });
+    messages.append(chatId, queuedMsg);
+
+    const session = { state: makeSessionState() } as unknown as ClaudeSession;
+    const replayEvent =
+      JSON.stringify({
+        type: 'user',
+        uuid: 'uuid-B',
+        isReplay: true,
+        message: { role: 'user', content: [] },
+      }) + '\n';
+
+    handleStdout(session, Buffer.from(replayEvent), sink);
+
+    const processedEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.processed');
+    expect(processedEvents).toHaveLength(1);
+    expect(processedEvents[0][0].uuid).toBe('uuid-B');
+    // metadata.queued is stripped from the cached message:
+    expect(messages.get(chatId)![0]?.metadata?.queued).toBeUndefined();
+  });
+
+  it('onQueuedProcessed invokes the chat-manager callback so queuedRefs can be pruned', () => {
+    const onQueuedProcessed = vi.fn();
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { onQueuedProcessed });
+    const queuedMsg = messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'queued B' }], {
+      queued: true,
+      uuid: 'uuid-B',
+    });
+    messages.append(chatId, queuedMsg);
+
+    sink.onQueuedProcessed('uuid-B');
+
+    expect(onQueuedProcessed).toHaveBeenCalledWith(chatId, 'uuid-B');
+  });
+
+  it('stream-json user events without isReplay do not trigger processed', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink } = makeSink(activeChats, chatId, emit);
+    const session = { state: makeSessionState() } as unknown as ClaudeSession;
+    const normalEvent =
+      JSON.stringify({
+        type: 'user',
+        uuid: 'uuid-B',
+        message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      }) + '\n';
+
+    handleStdout(session, Buffer.from(normalEvent), sink);
+
+    const processedEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.processed');
+    expect(processedEvents).toHaveLength(0);
+  });
+});
+
+describe('Queued message cleanup — onResult must NOT prematurely clear', () => {
+  const chatId = 'chat-q';
+  let activeChats: Map<string, any>;
+  let emitEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    activeChats = makeActiveChat(chatId);
+    emitEvent = vi.fn();
+  });
+
+  it('does not strip metadata.queued from messages still waiting in the CLI queue', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink, messages } = makeSink(activeChats, chatId, emit);
+    // Two queued messages, neither yet dequeued by the CLI
+    messages.append(
+      chatId,
+      messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'B' }], { queued: true, uuid: 'uuid-B' }),
+    );
+    messages.append(
+      chatId,
+      messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'C' }], { queued: true, uuid: 'uuid-C' }),
+    );
+
+    // The current turn finishes (for an earlier, non-queued message)
+    sink.onResult({ total_cost_usd: 0.01, usage: { input_tokens: 10, output_tokens: 5 } });
+
+    // Queued metadata must survive — per-uuid isReplay events will clear each
+    // one as the CLI actually dequeues it.
+    const msgs = messages.get(chatId)!;
+    expect(msgs.find((m) => m.metadata?.uuid === 'uuid-B')?.metadata?.queued).toBe(true);
+    expect(msgs.find((m) => m.metadata?.uuid === 'uuid-C')?.metadata?.queued).toBe(true);
+
+    // And no bulk clear event leaks out.
+    const clearEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.cleared');
+    expect(clearEvents).toHaveLength(0);
+  });
+});
+
+describe('ChatManager — queued refs access', () => {
+  it('exposes getQueuedForChat returning only refs for that chat', async () => {
+    const { ChatManager } = await import('../chat/chat-manager.js');
+    const db: any = {
+      chats: { get: vi.fn(), list: vi.fn(), update: vi.fn(), listAll: vi.fn().mockReturnValue([]) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    const adapters: any = { get: vi.fn(), list: vi.fn().mockReturnValue([]) };
+    const manager = new ChatManager(db, adapters);
+    const internal = manager as unknown as { queuedRefs: Map<string, any> };
+    internal.queuedRefs.set('u1', { uuid: 'u1', chatId: 'A', messageId: 'mA', content: '', timestamp: '' });
+    internal.queuedRefs.set('u2', { uuid: 'u2', chatId: 'A', messageId: 'mA2', content: '', timestamp: '' });
+    internal.queuedRefs.set('u3', { uuid: 'u3', chatId: 'B', messageId: 'mB', content: '', timestamp: '' });
+
+    const api = manager as unknown as { getQueuedForChat(id: string): unknown[] };
+    expect(api.getQueuedForChat('A')).toHaveLength(2);
+    expect(api.getQueuedForChat('B')).toHaveLength(1);
+    expect(api.getQueuedForChat('ZZ')).toHaveLength(0);
+  });
+});
+
+describe('Queued message cleanup — onExit clears queue on abnormal termination', () => {
+  const chatId = 'chat-q3';
+  let activeChats: Map<string, any>;
+  let emitEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    activeChats = makeActiveChat(chatId);
+    emitEvent = vi.fn();
+  });
+
+  it('strips metadata.queued and emits message.queued.cleared when the CLI exits', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink, messages } = makeSink(activeChats, chatId, emit);
+    messages.append(
+      chatId,
+      messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'B' }], { queued: true, uuid: 'uuid-B' }),
+    );
+
+    sink.onExit(1);
+
+    const clearEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.cleared');
+    expect(clearEvents).toHaveLength(1);
+    expect(messages.get(chatId)![0]?.metadata?.queued).toBeUndefined();
+  });
+
+  it('invokes the chat-manager callback so queuedRefs can be wiped for the chat', () => {
+    const onQueuedCleared = vi.fn();
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { onQueuedCleared });
+    messages.append(
+      chatId,
+      messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'B' }], { queued: true, uuid: 'uuid-B' }),
+    );
+
+    sink.onExit(1);
+
+    expect(onQueuedCleared).toHaveBeenCalledWith(chatId);
+  });
+
+  it('is a no-op (no event) when there are no queued messages', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    const { sink } = makeSink(activeChats, chatId, emit);
+
+    sink.onExit(0);
+
+    const clearEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.cleared');
+    expect(clearEvents).toHaveLength(0);
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -63,6 +63,8 @@ export class ChatManager {
         const adapter = chat ? this.adapters.get(chat.adapterId) : undefined;
         return adapter?.getToolCategories?.();
       },
+      (chatId, uuid) => this.handleQueuedProcessed(chatId, uuid),
+      (chatId) => this.clearAllQueuedForChat(chatId),
     );
     this.planMode = new PlanModeHandler({
       permissions: this.permissions,
@@ -363,6 +365,25 @@ export class ChatManager {
     if (!ref) return;
     this.queuedRefs.delete(uuid);
     logger.info({ chatId, uuid, messageId: ref.messageId }, 'CLI processed queued message');
+  }
+
+  /** Return all queued refs for a chat, oldest-first. */
+  getQueuedForChat(chatId: string): QueuedMessageRef[] {
+    return [...this.queuedRefs.values()].filter((r) => r.chatId === chatId);
+  }
+
+  /** Drop every queuedRef belonging to a chat. Called when the CLI process exits. */
+  clearAllQueuedForChat(chatId: string): void {
+    let removed = 0;
+    for (const [uuid, ref] of this.queuedRefs) {
+      if (ref.chatId === chatId) {
+        this.queuedRefs.delete(uuid);
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      logger.info({ chatId, removed }, 'cleared queued refs for exited chat');
+    }
   }
 
   async respondToPermission(chatId: string, response: ControlResponse): Promise<void> {

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -50,6 +50,8 @@ export class EventHandler {
     private getActiveChat: (chatId: string) => ActiveChat | undefined,
     private emitEvent: (event: DaemonEvent) => void,
     private getToolCategories: (chatId: string) => ToolCategories | undefined = () => undefined,
+    private onQueuedProcessed: (chatId: string, uuid: string) => void = () => {},
+    private onQueuedCleared: (chatId: string) => void = () => {},
   ) {}
 
   setPushService(service: PushService): void {
@@ -67,6 +69,8 @@ export class EventHandler {
       respondToPermission,
       this.displayCache,
       this.getToolCategories,
+      this.onQueuedProcessed,
+      this.onQueuedCleared,
       this.pushService,
     );
   }
@@ -93,6 +97,8 @@ function buildSessionSink(
   _respondToPermission: (response: ControlResponse) => Promise<void>,
   displayCache: Map<string, DisplayMessage[]>,
   getToolCategories: (chatId: string) => ToolCategories | undefined,
+  onQueuedProcessedCb: (chatId: string, uuid: string) => void,
+  onQueuedClearedCb: (chatId: string) => void,
   pushService?: PushService,
 ): SessionSink {
   function emitDisplay(): void {
@@ -279,42 +285,49 @@ function buildSessionSink(
           .catch((err) => log.warn({ err }, 'push notification failed'));
       }
 
-      // Clear queued badges on turn completion — the CLI has processed all queued
-      // messages by this point. We can't rely on isReplay events in stream-json mode.
-      const allMsgs = messages.get(chatId);
-      if (allMsgs) {
-        let cleared = false;
-        for (const msg of allMsgs) {
-          if (msg.metadata?.queued) {
-            delete (msg.metadata as Record<string, unknown>).queued;
-            delete (msg.metadata as Record<string, unknown>).uuid;
-            cleared = true;
-          }
-        }
-        if (cleared) {
-          emitDisplay();
-          emitEvent({ type: 'message.queued.cleared', chatId });
-        }
-      }
+      // Per-queued-uuid cleanup happens in onQueuedProcessed (driven by the
+      // CLI's isReplay acks under --replay-user-messages). Don't bulk-clear
+      // on turn completion — that strips metadata.queued from messages the
+      // CLI hasn't dequeued yet.
     },
 
     onQueuedProcessed(uuid: string) {
       const msgs = messages.get(chatId);
-      if (!msgs) return;
-      const msg = msgs.find((m) => m.metadata?.uuid === uuid);
-      if (!msg) return;
-      if (msg.metadata) {
+      const msg = msgs?.find((m) => m.metadata?.uuid === uuid);
+      if (msg?.metadata) {
         delete (msg.metadata as Record<string, unknown>).queued;
         delete (msg.metadata as Record<string, unknown>).uuid;
+        emitDisplay();
       }
-      emitDisplay();
       emitEvent({ type: 'message.queued.processed', chatId, uuid });
+      onQueuedProcessedCb(chatId, uuid);
     },
 
     onExit(_code: number | null) {
       const active = getActiveChat(chatId);
       const sessionId = active?.session?.id ?? '';
       log.debug({ sessionId, chatId }, 'session exited');
+
+      // Any messages still flagged as queued are stranded — the CLI process
+      // is gone and will never emit an isReplay ack for them. Clear here so
+      // the composer banner and the daemon's queuedRefs don't leak.
+      const cachedMsgs = messages.get(chatId);
+      let hadQueued = false;
+      if (cachedMsgs) {
+        for (const msg of cachedMsgs) {
+          if (msg.metadata?.queued) {
+            delete (msg.metadata as Record<string, unknown>).queued;
+            delete (msg.metadata as Record<string, unknown>).uuid;
+            hadQueued = true;
+          }
+        }
+      }
+      if (hadQueued) {
+        emitDisplay();
+        emitEvent({ type: 'message.queued.cleared', chatId });
+      }
+      onQueuedClearedCb(chatId);
+
       if (active) {
         active.chat.processState = null;
         db.chats.update(chatId, { processState: null });

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -131,6 +131,10 @@ export class ClaudeSession implements AdapterSession {
       '--verbose',
       '--permission-prompt-tool',
       'stdio',
+      // Make the CLI emit `isReplay: true` user events for every queued uuid
+      // it dequeues, so the daemon can ack per-message instead of relying on
+      // brittle turn-boundary heuristics.
+      '--replay-user-messages',
     ];
 
     if (options.systemPrompt === 'enabled') {

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -175,6 +175,18 @@ export class WebSocketManager {
 
       case 'subscribe': {
         client.subscriptions.add(event.chatId);
+        // Rehydrate queued-message state for this client — the daemon is the
+        // source of truth; the renderer's Zustand store may have drifted
+        // during a WS disconnect.
+        const refs = this.chats.getQueuedForChat(event.chatId);
+        const snapshot: DaemonEvent = {
+          type: 'message.queued.snapshot',
+          chatId: event.chatId,
+          refs,
+        };
+        if (client.ws.readyState === WebSocket.OPEN) {
+          client.ws.send(JSON.stringify(snapshot));
+        }
         break;
       }
 

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -190,6 +190,9 @@ export function routeEvent(event: DaemonEvent): void {
     case 'message.queued.cleared':
       chats.clearQueuedMessages(event.chatId);
       break;
+    case 'message.queued.snapshot':
+      chats.setQueuedMessages(event.chatId, event.refs);
+      break;
     case 'adapter.models.updated':
       log.info('event:adapter.models.updated', { adapterId: event.adapterId, count: event.models.length });
       useAdaptersStore.getState().updateAdapterModels(event.adapterId, event.models);

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -73,6 +73,7 @@ interface ChatsState {
   addQueuedMessage: (chatId: string, ref: QueuedMessageRef) => void;
   removeQueuedMessage: (chatId: string, uuid: string) => void;
   clearQueuedMessages: (chatId: string) => void;
+  setQueuedMessages: (chatId: string, refs: QueuedMessageRef[]) => void;
   setCompacting: (chatId: string, compacting: boolean) => void;
   setContextUsage: (chatId: string, usage: ContextUsageState) => void;
   setTodos: (chatId: string, todos: TodoItem[]) => void;
@@ -275,6 +276,16 @@ export const useChatsStore = create<ChatsState>((set) => ({
     set((state) => {
       const next = new Map(state.queuedMessages);
       next.delete(chatId);
+      return { queuedMessages: next };
+    }),
+  setQueuedMessages: (chatId, refs) =>
+    set((state) => {
+      const next = new Map(state.queuedMessages);
+      if (refs.length === 0) {
+        next.delete(chatId);
+      } else {
+        next.set(chatId, refs);
+      }
       return { queuedMessages: next };
     }),
   setCompacting: (chatId, compacting) =>

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -56,6 +56,7 @@ export type DaemonEvent =
   | { type: 'message.queued.cancelled'; chatId: string; uuid: string }
   | { type: 'message.queued.cancel_failed'; chatId: string; uuid: string }
   | { type: 'message.queued.cleared'; chatId: string }
+  | { type: 'message.queued.snapshot'; chatId: string; refs: QueuedMessageRef[] }
   | { type: 'chat.notification'; chatId: string; title: string; body: string; level: 'success' | 'error' }
   | { type: 'chat.compacting'; chatId: string }
   | { type: 'chat.compactDone'; chatId: string }


### PR DESCRIPTION
## Summary

Closes #116. Queued messages were stranded in the composer banner after the agent processed them — sometimes indefinitely. Root cause: cleanup relied on the CLI emitting \`isReplay: true\` acks for queued uuids, but those only fire when the CLI is spawned with \`--replay-user-messages\`, which we weren't passing. The fallback — a cache scan on turn completion — was fragile (mis-fired after JSONL reload, missed on abnormal exit) and occasionally cleared metadata prematurely for messages still waiting in the CLI queue.

### Fixes

- **Pass \`--replay-user-messages\`** so the CLI emits a per-uuid \`isReplay\` ack for every queued message it dequeues (verified against the CLI source in \`cli/print.ts\` and \`QueryEngine.ts\`).
- **Wire \`onQueuedProcessed\`** back into \`ChatManager.handleQueuedProcessed\` so \`queuedRefs\` is pruned in lockstep with the composer banner (previously dead code).
- **Clear queued state on abnormal exit** — \`onExit\` now strips \`metadata.queued\` and emits \`message.queued.cleared\` so the banner doesn't strand if the CLI crashes.
- **Drop the bulk-clear in \`onResult\`** that was stripping metadata from messages the CLI hadn't dequeued yet.
- **Rehydrate on reconnect** — a new \`message.queued.snapshot\` event is sent to each client on \`subscribe\`, so the renderer's Zustand store re-syncs with the daemon's \`queuedRefs\` after a WS disconnect.

### Tests

9 new tests across \`queued-message-lifecycle.test.ts\` and \`claude-spawn-args.test.ts\` — written failing-first (TDD), confirming both the bug paths and the fixes. Full suite: core 1013/1013, desktop 421/421.

## Test plan

- [ ] Queue 2–3 messages while the agent is working — banner clears one-by-one as they're dequeued
- [ ] Queue a message, then interrupt/kill the session — banner clears (no longer stranded on abnormal exit)
- [ ] Queue messages, reload the renderer — banner reflects daemon state after reconnect (snapshot)
- [ ] Normal single-message send is unaffected (no queue badge)
- [ ] Edit/cancel on a queued message still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)