### PR TITLE
fix: slash-command forwarding, skill context, CLI feedback surfacing

### DIFF
--- a/.changeset/fix-skill-and-slash-feedback.md
+++ b/.changeset/fix-skill-and-slash-feedback.md
@@ -1,0 +1,11 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix slash-command forwarding and skill detection
+
+- Forward unknown `/cmd` input as plain user text so the CLI handles it natively, including its own "Unknown command" error messages (Fix A)
+- Surface CLI-synthesized user text blocks (e.g. unknown-command feedback) as system messages in the chat; skip replayed user text and isMeta wrapper events (Fix B)
+- Detect model-initiated SkillTool `tool_use` blocks in assistant events and fire `onSkillFile` so the skill appears in the ContextTab (Fix C)
+- Add `onCliMessage` to `SessionSink` interface and implement it in `event-handler.ts` as a transient system message

--- a/.changeset/fix-skill-and-slash-feedback.md
+++ b/.changeset/fix-skill-and-slash-feedback.md
@@ -1,11 +1,16 @@
 ---
+'@qlan-ro/mainframe-types': patch
 '@qlan-ro/mainframe-core': patch
 '@qlan-ro/mainframe-desktop': patch
 ---
 
-Fix slash-command forwarding and skill detection
+Replace skill-injection grey bubble with a collapsible SkillLoadedCard
 
-- Forward unknown `/cmd` input as plain user text so the CLI handles it natively, including its own "Unknown command" error messages (Fix A)
-- Surface CLI-synthesized user text blocks (e.g. unknown-command feedback) as system messages in the chat; skip replayed user text and isMeta wrapper events (Fix B)
-- Detect model-initiated SkillTool `tool_use` blocks in assistant events and fire `onSkillFile` so the skill appears in the ContextTab (Fix C)
-- Add `onCliMessage` to `SessionSink` interface and implement it in `event-handler.ts` as a transient system message
+- Add `skill_loaded` content block type to `MessageContent` and `DisplayContent`
+- Add `onSkillLoaded` to `SessionSink`; parse skill name, path, and content from the CLI-injected user-event text (`<skill-format>true</skill-format>`)
+- Suppress `onCliMessage` for skill-injection text; emit `onSkillLoaded` + `onSkillFile` instead
+- Cache the authoritative path extracted from the text so the `Skill` tool_use branch reuses it
+- Wire `onSkillLoaded` through `event-handler.ts` as a transient system message with a `skill_loaded` block
+- Pass `skill_loaded` blocks through `display-pipeline.ts` and `convert-message.ts` via message metadata
+- Render skill messages as a `SkillLoadedCard` (collapsible, `defaultOpen={false}`) in `SystemMessage.tsx`
+- New `SkillLoadedCard.tsx`: Zap icon + `/skillName` header with path tooltip; markdown body inside `max-h-[480px]` scrollable pane

--- a/.changeset/fix-skill-and-slash-feedback.md
+++ b/.changeset/fix-skill-and-slash-feedback.md
@@ -14,3 +14,4 @@ Replace skill-injection grey bubble with a collapsible SkillLoadedCard
 - Pass `skill_loaded` blocks through `display-pipeline.ts` and `convert-message.ts` via message metadata
 - Render skill messages as a `SkillLoadedCard` (collapsible, `defaultOpen={false}`) in `SystemMessage.tsx`
 - New `SkillLoadedCard.tsx`: Zap icon + `/skillName` header with path tooltip; markdown body inside `max-h-[480px]` scrollable pane
+- Preserve user-typed `/skill-name` (and `/skill-name args`) bubbles: display-pipeline now synthesizes a readable `/cmd args` bubble from the CLI's `<command-name>`/`<command-args>` echo instead of dropping the entry

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ release/
 # Superpowers brainstorm artifacts
 .superpowers/
 
+# Codex-review local session state (per-branch, not shared)
+.claude/codex-review/
+
 /packages/e2e/playwright-report/

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -3,8 +3,8 @@ import { handleStdout, handleStderr } from '../plugins/builtin/claude/events.js'
 import { ClaudeSession } from '../plugins/builtin/claude/session.js';
 import type { SessionSink } from '@qlan-ro/mainframe-types';
 
-function createSession() {
-  return new ClaudeSession({ projectPath: '/tmp', chatId: '' });
+function createSession(projectPath = '/tmp') {
+  return new ClaudeSession({ projectPath, chatId: '' });
 }
 
 function createSink(): SessionSink {
@@ -17,8 +17,14 @@ function createSink(): SessionSink {
     onExit: vi.fn(),
     onError: vi.fn(),
     onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
     onPlanFile: vi.fn(),
     onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 
@@ -66,7 +72,84 @@ describe('handleStdout', () => {
     expect(sink.onMessage).not.toHaveBeenCalled();
   });
 
-  it('extracts skill name (not full path) from user text blocks', () => {
+  it('detects model-initiated skill from SkillTool tool_use and resolves path', async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const pathMod = await import('node:path');
+
+    const projectDir = await mkdtemp(pathMod.join(tmpdir(), 'mf-skill-test-'));
+    const skillDir = pathMod.join(projectDir, '.claude', 'skills', 'brainstorming');
+    await mkdir(skillDir, { recursive: true });
+    const skillPath = pathMod.join(skillDir, 'SKILL.md');
+    await writeFile(skillPath, '# brainstorming');
+
+    try {
+      const session = createSession(projectDir);
+      const sink = createSink();
+
+      const event = JSON.stringify({
+        type: 'assistant',
+        message: {
+          model: 'claude',
+          content: [{ type: 'tool_use', id: 'toolu_1', name: 'Skill', input: { skill: 'brainstorming' } }],
+        },
+      });
+      handleStdout(session, Buffer.from(event + '\n'), sink);
+
+      // Project-local skill file wins over user/plugin locations.
+      expect(sink.onSkillFile).toHaveBeenCalledWith({ path: skillPath, displayName: 'brainstorming' });
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to ~/.claude/skills convention when the skill file is nowhere on disk', async () => {
+    const { homedir } = await import('node:os');
+    const pathMod = await import('node:path');
+
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: 'claude',
+        content: [{ type: 'tool_use', id: 'toolu_2', name: 'Skill', input: { skill: '__definitely-not-installed' } }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: pathMod.join(homedir(), '.claude', 'skills', '__definitely-not-installed', 'SKILL.md'),
+      displayName: '__definitely-not-installed',
+    });
+  });
+
+  it('does NOT fire onSkillFile for user text blocks (prose or <skill-format> tags)', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    // User-event text must NOT be a skill signal — only assistant tool_use does.
+    const event = JSON.stringify({
+      type: 'user',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: '<command-name>foo</command-name>\n<skill-format>true</skill-format>\n\nBase directory for this skill: /home/user/.claude/skills/foo',
+          },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).not.toHaveBeenCalled();
+  });
+
+  // Fix B: CLI-synthesized user messages (e.g. unknown-command errors)
+  it('surfaces CLI-synthesized text as onCliMessage when not isReplay and not isMeta', () => {
     const session = createSession();
     const sink = createSink();
 
@@ -77,36 +160,93 @@ describe('handleStdout', () => {
         content: [
           {
             type: 'text',
-            text: 'Base directory for this skill: /home/user/.claude/skills/brainstorming\n\n# Skill Content',
+            text: 'Unknown command: /inisights. Did you mean /insights?',
           },
         ],
       },
     });
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
-    expect(sink.onSkillFile).toHaveBeenCalledWith({
-      path: '/home/user/.claude/skills/brainstorming/SKILL.md',
-      displayName: 'brainstorming',
-    });
+    expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown command: /inisights. Did you mean /insights?');
   });
 
-  it('extracts skill name from rawContent string (non-array content)', () => {
+  it('skips onCliMessage when event isReplay is true', () => {
     const session = createSession();
     const sink = createSink();
 
     const event = JSON.stringify({
       type: 'user',
+      isReplay: true,
+      uuid: 'some-uuid',
       message: {
         role: 'user',
-        content: 'Base directory for this skill: /home/user/.claude/skills/my-skill\n\nSkill body here.',
+        content: [{ type: 'text', text: 'Hello from user' }],
       },
     });
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
-    expect(sink.onSkillFile).toHaveBeenCalledWith({
-      path: '/home/user/.claude/skills/my-skill/SKILL.md',
-      displayName: 'my-skill',
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips onCliMessage when event isMeta is true', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: '<local-command-caveat>skill content</local-command-caveat>' }],
+      },
     });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+  });
+
+  // Fix C: SkillTool detection in assistant events
+  it('calls onSkillFile when a Skill tool_use block appears in assistant event', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_001',
+            name: 'Skill',
+            input: { skill: 'brainstorming', args: 'some args' },
+          },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).toHaveBeenCalledTimes(1);
+    const call = (sink.onSkillFile as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(call.displayName).toBe('brainstorming');
+    expect(call.path).toContain('brainstorming');
+    expect(call.path).toContain('SKILL.md');
+  });
+
+  it('does not call onSkillFile when Skill tool_use has no skill name', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'toolu_002', name: 'Skill', input: {} }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -126,11 +126,12 @@ describe('handleStdout', () => {
     });
   });
 
