### PR TITLE
fix(editor): apply InlineCommentWidget width after Monaco's addZone

### DIFF
--- a/.changeset/fix-second-comment-widget-full-width.md
+++ b/.changeset/fix-second-comment-widget-full-width.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(editor): apply InlineCommentWidget width after Monaco's addZone, not before. Monaco's view-zones implementation sets `domNode.style.width = '100%'` inside `_addZone`, clobbering the contentWidth-based width we were setting beforehand. The first widget happened to get corrected by a later layout event; subsequent widgets stayed at full width. Width is now re-applied after addZone, and an `onDidContentSizeChange` listener keeps every open widget in sync when a scrollbar toggles.

--- a/packages/desktop/src/renderer/components/editor/useInlineComments.ts
+++ b/packages/desktop/src/renderer/components/editor/useInlineComments.ts
@@ -67,14 +67,13 @@ export function useInlineComments(changeViewZones: ChangeViewZones | null, getMo
       // Pin the view-zone node width to the editor's content column so it never
       // inflates Monaco's scrollWidth and causes the horizontal scrollbar to
       // diverge. Leave a small gap before the vertical scrollbar — contentWidth
-      // in side-by-side diff editors can abut the scrollbar track, and without
-      // clearance the two hit-regions conflict visually and on hover.
+      // can abut the scrollbar track, and without clearance the two hit-regions
+      // conflict visually and on hover.
       const SCROLLBAR_CLEARANCE = 12;
-      const computeWidth = (info: { contentWidth: number }) => Math.max(0, info.contentWidth - SCROLLBAR_CLEARANCE);
-      domNode.style.width = `${computeWidth(editor.getLayoutInfo())}px`;
-      const layoutListener = editor.onDidLayoutChange((info) => {
-        domNode.style.width = `${computeWidth(info)}px`;
-      });
+      const updateWidth = () => {
+        const info = editor.getLayoutInfo();
+        domNode.style.width = `${Math.max(0, info.contentWidth - SCROLLBAR_CLEARANCE)}px`;
+      };
 
       // Monaco swallows wheel events inside view zones and drives its own
       // scroll. Treat the widget as an island: stop propagation so the
@@ -91,8 +90,31 @@ export function useInlineComments(changeViewZones: ChangeViewZones | null, getMo
         });
       });
 
+      // Monaco's _addZone sets domNode.style.width = '100%' synchronously
+      // (monaco-editor/.../viewZones.js), clobbering anything we set before
+      // addZone. Apply our width AFTER addZone so it sticks. Without this the
+      // first widget happens to get corrected by a later layout event, but the
+      // second widget stays at 100% because nothing fires after its addZone.
+      updateWidth();
+
+      // onDidLayoutChange covers outer-container changes (splitter drag, window
+      // resize, sidebar toggle, font/option change). onDidContentSizeChange
+      // covers internal content-size changes — most importantly when a vertical
+      // scrollbar appears/disappears as a side effect of addZone shrinking
+      // contentWidth. Together they keep every open widget in lockstep.
+      const layoutListener = editor.onDidLayoutChange(updateWidth);
+      const contentSizeListener = editor.onDidContentSizeChange((e) => {
+        if (e.contentWidthChanged) updateWidth();
+      });
+      const composite: monacoType.IDisposable = {
+        dispose: () => {
+          layoutListener.dispose();
+          contentSizeListener.dispose();
+        },
+      };
+
       const id = `comment-${++nextId}`;
-      layoutListenersRef.current.set(id, layoutListener);
+      layoutListenersRef.current.set(id, composite);
       setComments((prev) => [...prev, { id, startLine, endLine, lineContent, zoneId, domNode, text: '' }]);
     },
     [changeViewZones, getModel],


### PR DESCRIPTION
## Symptom

Open one inline comment widget — correct width. Open a second — full width (no scrollbar clearance, ignores SCROLLBAR_CLEARANCE entirely).

## Root cause

Monaco's view-zones implementation sets `domNode.style.width = '100%'` synchronously inside `_addZone`:

```js
// node_modules/monaco-editor/.../viewZones.js:182
myZone.domNode.domNode.style.width = '100%';
```

`useInlineComments.ts` was setting `domNode.style.width = ${contentWidth - 12}px` *before* calling `accessor.addZone(...)`. Monaco then immediately overwrote it with `100%`. Our `onDidLayoutChange` listener would re-apply the correct width, but only when a layout event eventually fires.

The first widget happened to get corrected because opening the second widget triggered a content-size change that Monaco bubbles up via the layout listener. The second (and any subsequent) widget never got a follow-up event after its own `addZone`, so it stayed at `100%`.

## Fix

Two small changes in `packages/desktop/src/renderer/components/editor/useInlineComments.ts`:

1. **Apply width *after* `addZone`**, not before. This overrides Monaco's `100%` reliably, regardless of timing.
2. **Add `onDidContentSizeChange` alongside `onDidLayoutChange`.** The former fires when a vertical scrollbar appears/disappears (a content-size change) — the existing layout listener doesn't catch that, so the widget could stay stale on scrollbar toggles even after the first fix. With both, all open widgets stay in sync across:

| Trigger | Event |
|---|---|
| Drag splitter / resize file editor pane | `onDidLayoutChange` |
| Window resize | `onDidLayoutChange` |
| Toggle sidebar / collapse file view | `onDidLayoutChange` |
| Font size / option change | `onDidLayoutChange` |
| Vertical scrollbar appears/disappears | `onDidContentSizeChange` (new) |
| Open another widget that pushes content past viewport | `onDidContentSizeChange` (new) |

Both listeners are wrapped in a composite disposable so `closeComment` / `closeAll` continue to clean up correctly via the existing `layoutListenersRef` map.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` — clean
- [x] Manual: open inline comment widget on first line of a diff → correct width with scrollbar gap
- [x] Manual: open a second inline comment widget on a different line → correct width matching the first
- [x] Manual: drag the file editor splitter → both widgets resize in lockstep
- [x] Manual: trigger a vertical scrollbar (open enough widgets that content overflows) → widgets shrink to keep the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)