### PR TITLE
fix(core): suppress empty user bubble from bare <command-name> blocks

### DIFF
--- a/.changeset/explore-agent-user-bubble.md
+++ b/.changeset/explore-agent-user-bubble.md
@@ -1,0 +1,15 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix spurious empty user bubble in Explore agent / Task tool subagent threads.
+
+Bare `<command-name>` CLI echoes (no accompanying `<command-message>` tag) are
+now suppressed in `convertUserContent` instead of being synthesized into a
+`/commandName` bubble. An additional guard in `convertGroupedToDisplay` drops
+user messages whose display content and metadata are both empty, preventing any
+residual empty bubble from reaching the client.
+
+User-typed `/skill-name` invocations are unaffected — they always carry a
+`<command-message>` tag alongside `<command-name>` and continue to render
+correctly.

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -281,6 +281,56 @@ describe('prepareMessagesForClient', () => {
     expect(result[0]!.type).toBe('user');
   });
 
+  it('suppresses a bare <command-name> message with no body (subagent/replay echo)', () => {
+    // Subagent CLI echoes emit <command-name>skill</command-name> with no <command-message>
+    // and no other content. These are internal CLI metadata and must not produce a visible bubble.
+    const messages = [
+      rawMsg('user', [txt('<command-name>do-thing</command-name>')]),
+      rawMsg('assistant', [txt('response')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    // The bare <command-name> message must be suppressed; only the assistant reply remains
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('assistant');
+  });
+
+  it('suppresses a <command-name> with empty body after stripping (replay path with no visible text)', () => {
+    // Replay path: <command-name> only, no command-message, no args, no body
+    const messages = [rawMsg('user', [txt('<command-name>/some-internal-skill</command-name>')])];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(0);
+  });
+
+  it('still renders user-typed /skill-name that has <command-message> alongside <command-name>', () => {
+    // User-typed slash commands always arrive with both <command-message> and <command-name>
+    const messages = [
+      rawMsg('user', [
+        txt(
+          '<command-message>systematic-debugging</command-message>\n<command-name>/systematic-debugging</command-name>',
+        ),
+      ]),
+      rawMsg('assistant', [txt('response')]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.type).toBe('user');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: '/systematic-debugging' }]);
+  });
+
+  it('still renders user-typed /skill-name args bubble when <command-message> is present', () => {
+    const messages = [
+      rawMsg('user', [
+        txt(
+          '<command-message>brainstorming</command-message>\n<command-name>/brainstorming</command-name>\n<command-args>new feature idea</command-args>',
+        ),
+      ]),
+    ];
+    const result = prepareMessagesForClient(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe('user');
+    expect(result[0]!.content).toEqual([{ type: 'text', text: '/brainstorming new feature idea' }]);
+  });
+
   describe('tool grouping with categories', () => {
     it('groups consecutive explore tools into a tool_group', () => {
       const messages = [

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -80,6 +80,14 @@ export function convertUserContent(content: MessageContent[]): {
 
       const cmdInfo = parseCommandMessage(block.text);
       if (cmdInfo) {
+        // Only synthesize a user bubble when the raw text includes a <command-message>
+        // tag — that tag is present exclusively for user-typed slash commands. Subagent
+        // and replay CLI echoes emit bare <command-name>…</command-name> with no
+        // <command-message> wrapper; those are internal CLI metadata, not user input,
+        // so we suppress them to avoid a spurious empty bubble in the Explore thread.
+        const hasCommandMessage = block.text.includes('<command-message>');
+        if (!hasCommandMessage) continue;
+
         metadata.command = { name: cmdInfo.commandName, userText: cmdInfo.userText };
         metadata.cleanText = cmdInfo.userText;
         // Synthesize a readable bubble from the CLI's <command-name>/<command-args>

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -70,6 +70,11 @@ function convertGroupedToDisplay(
 
     case 'user': {
       const { displayContent, metadata: extraMeta } = convertUserContent(msg.content);
+      // Suppress user messages whose entire content was stripped to nothing
+      // (e.g. bare <command-name> CLI echoes from subagent/replay paths that
+      // contain no visible text, no images, and no tool results). Returning
+      // null here prevents an empty bubble from appearing in the chat thread.
+      if (displayContent.length === 0 && Object.keys(extraMeta).length === 0) return null;
       const metadata = {
         ...(msg.metadata ?? {}),
         ...extraMeta,


### PR DESCRIPTION
Closes #131.

## Root cause
Commit \`1ff74d57\` ("fix: slash-command forwarding…") narrowed \`INTERNAL_USER_RE\` from \`/<command-name>|<mainframe-command[\s>]/\` to \`/<mainframe-command[\s>]/\` so user-typed \`/skill\` invocations would render visibly. The narrower filter no longer catches subagent / replay user messages whose payload is a bare \`<command-name>...</command-name>\` block — \`convertUserContent\` synthesizes a \`/commandName\` bubble for them even though the user never typed it. Result: empty / spurious "user" bubbles in Explore agent output.

## Fix (Approach A from the plan)
Two targeted changes in core:

1. \`packages/core/src/messages/display-helpers.ts\` — In \`convertUserContent\`, when \`parseCommandMessage\` finds \`<command-name>\` but the raw block lacks \`<command-message>\`, skip the block. The \`<command-message>\` tag is written by the CLI exclusively for user-typed slash commands; subagent and replay echoes never include it.
2. \`packages/core/src/messages/display-pipeline.ts\` — In \`convertGroupedToDisplay\`, return \`null\` when both \`displayContent\` and \`extraMeta\` are empty after the user-content conversion. Defense-in-depth so future code paths can't sneak an empty bubble through.

## Tests
4 new cases in \`display-pipeline.test.ts\`:
- Bare \`<command-name>\` with no body → suppressed (primary regression)
- Bare \`<command-name>\` with leading slash, no body → suppressed
- User-typed \`/skill-name\` with \`<command-message>\` → still renders
- User-typed \`/skill-name args\` with \`<command-message>\` → still renders

All 1114 existing core tests pass.

## Test plan
- [x] Run an Explore agent task that involves slash commands → no empty user bubbles in the chat
- [x] User types \`/some-skill\` → still renders as visible user message
- [x] Replay a chat that contains old \`<command-name>\` tool dispatches → no empty bubbles on rehydrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)