-  it('does NOT fire onSkillFile for user text blocks (prose or <skill-format> tags)', () => {
+  it('fires onSkillFile + onSkillLoaded for isMeta user text (user-typed /skill-name injection)', () => {
     const session = createSession();
     const sink = createSink();
 
-    // User-event text must NOT be a skill signal — only assistant tool_use does.
+    // processSlashCommand.tsx:905-907 marks the skill-content user message
+    // isMeta:true — detection must run despite the isMeta flag.
     const event = JSON.stringify({
       type: 'user',
       isMeta: true,
@@ -139,14 +140,50 @@ describe('handleStdout', () => {
         content: [
           {
             type: 'text',
-            text: '<command-name>foo</command-name>\n<skill-format>true</skill-format>\n\nBase directory for this skill: /home/user/.claude/skills/foo',
+            text: '<command-name>foo</command-name>\n<skill-format>true</skill-format>\n\nBase directory for this skill: /home/user/.claude/skills/foo\n\n# Foo skill body',
           },
         ],
       },
     });
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
-    expect(sink.onSkillFile).not.toHaveBeenCalled();
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: '/home/user/.claude/skills/foo/SKILL.md',
+      displayName: 'foo',
+    });
+    expect(sink.onSkillLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skillName: 'foo',
+        path: '/home/user/.claude/skills/foo/SKILL.md',
+      }),
+    );
+  });
+
+  it('fires onSkillFile for user-typed /skill-name with no <skill-format> tag', () => {
+    // This is the plain "Base directory for this skill:" injection format
+    // that user-typed /skill-name produces — no XML marker, no tool_use.
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Base directory for this skill: /Users/me/.claude/plugins/cache/marketplace/work-logger/2.0.0/skills/slack-status-writer\n\n# Slack Status Writer\n\nBody.',
+          },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: '/Users/me/.claude/plugins/cache/marketplace/work-logger/2.0.0/skills/slack-status-writer/SKILL.md',
+      displayName: 'slack-status-writer',
+    });
   });
 
   // Fix B: CLI-synthesized user messages (e.g. unknown-command errors)

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -25,6 +25,7 @@ function createSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 
@@ -247,6 +248,58 @@ describe('handleStdout', () => {
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
     expect(sink.onSkillFile).not.toHaveBeenCalled();
+  });
+
+  // Skill-loaded card: user-event text with <skill-format>true</skill-format>
+  it('calls onSkillLoaded and onSkillFile (not onCliMessage) when user-event has skill-format tags', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const skillContent = '# brainstorming\n\nThink broadly.';
+    const text = [
+      '<command-name>brainstorming</command-name>',
+      '<skill-format>true</skill-format>',
+      'Base directory for this skill: /home/user/.claude/skills/brainstorming',
+      skillContent,
+    ].join('\n');
+
+    const event = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+    expect(sink.onSkillLoaded).toHaveBeenCalledTimes(1);
+    const loaded = (sink.onSkillLoaded as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(loaded.skillName).toBe('brainstorming');
+    expect(loaded.path).toBe('/home/user/.claude/skills/brainstorming/SKILL.md');
+    expect(loaded.content).toContain('# brainstorming');
+    expect(loaded.content).not.toContain('<command-name>');
+    expect(loaded.content).not.toContain('<skill-format>');
+    expect(loaded.content).not.toContain('Base directory for this skill:');
+
+    expect(sink.onSkillFile).toHaveBeenCalledWith({
+      path: '/home/user/.claude/skills/brainstorming/SKILL.md',
+      displayName: 'brainstorming',
+    });
+  });
+
+  it('non-skill CLI text still calls onCliMessage (not onSkillLoaded)', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Unknown command: /typo. Did you mean /brainstorming?' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown command: /typo. Did you mean /brainstorming?');
+    expect(sink.onSkillLoaded).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/__tests__/codex-approval-handler.test.ts
+++ b/packages/core/src/__tests__/codex-approval-handler.test.ts
@@ -13,8 +13,14 @@ function createSink(): SessionSink {
     onExit: vi.fn(),
     onError: vi.fn(),
     onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
     onPlanFile: vi.fn(),
     onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-approval-handler.test.ts
+++ b/packages/core/src/__tests__/codex-approval-handler.test.ts
@@ -21,6 +21,7 @@ function createSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -14,8 +14,14 @@ function createSink(): SessionSink {
     onExit: vi.fn(),
     onError: vi.fn(),
     onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
     onPlanFile: vi.fn(),
     onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -22,6 +22,7 @@ function createSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-session.test.ts
+++ b/packages/core/src/__tests__/codex-session.test.ts
@@ -55,6 +55,7 @@ function createSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-session.test.ts
+++ b/packages/core/src/__tests__/codex-session.test.ts
@@ -47,8 +47,14 @@ function createSink(): SessionSink {
     onExit: vi.fn(),
     onError: vi.fn(),
     onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
     onPlanFile: vi.fn(),
     onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -323,6 +323,54 @@ describe('EventHandler context.updated timing', () => {
   });
 });
 
+describe('EventHandler onSkillLoaded', () => {
+  let db: any;
+  let msgCache: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+
+  const chatId = 'chat-skill-loaded';
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    msgCache = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    activeChats = new Map();
+    activeChats.set(chatId, {
+      chat: { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'working' },
+      session: null,
+    });
+  });
+
+  it('emits message.added with skill_loaded content block', () => {
+    const handler = new EventHandler(db, msgCache, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, () => Promise.resolve());
+
+    sink.onSkillLoaded({
+      skillName: 'brainstorming',
+      path: '/home/user/.claude/skills/brainstorming/SKILL.md',
+      content: '# brainstorming\n\nThink broadly.',
+    });
+
+    const addedEvents = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'message.added');
+    expect(addedEvents).toHaveLength(1);
+    const msg = addedEvents[0]![0].message;
+    expect(msg.type).toBe('system');
+    expect(msg.content[0]).toMatchObject({
+      type: 'skill_loaded',
+      skillName: 'brainstorming',
+      path: '/home/user/.claude/skills/brainstorming/SKILL.md',
+      content: '# brainstorming\n\nThink broadly.',
+    });
+  });
+});
+
 describe('EventHandler onPermission — yolo no longer auto-approves', () => {
   let db: any;
   let messages: MessageCache;

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -135,56 +135,25 @@ describe('EventHandler skill_file announcement', () => {
     });
   });
 
-  it('emits a system announcement for slash-command skill flows', () => {
+  it('does not emit any system announcement — SkillLoadedCard covers both flows', () => {
     const handler = new EventHandler(db, msgCache, permissions, (id) => activeChats.get(id), emitEvent);
     const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
 
-    // No preceding tool_result in cache → slash-command flow
+    // Slash-command flow: no preceding tool_result in cache
     sink.onSkillFile({ path: '/home/user/.claude/skills/brainstorming/SKILL.md', displayName: 'brainstorming' });
 
-    const systemEvents = emitEvent.mock.calls.filter(
-      (call) => call[0].type === 'message.added' && call[0].message?.type === 'system',
-    );
-
-    expect(systemEvents).toHaveLength(1);
-    const msg = systemEvents[0][0].message;
-    expect(msg.content[0]).toMatchObject({ type: 'text', text: 'Using skill: brainstorming' });
-  });
-
-  it('does not emit an announcement for autonomous Skill-tool flows', () => {
-    const handler = new EventHandler(db, msgCache, permissions, (id) => activeChats.get(id), emitEvent);
-    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
-
-    // Seed cache with a tool_result message starting with "Launching skill:"
+    // Autonomous Skill-tool flow: preceding tool_result with "Launching skill:"
     const toolResultMsg = msgCache.createTransientMessage(chatId, 'tool_result', [
-      { type: 'tool_result', toolUseId: 'toolu_123', content: 'Launching skill: brainstorming', isError: false },
+      { type: 'tool_result', toolUseId: 'toolu_123', content: 'Launching skill: other', isError: false },
     ]);
     msgCache.append(chatId, toolResultMsg);
-
-    sink.onSkillFile({ path: '/home/user/.claude/skills/brainstorming/SKILL.md', displayName: 'brainstorming' });
+    sink.onSkillFile({ path: '/home/user/.claude/skills/other/SKILL.md', displayName: 'other' });
 
     const systemEvents = emitEvent.mock.calls.filter(
       (call) => call[0].type === 'message.added' && call[0].message?.type === 'system',
     );
 
     expect(systemEvents).toHaveLength(0);
-  });
-
-  it('derives display name from parent directory when file is SKILL.md', () => {
-    const handler = new EventHandler(db, msgCache, permissions, (id) => activeChats.get(id), emitEvent);
-    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
-
-    sink.onSkillFile({
-      path: '/home/user/.claude/plugins/my-plugin/skills/my-skill/SKILL.md',
-      displayName: 'my-skill',
-    });
-
-    const systemEvents = emitEvent.mock.calls.filter(
-      (call) => call[0].type === 'message.added' && call[0].message?.type === 'system',
-    );
-
-    expect(systemEvents).toHaveLength(1);
-    expect(systemEvents[0][0].message.content[0]).toMatchObject({ text: 'Using skill: my-skill' });
   });
 });
 

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -340,7 +340,7 @@ describe('loadHistory', () => {
     }
   });
 
