### PR TITLE
fix(worktree): stop git polls for sessions whose worktree was deleted

### DIFF
--- a/.changeset/worktree-missing-effective-path.md
+++ b/.changeset/worktree-missing-effective-path.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Stop hammering deleted worktrees with git polls. When a worktree is removed, chats bound to it are now flagged so `getEffectivePath` returns null (routes 404 cleanly) and the StatusBar pauses its branch/status poll instead of throwing `GitConstructError` on every tick.

--- a/packages/core/src/__tests__/routes/types.test.ts
+++ b/packages/core/src/__tests__/routes/types.test.ts
@@ -58,4 +58,16 @@ describe('getEffectivePath', () => {
     const result = getEffectivePath(ctx, 'p1', 'unknown-chat');
     expect(result).toBe('/my/project');
   });
+
+  it('returns null when chat has a worktree but it is missing on disk', () => {
+    (ctx.db.projects.get as any).mockReturnValue({ id: 'p1', path: '/my/project' });
+    (ctx.chats.getChat as any).mockReturnValue({
+      id: 'c1',
+      worktreePath: '/deleted/worktree',
+      worktreeMissing: true,
+    });
+
+    const result = getEffectivePath(ctx, 'p1', 'c1');
+    expect(result).toBeNull();
+  });
 });

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -449,6 +449,15 @@ export class ChatManager {
     return chats.map((chat) => this.enrichChat(chat));
   }
 
+  /** Re-emit chat.updated for every non-archived chat bound to the given worktree path so clients pick up the new worktreeMissing flag. */
+  notifyWorktreeDeleted(worktreePath: string): void {
+    for (const raw of this.db.chats.listAll()) {
+      if (raw.worktreePath !== worktreePath) continue;
+      const enriched = this.enrichChat(raw);
+      this.emitEvent({ type: 'chat.updated', chat: enriched });
+    }
+  }
+
   getChat(chatId: string): Chat | null {
     const active = this.activeChats.get(chatId);
     const chat = active ? active.chat : this.db.chats.get(chatId);

--- a/packages/core/src/server/routes/__tests__/delete-worktree.test.ts
+++ b/packages/core/src/server/routes/__tests__/delete-worktree.test.ts
@@ -29,6 +29,7 @@ function makeCtx(projectPath: string | null = PROJECT_PATH) {
       disableWorktree: vi.fn(),
       forkToWorktree: vi.fn(),
       attachWorktree: vi.fn(),
+      notifyWorktreeDeleted: vi.fn(),
     },
   } as any;
 }
