### PR TITLE
fix(claude/history): drop ghost skill cards from subagent JSONLs on replay

### DIFF
--- a/.changeset/quick-bugs-sleep.md
+++ b/.changeset/quick-bugs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Stop synthesizing duplicate "Using skill" cards from subagent JSONLs on history replay. Each subagent (Task/Agent tool) writes its own `Base directory for this skill: …` isMeta entry; live mode never surfaces those at the parent level, so promoting them on replay produced ghost SkillLoadedCards that never appeared during the live session. Skill synthesis now skips entries from subagent files and sidechain entries.

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -509,6 +509,82 @@ describe('loadHistory', () => {
     }
   });
 
+  it('does not synthesize skill_loaded messages for subagent skill loads', async () => {
+    // Regression: each subagent (Task/Agent tool) writes its own
+    // "Base directory for this skill: …" isMeta entry into a JSONL under
+    // <session>/subagents/. Live mode never surfaces those at the parent
+    // level (they only flow through agent_progress), so synthesizing them
+    // on replay creates duplicate "Using skill: X" pills that never
+    // appeared during the live session.
+    writeJsonl(SESSION_ID, [userTextEntry('Dispatch four subagents'), assistantTextEntry('Dispatching.')]);
+
+    const subagentDir = join(PROJECT_DIR, SESSION_ID, 'subagents');
+    mkdirSync(subagentDir, { recursive: true });
+    for (const agentId of ['a1', 'a2', 'a3', 'a4']) {
+      const subagentJsonl = join(subagentDir, `agent-${agentId}.jsonl`);
+      writeFileSync(
+        subagentJsonl,
+        jsonlEntry({
+          type: 'user',
+          isMeta: true,
+          isSidechain: true,
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Base directory for this skill: /repo/.claude/skills/azure-devops-cli\n\n# Azure DevOps CLI\nbody',
+              },
+            ],
+          },
+        }) + '\n',
+      );
+    }
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    expect(messages.map((m) => m.type)).toEqual(['user', 'assistant']);
+    for (const m of messages) {
+      for (const block of m.content) {
+        expect(block.type).not.toBe('skill_loaded');
+      }
+    }
+  });
+
+  it('still synthesizes skill_loaded messages from sidechain sibling JSONLs', async () => {
+    // Belt-and-braces: sibling sidechain files (not under /subagents/) also
+    // carry isSidechain:true and must not promote skill loads either.
+    writeJsonl(SESSION_ID, [userTextEntry('Run a thing')]);
+
+    const sidechainId = 'sidechain-skill-xyz';
+    writeJsonl(sidechainId, [
+      jsonlEntry({
+        type: 'user',
+        sessionId: SESSION_ID,
+        isSidechain: true,
+        isMeta: true,
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Base directory for this skill: /repo/.claude/skills/azure-devops-cli\n\nbody',
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    expect(messages.map((m) => m.type)).toEqual(['user']);
+    for (const m of messages) {
+      for (const block of m.content) {
+        expect(block.type).not.toBe('skill_loaded');
+      }
+    }
+  });
+
   it('returns empty array for non-existent session', async () => {
     const messages = await loadHistory('nonexistent-session', PROJECT_PATH);
     expect(messages).toEqual([]);

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -438,7 +438,14 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           // only chance to surface a SkillLoadedCard for these turns. Detect
           // and synthesize a system 'skill_loaded' message BEFORE the generic
           // isMeta filter drops them below.
-          if (entry.isMeta === true && entry.type === 'user') {
+          //
+          // Skip subagent and sidechain entries: each subagent loads its own
+          // skills and writes its own "Base directory for this skill:" entry.
+          // Live mode hides those from the parent thread (subagent activity
+          // surfaces only through agent_progress + the parent's Task tool_use),
+          // so promoting them on replay creates ghost SkillLoadedCards that
+          // never appeared during the live session.
+          if (entry.isMeta === true && entry.type === 'user' && !isSubagentFile && entry.isSidechain !== true) {
             const synthesized = synthesizeSkillLoadedFromUserEntry(entry, sessionId);
             if (synthesized) {
               if (!seenUuids.has(synthesized.id)) {


### PR DESCRIPTION
## Summary

After restarting the app, conversations reloaded from history showed multiple "Using skill: X" pills that never appeared during the live session. Repro: session `492cbb43` in DBricks_Optimizer dispatched 4 `Agent` subagents that each loaded `azure-devops-cli` — on replay all 4 surfaced as top-level `SkillLoadedCard`s in the parent thread.

**Root cause** (`packages/core/src/plugins/builtin/claude/history.ts`): `loadHistory()` synthesized a `skill_loaded` system message for every isMeta `Base directory for this skill: …` entry it saw, BEFORE the `isSidechain` and `isSubagentFile` filters. Subagent JSONLs (under `<session>/subagents/`) carry one such entry per skill the subagent loads; live mode never exposes those at the parent level (subagent activity flows through `agent_progress` + the parent's `Task` tool_use), so the cards only appeared on reload.

**Fix:** restrict synthesis to primary, non-sidechain entries — `!isSubagentFile && entry.isSidechain !== true`.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-loading.test.ts` — 32/32 pass, including two new regressions:
  - subagent skill loads under `<session>/subagents/` produce no top-level messages
  - sidechain sibling JSONL skill loads produce no top-level messages
- [ ] Manual: open the affected session, restart the app, confirm only the parent's own skill loads render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)