### PR TITLE
feat(core): detect PR mutation commands (gh pr edit/ready/merge/close/...)

### DIFF
--- a/.changeset/pr-mutation-detection.md
+++ b/.changeset/pr-mutation-detection.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Detect PR mutation commands (gh pr edit/ready/merge/close/reopen/comment/review and GitLab/Azure equivalents) so the PR badge appears when the agent mutates a PR, not only when it creates one.

--- a/docs/superpowers/plans/2026-04-21-pr-mutation-detection.md
+++ b/docs/superpowers/plans/2026-04-21-pr-mutation-detection.md
@@ -1,0 +1,980 @@
+# PR Mutation Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend PR detection so that `gh pr edit|ready|merge|close|reopen|comment|review` and GitLab/Azure equivalents register a "session touched PR #N" signal, even when the tool_result output omits the PR URL.
+
+**Architecture:** Add a second detection path in `packages/core/src/plugins/builtin/claude/events.ts` that parses the PR identifier from Bash **command args** (URL or `owner/repo#N` compact form) at assistant-event time, stashes it keyed by `tool_use_id`, and emits `sink.onPrDetected({..., source: 'mentioned'})` at user-event time if the tool_result didn't error. The existing tool_result URL scraper (Path A) continues unchanged; the frontend's `(owner, repo, number)` dedup absorbs any overlap.
+
+**Tech Stack:** TypeScript (strict, NodeNext), Vitest, pnpm workspaces. No new runtime dependencies. Changes are confined to the `@qlan-ro/mainframe-core` package and one docs file.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-pr-mutation-detection-design.md`
+
+---
+
+## Task 1: Add `pendingPrMutations` to session state
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts:48-66` (interface `ClaudeSessionState`)
+- Modify: `packages/core/src/plugins/builtin/claude/session.ts:94-105` (constructor state init)
+
+This task introduces the state field but leaves it unused. It's a one-line-each change that makes later tasks' type references valid.
+
+- [ ] **Step 1: Extend `ClaudeSessionState` with `pendingPrMutations`**
+
+Modify the interface at `packages/core/src/plugins/builtin/claude/session.ts` (around lines 48-66). Add one field right after `pendingPrCreates`:
+
+```ts
+export interface ClaudeSessionState {
+  chatId: string;
+  buffer: string;
+  lastAssistantUsage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  child: ChildProcess | null;
+  status: 'starting' | 'ready' | 'running' | 'stopped' | 'error';
+  pid: number;
+  activeTasks: Map<string, { type: string; command?: string }>;
+  interruptTimer: ReturnType<typeof setTimeout> | null;
+  /** Pending cancel_async_message callbacks keyed by request_id */
+  pendingCancelCallbacks: Map<string, (cancelled: boolean) => void>;
+  /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
+  pendingPrCreates: Set<string>;
+  /** Tool_use IDs → parsed PR info for mutation commands (gh pr edit/ready/merge/close/reopen/comment/review, etc.) */
+  pendingPrMutations: Map<string, { url: string; owner: string; repo: string; number: number }>;
+}
+```
+
+- [ ] **Step 2: Initialize `pendingPrMutations` in the constructor**
+
+In the same file, the constructor currently sets `pendingPrCreates: new Set()` around line 103. Add the mutations map right below it:
+
+```ts
+    this.state = {
+      chatId: options.chatId ?? '',
+      buffer: '',
+      child: null,
+      status: 'starting',
+      pid: 0,
+      activeTasks: new Map(),
+      interruptTimer: null,
+      pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
+      pendingPrMutations: new Map(),
+    };
+```
+
+- [ ] **Step 3: Typecheck via build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/session.ts
+git commit -m "feat(core): add pendingPrMutations to claude session state"
+```
+
+---
+
+## Task 2: Add mutation-command regexes and arg parser (TDD)
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/events.ts` (add near the existing `PR_CREATE_COMMANDS`, around lines 23-31)
+- Create: `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+
+This task adds pure functions: `PR_MUTATION_COMMANDS`, `isPrMutationCommand`, `parsePrIdentifierFromArgs`. No call-sites yet — those come in Tasks 3 and 4.
+
+- [ ] **Step 1: Write failing tests for `isPrMutationCommand`**
+
+Create `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+import { handleStdout, isPrMutationCommand, parsePrIdentifierFromArgs } from '../events.js';
+import type { ClaudeSession } from '../session.js';
+
+function createMockSink(): SessionSink {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: vi.fn(),
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+  };
+}
+
+function createMockSession(): ClaudeSession {
+  return {
+    id: 'test-session',
+    state: {
+      buffer: '',
+      chatId: null,
+      status: 'ready',
+      lastAssistantUsage: undefined,
+      activeTasks: new Map(),
+      pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
+      pendingPrMutations: new Map(),
+    },
+    clearInterruptTimer: vi.fn(),
+    requestContextUsage: vi.fn(),
+  } as unknown as ClaudeSession;
+}
+
+describe('isPrMutationCommand', () => {
+  it('matches gh pr mutations', () => {
+    expect(isPrMutationCommand('gh pr edit 42 --title "new"')).toBe(true);
+    expect(isPrMutationCommand('gh pr ready 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr merge 42 --squash')).toBe(true);
+    expect(isPrMutationCommand('gh pr close 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr reopen 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr comment 42 --body "hi"')).toBe(true);
+    expect(isPrMutationCommand('gh pr review 42 --approve')).toBe(true);
+  });
+
+  it('matches glab mr mutations', () => {
+    expect(isPrMutationCommand('glab mr update 7 --title "new"')).toBe(true);
+    expect(isPrMutationCommand('glab mr merge 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr close 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr reopen 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr note 7 --message "hi"')).toBe(true);
+  });
+
+  it('matches az repos pr update', () => {
+    expect(isPrMutationCommand('az repos pr update --id 5 --status completed')).toBe(true);
+  });
+
+  it('does not match read-only or create commands', () => {
+    expect(isPrMutationCommand('gh pr view 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr list')).toBe(false);
+    expect(isPrMutationCommand('gh pr create --title "x"')).toBe(false);
+    expect(isPrMutationCommand('gh pr checkout 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr diff 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr status')).toBe(false);
+    expect(isPrMutationCommand('glab mr list')).toBe(false);
+    expect(isPrMutationCommand('glab mr view 7')).toBe(false);
+    expect(isPrMutationCommand('glab mr create')).toBe(false);
+    expect(isPrMutationCommand('git push')).toBe(false);
+    expect(isPrMutationCommand('echo gh pr edit 42')).toBe(true); // word-boundary match; acceptable — rare false positive
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+Expected: FAIL. Errors reference missing exports `isPrMutationCommand`, `parsePrIdentifierFromArgs`.
+
+- [ ] **Step 3: Implement `PR_MUTATION_COMMANDS` and `isPrMutationCommand`**
+
+In `packages/core/src/plugins/builtin/claude/events.ts`, right after the existing `PR_CREATE_COMMANDS` block (around lines 23-31), add:
+
+```ts
+export const PR_MUTATION_COMMANDS: RegExp[] = [
+  /\bgh\s+pr\s+(edit|ready|merge|close|reopen|comment|review)\b/,
+  /\bglab\s+mr\s+(update|merge|close|reopen|note)\b/,
+  /\baz\s+repos\s+pr\s+update\b/,
+];
+
+export function isPrMutationCommand(command: string): boolean {
+  return PR_MUTATION_COMMANDS.some((re) => re.test(command));
+}
+```
+
+- [ ] **Step 4: Run tests for `isPrMutationCommand` to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts -t isPrMutationCommand`
+Expected: `isPrMutationCommand` suite passes. Other tests in the file still fail (missing `parsePrIdentifierFromArgs`).
+
+- [ ] **Step 5: Write failing tests for `parsePrIdentifierFromArgs`**
+
+Append to the same test file:
+
+```ts
+describe('parsePrIdentifierFromArgs', () => {
+  it('parses a GitHub PR URL', () => {
+    expect(parsePrIdentifierFromArgs('gh pr edit https://github.com/org/repo/pull/42 --add-label bug')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('parses a GitLab MR URL', () => {
+    expect(parsePrIdentifierFromArgs('glab mr update https://gitlab.com/org/repo/-/merge_requests/7')).toEqual({
+      url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+      owner: 'org',
+      repo: 'repo',
+      number: 7,
+    });
+  });
+
+  it('parses an Azure DevOps PR URL', () => {
+    expect(
+      parsePrIdentifierFromArgs(
+        'az repos pr update https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/5',
+      ),
+    ).toEqual({
+      url: 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/5',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 5,
+    });
+  });
+
+  it('parses gh compact syntax owner/repo#N', () => {
+    expect(parsePrIdentifierFromArgs('gh pr ready org/repo#42')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('returns null when command has no PR identifier', () => {
+    expect(parsePrIdentifierFromArgs('gh pr edit 42 --title x')).toBeNull();
+    expect(parsePrIdentifierFromArgs('gh pr edit')).toBeNull();
+    expect(parsePrIdentifierFromArgs('az repos pr update --id 5')).toBeNull();
+  });
+
+  it('does not accept compact syntax for non-gh commands', () => {
+    expect(parsePrIdentifierFromArgs('glab mr update org/repo#42')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts -t parsePrIdentifierFromArgs`
+Expected: FAIL. `parsePrIdentifierFromArgs is not a function`.
+
+- [ ] **Step 7: Implement `parsePrIdentifierFromArgs`**
+
+Still in `events.ts`, add after `isPrMutationCommand`:
+
+```ts
+const GH_COMPACT_REF_REGEX = /\b([^/\s#]+)\/([^/\s#]+)#(\d+)\b/;
+
+export function parsePrIdentifierFromArgs(
+  command: string,
+): { url: string; owner: string; repo: string; number: number } | null {
+  // Try full URLs first — any of the three existing regexes.
+  const fromUrl = extractPrFromToolResult(command);
+  if (fromUrl) return fromUrl;
+
+  // gh-only compact syntax: owner/repo#N
+  if (/\bgh\s+pr\s+/.test(command)) {
+    const match = GH_COMPACT_REF_REGEX.exec(command);
+    if (match) {
+      const owner = match[1]!;
+      const repo = match[2]!;
+      const number = parseInt(match[3]!, 10);
+      if (owner && repo && !isNaN(number)) {
+        return { url: `https://github.com/${owner}/${repo}/pull/${number}`, owner, repo, number };
+      }
+    }
+  }
+  return null;
+}
+```
+
+The parser delegates to `extractPrFromToolResult` for full URLs (the regex set is identical to what the tool-result scanner already uses). The compact-syntax branch only fires for `gh pr *` commands.
+
+- [ ] **Step 8: Run all tests in the new file to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+Expected: all `isPrMutationCommand` and `parsePrIdentifierFromArgs` tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/events.ts packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+git commit -m "feat(core): parse PR identifier from Bash mutation-command args"
+```
+
+---
+
+## Task 3: Stash pending mutations at assistant-event time (TDD)
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/events.ts:138-183` (function `handleAssistantEvent`)
+- Modify: `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+
+Wire the assistant-event path: when a Bash tool_use command is a mutation command **and** the args contain a parseable identifier, stash `tool_use_id → prInfo` in `session.state.pendingPrMutations`.
+
+- [ ] **Step 1: Write failing stash test**
+
+Append to `pr-mutation-detection.test.ts`:
+
+```ts
+describe('handleAssistantEvent stashes pending mutations', () => {
+  it('stashes tool_use_id and PR info for gh pr edit with URL arg', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/42 --add-label bug' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.get('tu_mut_1')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('stashes with gh compact syntax', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_2',
+            name: 'BashTool',
+            input: { command: 'gh pr ready org/repo#42' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.get('tu_mut_2')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('does not stash number-only args (gh pr edit 42)', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_3',
+            name: 'Bash',
+            input: { command: 'gh pr edit 42 --title new' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.has('tu_mut_3')).toBe(false);
+  });
+
+  it('does not stash non-mutation commands even with PR URL in args', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_4',
+            name: 'Bash',
+            input: { command: 'echo https://github.com/org/repo/pull/42' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.has('tu_mut_4')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts -t "stashes pending mutations"`
+Expected: FAIL. `pendingPrMutations` stays empty.
+
+- [ ] **Step 3: Wire the stash in `handleAssistantEvent`**
+
+In `packages/core/src/plugins/builtin/claude/events.ts`, find the existing `isPrCreateCommand` block (around lines 168-174) inside `handleAssistantEvent`:
+
+```ts
+        const name = block.name as string;
+        if (name === 'Bash' || name === 'BashTool') {
+          const input = block.input as { command?: string } | undefined;
+          if (input?.command && isPrCreateCommand(input.command)) {
+            session.state.pendingPrCreates.add(block.id as string);
+          }
+        }
+```
+
+Extend it to also stash mutations:
+
+```ts
+        const name = block.name as string;
+        if (name === 'Bash' || name === 'BashTool') {
+          const input = block.input as { command?: string } | undefined;
+          if (input?.command && isPrCreateCommand(input.command)) {
+            session.state.pendingPrCreates.add(block.id as string);
+          }
+          if (input?.command && isPrMutationCommand(input.command)) {
+            const pr = parsePrIdentifierFromArgs(input.command);
+            if (pr) session.state.pendingPrMutations.set(block.id as string, pr);
+          }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts -t "stashes pending mutations"`
+Expected: all four stash tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/events.ts packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+git commit -m "feat(core): stash pending PR mutations at assistant-event time"
+```
+
+---
+
+## Task 4: Consume pending mutations at user-event time (TDD)
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/events.ts:213-226` (tool_result branch in `handleUserEvent`)
+- Modify: `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+
+At tool_result time: if `tool_use_id` is in `pendingPrMutations` and `is_error !== true`, emit `sink.onPrDetected({...stashed, source: 'mentioned'})` and remove the entry.
+
+- [ ] **Step 1: Write failing emission tests**
+
+Append to `pr-mutation-detection.test.ts`:
+
+```ts
+describe('handleUserEvent consumes pending mutations', () => {
+  it('emits source:mentioned when tool_result matches a pending mutation', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    // Simulate stash
+    session.state.pendingPrMutations.set('tu_mut_ok', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_mut_ok',
+            content: 'OK',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+    expect(session.state.pendingPrMutations.has('tu_mut_ok')).toBe(false);
+  });
+
+  it('does not emit when tool_result has is_error: true', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    session.state.pendingPrMutations.set('tu_mut_err', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_mut_err',
+            content: 'authentication failed',
+            is_error: true,
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).not.toHaveBeenCalled();
+    expect(session.state.pendingPrMutations.has('tu_mut_err')).toBe(false);
+  });
+
+  it('end-to-end: gh pr edit with URL arg emits source:mentioned after success', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_e2e_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/42 --add-label bug' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_e2e_1',
+            content: '✓ Edited pull request #42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+
+  it('number-only gh pr edit 42 still detected via Path A when output contains URL', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    // tool_use with number-only arg → Path B does NOT stash
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_num_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit 42 --title new' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+    expect(session.state.pendingPrMutations.has('tu_num_1')).toBe(false);
+
+    // tool_result contains URL → Path A emits as 'mentioned' (not in pendingPrCreates)
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_num_1',
+            content: 'https://github.com/org/repo/pull/42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+
+  it('create and mutate in the same assistant turn are handled independently', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_create',
+            name: 'Bash',
+            input: { command: 'gh pr create --title "feat"' },
+          },
+          {
+            type: 'tool_use',
+            id: 'tu_edit',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/10 --add-label priority' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+
+    expect(session.state.pendingPrCreates.has('tu_create')).toBe(true);
+    expect(session.state.pendingPrMutations.has('tu_edit')).toBe(true);
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_create',
+            content: 'https://github.com/org/repo/pull/11',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_edit',
+            content: '✓ Edited',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/11',
+      owner: 'org',
+      repo: 'repo',
+      number: 11,
+      source: 'created',
+    });
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/10',
+      owner: 'org',
+      repo: 'repo',
+      number: 10,
+      source: 'mentioned',
+    });
+  });
+
+  it('emits only once when tool_result output also contains the same URL (dedup handled by frontend, core still fires twice)', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    session.state.pendingPrMutations.set('tu_overlap', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_overlap',
+            content: '✓ https://github.com/org/repo/pull/42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    // Path A emits 'mentioned' from the URL in output; Path B also emits 'mentioned'.
+    // Both calls are to onPrDetected with source:'mentioned' for the same PR.
+    // The frontend dedup (chats.addDetectedPr) collapses them; core does not.
+    expect(sink.onPrDetected).toHaveBeenCalledTimes(2);
+    expect(sink.onPrDetected).toHaveBeenNthCalledWith(1, {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+    expect(sink.onPrDetected).toHaveBeenNthCalledWith(2, {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts -t "consumes pending mutations"`
+Expected: FAIL. `onPrDetected` not called for the mutation cases.
+
+- [ ] **Step 3: Wire consumption in `handleUserEvent`**
+
+In `packages/core/src/plugins/builtin/claude/events.ts`, find the existing tool_result branch inside `handleUserEvent` (around lines 213-226):
+
+```ts
+  for (const block of message.content) {
+    if (block.type === 'tool_result') {
+      const text = typeof block.content === 'string' ? block.content : '';
+      const planMatch = text.match(/Your plan has been saved to: (\/\S+\.md)/);
+      if (planMatch?.[1]) {
+        sink.onPlanFile(planMatch[1].trim());
+      }
+      const pr = extractPrFromToolResult(text);
+      if (pr) {
+        const toolUseId = block.tool_use_id as string | undefined;
+        const source = toolUseId && session.state.pendingPrCreates.has(toolUseId) ? 'created' : 'mentioned';
+        if (source === 'created') session.state.pendingPrCreates.delete(toolUseId!);
+        sink.onPrDetected({ ...pr, source });
+      }
+    } else if (block.type === 'text') {
+```
+
+Add a Path B consumption block right after the existing Path A emission (after `sink.onPrDetected({ ...pr, source });`), still inside the `if (block.type === 'tool_result')` branch:
+
+```ts
+  for (const block of message.content) {
+    if (block.type === 'tool_result') {
+      const text = typeof block.content === 'string' ? block.content : '';
+      const planMatch = text.match(/Your plan has been saved to: (\/\S+\.md)/);
+      if (planMatch?.[1]) {
+        sink.onPlanFile(planMatch[1].trim());
+      }
+      const pr = extractPrFromToolResult(text);
+      if (pr) {
+        const toolUseId = block.tool_use_id as string | undefined;
+        const source = toolUseId && session.state.pendingPrCreates.has(toolUseId) ? 'created' : 'mentioned';
+        if (source === 'created') session.state.pendingPrCreates.delete(toolUseId!);
+        sink.onPrDetected({ ...pr, source });
+      }
+
+      // Path B: command-arg-based mutation detection. Consume any pending stash
+      // keyed by this tool_use_id, regardless of whether the output contained a URL.
+      const mutationToolUseId = block.tool_use_id as string | undefined;
+      if (mutationToolUseId && session.state.pendingPrMutations.has(mutationToolUseId)) {
+        const stashed = session.state.pendingPrMutations.get(mutationToolUseId)!;
+        session.state.pendingPrMutations.delete(mutationToolUseId);
+        if (block.is_error !== true) {
+          sink.onPrDetected({ ...stashed, source: 'mentioned' });
+        }
+      }
+    } else if (block.type === 'text') {
+```
+
+The `mutationToolUseId` local is separate from `toolUseId` so the two paths remain visually independent — they can be refactored later if needed, but keeping them distinct now makes the control flow easier to read during review.
+
+- [ ] **Step 4: Run full test file to verify all tests pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the existing PR detection tests to verify no regression**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/plugins/builtin/claude/__tests__/pr-detection.test.ts`
+Expected: all existing tests still pass (no changes to create-path behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/events.ts packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+git commit -m "feat(core): emit source:mentioned for successful PR mutation commands"
+```
+
+---
+
+## Task 5: Update `PR_TRACKING.md` docs
+
+**Files:**
+- Modify: `docs/adapters/claude/PR_TRACKING.md:152-154` (the "What Mainframe Currently Does" section)
+
+The doc currently says "Nothing — we don't detect or display PRs" which is stale. Replace it with a description of both paths.
+
+- [ ] **Step 1: Replace the stale section**
+
+In `docs/adapters/claude/PR_TRACKING.md`, find the final section:
+
+```markdown
+## What Mainframe Currently Does
+
+Nothing — we don't detect or display PRs. Tool results flow through `sink.onToolResult()` but we don't scan them for PR URLs.
+```
+
+Replace it with:
+
+```markdown
+## What Mainframe Currently Does
+
+Two detection paths in `packages/core/src/plugins/builtin/claude/events.ts`:
+
+**Path A — tool_result URL scraping.** `extractPrFromToolResult()` scans Bash tool_result text for GitHub, GitLab, or Azure PR URLs. If the originating tool_use_id was stashed as a PR-create command (`gh pr create`, `glab mr create`, `az repos pr create`), the detection emits `source: 'created'`; otherwise `source: 'mentioned'`.
+
+**Path B — command-args parsing for mutations.** When a Bash tool_use's command matches a PR mutation command and its args contain a parseable identifier (full URL or GitHub's compact `owner/repo#N`), the PR info is stashed under the `tool_use_id` in `session.state.pendingPrMutations`. On the matching tool_result, if `is_error !== true`, the PR is emitted with `source: 'mentioned'`.
+
+Tracked mutation commands: `gh pr edit|ready|merge|close|reopen|comment|review`, `glab mr update|merge|close|reopen|note`, `az repos pr update`. Number-only args (e.g. `gh pr edit 42`) are not handled by Path B — they fall through to Path A when the command's output prints the PR URL.
+
+Events emit via `sink.onPrDetected(pr)`. The frontend store (`packages/desktop/src/renderer/store/chats.ts`) dedups by `(owner, repo, number)` and upgrades `'mentioned'` → `'created'` when the same PR is later detected via a create command.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adapters/claude/PR_TRACKING.md
+git commit -m "docs: refresh PR_TRACKING.md to describe current detection paths"
+```
+
+---
+
+## Task 6: Add changeset, run typecheck, run full tests
+
+**Files:**
+- Create: `.changeset/<generated-name>.md` (via `pnpm changeset`)
+
+Per project rules, every PR must ship with a changeset.
+
+- [ ] **Step 1: Create a changeset**
+
+Run: `pnpm changeset`
+
+Select: `@qlan-ro/mainframe-core` (space to toggle, enter to confirm). Bump type: `patch`. Summary text:
+
+```
+Detect PR mutation commands (gh pr edit/ready/merge/close/reopen/comment/review and GitLab/Azure equivalents) so the PR badge appears when the agent mutates a PR, not only when it creates one.
+```
+
+- [ ] **Step 2: Typecheck via build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
+Expected: exits 0. This runs `tsc -p tsconfig.build.json` which is the project's typecheck gate for core.
+
+- [ ] **Step 3: Run core tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test`
+Expected: all tests pass, including both `pr-detection.test.ts` and the new `pr-mutation-detection.test.ts`.
+
+- [ ] **Step 4: Verify no test file exceeds 300 lines**
+
+Run: `wc -l packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+Expected: under 300 lines. If over, split into `pr-mutation-detection.parser.test.ts` and `pr-mutation-detection.flow.test.ts`.
+
+- [ ] **Step 5: Commit the changeset**
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for PR mutation detection"
+```
+
+---
+
+## Task 7: Push branch and open PR
+
+- [ ] **Step 1: Verify branch state**
+
+Run:
+
+```bash
+git branch --show-current
+git log --oneline origin/main..HEAD
+```
+
+Expected: branch is `feat/pr-mutation-detection`; commits include the spec, session-state, parser, stash, consume, docs, and changeset commits.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin feat/pr-mutation-detection
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --title "feat(core): detect PR mutation commands (gh pr edit/ready/merge/close/...)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds a second PR detection path that parses the PR identifier from Bash **command args** for `gh pr edit|ready|merge|close|reopen|comment|review`, `glab mr update|merge|close|reopen|note`, and `az repos pr update`.
+- Emits `source: 'mentioned'` — no new source state, no UI change.
+- Complements the existing tool_result URL scraper; the frontend dedup handles overlap.
+- Number-only args (`gh pr edit 42`) are intentionally not handled by the new path; they still fall through to the existing URL scraper when output contains the PR URL.
+
+Spec: `docs/superpowers/specs/2026-04-21-pr-mutation-detection-design.md`
+
+## Test plan
+
+- [ ] Run `pnpm --filter @qlan-ro/mainframe-core test` — all tests pass
+- [ ] Open a chat and have the agent run `gh pr edit <url> --add-label …` — PR appears in the detected list as a faded badge
+- [ ] Open a chat and have the agent run `gh pr ready org/repo#42` — PR appears
+- [ ] Have the agent run a mutation that fails (`is_error: true`) — PR does **not** appear
+- [ ] Verify existing `gh pr create` flow still emits `source: 'created'` (green badge)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- Scope (gh/glab/az mutation commands, excludes git push) → Task 2 regex list and Task 3 tests cover all commands.
+- `pendingPrMutations` session state → Task 1.
+- Path B args parser (URL + `owner/repo#N`) → Task 2 with dedicated tests.
+- Stash at tool_use → Task 3.
+- Consume at tool_result with `is_error` filter → Task 4.
+- No new source state, `'mentioned'` reused → Task 4 implementation.
+- Frontend dedup absorbs overlap → Task 4's "overlap" test documents the core-level behavior; no frontend changes needed.
+- Docs update → Task 5.
+- Changeset → Task 6.
+
+**Placeholder scan:** No TBDs, no "add appropriate handling", every code block is literal.
+
+**Type consistency:** `DetectedPrCore` shape `{url, owner, repo, number}` matches between `session.ts` field, `parsePrIdentifierFromArgs` return type, and `pendingPrMutations.set(...)` calls. `isPrMutationCommand` and `parsePrIdentifierFromArgs` signatures match usage sites in Task 3.
+
+**File-size check:** `events.ts` current length ~352 lines; added code ~15 lines → ~367, still under the 300-line soft ceiling? No — `events.ts` is already over 300. The project's soft rule is 300 lines and this file is pre-existing. Not adding a decomposition task here because: the file has a single coherent responsibility (Claude event → sink dispatch), splitting it mid-feature would expand the diff significantly, and the new additions are small. If review flags the file size, a follow-up PR can split by event type.

--- a/docs/superpowers/specs/2026-04-21-pr-mutation-detection-design.md
+++ b/docs/superpowers/specs/2026-04-21-pr-mutation-detection-design.md
@@ -1,0 +1,165 @@
+# PR Mutation Detection
+
+**Status:** Approved · **Date:** 2026-04-21
+
+## Summary
+
+Extend PR detection to catch `gh pr edit|ready|merge|close|comment|reopen|review` (and GitLab/Azure equivalents) by parsing the PR identifier from the Bash command args, not just from the tool_result output. Emissions use the existing `source: 'mentioned'` — no new source state, no UI change.
+
+## Motivation
+
+Today, `packages/core/src/plugins/builtin/claude/events.ts` only stashes Bash tool_use IDs for PR-creation commands (`gh pr create`, `glab mr create`, `az repos pr create`) and relies on URL scraping in tool_result text. That works for creates (the URL is the output) and for passive mentions, but silently misses PR mutations when:
+
+- the command output omits the PR URL (`--json` with a url-less field set, quiet flags, newer `gh` behaviors, errored-but-partially-succeeded mutations),
+- the mutation completes silently.
+
+The goal is a reliable "this session touched PR #N" signal: if the agent ran a mutation command against a specific PR and it succeeded, that PR should show up in the chat's detected-PR list, even if the URL never appears in stdout.
+
+## Scope
+
+Detect the following commands and emit `source: 'mentioned'` when the PR identifier can be extracted from the **command args**:
+
+| Provider | Commands |
+|----------|----------|
+| GitHub | `gh pr edit`, `gh pr ready`, `gh pr merge`, `gh pr close`, `gh pr reopen`, `gh pr comment`, `gh pr review` |
+| GitLab | `glab mr update`, `glab mr merge`, `glab mr close`, `glab mr reopen`, `glab mr note` |
+| Azure | `az repos pr update` |
+
+Explicitly **out of scope**:
+
+- `git push`, `git commit`, `git branch` — no PR identifier in args or reliable output.
+- `gh pr view`, `gh pr list`, `gh pr diff`, `gh pr checkout`, `gh pr status` — read-only or repo-level, not per-PR mutations.
+- Number-only args (`gh pr edit 42`) — the owner/repo context is ambiguous without a `git remote` shell-out, which we've chosen not to add. These still get caught by the existing output-URL scraper (Path A) when the command prints the PR URL on success, so coverage remains practically unchanged.
+
+## Detection logic
+
+Two detection paths run in parallel on every Bash tool call. Both feed `sink.onPrDetected()`; the frontend's existing `(owner, repo, number)` dedup in `chats.addDetectedPr` (`packages/desktop/src/renderer/store/chats.ts`) absorbs overlap, and the existing `mentioned → created` upgrade rule still applies.
+
+**Path A (existing, unchanged):** scan tool_result text with `extractPrFromToolResult`. If the originating tool_use_id is in `session.state.pendingPrCreates`, emit `source: 'created'`; otherwise `source: 'mentioned'`.
+
+**Path B (new):** at assistant tool_use time, if the command matches a mutation pattern **and** the args contain a parseable PR reference, stash `(toolUseId → {owner, repo, number, url})` in a new `session.state.pendingPrMutations: Map<string, DetectedPrCore>`. At user tool_result time, if the result's `tool_use_id` is in that map and `is_error !== true`, emit `sink.onPrDetected({...stashed, source: 'mentioned'})` and delete the entry.
+
+### Parseable PR references in args
+
+A command arg is parseable when it is one of:
+
+1. A full PR/MR URL — any of the three existing URL regexes (`PR_URL_REGEX`, `GITLAB_MR_URL_REGEX`, `AZURE_PR_URL_REGEX`) matches.
+2. GitHub's compact `owner/repo#N` syntax — new regex: `^([^/\s#]+)\/([^/\s#]+)#(\d+)$`. Only accepted for `gh pr *` commands (the syntax is gh-specific).
+
+Anything else — bare number, no identifier at all, or unrecognized format — means Path B skips. Path A still runs.
+
+### Why wait for tool_result instead of emitting at tool_use
+
+Two reasons:
+
+1. **Error filtering.** `is_error: true` on the tool_result means the command failed; we don't want to claim the agent "touched" a PR that rejected the mutation (auth failure, merge conflict, PR-not-found, etc.). This mirrors the create path, which only marks `'created'` when a URL actually appears in the result.
+2. **Symmetry.** The existing stash-and-consume pattern for creates is well-understood and tested. Keeping mutations on the same shape avoids two divergent lifecycles.
+
+## Types
+
+No changes to `packages/types/src/adapter.ts`. `DetectedPr.source` stays `'created' | 'mentioned'`.
+
+New internal type local to `events.ts`:
+
+```ts
+type DetectedPrCore = Omit<DetectedPr, 'source'>;
+```
+
+New session state in `packages/core/src/plugins/builtin/claude/session.ts`:
+
+```ts
+pendingPrMutations: Map<string, DetectedPrCore>; // tool_use_id → pr info
+```
+
+Initialized to `new Map()` alongside `pendingPrCreates`.
+
+## Implementation outline
+
+All changes live in `packages/core/src/plugins/builtin/claude/events.ts` except the session-state field.
+
+New exports:
+
+```ts
+export const PR_MUTATION_COMMANDS: RegExp[] = [
+  /\bgh\s+pr\s+(edit|ready|merge|close|reopen|comment|review)\b/,
+  /\bglab\s+mr\s+(update|merge|close|reopen|note)\b/,
+  /\baz\s+repos\s+pr\s+update\b/,
+];
+
+export function isPrMutationCommand(command: string): boolean;
+
+export function parsePrIdentifierFromArgs(
+  command: string
+): DetectedPrCore | null;
+```
+
+`parsePrIdentifierFromArgs` tries the three URL regexes first, then the `owner/repo#N` pattern (only if the command starts with `gh pr `). Returns the first match's `{url, owner, repo, number}` or `null`.
+
+In `handleAssistantEvent`, right after the existing `isPrCreateCommand` block:
+
+```ts
+if (input?.command && isPrMutationCommand(input.command)) {
+  const pr = parsePrIdentifierFromArgs(input.command);
+  if (pr) session.state.pendingPrMutations.set(block.id as string, pr);
+}
+```
+
+In `handleUserEvent`, inside the `tool_result` branch, after the existing Path A block:
+
+```ts
+const toolUseId = block.tool_use_id as string | undefined;
+if (toolUseId && session.state.pendingPrMutations.has(toolUseId)) {
+  const isError = block.is_error === true;
+  const stashed = session.state.pendingPrMutations.get(toolUseId)!;
+  session.state.pendingPrMutations.delete(toolUseId);
+  if (!isError) {
+    sink.onPrDetected({ ...stashed, source: 'mentioned' });
+  }
+}
+```
+
+Path A and Path B both running means the same `(owner, repo, number)` could be emitted twice for a single command (URL also appears in output). The frontend store already short-circuits the duplicate emission; no change needed there.
+
+## Testing
+
+New file: `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`.
+
+Cases:
+
+1. `gh pr edit https://github.com/org/repo/pull/42 --add-label bug` → emits `{owner: 'org', repo: 'repo', number: 42, source: 'mentioned'}`.
+2. `gh pr ready org/repo#42` → emits the same.
+3. `gh pr edit 42` (number-only) → Path B does not emit; if the tool_result stdout includes the URL, Path A emits as `'mentioned'`.
+4. `gh pr merge https://github.com/org/repo/pull/42 --squash` with `is_error: true` on tool_result → no emission.
+5. `glab mr update https://gitlab.com/org/repo/-/merge_requests/7` → emits with GitLab URL.
+6. `az repos pr update --id 5` → Path B skips (no URL in args); if output has URL, Path A handles.
+7. One assistant turn with both `gh pr create` and `gh pr edit <url>` for different PRs → first is `'created'` (at tool_result with URL), second is `'mentioned'`.
+8. `gh pr view 42` → neither path B nor A emits (no URL in args, no URL in typical view output for this test fixture).
+9. Command arg contains a URL but is not a mutation command (e.g., `echo https://github.com/org/repo/pull/42`) → Path B skips; Path A emits `'mentioned'` from the output, same as today.
+
+Mock `SessionSink` as in the existing `pr-detection.test.ts`. Assertions use `expect(sink.onPrDetected).toHaveBeenCalledWith(...)` / `.not.toHaveBeenCalled()`.
+
+No new frontend tests: the store's dedup path is already covered by `chats.ts` tests, and no UI behavior changes.
+
+## UI
+
+No changes. New `'mentioned'` emissions render with the existing faded-badge styling in `PrBadge.tsx`. The `mentioned → created` upgrade still works because a later `gh pr create` on the same PR goes through the unchanged create path.
+
+## Documentation
+
+Update `docs/adapters/claude/PR_TRACKING.md`:
+
+- "What Mainframe Currently Does" is already stale (says "Nothing"). Rewrite it to describe both paths:
+  - Path A: tool_result URL scraping (source: `'created'` when tool_use was a create command, else `'mentioned'`).
+  - Path B: command-args parsing for mutation commands (source: `'mentioned'`).
+- Update the "Detected Commands" table's "What Mainframe Can Do" section to reflect that mutations are now tracked.
+
+## Scope summary
+
+| File | Change |
+|---|---|
+| `packages/core/src/plugins/builtin/claude/events.ts` | Add `PR_MUTATION_COMMANDS`, `isPrMutationCommand`, `parsePrIdentifierFromArgs`. Extend `handleAssistantEvent` and `handleUserEvent`. |
+| `packages/core/src/plugins/builtin/claude/session.ts` | Add `pendingPrMutations: Map<string, DetectedPrCore>` to state; initialize to `new Map()`. |
+| `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts` | New test file, ~9 cases. |
+| `docs/adapters/claude/PR_TRACKING.md` | Update "What Mainframe Currently Does" section. |
+
+No type changes in `packages/types`. No changes to `packages/desktop`. No changes to the daemon event router, HTTP/WS protocol, or SQLite schema.

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+import { handleStdout, isPrMutationCommand, parsePrIdentifierFromArgs } from '../events.js';
+import type { ClaudeSession } from '../session.js';
+
+function createMockSink(): SessionSink {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: vi.fn(),
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+  };
+}
+
+function createMockSession(): ClaudeSession {
+  return {
+    id: 'test-session',
+    state: {
+      buffer: '',
+      chatId: null,
+      status: 'ready',
+      lastAssistantUsage: undefined,
+      activeTasks: new Map(),
+      pendingCancelCallbacks: new Map(),
+      pendingPrCreates: new Set(),
+      pendingPrMutations: new Map(),
+    },
+    clearInterruptTimer: vi.fn(),
+    requestContextUsage: vi.fn(),
+  } as unknown as ClaudeSession;
+}
+
+describe('isPrMutationCommand', () => {
+  it('matches gh pr mutations', () => {
+    expect(isPrMutationCommand('gh pr edit 42 --title "new"')).toBe(true);
+    expect(isPrMutationCommand('gh pr ready 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr merge 42 --squash')).toBe(true);
+    expect(isPrMutationCommand('gh pr close 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr reopen 42')).toBe(true);
+    expect(isPrMutationCommand('gh pr comment 42 --body "hi"')).toBe(true);
+    expect(isPrMutationCommand('gh pr review 42 --approve')).toBe(true);
+  });
+
+  it('matches glab mr mutations', () => {
+    expect(isPrMutationCommand('glab mr update 7 --title "new"')).toBe(true);
+    expect(isPrMutationCommand('glab mr merge 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr close 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr reopen 7')).toBe(true);
+    expect(isPrMutationCommand('glab mr note 7 --message "hi"')).toBe(true);
+  });
+
+  it('matches az repos pr update', () => {
+    expect(isPrMutationCommand('az repos pr update --id 5 --status completed')).toBe(true);
+  });
+
+  it('does not match read-only or create commands', () => {
+    expect(isPrMutationCommand('gh pr view 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr list')).toBe(false);
+    expect(isPrMutationCommand('gh pr create --title "x"')).toBe(false);
+    expect(isPrMutationCommand('gh pr checkout 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr diff 42')).toBe(false);
+    expect(isPrMutationCommand('gh pr status')).toBe(false);
+    expect(isPrMutationCommand('glab mr list')).toBe(false);
+    expect(isPrMutationCommand('glab mr view 7')).toBe(false);
+    expect(isPrMutationCommand('glab mr create')).toBe(false);
+    expect(isPrMutationCommand('git push')).toBe(false);
+    expect(isPrMutationCommand('echo gh pr edit 42')).toBe(true); // word-boundary match; acceptable — rare false positive
+  });
+});
+
+describe('parsePrIdentifierFromArgs', () => {
+  it('parses a GitHub PR URL', () => {
+    expect(parsePrIdentifierFromArgs('gh pr edit https://github.com/org/repo/pull/42 --add-label bug')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('parses a GitLab MR URL', () => {
+    expect(parsePrIdentifierFromArgs('glab mr update https://gitlab.com/org/repo/-/merge_requests/7')).toEqual({
+      url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+      owner: 'org',
+      repo: 'repo',
+      number: 7,
+    });
+  });
+
+  it('parses an Azure DevOps PR URL', () => {
+    expect(
+      parsePrIdentifierFromArgs('az repos pr update https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/5'),
+    ).toEqual({
+      url: 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/5',
+      owner: 'myorg',
+      repo: 'myrepo',
+      number: 5,
+    });
+  });
+
+  it('parses gh compact syntax owner/repo#N', () => {
+    expect(parsePrIdentifierFromArgs('gh pr ready org/repo#42')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('returns null when command has no PR identifier', () => {
+    expect(parsePrIdentifierFromArgs('gh pr edit 42 --title x')).toBeNull();
+    expect(parsePrIdentifierFromArgs('gh pr edit')).toBeNull();
+    expect(parsePrIdentifierFromArgs('az repos pr update --id 5')).toBeNull();
+  });
+
+  it('does not accept compact syntax for non-gh commands', () => {
+    expect(parsePrIdentifierFromArgs('glab mr update org/repo#42')).toBeNull();
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
@@ -228,3 +228,266 @@ describe('handleAssistantEvent stashes pending mutations', () => {
     expect(session.state.pendingPrMutations.has('tu_mut_4')).toBe(false);
   });
 });
+
+describe('handleUserEvent consumes pending mutations', () => {
+  it('emits source:mentioned when tool_result matches a pending mutation', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    // Simulate stash
+    session.state.pendingPrMutations.set('tu_mut_ok', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_mut_ok',
+            content: 'OK',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+    expect(session.state.pendingPrMutations.has('tu_mut_ok')).toBe(false);
+  });
+
+  it('does not emit when tool_result has is_error: true', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    session.state.pendingPrMutations.set('tu_mut_err', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_mut_err',
+            content: 'authentication failed',
+            is_error: true,
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).not.toHaveBeenCalled();
+    expect(session.state.pendingPrMutations.has('tu_mut_err')).toBe(false);
+  });
+
+  it('end-to-end: gh pr edit with URL arg emits source:mentioned after success', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_e2e_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/42 --add-label bug' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_e2e_1',
+            content: '✓ Edited pull request #42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+
+  it('number-only gh pr edit 42 still detected via Path A when output contains URL', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    // tool_use with number-only arg → Path B does NOT stash
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_num_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit 42 --title new' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+    expect(session.state.pendingPrMutations.has('tu_num_1')).toBe(false);
+
+    // tool_result contains URL → Path A emits as 'mentioned' (not in pendingPrCreates)
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_num_1',
+            content: 'https://github.com/org/repo/pull/42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+
+  it('create and mutate in the same assistant turn are handled independently', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const assistantEvent = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_create',
+            name: 'Bash',
+            input: { command: 'gh pr create --title "feat"' },
+          },
+          {
+            type: 'tool_use',
+            id: 'tu_edit',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/10 --add-label priority' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(assistantEvent) + '\n'), sink);
+
+    expect(session.state.pendingPrCreates.has('tu_create')).toBe(true);
+    expect(session.state.pendingPrMutations.has('tu_edit')).toBe(true);
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_create',
+            content: 'https://github.com/org/repo/pull/11',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_edit',
+            content: '✓ Edited',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/11',
+      owner: 'org',
+      repo: 'repo',
+      number: 11,
+      source: 'created',
+    });
+    expect(sink.onPrDetected).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo/pull/10',
+      owner: 'org',
+      repo: 'repo',
+      number: 10,
+      source: 'mentioned',
+    });
+  });
+
+  it('emits twice when tool_result output contains the same URL — frontend dedup absorbs', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    session.state.pendingPrMutations.set('tu_overlap', {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+
+    const userEvent = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu_overlap',
+            content: '✓ https://github.com/org/repo/pull/42',
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(userEvent) + '\n'), sink);
+
+    // Path A emits 'mentioned' from the URL in output; Path B also emits 'mentioned'.
+    // Both calls are to onPrDetected with source:'mentioned' for the same PR.
+    // The frontend dedup (chats.addDetectedPr) collapses them; core does not.
+    expect(sink.onPrDetected).toHaveBeenCalledTimes(2);
+    expect(sink.onPrDetected).toHaveBeenNthCalledWith(1, {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+    expect(sink.onPrDetected).toHaveBeenNthCalledWith(2, {
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+      source: 'mentioned',
+    });
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
@@ -128,3 +128,103 @@ describe('parsePrIdentifierFromArgs', () => {
     expect(parsePrIdentifierFromArgs('glab mr update org/repo#42')).toBeNull();
   });
 });
+
+describe('handleAssistantEvent stashes pending mutations', () => {
+  it('stashes tool_use_id and PR info for gh pr edit with URL arg', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_1',
+            name: 'Bash',
+            input: { command: 'gh pr edit https://github.com/org/repo/pull/42 --add-label bug' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.get('tu_mut_1')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('stashes with gh compact syntax', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_2',
+            name: 'BashTool',
+            input: { command: 'gh pr ready org/repo#42' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.get('tu_mut_2')).toEqual({
+      url: 'https://github.com/org/repo/pull/42',
+      owner: 'org',
+      repo: 'repo',
+      number: 42,
+    });
+  });
+
+  it('does not stash number-only args (gh pr edit 42)', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_3',
+            name: 'Bash',
+            input: { command: 'gh pr edit 42 --title new' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.has('tu_mut_3')).toBe(false);
+  });
+
+  it('does not stash non-mutation commands even with PR URL in args', () => {
+    const sink = createMockSink();
+    const session = createMockSession();
+
+    const event = {
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_mut_4',
+            name: 'Bash',
+            input: { command: 'echo https://github.com/org/repo/pull/42' },
+          },
+        ],
+      },
+    };
+    handleStdout(session, Buffer.from(JSON.stringify(event) + '\n'), sink);
+
+    expect(session.state.pendingPrMutations.has('tu_mut_4')).toBe(false);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -207,6 +207,10 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
           if (input?.command && isPrCreateCommand(input.command)) {
             session.state.pendingPrCreates.add(block.id as string);
           }
+          if (input?.command && isPrMutationCommand(input.command)) {
+            const pr = parsePrIdentifierFromArgs(input.command);
+            if (pr) session.state.pendingPrMutations.set(block.id as string, pr);
+          }
         }
       }
     }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -253,13 +253,13 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   for (const block of message.content) {
     if (block.type === 'tool_result') {
       const text = typeof block.content === 'string' ? block.content : '';
+      const toolUseId = block.tool_use_id as string | undefined;
       const planMatch = text.match(/Your plan has been saved to: (\/\S+\.md)/);
       if (planMatch?.[1]) {
         sink.onPlanFile(planMatch[1].trim());
       }
       const pr = extractPrFromToolResult(text);
       if (pr) {
-        const toolUseId = block.tool_use_id as string | undefined;
         const source = toolUseId && session.state.pendingPrCreates.has(toolUseId) ? 'created' : 'mentioned';
         if (source === 'created') session.state.pendingPrCreates.delete(toolUseId!);
         sink.onPrDetected({ ...pr, source });
@@ -267,10 +267,9 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
 
       // Path B: command-arg-based mutation detection. Consume any pending stash
       // keyed by this tool_use_id, regardless of whether the output contained a URL.
-      const mutationToolUseId = block.tool_use_id as string | undefined;
-      if (mutationToolUseId && session.state.pendingPrMutations.has(mutationToolUseId)) {
-        const stashed = session.state.pendingPrMutations.get(mutationToolUseId)!;
-        session.state.pendingPrMutations.delete(mutationToolUseId);
+      if (toolUseId && session.state.pendingPrMutations.has(toolUseId)) {
+        const stashed = session.state.pendingPrMutations.get(toolUseId)!;
+        session.state.pendingPrMutations.delete(toolUseId);
         if (block.is_error !== true) {
           sink.onPrDetected({ ...stashed, source: 'mentioned' });
         }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -3,6 +3,7 @@ import type {
   ContextUsage,
   ControlRequest,
   ControlUpdate,
+  DetectedPr,
   MessageContent,
   SessionSink,
 } from '@qlan-ro/mainframe-types';
@@ -31,7 +32,7 @@ function isPrCreateCommand(command: string): boolean {
 }
 
 /** PR info without the `source` field — used as the value shape for stashed mutations and as the parser return type. */
-export type DetectedPrCore = { url: string; owner: string; repo: string; number: number };
+export type DetectedPrCore = Omit<DetectedPr, 'source'>;
 
 export const PR_MUTATION_COMMANDS: RegExp[] = [
   /\bgh\s+pr\s+(edit|ready|merge|close|reopen|comment|review)\b/,

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -30,6 +30,41 @@ function isPrCreateCommand(command: string): boolean {
   return PR_CREATE_COMMANDS.some((re) => re.test(command));
 }
 
+/** PR info without the `source` field — used as the value shape for stashed mutations and as the parser return type. */
+export type DetectedPrCore = { url: string; owner: string; repo: string; number: number };
+
+export const PR_MUTATION_COMMANDS: RegExp[] = [
+  /\bgh\s+pr\s+(edit|ready|merge|close|reopen|comment|review)\b/,
+  /\bglab\s+mr\s+(update|merge|close|reopen|note)\b/,
+  /\baz\s+repos\s+pr\s+update\b/,
+];
+
+export function isPrMutationCommand(command: string): boolean {
+  return PR_MUTATION_COMMANDS.some((re) => re.test(command));
+}
+
+const GH_COMPACT_REF_REGEX = /\b([^/\s#]+)\/([^/\s#]+)#(\d+)\b/;
+
+export function parsePrIdentifierFromArgs(command: string): DetectedPrCore | null {
+  // Try full URLs first — any of the three existing regexes.
+  const fromUrl = extractPrFromToolResult(command);
+  if (fromUrl) return fromUrl;
+
+  // gh-only compact syntax: owner/repo#N
+  if (/\bgh\s+pr\s+/.test(command)) {
+    const match = GH_COMPACT_REF_REGEX.exec(command);
+    if (match) {
+      const owner = match[1]!;
+      const repo = match[2]!;
+      const number = parseInt(match[3]!, 10);
+      if (owner && repo && !isNaN(number)) {
+        return { url: `https://github.com/${owner}/${repo}/pull/${number}`, owner, repo, number };
+      }
+    }
+  }
+  return null;
+}
+
 export function parsePrUrl(text: string): { url: string; owner: string; repo: string; number: number } | null {
   const match = PR_URL_REGEX.exec(text);
   if (!match) return null;

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -264,6 +264,17 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
         if (source === 'created') session.state.pendingPrCreates.delete(toolUseId!);
         sink.onPrDetected({ ...pr, source });
       }
+
+      // Path B: command-arg-based mutation detection. Consume any pending stash
+      // keyed by this tool_use_id, regardless of whether the output contained a URL.
+      const mutationToolUseId = block.tool_use_id as string | undefined;
+      if (mutationToolUseId && session.state.pendingPrMutations.has(mutationToolUseId)) {
+        const stashed = session.state.pendingPrMutations.get(mutationToolUseId)!;
+        session.state.pendingPrMutations.delete(mutationToolUseId);
+        if (block.is_error !== true) {
+          sink.onPrDetected({ ...stashed, source: 'mentioned' });
+        }
+      }
     } else if (block.type === 'text') {
       const text = (block.text as string) || '';
       const skillMatch = text.match(/^Base directory for this skill: (.+)/m);

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -16,7 +16,7 @@ import type {
   ContextFile,
   SkillFileEntry,
 } from '@qlan-ro/mainframe-types';
-import { handleStdout, handleStderr } from './events.js';
+import { handleStdout, handleStderr, type DetectedPrCore } from './events.js';
 import { MAINFRAME_SYSTEM_PROMPT_APPEND } from './constants.js';
 import { createChildLogger } from '../../../logger.js';
 import {
@@ -64,7 +64,7 @@ export interface ClaudeSessionState {
   /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
   pendingPrCreates: Set<string>;
   /** Tool_use IDs → parsed PR info for mutation commands (gh pr edit/ready/merge/close/reopen/comment/review, etc.) */
-  pendingPrMutations: Map<string, { url: string; owner: string; repo: string; number: number }>;
+  pendingPrMutations: Map<string, DetectedPrCore>;
 }
 
 /**

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -63,6 +63,8 @@ export interface ClaudeSessionState {
   pendingCancelCallbacks: Map<string, (cancelled: boolean) => void>;
   /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
   pendingPrCreates: Set<string>;
+  /** Tool_use IDs → parsed PR info for mutation commands (gh pr edit/ready/merge/close/reopen/comment/review, etc.) */
+  pendingPrMutations: Map<string, { url: string; owner: string; repo: string; number: number }>;
 }
 
 /**
@@ -101,6 +103,7 @@ export class ClaudeSession implements AdapterSession {
       interruptTimer: null,
       pendingCancelCallbacks: new Map(),
       pendingPrCreates: new Set(),
+      pendingPrMutations: new Map(),
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds a second PR detection path that parses the PR identifier from Bash **command args** for `gh pr edit|ready|merge|close|reopen|comment|review`, `glab mr update|merge|close|reopen|note`, and `az repos pr update`.
- Emits `source: 'mentioned'` — no new source state, no UI change.
- Complements the existing tool_result URL scraper (Path A); the frontend dedup absorbs overlap.
- Number-only args (`gh pr edit 42`) are intentionally not handled by the new path; they still fall through to Path A when the command output contains the PR URL.
- Stash is unconditionally cleared at tool_result time (leak prevention); emission is gated on `is_error !== true`.

Spec and plan are committed to the branch under `docs/superpowers/`.

## Test plan

- [ ] `pnpm --filter @qlan-ro/mainframe-core test` — 1026/1026 passing locally
- [ ] Run a real `gh pr edit <url> --add-label …` in a chat — PR appears in detected list as a faded badge
- [ ] Run `gh pr ready org/repo#42` — PR appears
- [ ] Run a mutation that fails (`is_error: true`) — PR does NOT appear; pending stash is cleared
- [ ] Verify existing `gh pr create` flow still emits `source: 'created'` (green badge)

## Follow-ups (out of scope)

- Split \`events.ts\` (now ~400 lines) into a dedicated \`pr-detection.ts\` module
- Clear \`pendingPrCreates\` and \`pendingPrMutations\` on \`interrupt()\`/\`kill()\` to bound leakage on killed turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)