### PR TITLE
fix(claude): drop sidechain entries from history to stop ghost user bubbles

### DIFF
--- a/.changeset/drop-sidechain-bubbles.md
+++ b/.changeset/drop-sidechain-bubbles.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+fix(claude): drop sidechain entries from history loader so subagent dispatch prompts no longer render as ghost user bubbles in the parent thread. Skill-loaded synthesis still runs first, so user-typed `/skill` invocations are preserved.

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -468,6 +468,47 @@ describe('loadHistory', () => {
     expect(messages[3].content[0]).toMatchObject({ text: 'Continued response' });
   });
 
+  it('drops isSidechain=true entries from sibling JSONL files (subagent prompts)', async () => {
+    // Regression: when the parent CLI session spawns a subagent (Task/Agent tool),
+    // the subagent's CLI process writes its own messages — including its dispatch
+    // prompt as a `user` entry — to a sibling JSONL marked with isSidechain:true.
+    // Discovering sibling JSONLs by sessionId pulls these in, and without filtering,
+    // the subagent's prompt rendered as a ghost user bubble in the parent thread.
+    writeJsonl(SESSION_ID, [userTextEntry('Run a search'), assistantTextEntry('Dispatching the search agent.')]);
+
+    const sidechainId = 'sidechain-session-xyz';
+    writeJsonl(sidechainId, [
+      jsonlEntry({
+        type: 'user',
+        sessionId: SESSION_ID,
+        isSidechain: true,
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'Subagent prompt: search for monaco scrollbar fixes...' }],
+        },
+      }),
+      jsonlEntry({
+        type: 'assistant',
+        sessionId: SESSION_ID,
+        isSidechain: true,
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Searching...' }] },
+      }),
+    ]);
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((m) => m.type)).toEqual(['user', 'assistant']);
+    // No subagent prompt leaks into the parent thread
+    for (const m of messages) {
+      for (const block of m.content) {
+        if (block.type === 'text') {
+          expect(block.text).not.toMatch(/Subagent prompt/);
+        }
+      }
+    }
+  });
+
   it('returns empty array for non-existent session', async () => {
     const messages = await loadHistory('nonexistent-session', PROJECT_PATH);
     expect(messages).toEqual([]);

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -452,6 +452,16 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           if (entry.isMeta === true) continue;
           if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) continue;
 
+          // Sidechain entries are subagent activity (Task/Agent tool spawns its
+          // own CLI session whose messages share our sessionId but live in a
+          // sibling JSONL). The subagent's first user message is its dispatch
+          // prompt — converting it would render a ghost user bubble in the
+          // parent thread. Tool_results we still want are attached to the
+          // parent's Task tool_use via collectSubagentToolResults below.
+          // Skill-loaded synthesis above runs first so user-typed /skill
+          // invocations are preserved.
+          if (entry.isSidechain === true) continue;
+
           // "Unknown command: /X" — CLI feedback for slash commands that don't
           // resolve. Split into invocation bubble + error pill on replay.
           if (entry.type === 'user') {


### PR DESCRIPTION
Closes #131.

## Why this happens

When the parent Claude CLI session spawns a subagent (Task / Agent tool), the subagent's own CLI process writes its messages — including its dispatch prompt as a `user` entry — into a sibling JSONL file. Those entries carry `isSidechain: true` and share the parent's `sessionId`.

`discoverSessionJsonlFiles` (`packages/core/src/plugins/builtin/claude/history.ts`) deliberately picks up sibling JSONLs that match the session's id so continuation files stay attached. Without a sidechain filter, every subagent prompt entry flowed through `convertHistoryEntry` → `convertUserEntry` → `convertUserContent` and rendered as a ghost user bubble in the parent thread — most visibly with the Explore subagent.

PR #254 only suppressed bare `<command-name>` echoes, which is a different shape; subagent prompts are free-form prompt text and slipped through that gate.

## The fix

One-liner in `loadHistory`'s entry loop:

```ts
if (entry.isSidechain === true) continue;
```

Placed **after** the existing skill-loaded synthesis (`synthesizeSkillLoadedFromUserEntry`) so user-typed `/skill` invocations remain intact, and **after** the `isMeta` / `isCompactSummary` guards. Subagent tool_results are still attached to the parent's Task tool_use via the existing `collectSubagentToolResults` path (subagent files in `<sessionId>/subagents/*.jsonl` were already filtered separately — this extends the same pattern to sibling sidechain files).

The live event handler (`handleUserEvent` in `events.ts`) already routes user-event text exclusively to `onSkillLoaded` / `onCliMessage` — it never synthesizes a user bubble, so no live-path change is needed.

## Tests

- New regression test in `packages/core/src/__tests__/message-loading.test.ts`: `drops isSidechain=true entries from sibling JSONL files (subagent prompts)` — writes a sidechain JSONL with a subagent prompt + reply, asserts the parent thread renders only the two real entries and no subagent text leaks through.
- Full core suite: 1130/1130 passing.

## Test plan
- [x] Unit: `pnpm --filter @qlan-ro/mainframe-core test message-loading` — 30/30
- [x] Full suite: `pnpm --filter @qlan-ro/mainframe-core test` — 1130/1130
- [x] Build: `pnpm --filter @qlan-ro/mainframe-core build` — clean
- [ ] Manual: open a chat that previously dispatched an Explore subagent — no ghost user bubble between the Task tool card and the next assistant turn
- [ ] Manual: invoke a user-typed `/skill` — skill_loaded pill still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)