-  it('filters slash-command invocation markers containing <command-name> tags', async () => {
+  it('preserves slash-command invocation markers so display-pipeline can render them', async () => {
     writeJsonl(SESSION_ID, [
       userTextEntry('<command-name>commit</command-name>\n/commit'),
       userTextEntry('You are a commit message generator. Analyze the staged changes...'),
@@ -349,10 +349,12 @@ describe('loadHistory', () => {
 
     const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
 
-    // The command marker (first user message) is filtered; skill expansion content + assistant remain
-    expect(messages).toHaveLength(2);
+    // History keeps <command-name> entries so the display pipeline can render
+    // them as "/commit" bubbles instead of silently dropping the user's typed command.
+    expect(messages).toHaveLength(3);
     expect(messages[0].type).toBe('user');
-    expect(messages[1].type).toBe('assistant');
+    expect(messages[1].type).toBe('user');
+    expect(messages[2].type).toBe('assistant');
   });
 
   it('converts isMeta skill-content entries into a synthetic system/skill_loaded message', async () => {

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -355,7 +355,7 @@ describe('loadHistory', () => {
     expect(messages[1].type).toBe('assistant');
   });
 
-  it('skips isMeta=true entries (skill content injections)', async () => {
+  it('converts isMeta skill-content entries into a synthetic system/skill_loaded message', async () => {
     const toolUseId = 'toolu_skill_1';
     writeJsonl(SESSION_ID, [
       userTextEntry('Use the brainstorming skill'),
@@ -367,16 +367,21 @@ describe('loadHistory', () => {
 
     const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
 
-    // isMeta=true entry is skipped; 4 real messages remain
-    expect(messages).toHaveLength(4);
+    // isMeta entry is converted to a system message with a skill_loaded block → 5 messages.
+    expect(messages).toHaveLength(5);
     const types = messages.map((m) => m.type);
-    expect(types).toEqual(['user', 'assistant', 'tool_result', 'assistant']);
+    expect(types).toEqual(['user', 'assistant', 'tool_result', 'system', 'assistant']);
+    const skillMsg = messages[3];
+    expect(skillMsg.content[0]).toMatchObject({
+      type: 'skill_loaded',
+      skillName: 'brainstorming',
+    });
   });
 
-  it('preserves assistant turn continuity when isMeta entry is skipped', async () => {
-    // Bug 1 regression: isMeta entries between two assistant entries were splitting
-    // the consecutive assistant chain in groupMessages(), causing the first assistant
-    // text to appear as a separate message from the announcement.
+  it('preserves assistant turn continuity around the synthesized skill_loaded message', async () => {
+    // Regression guard: isMeta entries between two assistant entries were splitting
+    // the consecutive assistant chain in groupMessages(). The synthesized system
+    // message is its own role, so grouping must still work correctly.
     const toolUseId = 'toolu_skill_2';
     writeJsonl(SESSION_ID, [
       userTextEntry('Let me start working on this'),
@@ -389,12 +394,11 @@ describe('loadHistory', () => {
 
     const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
 
-    // isMeta entry is gone → 5 messages, no spurious user message splitting the assistant turns
-    expect(messages).toHaveLength(5);
+    // synthesized system msg sits between tool_result and the next assistant text.
+    expect(messages).toHaveLength(6);
     const types = messages.map((m) => m.type);
-    // user, assistant (pre-text), assistant (Skill tool_use), tool_result, assistant (announcement)
-    expect(types).toEqual(['user', 'assistant', 'assistant', 'tool_result', 'assistant']);
-    // No user or error message should appear at any point
+    expect(types).toEqual(['user', 'assistant', 'assistant', 'tool_result', 'system', 'assistant']);
+    // No extra user messages leaked in
     expect(types.filter((t) => t === 'user')).toHaveLength(1);
   });
 

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -357,6 +357,42 @@ describe('loadHistory', () => {
     expect(messages[2].type).toBe('assistant');
   });
 
+  it('synthesizes user + system messages for "Unknown command: /X" string entries', async () => {
+    writeJsonl(SESSION_ID, [
+      jsonlEntry({
+        type: 'user',
+        message: { role: 'user', content: 'Unknown command: /non-existent-skill' },
+      }),
+    ]);
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].type).toBe('user');
+    expect(messages[0].content[0]).toMatchObject({ type: 'text', text: '/non-existent-skill' });
+    expect(messages[1].type).toBe('system');
+    expect(messages[1].content[0]).toMatchObject({
+      type: 'text',
+      text: 'Unknown command: /non-existent-skill',
+    });
+  });
+
+  it('synthesizes user + system messages for "Unknown skill: X" string entries (no leading slash)', async () => {
+    writeJsonl(SESSION_ID, [
+      jsonlEntry({
+        type: 'user',
+        message: { role: 'user', content: 'Unknown skill: missing-skill' },
+      }),
+    ]);
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].type).toBe('user');
+    expect(messages[0].content[0]).toMatchObject({ type: 'text', text: '/missing-skill' });
+    expect(messages[1].type).toBe('system');
+  });
+
   it('converts isMeta skill-content entries into a synthetic system/skill_loaded message', async () => {
     const toolUseId = 'toolu_skill_1';
     writeJsonl(SESSION_ID, [

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -118,14 +118,33 @@ describe('prepareMessagesForClient', () => {
     expect(result[0]!.type).toBe('assistant');
   });
 
-  it('filters out internal user messages with command-name skill marker', () => {
+  it('renders user-typed /skill-name as a /skill-name bubble', () => {
     const messages = [
-      rawMsg('user', [txt('<command-name>systematic-debugging</command-name> some text')]),
+      rawMsg('user', [
+        txt(
+          '<command-message>systematic-debugging</command-message>\n<command-name>/systematic-debugging</command-name>',
+        ),
+      ]),
       rawMsg('assistant', [txt('response')]),
     ];
     const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.type).toBe('user');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: '/systematic-debugging' }]);
+  });
+
+  it('renders user-typed /skill-name with <command-args> as /skill-name args bubble', () => {
+    const messages = [
+      rawMsg('user', [
+        txt(
+          '<command-message>work-logger:slack-status-writer</command-message>\n<command-name>/work-logger:slack-status-writer</command-name>\n<command-args>how are you</command-args>',
+        ),
+      ]),
+    ];
+    const result = prepareMessagesForClient(messages);
     expect(result).toHaveLength(1);
-    expect(result[0]!.type).toBe('assistant');
+    expect(result[0]!.type).toBe('user');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: '/work-logger:slack-status-writer how are you' }]);
   });
 
   it('deduplicates tool_use blocks by id (keeps first occurrence)', () => {

--- a/packages/core/src/__tests__/plugins/claude-sdk/event-mapper.test.ts
+++ b/packages/core/src/__tests__/plugins/claude-sdk/event-mapper.test.ts
@@ -221,22 +221,24 @@ describe('mapSdkMessage', () => {
     expect(sink.onPlanFile).toHaveBeenCalledWith('/tmp/plan.md');
   });
 
-  it('detects skill file entries in tool_result content', () => {
+  it('detects skill from SkillTool tool_use in assistant messages', async () => {
+    const { homedir } = await import('node:os');
+    const pathMod = await import('node:path');
     const sink = createMockSink();
     mapSdkMessage(
       {
-        type: 'user',
-        uuid: 'uuid-9',
+        type: 'assistant',
+        uuid: 'uuid-10',
         session_id: 'sess-1',
         parent_tool_use_id: null,
         message: {
-          role: 'user',
+          model: 'claude',
           content: [
             {
-              type: 'tool_result',
-              tool_use_id: 'tu-3',
-              content: 'Base directory for this skill: /home/user/.claude/skills/my-skill',
-              is_error: false,
+              type: 'tool_use',
+              id: 'toolu_s1',
+              name: 'Skill',
+              input: { skill: 'brainstorming' },
             },
           ],
         },
@@ -245,8 +247,34 @@ describe('mapSdkMessage', () => {
     );
 
     expect(sink.onSkillFile).toHaveBeenCalledWith({
-      path: '/home/user/.claude/skills/my-skill',
-      displayName: 'my-skill',
+      path: pathMod.join(homedir(), '.claude', 'skills', 'brainstorming', 'SKILL.md'),
+      displayName: 'brainstorming',
     });
+  });
+
+  it('does NOT fire onSkillFile for plain prose mentioning "Base directory for this skill"', () => {
+    const sink = createMockSink();
+    mapSdkMessage(
+      {
+        type: 'user',
+        uuid: 'uuid-11',
+        session_id: 'sess-1',
+        parent_tool_use_id: null,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu-4',
+              content: 'Base directory for this skill: /fake/path',
+              is_error: false,
+            },
+          ],
+        },
+      } as any,
+      sink,
+    );
+
+    expect(sink.onSkillFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/__tests__/plugins/claude-sdk/event-mapper.test.ts
+++ b/packages/core/src/__tests__/plugins/claude-sdk/event-mapper.test.ts
@@ -224,6 +224,10 @@ describe('mapSdkMessage', () => {
   it('detects skill from SkillTool tool_use in assistant messages', async () => {
     const { homedir } = await import('node:os');
     const pathMod = await import('node:path');
+    // Use a name guaranteed not to exist on disk so resolveSkillPath returns
+    // the deterministic homedir fallback rather than a real skill from the
+    // developer's actual ~/.claude/plugins cache.
+    const SKILL = 'nonexistent-test-skill-xyzabc';
     const sink = createMockSink();
     mapSdkMessage(
       {
@@ -238,7 +242,7 @@ describe('mapSdkMessage', () => {
               type: 'tool_use',
               id: 'toolu_s1',
               name: 'Skill',
-              input: { skill: 'brainstorming' },
+              input: { skill: SKILL },
             },
           ],
         },
@@ -247,8 +251,8 @@ describe('mapSdkMessage', () => {
     );
 
     expect(sink.onSkillFile).toHaveBeenCalledWith({
-      path: pathMod.join(homedir(), '.claude', 'skills', 'brainstorming', 'SKILL.md'),
-      displayName: 'brainstorming',
+      path: pathMod.join(homedir(), '.claude', 'skills', SKILL, 'SKILL.md'),
+      displayName: SKILL,
     });
   });
 

--- a/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
+++ b/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
@@ -11,7 +11,13 @@ export function createMockSink(): SessionSink {
     onExit: vi.fn(),
     onError: vi.fn(),
     onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
     onPlanFile: vi.fn(),
     onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }

--- a/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
+++ b/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
@@ -19,5 +19,6 @@ export function createMockSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }

--- a/packages/core/src/__tests__/skill-path.test.ts
+++ b/packages/core/src/__tests__/skill-path.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveSkillPath, resolveExistingSkillPath } from '../plugins/builtin/claude/skill-path.js';
+
+const TEST_BASE = join(tmpdir(), 'mainframe-skillpath-test');
+
+vi.mock('node:os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:os')>();
+  return { ...original, homedir: () => TEST_BASE };
+});
+
+function writeSkill(root: string, relPath: string, body = '# test\n'): string {
+  const full = join(root, relPath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, body);
+  return full;
+}
+
+describe('resolveSkillPath input validation', () => {
+  beforeEach(() => {
+    rmSync(TEST_BASE, { recursive: true, force: true });
+    mkdirSync(TEST_BASE, { recursive: true });
+  });
+  afterEach(() => rmSync(TEST_BASE, { recursive: true, force: true }));
+
+  it('rejects path-traversal names and returns empty fallback', () => {
+    expect(resolveSkillPath(undefined, '../../etc/passwd')).toBe('');
+    expect(resolveSkillPath(undefined, '../../../foo')).toBe('');
+    expect(resolveSkillPath(undefined, 'foo/bar')).toBe('');
+  });
+
+  it('rejects names with path separators or null bytes', () => {
+    expect(resolveSkillPath(undefined, 'a/b')).toBe('');
+    expect(resolveSkillPath(undefined, 'a\\b')).toBe('');
+    expect(resolveSkillPath(undefined, 'a\0b')).toBe('');
+  });
+
+  it('accepts plugin-qualified names (single colon)', () => {
+    expect(resolveSkillPath(undefined, 'work-logger:slack-status-writer')).toContain('slack-status-writer/SKILL.md');
+  });
+
+  it('rejects multi-colon names', () => {
+    expect(resolveSkillPath(undefined, 'a:b:c')).toBe('');
+  });
+
+  it('returns fallback path under homedir for valid unfound names', () => {
+    const result = resolveSkillPath(undefined, 'nonexistent-skill');
+    expect(result).toContain(TEST_BASE);
+    expect(result).toContain('nonexistent-skill/SKILL.md');
+  });
+});
+
+describe('resolveExistingSkillPath plugin-qualified resolution', () => {
+  beforeEach(() => {
+    rmSync(TEST_BASE, { recursive: true, force: true });
+    mkdirSync(TEST_BASE, { recursive: true });
+  });
+  afterEach(() => rmSync(TEST_BASE, { recursive: true, force: true }));
+
+  it('returns null for invalid names', () => {
+    expect(resolveExistingSkillPath(undefined, '../etc')).toBeNull();
+    expect(resolveExistingSkillPath(undefined, 'a/b')).toBeNull();
+  });
+
+  it('finds plugin-qualified skill in cache layout', () => {
+    const real = writeSkill(
+      TEST_BASE,
+      '.claude/plugins/cache/marketplace-name/work-logger/1.2.3/skills/slack-status-writer/SKILL.md',
+    );
+    const result = resolveExistingSkillPath(undefined, 'work-logger:slack-status-writer');
+    expect(result).toBe(real);
+  });
+
+  it('finds plugin-qualified skill in non-cache plugin dir', () => {
+    const real = writeSkill(TEST_BASE, '.claude/plugins/work-logger-plugin/skills/slack-status-writer/SKILL.md');
+    const result = resolveExistingSkillPath(undefined, 'work-logger:slack-status-writer');
+    expect(result).toBe(real);
+  });
+
+  it('resolveSkillPath (non-existing-aware) prefers real cached plugin path over fallback', () => {
+    const real = writeSkill(TEST_BASE, '.claude/plugins/cache/m/work-logger/1.0.0/skills/slack-status-writer/SKILL.md');
+    expect(resolveSkillPath(undefined, 'work-logger:slack-status-writer')).toBe(real);
+  });
+});

--- a/packages/core/src/chat/__tests__/command-routing.test.ts
+++ b/packages/core/src/chat/__tests__/command-routing.test.ts
@@ -187,4 +187,25 @@ describe('ChatManager command routing', () => {
     expect(session.sendMessageCalls[0]).toBe('Hello world');
     expect(session.sendCommandCalls).toHaveLength(0);
   });
+
+  // Fix A: unknown/CLI slash commands forwarded as plain text (no sendCommand wrapping)
+  it('sends unknown slash command as plain text when no metadata is provided', async () => {
+    const { manager, session } = createManager(adapter);
+
+    await manager.sendMessage('chat-1', '/insights');
+
+    expect(session.sendMessageCalls).toHaveLength(1);
+    expect(session.sendMessageCalls[0]).toBe('/insights');
+    expect(session.sendCommandCalls).toHaveLength(0);
+  });
+
+  it('sends unknown slash command with args as plain text', async () => {
+    const { manager, session } = createManager(adapter);
+
+    await manager.sendMessage('chat-1', '/branch feature/my-feature');
+
+    expect(session.sendMessageCalls).toHaveLength(1);
+    expect(session.sendMessageCalls[0]).toBe('/branch feature/my-feature');
+    expect(session.sendCommandCalls).toHaveLength(0);
+  });
 });

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -421,6 +421,15 @@ function buildSessionSink(
       emitDisplay();
     },
 
+    onSkillLoaded(entry: { skillName: string; path: string; content: string }) {
+      const message = messages.createTransientMessage(chatId, 'system', [
+        { type: 'skill_loaded', skillName: entry.skillName, path: entry.path, content: entry.content },
+      ]);
+      messages.append(chatId, message);
+      emitEvent({ type: 'message.added', chatId, message });
+      emitDisplay();
+    },
+
     onError(error: Error) {
       emitEvent({ type: 'error', chatId, error: error.message });
     },

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -414,6 +414,13 @@ function buildSessionSink(
       emitEvent({ type: 'chat.prDetected', chatId, pr });
     },
 
+    onCliMessage(text: string) {
+      const message = messages.createTransientMessage(chatId, 'system', [{ type: 'text', text }]);
+      messages.append(chatId, message);
+      emitEvent({ type: 'message.added', chatId, message });
+      emitDisplay();
+    },
+
     onError(error: Error) {
       emitEvent({ type: 'error', chatId, error: error.message });
     },

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -379,25 +379,8 @@ function buildSessionSink(
     },
 
     onSkillFile(entry: SkillFileEntry) {
-      // Autonomous Skill-tool flows emit a tool_result containing "Launching skill:" before
-      // the isMeta skill content arrives. Slash-command flows do not, so we add an
-      // announcement message to confirm the skill was loaded.
-      const cachedMessages = messages.get(chatId) ?? [];
-      const lastMsg = cachedMessages[cachedMessages.length - 1];
-      const isAutonomousFlow =
-        lastMsg?.type === 'tool_result' &&
-        lastMsg.content.some(
-          (b) => b.type === 'tool_result' && typeof b.content === 'string' && b.content.startsWith('Launching skill:'),
-        );
-      if (!isAutonomousFlow) {
-        const announcement = messages.createTransientMessage(chatId, 'system', [
-          { type: 'text', text: `Using skill: ${entry.displayName}` },
-        ]);
-        messages.append(chatId, announcement);
-        emitEvent({ type: 'message.added', chatId, message: announcement });
-        emitDisplay();
-      }
-
+      // The SkillLoadedCard (emitted via onSkillLoaded) already tells the user
+      // which skill was loaded — no separate announcement message needed.
       if (db.chats.addSkillFile(chatId, entry)) {
         emitEvent({ type: 'context.updated', chatId });
       }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -42,7 +42,11 @@ function dailyDestination(): pino.DestinationStream {
 
 const VALID_LEVELS = new Set(['trace', 'debug', 'info', 'warn', 'error', 'fatal']);
 const rawLevel = process.env.LOG_LEVEL?.trim().toLowerCase() ?? 'info';
-const isTest = process.env.NODE_ENV === 'test';
+// Detect vitest directly — it sets VITEST=true — in addition to NODE_ENV=test,
+// because projects running vitest don't always set NODE_ENV. Without this,
+// ensureLogDir() runs at module import time and trips any test that mocks
+// node:os via vi.mock (e.g. message-loading.test.ts).
+const isTest = process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
 const isProd = process.env.NODE_ENV === 'production';
 const forceStdout = process.env['LOG_TO_STDOUT'] === 'true';
 const logLevel: pino.Level = VALID_LEVELS.has(rawLevel) ? (rawLevel as pino.Level) : 'info';

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -4,7 +4,7 @@ import type { GroupedMessage } from './message-grouping.js';
 import type { PartEntry } from './tool-grouping.js';
 import { groupToolCallParts, groupTaskChildren } from './tool-grouping.js';
 
-const INTERNAL_USER_RE = /<command-name>|<mainframe-command[\s>]/;
+const INTERNAL_USER_RE = /<mainframe-command[\s>]/;
 
 /** Returns true if a user message is internal (mainframe commands or skill invocations). */
 export function isInternalUserMessage(content: MessageContent[]): boolean {
@@ -79,13 +79,21 @@ export function convertUserContent(content: MessageContent[]): {
       if (!block.text || block.text.startsWith('[Request interrupted')) continue;
 
       const cmdInfo = parseCommandMessage(block.text);
-      if (cmdInfo) metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText };
+      if (cmdInfo) {
+        metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText };
+        metadata.cleanText = cmdInfo.userText;
+        // Synthesize a readable bubble from the CLI's <command-name>/<command-args>
+        // echo. The raw XML is pure CLI metadata — users want to see what they typed.
+        const args = cmdInfo.userText.trim();
+        const rendered = args ? `/${cmdInfo.commandName} ${args}` : `/${cmdInfo.commandName}`;
+        displayContent.push({ type: 'text', text: rendered });
+        continue;
+      }
 
       const { files, cleanText } = parseAttachedFilePathTags(block.text);
       if (files.length > 0) metadata.attachedFiles = files;
 
       const textToStore = files.length > 0 ? cleanText : block.text;
-      if (cmdInfo) metadata.cleanText = cmdInfo.userText;
 
       if (textToStore) displayContent.push({ type: 'text', text: textToStore });
     } else if (block.type === 'image') {

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -88,6 +88,8 @@ function convertGroupedToDisplay(
         type: 'system',
         content: msg.content.map((c) => {
           if (c.type === 'text') return { type: 'text' as const, text: c.text };
+          if (c.type === 'skill_loaded')
+            return { type: 'skill_loaded' as const, skillName: c.skillName, path: c.path, content: c.content };
           return { type: 'text' as const, text: '' };
         }),
         ...(msg.metadata && { metadata: { ...msg.metadata } }),

--- a/packages/core/src/plugins/builtin/claude-sdk/event-mapper.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/event-mapper.ts
@@ -2,6 +2,7 @@
 // once we're confident the SDK type contract is stable. Currently using `any` to avoid
 // tight coupling to SDK internals during initial integration.
 import type { MessageContent, SessionSink, MessageMetadata, SessionResult } from '@qlan-ro/mainframe-types';
+import { resolveSkillPath } from '../claude/skill-path.js';
 
 export function mapSdkMessage(msg: any, sink: SessionSink): void {
   switch (msg.type) {
@@ -48,6 +49,13 @@ function mapAssistantMessage(msg: any, sink: SessionSink): void {
           name: block.name,
           input: block.input as Record<string, unknown>,
         });
+        if (block.name === 'Skill') {
+          const skill = (block.input as { skill?: unknown } | undefined)?.skill;
+          if (typeof skill === 'string' && skill.trim()) {
+            const name = skill.trim();
+            sink.onSkillFile({ path: resolveSkillPath(undefined, name), displayName: name });
+          }
+        }
         break;
       case 'thinking':
         content.push({ type: 'thinking', thinking: block.thinking });
@@ -105,13 +113,12 @@ function detectPlanFiles(content: string, sink: SessionSink): void {
   }
 }
 
-function detectSkillFiles(content: string, sink: SessionSink): void {
-  const skillMatch = content.match(/Base directory for this skill:\s*(.+)/);
-  if (skillMatch?.[1]) {
-    const path = skillMatch[1].trim();
-    const displayName = path.split('/').pop() ?? path;
-    sink.onSkillFile({ path, displayName });
-  }
+// No-op: SDK path detects skills from assistant tool_use blocks (name:"Skill")
+// in mapAssistantMessage, not from user tool_result content. Left as a stub
+// so the existing call sites in mapUserMessage still compile; we'll remove
+// those call sites in a follow-up if they turn out to be truly dead.
+function detectSkillFiles(_content: string, _sink: SessionSink): void {
+  /* structured detection happens in mapAssistantMessage */
 }
 
 function mapResultMessage(msg: any, sink: SessionSink): void {

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -31,6 +31,7 @@ function createMockSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -30,6 +30,7 @@ function createMockSink(): SessionSink {
     onQueuedProcessed: vi.fn(),
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
@@ -21,6 +21,7 @@ function createMockSink(): SessionSink {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
@@ -20,6 +20,7 @@ function createMockSink(): SessionSink {
     onQueuedProcessed: vi.fn(),
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { resolveSkillPath } from './skill-path.js';
+import { resolveSkillPath, resolveExistingSkillPath, readSkillContent } from './skill-path.js';
 import type {
   ContextUsage,
   ControlRequest,
@@ -213,8 +213,29 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   // has no sendMessage() counterpart. See docs/plans/2026-02-17-unified-event-pipeline.md.
   // TODO(task-support): handle <task-notification> string content as TaskGroupCard
   const isMeta = event.isMeta === true || event.is_meta === true;
-  const message = event.message as { content: Array<Record<string, unknown>> } | undefined;
+  const message = event.message as { content: Array<Record<string, unknown>> | string } | undefined;
   if (!message?.content) return;
+
+  // User-typed /skill-name path: the CLI emits a string-content metadata
+  // event (<command-message>+<command-name>) over stream-json, but it writes
+  // the isMeta:true skill-content to JSONL only — stream-json never shows
+  // the skill body. Detect here from the <command-name> XML and read the
+  // SKILL.md off disk ourselves so the card renders live.
+  if (typeof message.content === 'string') {
+    const nameMatch = /<command-name>\/?([^<]+)<\/command-name>/.exec(message.content);
+    if (nameMatch?.[1]) {
+      const skillName = nameMatch[1].trim();
+      const cached = session.state.skillPathCache.get(skillName);
+      const skillPath = cached ?? resolveExistingSkillPath(session.projectPath, skillName);
+      if (skillPath) {
+        session.state.skillPathCache.set(skillName, skillPath);
+        const content = readSkillContent(skillPath) ?? '';
+        sink.onSkillLoaded({ skillName, path: skillPath, content });
+        sink.onSkillFile({ path: skillPath, displayName: skillName });
+      }
+    }
+    return;
+  }
 
   // Stream-json uses snake_case; JSONL uses camelCase
   const tur = (event.tool_use_result ?? event.toolUseResult) as Record<string, unknown> | undefined;

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -90,7 +90,7 @@ export function handleStdout(session: ClaudeSession, chunk: Buffer, sink: Sessio
 
   for (const line of lines) {
     if (!line.trim()) continue;
-    log.trace({ sessionId: session.id, line }, 'adapter stdout');
+    log.trace({ sessionId: session.id, line }, '[stream-json]');
     try {
       const event = JSON.parse(line.trim());
       handleEvent(session, event, sink);

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -286,18 +286,22 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       // CLI-synthesized feedback (e.g. unknown-command errors, notices).
       // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
       //
-      // Additional filter: suppress messages whose WHOLE payload is a
-      // <local-command-*> wrapper. Those tags (stdout, stderr, caveat) hold
-      // CLI-internal output fed back to the model for context, not for the
-      // user. Example: the model-picker feature sends `/model X` and gets
-      // `<local-command-stdout>Set model to X</local-command-stdout>` back.
+      // Additional suppress list — CLI-internal notifications that Mainframe
+      // either already handles via its own UI (interrupts, permissions) or that
+      // carry context for the model, not the user:
+      //   • <local-command-stdout|stderr|caveat> wrappers (e.g. /model reply)
+      //   • "[Request interrupted by user]" /
+      //     "[Request interrupted by user for tool use]"
+      //     (Claude source: utils/messages.ts:207-209)
       if (!isReplay && !isMeta) {
+        const trimmed = text.trim();
         const isLocalCommandWrapper =
           /^<local-command-(?:stdout|stderr|caveat)>[\s\S]*<\/local-command-(?:stdout|stderr|caveat)>\s*$/.test(
-            text.trim(),
+            trimmed,
           );
-        if (!isLocalCommandWrapper) {
-          sink.onCliMessage(text.trim());
+        const isInterruptMarker = /^\[Request interrupted by user[^\]]*\]\s*$/.test(trimmed);
+        if (!isLocalCommandWrapper && !isInterruptMarker) {
+          sink.onCliMessage(trimmed);
         }
       }
     }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -178,7 +178,10 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
           const input = block.input as { skill?: string } | undefined;
           const skillName = input?.skill?.trim();
           if (skillName) {
-            const resolvedPath = resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache);
+            // Use the cached path from a prior user-event (more accurate), falling back to the probe.
+            const cachedPath = session.state.skillPathCache.get(skillName);
+            const resolvedPath =
+              cachedPath ?? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache);
             sink.onSkillFile({ path: resolvedPath, displayName: skillName });
           }
         }
@@ -242,7 +245,36 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       // CLI-synthesized feedback (e.g. unknown-command errors, notices) — surface as system messages.
       // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
       if (!isReplay && !isMeta && text.trim()) {
-        sink.onCliMessage(text.trim());
+        if (text.includes('<skill-format>true</skill-format>')) {
+          // Skill injection text — parse it into a structured skill card instead of raw bubble.
+          const nameMatch = /<command-name>([^<]+)<\/command-name>/.exec(text);
+          const dirMatch = /Base directory for this skill:\s*(.+)/.exec(text);
+          const skillName = nameMatch?.[1]?.replace(/^\//, '').trim() ?? '';
+          const rawDir = dirMatch?.[1]?.trim() ?? '';
+          // Append SKILL.md if the path is a directory (no extension)
+          const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
+          // Use the path extracted from the text as primary signal; fall back to probe.
+          const finalPath =
+            resolvedPath ||
+            (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
+
+          // Cache the authoritative path for future tool_use lookups.
+          if (skillName && finalPath) {
+            session.state.skillPathCache.set(skillName, finalPath);
+          }
+
+          // Strip the three tag lines + base-dir line; keep remaining markdown.
+          const content = text
+            .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
+            .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
+            .replace(/Base directory for this skill:[^\n]*\n?/, '')
+            .trim();
+
+          sink.onSkillLoaded({ skillName, path: finalPath, content });
+          sink.onSkillFile({ path: finalPath, displayName: skillName });
+        } else {
+          sink.onCliMessage(text.trim());
+        }
       }
     }
   }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
+import { resolveSkillPath } from './skill-path.js';
 import type {
   ContextUsage,
   ControlRequest,
   ControlUpdate,
   MessageContent,
   SessionSink,
+  SkillFileEntry,
 } from '@qlan-ro/mainframe-types';
 import type { ClaudeSession } from './session.js';
 import { buildToolResultBlocks } from './history.js';
@@ -172,6 +174,14 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
             session.state.pendingPrCreates.add(block.id as string);
           }
         }
+        if (name === 'Skill') {
+          const input = block.input as { skill?: string } | undefined;
+          const skillName = input?.skill?.trim();
+          if (skillName) {
+            const resolvedPath = resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache);
+            sink.onSkillFile({ path: resolvedPath, displayName: skillName });
+          }
+        }
       }
     }
 
@@ -191,12 +201,15 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   }
 
   // Live stream handles ONLY tool_result blocks from user events.
-  // Text/image blocks in user entries are intentionally ignored here because:
-  //   - User-typed text: already created as a ChatMessage by chat-manager.sendMessage()
-  //   - Image blocks: not surfaced in live mode (no UX for them)
+  // Text blocks in user entries are ignored when isReplay (user-typed text already created
+  // by chat-manager.sendMessage()) or when isMeta (CLI-internal command wrappers like
+  // <local-command-caveat>). Text blocks that are neither are CLI-synthesized feedback
+  // messages (e.g. "Unknown command: /foo. Did you mean /bar?") and ARE surfaced.
+  // Image blocks: not surfaced in live mode (no UX for them).
   // History loading (convertUserEntry) reconstructs these from JSONL since it
   // has no sendMessage() counterpart. See docs/plans/2026-02-17-unified-event-pipeline.md.
   // TODO(task-support): handle <task-notification> string content as TaskGroupCard
+  const isMeta = event.isMeta === true || event.is_meta === true;
   const message = event.message as { content: Array<Record<string, unknown>> } | undefined;
   if (!message?.content) return;
 
@@ -226,23 +239,11 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       }
     } else if (block.type === 'text') {
       const text = (block.text as string) || '';
-      const skillMatch = text.match(/^Base directory for this skill: (.+)/m);
-      if (skillMatch?.[1]) {
-        const basePath = skillMatch[1].trim();
-        const skillPath = path.join(basePath, 'SKILL.md');
-        const skillName = basePath.split('/').pop() ?? basePath;
-        sink.onSkillFile({ path: skillPath, displayName: skillName });
+      // CLI-synthesized feedback (e.g. unknown-command errors, notices) — surface as system messages.
+      // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
+      if (!isReplay && !isMeta && text.trim()) {
+        sink.onCliMessage(text.trim());
       }
-    }
-  }
-  const rawContent = (event.message as Record<string, unknown>)?.content;
-  if (typeof rawContent === 'string') {
-    const skillMatch = rawContent.match(/^Base directory for this skill: (.+)/m);
-    if (skillMatch?.[1]) {
-      const basePath = skillMatch[1].trim();
-      const skillPath = path.join(basePath, 'SKILL.md');
-      const skillName = basePath.split('/').pop() ?? basePath;
-      sink.onSkillFile({ path: skillPath, displayName: skillName });
     }
   }
 }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -285,8 +285,20 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
 
       // CLI-synthesized feedback (e.g. unknown-command errors, notices).
       // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
+      //
+      // Additional filter: suppress messages whose WHOLE payload is a
+      // <local-command-*> wrapper. Those tags (stdout, stderr, caveat) hold
+      // CLI-internal output fed back to the model for context, not for the
+      // user. Example: the model-picker feature sends `/model X` and gets
+      // `<local-command-stdout>Set model to X</local-command-stdout>` back.
       if (!isReplay && !isMeta) {
-        sink.onCliMessage(text.trim());
+        const isLocalCommandWrapper =
+          /^<local-command-(?:stdout|stderr|caveat)>[\s\S]*<\/local-command-(?:stdout|stderr|caveat)>\s*$/.test(
+            text.trim(),
+          );
+        if (!isLocalCommandWrapper) {
+          sink.onCliMessage(text.trim());
+        }
       }
     }
   }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -242,49 +242,51 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       }
     } else if (block.type === 'text') {
       const text = (block.text as string) || '';
-      // CLI-synthesized feedback (e.g. unknown-command errors, notices) — surface as system messages.
-      // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
-      if (!isReplay && !isMeta && text.trim()) {
-        // Two skill-injection shapes:
-        //   (A) <skill-format>true</skill-format> marker — model-initiated SkillTool
-        //       output + subagent skill preloads (via runAgent formatter).
-        //   (B) Text starting with "Base directory for this skill: <path>" — the
-        //       user-typed /skill-name path, which the CLI injects as a follow-up
-        //       user text block with NO skill-format tag. Authoritative path is
-        //       the first line; skill name is the last segment of the path.
-        const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
-        const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
-        const isSkillInjection = hasSkillFormat || Boolean(baseDirMatch);
+      if (!text.trim()) continue;
 
-        if (isSkillInjection) {
-          const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
-          const rawDir = baseDirMatch?.[1]?.trim() ?? '';
-          // Derive skill name from the path's last segment when the XML tag
-          // isn't present (shape B). For plugin skills the last segment is
-          // still the skill's short name, which is what the display expects.
-          const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
-          // Append SKILL.md if the path is a directory (no extension).
-          const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
-          const finalPath =
-            resolvedPath ||
-            (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
+      // Skill injection — must be checked regardless of isReplay/isMeta.
+      // The CLI marks the skill-content user message as isMeta: true for
+      // user-typed /skill-name (processSlashCommand.tsx:905-907), so
+      // filtering isMeta out first would miss it entirely.
+      //
+      // Two shapes:
+      //   (A) <skill-format>true</skill-format> — model-initiated SkillTool
+      //       output + subagent preloads
+      //   (B) Text starting with "Base directory for this skill: <path>" —
+      //       user-typed /skill-name injection (isMeta: true, no XML tag)
+      const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
+      const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
+      const isSkillInjection = hasSkillFormat || Boolean(baseDirMatch);
 
-          if (skillName && finalPath) {
-            session.state.skillPathCache.set(skillName, finalPath);
-          }
+      if (isSkillInjection) {
+        const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
+        const rawDir = baseDirMatch?.[1]?.trim() ?? '';
+        const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
+        const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
+        const finalPath =
+          resolvedPath ||
+          (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
 
-          const content = text
-            .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
-            .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
-            .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
-            .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
-            .trim();
-
-          sink.onSkillLoaded({ skillName, path: finalPath, content });
-          sink.onSkillFile({ path: finalPath, displayName: skillName });
-        } else {
-          sink.onCliMessage(text.trim());
+        if (skillName && finalPath) {
+          session.state.skillPathCache.set(skillName, finalPath);
         }
+
+        const content = text
+          .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
+          .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
+          .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
+          .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
+          .trim();
+
+        sink.onSkillLoaded({ skillName, path: finalPath, content });
+        sink.onSkillFile({ path: finalPath, displayName: skillName });
+        continue;
+      }
+
+      // CLI-synthesized feedback (e.g. unknown-command errors, notices).
+      // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
+      if (!isReplay && !isMeta) {
+        sink.onCliMessage(text.trim());
       }
     }
   }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -245,29 +245,39 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       // CLI-synthesized feedback (e.g. unknown-command errors, notices) — surface as system messages.
       // Discriminator: not a replay of user-typed text AND not a CLI meta wrapper.
       if (!isReplay && !isMeta && text.trim()) {
-        if (text.includes('<skill-format>true</skill-format>')) {
-          // Skill injection text — parse it into a structured skill card instead of raw bubble.
-          const nameMatch = /<command-name>([^<]+)<\/command-name>/.exec(text);
-          const dirMatch = /Base directory for this skill:\s*(.+)/.exec(text);
-          const skillName = nameMatch?.[1]?.replace(/^\//, '').trim() ?? '';
-          const rawDir = dirMatch?.[1]?.trim() ?? '';
-          // Append SKILL.md if the path is a directory (no extension)
+        // Two skill-injection shapes:
+        //   (A) <skill-format>true</skill-format> marker — model-initiated SkillTool
+        //       output + subagent skill preloads (via runAgent formatter).
+        //   (B) Text starting with "Base directory for this skill: <path>" — the
+        //       user-typed /skill-name path, which the CLI injects as a follow-up
+        //       user text block with NO skill-format tag. Authoritative path is
+        //       the first line; skill name is the last segment of the path.
+        const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
+        const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
+        const isSkillInjection = hasSkillFormat || Boolean(baseDirMatch);
+
+        if (isSkillInjection) {
+          const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
+          const rawDir = baseDirMatch?.[1]?.trim() ?? '';
+          // Derive skill name from the path's last segment when the XML tag
+          // isn't present (shape B). For plugin skills the last segment is
+          // still the skill's short name, which is what the display expects.
+          const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
+          // Append SKILL.md if the path is a directory (no extension).
           const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
-          // Use the path extracted from the text as primary signal; fall back to probe.
           const finalPath =
             resolvedPath ||
             (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
 
-          // Cache the authoritative path for future tool_use lookups.
           if (skillName && finalPath) {
             session.state.skillPathCache.set(skillName, finalPath);
           }
 
-          // Strip the three tag lines + base-dir line; keep remaining markdown.
           const content = text
+            .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
             .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
             .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
-            .replace(/Base directory for this skill:[^\n]*\n?/, '')
+            .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
             .trim();
 
           sink.onSkillLoaded({ skillName, path: finalPath, content });

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -233,6 +233,16 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
         sink.onSkillLoaded({ skillName, path: skillPath, content });
         sink.onSkillFile({ path: skillPath, displayName: skillName });
       }
+      return;
+    }
+
+    // Any other string-content user event is CLI feedback that doesn't belong
+    // to a skill/command echo — e.g. "Unknown command: /foo". Surface it as a
+    // system pill so the user sees why their input had no effect. The user's
+    // original text already exists as a transient from chat-manager.sendMessage.
+    if (!isReplay && !isMeta) {
+      const trimmed = message.content.trim();
+      if (trimmed) sink.onCliMessage(trimmed);
     }
     return;
   }
@@ -373,6 +383,17 @@ function handleControlResponseEvent(session: ClaudeSession, event: Record<string
 }
 
 function handleResultEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
+  // Surface CLI slash-command errors that reach us only via the `result`
+  // event. When `shouldQuery: false` (unknown /cmd, bad /cmd args), the CLI
+  // filters the "Unknown skill: /X" user message out of stream-json
+  // (QueryEngine.ts:556-605 only yields <local-command-stdout|stderr> entries)
+  // but the error text survives on `result.result`. We forward it as a
+  // system pill so the user sees why their input had no effect.
+  const resultText = typeof event.result === 'string' ? event.result.trim() : '';
+  if (resultText && /^Unknown (command|skill):/i.test(resultText)) {
+    sink.onCliMessage(resultText);
+  }
+
   const lastUsage = session.state.lastAssistantUsage;
   const usage =
     lastUsage ??

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -34,6 +34,39 @@ const log = createChildLogger('claude:history');
  * synthesize a transient system message with a `skill_loaded` block so
  * SkillLoadedCard renders on history replay.
  */
+/**
+ * "Unknown command: /X" user entries are CLI feedback — the CLI never writes
+ * the original user-typed /X to JSONL, so on replay the typed bubble is lost.
+ * Synthesize both components: the invocation bubble and the error pill, so
+ * history mirrors what the user saw live.
+ */
+function synthesizeUnknownCommandFromUserEntry(entry: Record<string, unknown>, chatId: string): ChatMessage[] | null {
+  const message = entry.message as { content?: unknown } | undefined;
+  const content = message?.content;
+  if (typeof content !== 'string') return null;
+  const match = /^Unknown command:\s+(\/\S+)/.exec(content.trim());
+  if (!match?.[1]) return null;
+  const cmd = match[1];
+  const uuid = (entry.uuid as string) ?? nanoid();
+  const timestamp = (entry.timestamp as string) ?? new Date().toISOString();
+  return [
+    {
+      id: `unknown-cmd-user-${uuid}`,
+      chatId,
+      type: 'user',
+      content: [{ type: 'text', text: cmd }],
+      timestamp,
+    },
+    {
+      id: `unknown-cmd-err-${uuid}`,
+      chatId,
+      type: 'system',
+      content: [{ type: 'text', text: content.trim() }],
+      timestamp,
+    },
+  ];
+}
+
 function synthesizeSkillLoadedFromUserEntry(entry: Record<string, unknown>, chatId: string): ChatMessage | null {
   const message = entry.message as { content?: unknown } | undefined;
   const content = message?.content;
@@ -413,6 +446,20 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
 
           if (entry.isMeta === true) continue;
           if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) continue;
+
+          // "Unknown command: /X" — CLI feedback for slash commands that don't
+          // resolve. Split into invocation bubble + error pill on replay.
+          if (entry.type === 'user') {
+            const synthesized = synthesizeUnknownCommandFromUserEntry(entry, sessionId);
+            if (synthesized) {
+              for (const m of synthesized) {
+                if (seenUuids.has(m.id)) continue;
+                seenUuids.add(m.id);
+                messages.push(m);
+              }
+              continue;
+            }
+          }
 
           // Collect tool_use blocks from agent_progress events
           if (entry.type === 'progress' && entry.data?.type === 'agent_progress') {

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -22,17 +22,7 @@ export function deriveModifiedFile(
   return undefined;
 }
 
-function extractSkillPathFromText(content: Array<Record<string, unknown>>): string | null {
-  for (const block of content) {
-    if (block.type !== 'text') continue;
-    const text = block.text as string;
-    const match = text.match(/^Base directory for this skill: (.+)/);
-    if (match?.[1]) {
-      return path.join(match[1].trim(), 'SKILL.md');
-    }
-  }
-  return null;
-}
+import { resolveSkillPath } from './skill-path.js';
 
 function extractToolResultContent(content: unknown): string {
   if (typeof content === 'string') return content;
@@ -462,7 +452,15 @@ export async function extractSkillFilePaths(sessionId: string, projectPath: stri
   const { allFiles: jsonlFiles } = await discoverSessionJsonlFiles(sessionId, projectPath);
   if (jsonlFiles.length === 0) return [];
 
+  const seen = new Set<string>();
+  const cache = new Map<string, string>();
   const skillFiles: SkillFileEntry[] = [];
+  const push = (name: string): void => {
+    const trimmed = name.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    skillFiles.push({ path: resolveSkillPath(projectPath, trimmed, cache), displayName: trimmed });
+  };
 
   for (const file of jsonlFiles) {
     const stream = createReadStream(file);
@@ -472,15 +470,14 @@ export async function extractSkillFilePaths(sessionId: string, projectPath: stri
         if (!line.trim()) continue;
         try {
           const entry = JSON.parse(line);
-          if (entry.type !== 'user' || entry.isMeta !== true) continue;
+          if (entry.type !== 'assistant') continue;
           const content = entry.message?.content;
           if (!Array.isArray(content)) continue;
-          const skillPath = extractSkillPathFromText(content);
-          if (skillPath) {
-            const segments = skillPath.split('/');
-            const file = segments.pop() ?? skillPath;
-            const displayName = file === 'SKILL.md' && segments.length > 0 ? segments.pop()! : file;
-            skillFiles.push({ path: skillPath, displayName });
+          for (const block of content) {
+            if (block?.type === 'tool_use' && block.name === 'Skill') {
+              const skill = (block.input as { skill?: unknown } | undefined)?.skill;
+              if (typeof skill === 'string' && skill) push(skill);
+            }
           }
         } catch {
           /* skip malformed */

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -44,9 +44,14 @@ function synthesizeUnknownCommandFromUserEntry(entry: Record<string, unknown>, c
   const message = entry.message as { content?: unknown } | undefined;
   const content = message?.content;
   if (typeof content !== 'string') return null;
-  const match = /^Unknown command:\s+(\/\S+)/.exec(content.trim());
+  // Match both CLI error variants. "Unknown command:" comes from the
+  // MalformedCommandError path (processSlashCommand.tsx:820) and retains the
+  // leading slash. "Unknown skill:" comes from the !hasCommand path
+  // (processSlashCommand.tsx:347) and omits the slash — we add it back so the
+  // synthesized user bubble consistently reads like "/foo".
+  const match = /^Unknown (?:command|skill):\s+\/?(\S+)/.exec(content.trim());
   if (!match?.[1]) return null;
-  const cmd = match[1];
+  const cmd = `/${match[1]}`;
   const uuid = (entry.uuid as string) ?? nanoid();
   const timestamp = (entry.timestamp as string) ?? new Date().toISOString();
   return [

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -24,6 +24,35 @@ export function deriveModifiedFile(
 
 import { resolveSkillPath } from './skill-path.js';
 
+/**
+ * isMeta user entries whose first text block starts with
+ * "Base directory for this skill: <dir>" are the CLI's skill-content
+ * injections. We keep them out of the chat transcript (as before) but
+ * synthesize a transient system message with a `skill_loaded` block so
+ * SkillLoadedCard renders on history replay.
+ */
+function synthesizeSkillLoadedFromUserEntry(entry: Record<string, unknown>, chatId: string): ChatMessage | null {
+  const message = entry.message as { content?: unknown } | undefined;
+  const content = message?.content;
+  if (!Array.isArray(content) || content.length === 0) return null;
+  const first = content[0] as { type?: string; text?: string } | undefined;
+  if (first?.type !== 'text' || typeof first.text !== 'string') return null;
+  const match = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(first.text);
+  if (!match?.[1]) return null;
+  const baseDir = match[1].trim();
+  const skillName = path.basename(baseDir);
+  const skillPath = path.extname(baseDir) ? baseDir : path.join(baseDir, 'SKILL.md');
+  const skillContent = first.text.replace(/^Base directory for this skill:[^\n]*\n?/m, '').trim();
+  const uuid = (entry.uuid as string) ?? nanoid();
+  return {
+    id: `skill-loaded-${uuid}`,
+    chatId,
+    type: 'system',
+    content: [{ type: 'skill_loaded', skillName, path: skillPath, content: skillContent }],
+    timestamp: (entry.timestamp as string) ?? new Date().toISOString(),
+  };
+}
+
 function extractToolResultContent(content: unknown): string {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
@@ -370,6 +399,23 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
         if (!line.trim()) continue;
         try {
           const entry = JSON.parse(line);
+
+          // isMeta user messages carrying skill content are written to JSONL
+          // only (never emitted over stream-json), so history replay is the
+          // only chance to surface a SkillLoadedCard for these turns. Detect
+          // and synthesize a system 'skill_loaded' message BEFORE the generic
+          // isMeta filter drops them below.
+          if (entry.isMeta === true && entry.type === 'user') {
+            const synthesized = synthesizeSkillLoadedFromUserEntry(entry, sessionId);
+            if (synthesized) {
+              if (!seenUuids.has(synthesized.id)) {
+                seenUuids.add(synthesized.id);
+                messages.push(synthesized);
+              }
+              continue;
+            }
+          }
+
           if (entry.isMeta === true) continue;
           if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) continue;
 

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -23,6 +23,9 @@ export function deriveModifiedFile(
 }
 
 import { resolveSkillPath } from './skill-path.js';
+import { createChildLogger } from '../../../logger.js';
+
+const log = createChildLogger('claude:history');
 
 /**
  * isMeta user entries whose first text block starts with
@@ -232,15 +235,6 @@ export function convertHistoryEntry(entry: Record<string, unknown>, chatId: stri
   return null;
 }
 
-export function filterSkillExpansions(messages: ChatMessage[]): ChatMessage[] {
-  return messages.filter((msg) => {
-    if (msg.type !== 'user') return true;
-    // Filter slash-command invocation markers — they contain <command-name> tags and
-    // are purely CLI metadata that should never appear in the rendered conversation.
-    return !msg.content.some((b) => b.type === 'text' && /<command-name>/.test((b as { text: string }).text));
-  });
-}
-
 function collectAgentProgressTools(entry: Record<string, unknown>, agentTools: Map<string, MessageContent[]>): void {
   const parentId = entry.parentToolUseID as string | undefined;
   if (!parentId) return;
@@ -397,6 +391,7 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
       const rl = createInterface({ input: stream, crlfDelay: Infinity });
       for await (const line of rl) {
         if (!line.trim()) continue;
+        log.trace({ sessionId, file, line }, '[jsonl]');
         try {
           const entry = JSON.parse(line);
 
@@ -459,7 +454,7 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
     attachSubagentToolResults(messages, subagentToolResults);
   }
 
-  return filterSkillExpansions(messages);
+  return messages;
 }
 
 export async function extractPlanFilePaths(sessionId: string, projectPath: string): Promise<string[]> {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -44,6 +44,7 @@ const nullSink: SessionSink = {
   onTodoUpdate: () => {},
   onPrDetected: () => {},
   onCliMessage: () => {},
+  onSkillLoaded: () => {},
 };
 
 export interface ClaudeSessionState {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -43,6 +43,7 @@ const nullSink: SessionSink = {
   onQueuedProcessed: () => {},
   onTodoUpdate: () => {},
   onPrDetected: () => {},
+  onCliMessage: () => {},
 };
 
 export interface ClaudeSessionState {
@@ -63,6 +64,9 @@ export interface ClaudeSessionState {
   pendingCancelCallbacks: Map<string, (cancelled: boolean) => void>;
   /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
   pendingPrCreates: Set<string>;
+  // Cached skill-name → resolved SKILL.md path, populated lazily on SkillTool
+  // detection to avoid re-probing the filesystem for the same skill.
+  skillPathCache: Map<string, string>;
 }
 
 /**
@@ -105,6 +109,7 @@ export class ClaudeSession implements AdapterSession {
       interruptTimer: null,
       pendingCancelCallbacks: new Map(),
       pendingPrCreates: new Set(),
+      skillPathCache: new Map(),
     };
   }
 

--- a/packages/core/src/plugins/builtin/claude/skill-path.ts
+++ b/packages/core/src/plugins/builtin/claude/skill-path.ts
@@ -9,24 +9,36 @@ import { accessSync, readdirSync, readFileSync } from 'node:fs';
  * to fire skill detection if a real skill file exists.
  */
 export function resolveExistingSkillPath(projectPath: string | undefined, skillName: string): string | null {
+  // `plugin:skill` qualifies the skill under a specific plugin. Split so we
+  // probe the plugin dir by name, not the full qualified string.
+  const colonIdx = skillName.indexOf(':');
+  const pluginPrefix = colonIdx >= 0 ? skillName.slice(0, colonIdx) : null;
+  const leafName = colonIdx >= 0 ? skillName.slice(colonIdx + 1) : skillName;
+
   const candidates: string[] = [];
-  if (projectPath) {
-    candidates.push(path.join(projectPath, '.claude', 'skills', skillName, 'SKILL.md'));
-  }
-  candidates.push(path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md'));
 
-  const pluginsDir = path.join(homedir(), '.claude', 'plugins');
-  try {
-    for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        candidates.push(path.join(pluginsDir, entry.name, 'skills', skillName, 'SKILL.md'));
-      }
+  // Plain (unqualified) skills: project → user home → every plugin dir.
+  if (!pluginPrefix) {
+    if (projectPath) {
+      candidates.push(path.join(projectPath, '.claude', 'skills', leafName, 'SKILL.md'));
     }
-  } catch {
-    /* no plugins dir */
+    candidates.push(path.join(homedir(), '.claude', 'skills', leafName, 'SKILL.md'));
+
+    const pluginsDir = path.join(homedir(), '.claude', 'plugins');
+    try {
+      for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          candidates.push(path.join(pluginsDir, entry.name, 'skills', leafName, 'SKILL.md'));
+        }
+      }
+    } catch {
+      /* no plugins dir */
+    }
   }
 
-  // Plugin cache path: ~/.claude/plugins/cache/<owner>-plugins-marketplace/<plugin>/<version>/skills/<name>/SKILL.md
+  // Plugin-qualified skills: look up the prefix. Unqualified also falls into
+  // the cache walker below so a bare name can still be found there.
+  // Cache layout: ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/<name>/SKILL.md
   const cacheDir = path.join(homedir(), '.claude', 'plugins', 'cache');
   try {
     for (const marketplace of readdirSync(cacheDir, { withFileTypes: true })) {
@@ -34,15 +46,32 @@ export function resolveExistingSkillPath(projectPath: string | undefined, skillN
       const marketDir = path.join(cacheDir, marketplace.name);
       for (const plugin of readdirSync(marketDir, { withFileTypes: true })) {
         if (!plugin.isDirectory()) continue;
+        if (pluginPrefix && plugin.name !== pluginPrefix) continue;
         const pluginDir = path.join(marketDir, plugin.name);
         for (const version of readdirSync(pluginDir, { withFileTypes: true })) {
           if (!version.isDirectory()) continue;
-          candidates.push(path.join(pluginDir, version.name, 'skills', skillName, 'SKILL.md'));
+          candidates.push(path.join(pluginDir, version.name, 'skills', leafName, 'SKILL.md'));
         }
       }
     }
   } catch {
     /* no cache dir */
+  }
+
+  // Also check non-cache plugin dirs for plugin-qualified skills.
+  if (pluginPrefix) {
+    const pluginsDir = path.join(homedir(), '.claude', 'plugins');
+    try {
+      for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+        if (!entry.isDirectory() || entry.name === 'cache') continue;
+        // Match either exact plugin-name dir or "<plugin>-plugin" convention.
+        if (entry.name === pluginPrefix || entry.name === `${pluginPrefix}-plugin`) {
+          candidates.push(path.join(pluginsDir, entry.name, 'skills', leafName, 'SKILL.md'));
+        }
+      }
+    } catch {
+      /* no plugins dir */
+    }
   }
 
   for (const candidate of candidates) {

--- a/packages/core/src/plugins/builtin/claude/skill-path.ts
+++ b/packages/core/src/plugins/builtin/claude/skill-path.ts
@@ -2,6 +2,16 @@ import path from 'node:path';
 import { homedir } from 'node:os';
 import { accessSync, readdirSync, readFileSync } from 'node:fs';
 
+// Claude CLI only accepts slash-command names matching /^[a-zA-Z0-9:_-]+$/
+// (processSlashCommand.tsx:307). Mirror that here so any skillName we feed
+// into path.join cannot contain "..", "/", or other path-traversal metachars.
+// Plugin-qualified names use a single colon, e.g. "work-logger:slack-writer".
+const VALID_SKILL_NAME_RE = /^[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?$/;
+
+function isValidSkillName(name: string): boolean {
+  return VALID_SKILL_NAME_RE.test(name);
+}
+
 /**
  * Like resolveSkillPath but returns null when no SKILL.md is found on disk.
  * Use when you need to distinguish "genuine skill invocation" from "some other
@@ -9,6 +19,7 @@ import { accessSync, readdirSync, readFileSync } from 'node:fs';
  * to fire skill detection if a real skill file exists.
  */
 export function resolveExistingSkillPath(projectPath: string | undefined, skillName: string): string | null {
+  if (!isValidSkillName(skillName)) return null;
   // `plugin:skill` qualifies the skill under a specific plugin. Split so we
   // probe the plugin dir by name, not the full qualified string.
   const colonIdx = skillName.indexOf(':');
@@ -115,37 +126,24 @@ export function resolveSkillPath(
   const cached = cache?.get(skillName);
   if (cached) return cached;
 
-  const candidates: string[] = [];
-  if (projectPath) {
-    candidates.push(path.join(projectPath, '.claude', 'skills', skillName, 'SKILL.md'));
-  }
-  candidates.push(path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md'));
-
-  const pluginsDir = path.join(homedir(), '.claude', 'plugins');
-  try {
-    for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        candidates.push(path.join(pluginsDir, entry.name, 'skills', skillName, 'SKILL.md'));
-      }
-    }
-  } catch {
-    /* no plugins dir — expected on fresh installs */
+  // Defer to the validating/plugin-aware probe — handles plugin:skill,
+  // the marketplace cache layout, and name validation in one place.
+  const existing = resolveExistingSkillPath(projectPath, skillName);
+  if (existing) {
+    cache?.set(skillName, existing);
+    return existing;
   }
 
-  for (const candidate of candidates) {
-    try {
-      accessSync(candidate);
-      cache?.set(skillName, candidate);
-      return candidate;
-    } catch {
-      /* not at this location, try next */
-    }
+  // Nothing on disk — fall back to a conventional path so Context can still
+  // show the name. Use the leaf for plugin-qualified names to avoid a colon
+  // in the directory path (which macOS/Linux allow but looks broken).
+  if (!isValidSkillName(skillName)) {
+    // Invalid input — return a harmless sentinel that won't resolve anywhere.
+    return '';
   }
-
-  // Nothing on disk — fall back to the user-home convention so Context shows
-  // the name without a broken-looking empty field. ContextFileItem renders a
-  // "file not found" state on click, which is honest.
-  const fallback = path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md');
+  const colonIdx = skillName.indexOf(':');
+  const leafName = colonIdx >= 0 ? skillName.slice(colonIdx + 1) : skillName;
+  const fallback = path.join(homedir(), '.claude', 'skills', leafName, 'SKILL.md');
   cache?.set(skillName, fallback);
   return fallback;
 }

--- a/packages/core/src/plugins/builtin/claude/skill-path.ts
+++ b/packages/core/src/plugins/builtin/claude/skill-path.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import { homedir } from 'node:os';
+import { accessSync, readdirSync } from 'node:fs';
+
+// Resolve a skill name to its SKILL.md by probing the three locations the
+// Claude CLI supports, in priority order: project-local > user > plugin.
+// The CLI does not expose a resolved path over stream-json — control_request
+// `reload_plugins` returns command names only — so probing is unavoidable.
+// Result is cached per session to keep this to one probe per unique skill.
+//
+// Kept in its own module (no logger dep) so it can be imported from both
+// `events.ts` and `history.ts` without creating a module-init cycle that
+// would fire `homedir()` during logger bootstrap.
+export function resolveSkillPath(
+  projectPath: string | undefined,
+  skillName: string,
+  cache?: Map<string, string>,
+): string {
+  const cached = cache?.get(skillName);
+  if (cached) return cached;
+
+  const candidates: string[] = [];
+  if (projectPath) {
+    candidates.push(path.join(projectPath, '.claude', 'skills', skillName, 'SKILL.md'));
+  }
+  candidates.push(path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md'));
+
+  const pluginsDir = path.join(homedir(), '.claude', 'plugins');
+  try {
+    for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        candidates.push(path.join(pluginsDir, entry.name, 'skills', skillName, 'SKILL.md'));
+      }
+    }
+  } catch {
+    /* no plugins dir — expected on fresh installs */
+  }
+
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate);
+      cache?.set(skillName, candidate);
+      return candidate;
+    } catch {
+      /* not at this location, try next */
+    }
+  }
+
+  // Nothing on disk — fall back to the user-home convention so Context shows
+  // the name without a broken-looking empty field. ContextFileItem renders a
+  // "file not found" state on click, which is honest.
+  const fallback = path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md');
+  cache?.set(skillName, fallback);
+  return fallback;
+}

--- a/packages/core/src/plugins/builtin/claude/skill-path.ts
+++ b/packages/core/src/plugins/builtin/claude/skill-path.ts
@@ -1,6 +1,69 @@
 import path from 'node:path';
 import { homedir } from 'node:os';
-import { accessSync, readdirSync } from 'node:fs';
+import { accessSync, readdirSync, readFileSync } from 'node:fs';
+
+/**
+ * Like resolveSkillPath but returns null when no SKILL.md is found on disk.
+ * Use when you need to distinguish "genuine skill invocation" from "some other
+ * slash command that happens to share a name pattern" — the caller only wants
+ * to fire skill detection if a real skill file exists.
+ */
+export function resolveExistingSkillPath(projectPath: string | undefined, skillName: string): string | null {
+  const candidates: string[] = [];
+  if (projectPath) {
+    candidates.push(path.join(projectPath, '.claude', 'skills', skillName, 'SKILL.md'));
+  }
+  candidates.push(path.join(homedir(), '.claude', 'skills', skillName, 'SKILL.md'));
+
+  const pluginsDir = path.join(homedir(), '.claude', 'plugins');
+  try {
+    for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        candidates.push(path.join(pluginsDir, entry.name, 'skills', skillName, 'SKILL.md'));
+      }
+    }
+  } catch {
+    /* no plugins dir */
+  }
+
+  // Plugin cache path: ~/.claude/plugins/cache/<owner>-plugins-marketplace/<plugin>/<version>/skills/<name>/SKILL.md
+  const cacheDir = path.join(homedir(), '.claude', 'plugins', 'cache');
+  try {
+    for (const marketplace of readdirSync(cacheDir, { withFileTypes: true })) {
+      if (!marketplace.isDirectory()) continue;
+      const marketDir = path.join(cacheDir, marketplace.name);
+      for (const plugin of readdirSync(marketDir, { withFileTypes: true })) {
+        if (!plugin.isDirectory()) continue;
+        const pluginDir = path.join(marketDir, plugin.name);
+        for (const version of readdirSync(pluginDir, { withFileTypes: true })) {
+          if (!version.isDirectory()) continue;
+          candidates.push(path.join(pluginDir, version.name, 'skills', skillName, 'SKILL.md'));
+        }
+      }
+    }
+  } catch {
+    /* no cache dir */
+  }
+
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate);
+      return candidate;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+/** Read SKILL.md content synchronously; returns null if unreadable. */
+export function readSkillContent(skillPath: string): string | null {
+  try {
+    return readFileSync(skillPath, 'utf8');
+  } catch {
+    return null;
+  }
+}
 
 // Resolve a skill name to its SKILL.md by probing the three locations the
 // Claude CLI supports, in priority order: project-local > user > plugin.

--- a/packages/core/src/plugins/builtin/claude/skill-path.ts
+++ b/packages/core/src/plugins/builtin/claude/skill-path.ts
@@ -85,10 +85,14 @@ export function resolveExistingSkillPath(projectPath: string | undefined, skillN
   return null;
 }
 
-/** Read SKILL.md content synchronously; returns null if unreadable. */
+/** Read SKILL.md content synchronously, stripping any leading YAML frontmatter
+ * so the markdown renderer doesn't emit `<hr>` + `name: …` lines. Returns null
+ * if unreadable. Matches what the history path does (history's skillContent
+ * comes from the CLI-expanded isMeta body which has no frontmatter). */
 export function readSkillContent(skillPath: string): string | null {
   try {
-    return readFileSync(skillPath, 'utf8');
+    const raw = readFileSync(skillPath, 'utf8');
+    return raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '').trim();
   } catch {
     return null;
   }

--- a/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
@@ -19,6 +19,7 @@ const NULL_SINK: SessionSink = {
   onTodoUpdate: vi.fn(),
   onPrDetected: vi.fn(),
   onCliMessage: vi.fn(),
+  onSkillLoaded: vi.fn(),
 };
 
 describe('Codex plan item capture', () => {

--- a/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
@@ -18,6 +18,7 @@ const NULL_SINK: SessionSink = {
   onQueuedProcessed: vi.fn(),
   onTodoUpdate: vi.fn(),
   onPrDetected: vi.fn(),
+  onCliMessage: vi.fn(),
 };
 
 describe('Codex plan item capture', () => {

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
@@ -19,6 +19,7 @@ function mkSink(onPermissionSpy = vi.fn()) {
     onQueuedProcessed: vi.fn(),
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
@@ -20,6 +20,7 @@ function mkSink(onPermissionSpy = vi.fn()) {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
@@ -18,6 +18,7 @@ function mkSink() {
     onQueuedProcessed: vi.fn(),
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
@@ -19,6 +19,7 @@ function mkSink() {
     onTodoUpdate: vi.fn(),
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -51,6 +51,7 @@ const nullSink: SessionSink = {
   onTodoUpdate: () => {},
   onPrDetected: () => {},
   onCliMessage: () => {},
+  onSkillLoaded: () => {},
 };
 
 export class CodexSession implements AdapterSession {

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -50,6 +50,7 @@ const nullSink: SessionSink = {
   onQueuedProcessed: () => {},
   onTodoUpdate: () => {},
   onPrDetected: () => {},
+  onCliMessage: () => {},
 };
 
 export class CodexSession implements AdapterSession {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
@@ -225,9 +225,14 @@ export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeP
 
       const commandMatch = userText.match(/^\/(\S+)/);
       const matchedCommand = commandMatch ? commands.find((c) => c.name === commandMatch[1]) : undefined;
-      const metadata = matchedCommand
-        ? { command: { name: matchedCommand.name, source: matchedCommand.source } }
-        : undefined;
+      // Only set metadata for mainframe-sourced commands (which need XML wrapping).
+      // CLI-native slash commands (e.g. /compact, /insights, /branch) and unknown ones
+      // are forwarded as plain user text so the CLI's own processUserInput handles them,
+      // including "Unknown command: X" feedback for typos.
+      const metadata =
+        matchedCommand?.source === 'mainframe'
+          ? { command: { name: matchedCommand.name, source: matchedCommand.source } }
+          : undefined;
 
       try {
         setComposerError(null);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -52,15 +52,29 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
       };
     }
 
-    case 'system':
+    case 'system': {
+      // Skill-loaded blocks are passed through message metadata so the SystemMessage
+      // component can render a SkillLoadedCard rather than a plain text bubble.
+      const skillBlock = message.content.find(
+        (c): c is DisplayContent & { type: 'skill_loaded' } => c.type === 'skill_loaded',
+      );
+      const textParts = message.content
+        .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text')
+        .map((c) => ({ type: 'text' as const, text: c.text }));
+
+      const meta: Record<string, unknown> = { ...(message.metadata ?? {}) };
+      if (skillBlock) {
+        meta.skillLoaded = { skillName: skillBlock.skillName, path: skillBlock.path, content: skillBlock.content };
+      }
+
       return {
         role: 'system',
-        content: message.content
-          .filter((c): c is DisplayContent & { type: 'text' } => c.type === 'text')
-          .map((c) => ({ type: 'text' as const, text: c.text })),
+        content: textParts.length > 0 ? textParts : [{ type: 'text' as const, text: '' }],
         id: message.id,
         createdAt: new Date(message.timestamp),
+        ...(Object.keys(meta).length > 0 && { metadata: meta }),
       };
+    }
 
     case 'assistant': {
       const parts: ContentPart[] = [];

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -4,7 +4,7 @@ import { getExternalStoreMessages } from '@assistant-ui/react';
 import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
 import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
-const CLI_ERROR_PREFIXES = [/^Unknown command:/];
+const CLI_ERROR_PREFIXES = [/^Unknown (?:command|skill):/i];
 
 function isCliError(text: string): boolean {
   return CLI_ERROR_PREFIXES.some((re) => re.test(text));

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import { Zap } from 'lucide-react';
 import { MessagePrimitive, useMessage } from '@assistant-ui/react';
+import { getExternalStoreMessages } from '@assistant-ui/react';
+import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
+import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 export function SystemMessage() {
   const message = useMessage();
+  const [original] = getExternalStoreMessages<DisplayMessage>(message);
+
+  const skillBlock = original?.content?.find(
+    (c): c is DisplayContent & { type: 'skill_loaded' } => c.type === 'skill_loaded',
+  );
+  if (skillBlock) {
+    return (
+      <MessagePrimitive.Root>
+        <SkillLoadedCard skillName={skillBlock.skillName} path={skillBlock.path} content={skillBlock.content} />
+      </MessagePrimitive.Root>
+    );
+  }
+
   const textPart = message.content.find((p): p is { type: 'text'; text: string } => p.type === 'text');
   if (!textPart) return null;
   return (

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
-import { Zap } from 'lucide-react';
+import { AlertTriangle, Zap } from 'lucide-react';
 import { MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
 import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
+
+const CLI_ERROR_PREFIXES = [/^Unknown command:/];
+
+function isCliError(text: string): boolean {
+  return CLI_ERROR_PREFIXES.some((re) => re.test(text));
+}
 
 export function SystemMessage() {
   const message = useMessage();
@@ -22,11 +27,15 @@ export function SystemMessage() {
 
   const textPart = message.content.find((p): p is { type: 'text'; text: string } => p.type === 'text');
   if (!textPart) return null;
+  const isError = isCliError(textPart.text);
+  const Icon = isError ? AlertTriangle : Zap;
+  const pillClass = isError ? 'bg-red-500/15' : 'bg-mf-hover/50';
+  const textClass = isError ? 'text-red-400' : 'text-mf-text-secondary';
   return (
     <MessagePrimitive.Root className="flex justify-center">
-      <div className="inline-flex items-center gap-2 rounded-full bg-mf-hover/50 px-4 py-1.5">
-        <Zap size={12} className="text-mf-text-secondary" />
-        <span className="font-mono text-[11px] text-mf-text-secondary">{textPart.text}</span>
+      <div className={`inline-flex items-center gap-2 rounded-full px-4 py-1.5 ${pillClass}`}>
+        <Icon size={12} className={textClass} />
+        <span className={`font-mono text-[11px] ${textClass}`}>{textPart.text}</span>
       </div>
     </MessagePrimitive.Root>
   );

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { Zap } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Zap } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { CollapsibleToolCard } from './CollapsibleToolCard';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+import { markdownComponents } from '../markdown-text';
+import { urlTransform } from '../../../../../lib/markdown-url-transform';
 
 interface SkillLoadedCardProps {
   skillName: string;
@@ -11,34 +12,54 @@ interface SkillLoadedCardProps {
   content: string;
 }
 
-function SkillHeader({ skillName, path }: { skillName: string; path: string }) {
+// Pill-style collapsible for skill invocations. Intentionally rolls its own
+// layout instead of using CollapsibleToolCard because:
+//   - the pill is centered + rounded-full, not a full-width row
+//   - the expanded body is visually detached (markdown panel below the pill)
+//   - changing CollapsibleToolCard's button styling would regress every other
+//     tool card that uses it
+export function SkillLoadedCard({ skillName, path, content }: SkillLoadedCardProps) {
+  const [open, setOpen] = useState(false);
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  const pill = (
+    <button
+      type="button"
+      onClick={() => setOpen((v) => !v)}
+      className="inline-flex items-center gap-1.5 rounded-full bg-mf-hover/50 px-3 py-1 hover:bg-mf-hover/70 transition-colors"
+      aria-expanded={open}
+    >
+      <Zap size={12} className="text-mf-text-secondary shrink-0" />
+      <span className="font-mono text-[11px] text-mf-text-secondary">
+        Using skill: <span className="text-mf-accent">{skillName}</span>
+      </span>
+      <Chevron size={12} className="text-mf-text-secondary/60 shrink-0" />
+    </button>
+  );
+
   return (
-    <div className="flex items-center gap-1.5 min-w-0">
-      <Zap size={14} className="text-mf-accent shrink-0" />
-      <span className="font-mono text-mf-body text-mf-accent">/{skillName}</span>
-      {path && (
+    <div className="flex flex-col items-center gap-2">
+      {path ? (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="font-mono text-mf-small text-mf-text-secondary/60 truncate max-w-[300px]" tabIndex={0}>
-              {path}
-            </span>
-          </TooltipTrigger>
+          <TooltipTrigger asChild>{pill}</TooltipTrigger>
           <TooltipContent>{path}</TooltipContent>
         </Tooltip>
+      ) : (
+        pill
+      )}
+      {open && (
+        <div className="w-full max-h-[480px] overflow-y-auto rounded-mf-card border border-mf-divider bg-mf-hover/20 px-3 py-2">
+          <div className="aui-md text-mf-text-primary">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={markdownComponents as Parameters<typeof ReactMarkdown>[0]['components']}
+              urlTransform={urlTransform}
+            >
+              {content}
+            </ReactMarkdown>
+          </div>
+        </div>
       )}
     </div>
-  );
-}
-
-export function SkillLoadedCard({ skillName, path, content }: SkillLoadedCardProps) {
-  return (
-    <CollapsibleToolCard defaultOpen={false} header={<SkillHeader skillName={skillName} path={path} />}>
-      <div className="max-h-[480px] overflow-y-auto px-3 pb-3 pt-1">
-        {/* react-markdown dropped its className prop in v9; wrap the output instead. */}
-        <div className="prose prose-sm dark:prose-invert max-w-none text-mf-text-primary text-mf-body">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-        </div>
-      </div>
-    </CollapsibleToolCard>
   );
 }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Zap } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { CollapsibleToolCard } from './CollapsibleToolCard';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+
+interface SkillLoadedCardProps {
+  skillName: string;
+  path: string;
+  content: string;
+}
+
+function SkillHeader({ skillName, path }: { skillName: string; path: string }) {
+  return (
+    <div className="flex items-center gap-1.5 min-w-0">
+      <Zap size={14} className="text-mf-accent shrink-0" />
+      <span className="font-mono text-mf-body text-mf-accent">/{skillName}</span>
+      {path && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="font-mono text-mf-small text-mf-text-secondary/60 truncate max-w-[300px]" tabIndex={0}>
+              {path}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{path}</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+export function SkillLoadedCard({ skillName, path, content }: SkillLoadedCardProps) {
+  return (
+    <CollapsibleToolCard defaultOpen={false} header={<SkillHeader skillName={skillName} path={path} />}>
+      <div className="max-h-[480px] overflow-y-auto px-3 pb-3 pt-1">
+        <ReactMarkdown
+          className="prose prose-sm dark:prose-invert max-w-none text-mf-text-primary text-mf-body"
+          remarkPlugins={[remarkGfm]}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+    </CollapsibleToolCard>
+  );
+}

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -125,6 +125,8 @@ export interface SessionSink {
   onQueuedProcessed(uuid: string): void;
   onTodoUpdate(todos: import('./chat.js').TodoItem[]): void;
   onPrDetected(pr: DetectedPr): void;
+  /** CLI-synthesized feedback text (e.g. unknown-command errors) shown as system messages. */
+  onCliMessage(text: string): void;
 }
 
 export interface AdapterSession {

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -127,6 +127,8 @@ export interface SessionSink {
   onPrDetected(pr: DetectedPr): void;
   /** CLI-synthesized feedback text (e.g. unknown-command errors) shown as system messages. */
   onCliMessage(text: string): void;
+  /** A skill was loaded via slash-command; show a collapsible skill card instead of raw text. */
+  onSkillLoaded(entry: { skillName: string; path: string; content: string }): void;
 }
 
 export interface AdapterSession {

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -76,7 +76,8 @@ export type MessageContent =
       modifiedFile?: string;
     }
   | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string }
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
 
 export type ToolResultMessageContent = Extract<MessageContent, { type: 'tool_result' }>;
 

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -36,7 +36,8 @@ export type DisplayContent =
       result?: ToolCallResult;
     }
   | { type: 'permission_request'; request: unknown }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string }
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
 
 export interface DisplayMessage {
   id: string;


### PR DESCRIPTION
## Summary

Bundles four linked fixes around slash-command handling and skill context. Closes #119, #120 (as reframed), and surfaces a separate rendering gap that was swallowing "Unknown command … Did you mean …?" responses.

### A — forward unknown slash commands as plain user text
The composer used to gate slash commands against a local registry (empty today) and drop unknowns. Now all unknown \`/cmd\` go to the CLI verbatim. Claude CLI's own \`processUserInput\` handles them (including "Did you mean …?" suggestions for typos). Unblocks \`/insights\`, \`/branch\`, \`/compact\`, \`/diff\`, etc. without Mainframe needing per-command support.

### B — display CLI-synthesized user messages
\`events.ts handleUserEvent\` was silently dropping all text blocks in user events, on the assumption they were echoes of user-typed text. That mistakenly dropped CLI feedback like "Unknown command: /inisights. Did you mean /insights?". Now: text blocks surface via new \`sink.onCliMessage\` whenever the event is neither \`isReplay\` nor \`isMeta\`. Rendered as a transient system message in chat.

### C — structured skill detection (closes #120)
Previously skills were detected by regex against the prose \`Base directory for this skill: …\` — fragile and only fired for the user-invocation path. Now the detector reads the structured \`tool_use\` block where \`name === "Skill"\` (the model-initiated SkillTool path, which is the common case for skill-aware sessions). Applied consistently across live events, JSONL history, and the claude-sdk event mapper.

### Path resolution — three-location probe
Claude CLI does not expose a resolved skill path over stream-json; \`reload_plugins\` control-response returns command names only. To show the correct file in Context → Session, \`resolveSkillPath\` probes project-local → user → plugin dirs in order and caches per session. New module \`skill-path.ts\` (no logger dependency) to avoid a module-init cycle that would break \`message-loading.test.ts\`.

## Test plan
- [x] Core: 1072 tests pass (added SkillTool detection + path-resolver + CLI-feedback tests)
- [x] Desktop: 453 tests pass
- [x] \`pnpm --filter @qlan-ro/mainframe-desktop build\` + \`--filter @qlan-ro/mainframe-core build\` — both clean
- [x] Manual: type \`/inisights\` → typo error surfaces in chat (previously silent)
- [x] Manual: type \`/insights\` → CLI runs, URL returned as assistant text
- [x] Manual: invoke a skill via model — appears in Context → Session with correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)