@@ -90,6 +91,21 @@ describe('POST /api/projects/:id/git/delete-worktree', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(removeWorktree).toHaveBeenCalledWith(PROJECT_PATH, WORKTREE_PATH, 'feat-x');
+  });
+
+  it('notifies chats bound to the deleted worktree on success', async () => {
+    vi.mocked(getWorktrees).mockResolvedValue([
+      { path: PROJECT_PATH, branch: 'refs/heads/main' },
+      { path: WORKTREE_PATH, branch: 'refs/heads/feat-x' },
+    ]);
+    vi.mocked(removeWorktree).mockReturnValue(undefined);
+    const ctx = makeCtx();
+    const app = makeApp(ctx);
+    const res = await request(app)
+      .post('/api/projects/proj1/git/delete-worktree')
+      .send({ worktreePath: WORKTREE_PATH });
+    expect(res.status).toBe(200);
+    expect(ctx.chats.notifyWorktreeDeleted).toHaveBeenCalledWith(WORKTREE_PATH);
   });
 
   it('uses provided branchName over the one from git worktree list', async () => {

--- a/packages/core/src/server/routes/types.ts
+++ b/packages/core/src/server/routes/types.ts
@@ -36,7 +36,10 @@ export function getEffectivePath(ctx: RouteContext, projectId: string, chatId?: 
   if (!project) return null;
   if (chatId) {
     const chat = ctx.chats.getChat(chatId);
-    if (chat?.worktreePath) return chat.worktreePath;
+    if (chat?.worktreePath) {
+      if (chat.worktreeMissing) return null;
+      return chat.worktreePath;
+    }
   }
   return project.path;
 }

--- a/packages/core/src/server/routes/worktree.ts
+++ b/packages/core/src/server/routes/worktree.ts
@@ -32,6 +32,7 @@ const AttachWorktreeBody = z.object({
 });
 
 async function validateAndDeleteWorktree(
+  ctx: RouteContext,
   projectPath: string,
   worktreePath: string,
   branchName: string | undefined,
@@ -62,6 +63,7 @@ async function validateAndDeleteWorktree(
     throw new Error('Cannot determine branch name for worktree');
   }
   removeWorktree(projectPath, worktreePath, resolvedBranch);
+  ctx.chats.notifyWorktreeDeleted(worktreePath);
 }
 
 export function worktreeRoutes(ctx: RouteContext): Router {
@@ -173,7 +175,7 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       }
       const { worktreePath, branchName } = parsed.data;
       try {
-        await validateAndDeleteWorktree(projectPath, worktreePath, branchName);
+        await validateAndDeleteWorktree(ctx, projectPath, worktreePath, branchName);
         res.json({ success: true });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to delete worktree';

--- a/packages/desktop/src/renderer/components/StatusBar.tsx
+++ b/packages/desktop/src/renderer/components/StatusBar.tsx
@@ -102,13 +102,14 @@ export function StatusBar(): React.ReactElement {
   const chats = useChatsStore((s) => s.chats);
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const inWorktree = useChatsStore((s) => !!s.chats.find((c) => c.id === s.activeChatId)?.worktreePath);
+  const worktreeMissing = useChatsStore((s) => !!s.chats.find((c) => c.id === s.activeChatId)?.worktreeMissing);
   const [gitBranch, setGitBranch] = useState<string | null>(null);
   const [hasConflicts, setHasConflicts] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchBranchAndStatus = useCallback(() => {
-    if (!activeProjectId) {
+    if (!activeProjectId || worktreeMissing) {
       setGitBranch(null);
       setHasConflicts(false);
       return;
@@ -128,7 +129,7 @@ export function StatusBar(): React.ReactElement {
         console.warn('[StatusBar] git status fetch failed', err);
         setHasConflicts(false);
       });
-  }, [activeProjectId, activeChatId]);
+  }, [activeProjectId, activeChatId, worktreeMissing]);
 
   useEffect(() => {
     fetchBranchAndStatus();


### PR DESCRIPTION
## Summary
- `getEffectivePath` (`routes/types.ts`) returns `null` when `chat.worktreeMissing === true`, so all path-resolved routes (git, files, search, launch) 404 cleanly instead of handing back a stale path.
- `ChatManager.notifyWorktreeDeleted(worktreePath)` re-emits `chat.updated` for every chat bound to the path, so clients pick up the new `worktreeMissing` flag without waiting for a refresh.
- `StatusBar.fetchBranchAndStatus` skips its branch/status poll when the active chat's worktree is missing, eliminating the recurring `GitConstructError: Cannot use simple-git on a directory that does not exist` log spam.

The existing infra (`worktreeMissing` computed in `enrichChat`, composer disabled, session-row badge, `sendMessage` blocked) already covered most of the UX — what was missing was the server path resolver and the StatusBar poll.

## Test plan
- [x] `getEffectivePath` returns `null` for a chat with `worktreeMissing: true` (new test in `__tests__/routes/types.test.ts`)
- [x] `delete-worktree` route calls `ctx.chats.notifyWorktreeDeleted` on success (new test in `routes/__tests__/delete-worktree.test.ts`)
- [x] Core build + targeted tests green
- [ ] Manual: open a session in a worktree, delete the worktree from BranchPopover, confirm StatusBar stops polling and no `GitConstructError` warnings appear in the daemon log

🤖 Generated with [Claude Code](https://claude.com/claude-code)