### PR TITLE
fix(desktop): clear sidebar project filter when active chat moves projects

### DIFF
--- a/.changeset/busy-schools-trade.md
+++ b/.changeset/busy-schools-trade.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix sidebar project filter drifting out of sync with the open chat. When the active chat changes (search palette, toast click, tab switch, daemon-driven activation, runtime thread switch), the filter is now cleared if the new chat lives in a different project, so the badge no longer points at a project the user is not viewing.

--- a/packages/desktop/src/__tests__/stores/chats.test.ts
+++ b/packages/desktop/src/__tests__/stores/chats.test.ts
@@ -382,76 +382,54 @@ describe('useChatsStore', () => {
   });
 
   describe('filterProjectId / activeChatId boot-time reconciliation', () => {
-    // Simulates the sequence executed by useAppInit.loadData() on startup.
-    // The fix ensures that when the restored active chat belongs to a different
-    // project than the persisted filterProjectId, the filter is updated to match
-    // the active chat so the badge and the chat list stay in sync.
+    // setActiveChat clears filterProjectId to null when the new active chat
+    // lives in a different project than the persisted filter. This keeps the
+    // sidebar badge from pointing at a project the user is no longer viewing
+    // and avoids yanking the filter to an unrelated project the user did not
+    // explicitly choose.
 
-    function simulateBoot(chats: Chat[], activeChatId: string, initialFilterProjectId: string | null): void {
-      useChatsStore.setState({ filterProjectId: initialFilterProjectId });
-      useChatsStore.getState().setChats(chats);
-      useChatsStore.getState().setActiveChat(activeChatId);
-
-      // Reconciliation logic (mirrors useAppInit loadData)
-      const restoredChat = chats.find((c) => c.id === activeChatId);
-      if (restoredChat) {
-        const { filterProjectId, setFilterProjectId } = useChatsStore.getState();
-        if (filterProjectId !== null && filterProjectId !== restoredChat.projectId) {
-          setFilterProjectId(restoredChat.projectId);
-        }
-      }
-    }
-
-    it('updates filterProjectId when it disagrees with the restored active chat project', () => {
+    it('clears filterProjectId when restored active chat is in a different project', () => {
       const chatA = makeChat({ id: 'chat-a', projectId: 'proj-a' });
       const chatB = makeChat({ id: 'chat-b', projectId: 'proj-b' });
+      useChatsStore.setState({ filterProjectId: 'proj-a' });
+      useChatsStore.getState().setChats([chatA, chatB]);
 
-      // User had proj-a filtered, but last active chat is in proj-b
-      simulateBoot([chatA, chatB], 'chat-b', 'proj-a');
+      useChatsStore.getState().setActiveChat('chat-b');
 
-      expect(useChatsStore.getState().filterProjectId).toBe('proj-b');
+      expect(useChatsStore.getState().filterProjectId).toBeNull();
       expect(useChatsStore.getState().activeChatId).toBe('chat-b');
     });
 
     it('leaves filterProjectId unchanged when it already matches the restored active chat', () => {
       const chatA = makeChat({ id: 'chat-a', projectId: 'proj-a' });
+      useChatsStore.setState({ filterProjectId: 'proj-a' });
+      useChatsStore.getState().setChats([chatA]);
 
-      simulateBoot([chatA], 'chat-a', 'proj-a');
+      useChatsStore.getState().setActiveChat('chat-a');
 
       expect(useChatsStore.getState().filterProjectId).toBe('proj-a');
     });
 
     it('leaves filterProjectId null (All) untouched regardless of active chat project', () => {
       const chatA = makeChat({ id: 'chat-a', projectId: 'proj-a' });
+      useChatsStore.setState({ filterProjectId: null });
+      useChatsStore.getState().setChats([chatA]);
 
-      // filterProjectId === null means "All" — not a user-set project filter,
-      // so no reconciliation should occur.
-      simulateBoot([chatA], 'chat-a', null);
+      useChatsStore.getState().setActiveChat('chat-a');
 
       expect(useChatsStore.getState().filterProjectId).toBeNull();
     });
 
-    it('handles fall-back-to-most-recent path: filter updated to match most recent chat project', () => {
+    it('clears filterProjectId on fall-back-to-most-recent across projects', () => {
       const chatOld = makeChat({ id: 'chat-old', projectId: 'proj-a', updatedAt: '2026-01-01T00:00:00Z' });
       const chatNew = makeChat({ id: 'chat-new', projectId: 'proj-b', updatedAt: '2026-01-02T00:00:00Z' });
-
-      // Simulate: stale activeChatId not in list → fall back to most recent
-      const chatsList = [chatOld, chatNew];
       useChatsStore.setState({ filterProjectId: 'proj-a' });
-      useChatsStore.getState().setChats(chatsList);
+      useChatsStore.getState().setChats([chatOld, chatNew]);
 
-      const sorted = [...chatsList].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-      const mostRecent = sorted[0]!;
-      useChatsStore.getState().setActiveChat(mostRecent.id);
-
-      // Reconciliation
-      const { filterProjectId, setFilterProjectId } = useChatsStore.getState();
-      if (filterProjectId !== null && filterProjectId !== mostRecent.projectId) {
-        setFilterProjectId(mostRecent.projectId);
-      }
+      useChatsStore.getState().setActiveChat('chat-new');
 
       expect(useChatsStore.getState().activeChatId).toBe('chat-new');
-      expect(useChatsStore.getState().filterProjectId).toBe('proj-b');
+      expect(useChatsStore.getState().filterProjectId).toBeNull();
     });
   });
 });

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -112,16 +112,8 @@ export function useAppInit(): void {
             localStorage.removeItem('mf:activeChatId');
           }
 
-          // Keep the project badge in sync with the restored active chat.
-          // If the persisted filterProjectId disagrees with the active chat's
-          // project (e.g. user reloaded after switching chats without clicking
-          // the badge), update the filter so both stay consistent.
-          if (restoredChat) {
-            const { filterProjectId, setFilterProjectId } = useChatsStore.getState();
-            if (filterProjectId !== null && filterProjectId !== restoredChat.projectId) {
-              setFilterProjectId(restoredChat.projectId);
-            }
-          }
+          // setActiveChat reconciles filterProjectId on its own: it clears the
+          // filter to null when the new active chat lives in a different project.
         } else {
           log.warn('chat fetch failed', { err: String(chatsResult.reason) });
         }

--- a/packages/desktop/src/renderer/store/chats.test.ts
+++ b/packages/desktop/src/renderer/store/chats.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useChatsStore } from './chats';
 import type { Chat } from '@qlan-ro/mainframe-types';
 
