### PR TITLE
feat(desktop): loading spinners during app startup and session switch

### DIFF
--- a/.changeset/loading-spinners.md
+++ b/.changeset/loading-spinners.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Show a spinner while messages load on app startup and session switch. The chat panel now displays a centered Loader2 indicator instead of a blank area whenever `getChatMessages` is in flight, and the app-level center panel shows a loading state during the initial data fetch.

--- a/packages/desktop/src/__tests__/hooks/useChatSession-subscription.test.ts
+++ b/packages/desktop/src/__tests__/hooks/useChatSession-subscription.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../renderer/store/chats.js', () => {
     pendingPermissions: new Map(),
     setMessages: vi.fn(),
     addPendingPermission: vi.fn(),
+    setLoadingChat: vi.fn(),
   };
   return {
     useChatsStore: Object.assign((selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state), {

--- a/packages/desktop/src/renderer/components/center/CenterPanel.tsx
+++ b/packages/desktop/src/renderer/components/center/CenterPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Loader2 } from 'lucide-react';
 import { useTabsStore } from '../../store/tabs';
 import { useChatsStore } from '../../store';
+import { useProjectsStore } from '../../store/projects';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useProject } from '../../hooks/useAppInit';
 import { ChatContainer } from '../chat/ChatContainer';
@@ -32,6 +34,7 @@ export function CenterPanel(): React.ReactElement {
   const activeProjectId = useActiveProjectId();
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const addPendingPermission = useChatsStore((s) => s.addPendingPermission);
+  const isAppLoading = useProjectsStore((s) => s.loading);
   const { createChat } = useProject(activeProjectId);
 
   React.useEffect(() => {
@@ -77,7 +80,12 @@ export function CenterPanel(): React.ReactElement {
   return (
     <div className="h-full flex flex-col">
       <div className="flex-1 overflow-hidden">
-        {!activePrimaryTab ? (
+        {isAppLoading ? (
+          <div className="h-full flex flex-col items-center justify-center gap-3 text-mf-text-secondary">
+            <Loader2 size={24} className="animate-spin motion-reduce:animate-none text-mf-accent" />
+            <span className="text-mf-body">Loading…</span>
+          </div>
+        ) : !activePrimaryTab ? (
           <div className="h-full flex flex-col items-center justify-center text-mf-text-secondary gap-4">
             <div className="w-14 h-14 rounded-full bg-mf-accent/10 flex items-center justify-center">
               <span className="text-2xl font-bold text-mf-accent">M</span>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
@@ -27,6 +27,15 @@ function EmptyState() {
   );
 }
 
+function LoadingState() {
+  return (
+    <div className="h-full flex flex-col items-center justify-center gap-3 text-mf-text-secondary">
+      <Loader2 size={24} className="animate-spin motion-reduce:animate-none text-mf-accent" />
+      <span className="text-mf-body">Loading messages…</span>
+    </div>
+  );
+}
+
 function GeneratingIndicator() {
   const thread = useThread();
   const activeChatId = useChatsStore((s) => s.activeChatId);
@@ -66,21 +75,29 @@ function BottomCard() {
 
 export function MainframeThread() {
   const { lightbox, closeLightbox, navigateLightbox } = useMainframeRuntime();
+  const activeChatId = useChatsStore((s) => s.activeChatId);
+  const isLoading = useChatsStore((s) => (activeChatId ? s.loadingChats.has(activeChatId) : false));
 
   return (
     <ThreadPrimitive.Root className="h-full flex flex-col">
       <ThreadPrimitive.Viewport autoScroll className="flex-1 overflow-y-auto scrollbar-on-hover">
-        <EmptyState />
-        <div data-mf-chat-thread className="px-6 py-6 space-y-5">
-          <ThreadPrimitive.Messages
-            components={{
-              UserMessage,
-              AssistantMessage,
-              SystemMessage,
-            }}
-          />
-          <GeneratingIndicator />
-        </div>
+        {isLoading ? (
+          <LoadingState />
+        ) : (
+          <>
+            <EmptyState />
+            <div data-mf-chat-thread className="px-6 py-6 space-y-5">
+              <ThreadPrimitive.Messages
+                components={{
+                  UserMessage,
+                  AssistantMessage,
+                  SystemMessage,
+                }}
+              />
+              <GeneratingIndicator />
+            </div>
+          </>
+        )}
       </ThreadPrimitive.Viewport>
       <QuoteOnSelectionButton />
       <div className="shrink-0 px-6 pb-5 pt-2">

--- a/packages/desktop/src/renderer/hooks/useChatSession.ts
+++ b/packages/desktop/src/renderer/hooks/useChatSession.ts
@@ -22,13 +22,17 @@ export function useChatSession(chatId: string | null) {
 
     // Always load messages from daemon — the store may have stale data from before
     // the WS subscription was dropped (e.g. user switched tabs/projects).
+    useChatsStore.getState().setLoadingChat(chatId, true);
     getChatMessages(chatId)
       .then((msgs) => {
         if (msgs.length > 0) {
           useChatsStore.getState().setMessages(chatId, msgs);
         }
       })
-      .catch((err) => log.warn('message fetch failed', { err: String(err) }));
+      .catch((err) => log.warn('message fetch failed', { err: String(err) }))
+      .finally(() => {
+        useChatsStore.getState().setLoadingChat(chatId, false);
+      });
 
     // Restore pending permission from daemon (survives desktop reloads)
     if (!useChatsStore.getState().pendingPermissions.has(chatId)) {
@@ -49,13 +53,17 @@ export function useChatSession(chatId: string | null) {
       if (daemonClient.connected) {
         daemonClient.resumeChat(chatId);
         reconnectTimer = setTimeout(() => {
+          useChatsStore.getState().setLoadingChat(chatId, true);
           getChatMessages(chatId)
             .then((msgs) => {
               if (msgs.length > 0) {
                 useChatsStore.getState().setMessages(chatId, msgs);
               }
             })
-            .catch((err) => log.warn('reconnect message fetch failed', { err: String(err) }));
+            .catch((err) => log.warn('reconnect message fetch failed', { err: String(err) }))
+            .finally(() => {
+              useChatsStore.getState().setLoadingChat(chatId, false);
+            });
           getPendingPermission(chatId)
             .then((permission) => {
               if (permission) {

--- a/packages/desktop/src/renderer/store/chats.test.ts
+++ b/packages/desktop/src/renderer/store/chats.test.ts
@@ -70,6 +70,36 @@ describe('chat ordering', () => {
   });
 });
 
+describe('loadingChats', () => {
+  beforeEach(() => {
+    useChatsStore.setState({ loadingChats: new Set() });
+  });
+
+  it('setLoadingChat(true) marks chat as loading', () => {
+    useChatsStore.getState().setLoadingChat('chat-1', true);
+    expect(useChatsStore.getState().loadingChats.has('chat-1')).toBe(true);
+  });
+
+  it('setLoadingChat(false) removes chat from loading set', () => {
+    useChatsStore.getState().setLoadingChat('chat-1', true);
+    useChatsStore.getState().setLoadingChat('chat-1', false);
+    expect(useChatsStore.getState().loadingChats.has('chat-1')).toBe(false);
+  });
+
+  it('tracks multiple chats independently', () => {
+    useChatsStore.getState().setLoadingChat('chat-1', true);
+    useChatsStore.getState().setLoadingChat('chat-2', true);
+    useChatsStore.getState().setLoadingChat('chat-1', false);
+    expect(useChatsStore.getState().loadingChats.has('chat-1')).toBe(false);
+    expect(useChatsStore.getState().loadingChats.has('chat-2')).toBe(true);
+  });
+
+  it('setLoadingChat(false) on unknown chat is a no-op', () => {
+    useChatsStore.getState().setLoadingChat('chat-x', false);
+    expect(useChatsStore.getState().loadingChats.size).toBe(0);
+  });
+});
+
 describe('unread state', () => {
   beforeEach(() => {
     useChatsStore.setState({

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -49,6 +49,7 @@ interface ChatsState {
   processes: Map<string, AdapterProcess>;
   queuedMessages: Map<string, QueuedMessageRef[]>;
   compactingChats: Set<string>;
+  loadingChats: Set<string>;
   contextUsage: Map<string, ContextUsageState>;
   unreadChatIds: Set<string>;
   todos: Map<string, TodoItem[]>;
@@ -75,6 +76,7 @@ interface ChatsState {
   clearQueuedMessages: (chatId: string) => void;
   setQueuedMessages: (chatId: string, refs: QueuedMessageRef[]) => void;
   setCompacting: (chatId: string, compacting: boolean) => void;
+  setLoadingChat: (chatId: string, loading: boolean) => void;
   setContextUsage: (chatId: string, usage: ContextUsageState) => void;
   setTodos: (chatId: string, todos: TodoItem[]) => void;
   addDetectedPr: (chatId: string, pr: DetectedPr) => void;
@@ -97,6 +99,7 @@ export const useChatsStore = create<ChatsState>((set) => ({
   processes: new Map(),
   queuedMessages: new Map(),
   compactingChats: new Set(),
+  loadingChats: new Set(),
   contextUsage: new Map(),
   unreadChatIds: new Set(),
   todos: new Map(),
@@ -299,6 +302,16 @@ export const useChatsStore = create<ChatsState>((set) => ({
         next.delete(chatId);
       }
       return { compactingChats: next };
+    }),
+  setLoadingChat: (chatId, loading) =>
+    set((state) => {
+      const next = new Set(state.loadingChats);
+      if (loading) {
+        next.add(chatId);
+      } else {
+        next.delete(chatId);
+      }
+      return { loadingChats: next };
     }),
   setContextUsage: (chatId, usage) =>
     set((state) => {


### PR DESCRIPTION
Closes #130.

## Summary
- App startup: centered Loader2 in the center panel while projects/adapters/providers/plugins/chats load — previously a blank welcome shell.
- Session switch: "Loading messages…" inside the thread viewport until message history arrives. Suppresses the empty welcome state during loading so it can't briefly flash.
- Composer stays visible throughout — input is always reachable.

## Implementation
- New per-chat loading state in `useChatsStore` (`loadingChats: Set<string>` + `setLoadingChat`).
- `useChatSession` sets/clears the flag around `getChatMessages` (covers initial fetch + reconnect).
- `MainframeThread` reads the flag for the active chat and renders a `LoadingState` inside the viewport when true.
- `CenterPanel` reads `useProjectsStore.loading` (already exists from `useAppInit`) and renders an app-startup spinner instead of the welcome screen during boot.
- 4 unit tests added for `setLoadingChat` (sets, clears, multiple chats, no-op on unknown chat).

## Test plan
- [x] Cold-start the app — spinner shows in the center panel until init completes
- [x] Switch between sessions — "Loading messages…" appears briefly in the viewport, composer stays usable
- [x] Open a brand-new empty chat — welcome state shows, no spinner stuck
- [x] Network hiccup during reconnect — spinner clears (via `.finally`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)