### PR TITLE
fix(sandbox): scale inspect screenshot by zoom factor (#123)

### DIFF
--- a/.changeset/fix-zoom-sandbox-coords.md
+++ b/.changeset/fix-zoom-sandbox-coords.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Fix element inspect screenshot offset when Electron zoom is not 1.0 (Cmd+/-). The crop rect passed to `capturePage` is now scaled by the webview zoom factor so device-pixel coordinates align with CSS-pixel coordinates from `getBoundingClientRect`.

--- a/packages/desktop/src/__tests__/components/sandbox/PreviewTab.test.tsx
+++ b/packages/desktop/src/__tests__/components/sandbox/PreviewTab.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { PreviewTab } from '../../../renderer/components/sandbox/PreviewTab';
+import { PreviewTab, scaleCropRect } from '../../../renderer/components/sandbox/PreviewTab';
 import { useSandboxStore } from '../../../renderer/store/sandbox';
 import { useChatsStore } from '../../../renderer/store/chats';
 import { TooltipProvider } from '../../../renderer/components/ui/tooltip.js';
@@ -13,6 +13,29 @@ vi.mock('../../../renderer/hooks/useActiveProjectId.js', () => ({
   useActiveProjectId: vi.fn(() => 'proj-1'),
   getActiveProjectId: vi.fn(() => 'proj-1'),
 }));
+
+describe('scaleCropRect', () => {
+  it('returns identical values at zoom 1.0', () => {
+    const rect = { x: 100, y: 200, width: 300, height: 150 };
+    expect(scaleCropRect(rect, 1.0)).toEqual({ x: 100, y: 200, width: 300, height: 150 });
+  });
+
+  it('scales up correctly at zoom 1.25', () => {
+    const rect = { x: 10, y: 20, width: 100, height: 50 };
+    expect(scaleCropRect(rect, 1.25)).toEqual({ x: 13, y: 25, width: 125, height: 63 });
+  });
+
+  it('scales down correctly at zoom 0.8', () => {
+    const rect = { x: 100, y: 200, width: 400, height: 200 };
+    expect(scaleCropRect(rect, 0.8)).toEqual({ x: 80, y: 160, width: 320, height: 160 });
+  });
+
+  it('rounds fractional device pixels', () => {
+    const rect = { x: 1, y: 1, width: 3, height: 3 };
+    // 1 * 1.5 = 1.5 → 2, 3 * 1.5 = 4.5 → 5
+    expect(scaleCropRect(rect, 1.5)).toEqual({ x: 2, y: 2, width: 5, height: 5 });
+  });
+});
 
 describe('PreviewTab', () => {
   beforeEach(() => {

--- a/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
+++ b/packages/desktop/src/renderer/components/sandbox/PreviewTab.tsx
@@ -104,6 +104,27 @@ interface ElementPickResult {
   viewport: { width: number; height: number };
 }
 
+interface CropRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Converts a CSS-pixel crop rectangle to device pixels by multiplying by the zoom factor.
+ * capturePage() operates in device pixels; getBoundingClientRect() returns CSS pixels.
+ * At zoom != 1.0 (Cmd+/-), failing to scale causes an offset crop rectangle.
+ */
+export function scaleCropRect(rect: CropRect, zoom: number): CropRect {
+  return {
+    x: Math.round(rect.x * zoom),
+    y: Math.round(rect.y * zoom),
+    width: Math.round(rect.width * zoom),
+    height: Math.round(rect.height * zoom),
+  };
+}
+
 export function PreviewTab(): React.ReactElement {
   const webviewRef = useRef<HTMLElement>(null);
   const [inspecting, setInspecting] = useState(false);
@@ -301,12 +322,11 @@ export function PreviewTab(): React.ReactElement {
       const right = Math.min(result.viewport.width, result.rect.x + result.rect.width + PAD);
       const bottom = Math.min(result.viewport.height, result.rect.y + result.rect.height + PAD);
 
-      const image = (await wv.capturePage({
-        x,
-        y,
-        width: Math.round(right - x),
-        height: Math.round(bottom - y),
-      })) as { toDataURL: () => string };
+      // getBoundingClientRect() returns CSS pixels, but capturePage() operates in device pixels.
+      // At non-1.0 zoom (Cmd+/Cmd-), we must scale the crop rect by the zoom factor to avoid offset captures.
+      const zoom: number = (wv.getZoomFactor?.() as number | undefined) ?? 1;
+      const cropRect = scaleCropRect({ x, y, width: right - x, height: bottom - y }, zoom);
+      const image = (await wv.capturePage(cropRect)) as { toDataURL: () => string };
       const dataUrl = image.toDataURL();
       addCapture({ type: 'element', imageDataUrl: dataUrl, selector: result.selector });
 


### PR DESCRIPTION
## Summary
Closes #123. At non-1.0 zoom (\`Cmd +\` / \`Cmd -\`), the inspect screenshot was offset because \`getBoundingClientRect()\` returns CSS pixels while \`webview.capturePage(rect)\` operates in device pixels.

### Fix
- New pure helper \`scaleCropRect(rect, zoom)\` — multiplies and rounds.
- Before each capture, read \`wv.getZoomFactor()\` (live, not cached) and scale the rect. Cmd+/- changes apply immediately, no reactivity wiring needed.

## Test plan
- [x] 4 unit tests on \`scaleCropRect\` (zoom 1.0, 1.25, 0.8, rounding)
- [ ] Manual: inspect at zoom 100%, 125%, 80% → captured image aligns with clicked element

🤖 Generated with [Claude Code](https://claude.com/claude-code)