-function makeChat(id: string, updatedAt: string, pinned = false): Chat {
+function makeChat(id: string, updatedAt: string, pinned = false, projectId = 'proj-1'): Chat {
   return {
     id,
     adapterId: 'claude',
-    projectId: 'proj-1',
+    projectId,
     status: 'active',
     createdAt: updatedAt,
     updatedAt,
@@ -131,5 +131,49 @@ describe('unread state', () => {
     useChatsStore.getState().markUnread('chat-2');
     useChatsStore.getState().setActiveChat('chat-1');
     expect(useChatsStore.getState().unreadChatIds.has('chat-2')).toBe(true);
+  });
+});
+
+describe('filterProjectId reconciliation on setActiveChat', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useChatsStore.setState({
+      chats: [
+        makeChat('chat-a', '2024-01-01T00:00:00.000Z', false, 'proj-A'),
+        makeChat('chat-b', '2024-01-01T00:00:00.000Z', false, 'proj-B'),
+      ],
+      activeChatId: null,
+      filterProjectId: null,
+    });
+  });
+
+  it("clears filterProjectId when active chat's project differs from the filter", () => {
+    useChatsStore.getState().setFilterProjectId('proj-A');
+    useChatsStore.getState().setActiveChat('chat-b');
+    expect(useChatsStore.getState().filterProjectId).toBeNull();
+    expect(localStorage.getItem('mf:filterProjectId')).toBeNull();
+  });
+
+  it("leaves filterProjectId unchanged when active chat's project matches the filter", () => {
+    useChatsStore.getState().setFilterProjectId('proj-A');
+    useChatsStore.getState().setActiveChat('chat-a');
+    expect(useChatsStore.getState().filterProjectId).toBe('proj-A');
+  });
+
+  it('leaves filterProjectId unchanged when no filter is set', () => {
+    useChatsStore.getState().setActiveChat('chat-b');
+    expect(useChatsStore.getState().filterProjectId).toBeNull();
+  });
+
+  it('leaves filterProjectId unchanged when active chat is cleared', () => {
+    useChatsStore.getState().setFilterProjectId('proj-A');
+    useChatsStore.getState().setActiveChat(null);
+    expect(useChatsStore.getState().filterProjectId).toBe('proj-A');
+  });
+
+  it('leaves filterProjectId unchanged when target chat is unknown', () => {
+    useChatsStore.getState().setFilterProjectId('proj-A');
+    useChatsStore.getState().setActiveChat('chat-missing');
+    expect(useChatsStore.getState().filterProjectId).toBe('proj-A');
   });
 });

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -142,7 +142,18 @@ export const useChatsStore = create<ChatsState>((set) => ({
               return s;
             })()
           : state.unreadChatIds;
-      return { activeChatId: id, unreadChatIds };
+      // Reconcile the sidebar project filter with the new active chat. If the
+      // chat's project differs from the persisted filter, clear it so the
+      // badge stops pointing at a project the user is not actually viewing.
+      let filterProjectId = state.filterProjectId;
+      if (id && filterProjectId !== null) {
+        const target = state.chats.find((c) => c.id === id);
+        if (target && target.projectId !== filterProjectId) {
+          localStorage.removeItem('mf:filterProjectId');
+          filterProjectId = null;
+        }
+      }
+      return { activeChatId: id, unreadChatIds, filterProjectId };
     });
   },
   addChat: (chat) =>


### PR DESCRIPTION
## Summary

- The sidebar's `filterProjectId` (project badge) only reconciled with the active chat on app init. Any runtime path that changes the active chat — search palette, toast click, tab switch, daemon-driven activation, assistant-ui thread switch — left the filter pointing at a project the user was no longer viewing.
- `setActiveChat` now clears `filterProjectId` to `null` when the new chat lives in a different project. The badge stops lying without yanking the user to a project they didn't choose.
- Removed the now-redundant boot-time reconciliation block from `useAppInit`.

Closes #135

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — 495/495 pass (5 new tests covering the reconciliation rule; existing boot-reconciliation suite updated for the new behavior)
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` clean
- [x] Manual: filter sidebar to project A, click a toast/search-result for a chat in project B → badge clears to "All", center shows the B chat
- [x] Manual: filter to project A, click a chat in A → badge stays on A

🤖 Generated with [Claude Code](https://claude.com/claude-code)