### PR TITLE
fix(claude/events): drop dispatch prompt when CLI normalizes it to a text block

### DIFF
--- a/.changeset/metal-friends-invite.md
+++ b/.changeset/metal-friends-invite.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Drop the duplicate subagent dispatch prompt when it arrives in the array-of-text-blocks shape. PR #264 caught the string-content path, but the CLI's `normalizeMessages` (`utils/messages.ts:782-793`) wraps any string-content user message into `[{type: 'text', text: <string>}]` before yielding to stream-json — so in practice the daemon receives the prompt as a single text block, not as a string. The new guard fires inside the array-content text-block branch, after the existing skill-injection check, so subagent skill loads still surface and only the duplicate prompt is suppressed.

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -364,6 +364,29 @@ describe('subagent dispatch prompt (parent_tool_use_id != null)', () => {
     expect(sink.onSkillLoaded).not.toHaveBeenCalled();
   });
 
+  it('drops the dispatch prompt when the CLI normalized it to [{type:"text", text:…}]', () => {
+    // The CLI's normalizeMessages (utils/messages.ts:782-793) wraps any
+    // string-content user message into a single text block before yielding
+    // to stream-json. So in practice the daemon receives the dispatch prompt
+    // in this shape, not as a raw string. Without this case covered, the
+    // earlier string-only guard never fires and onCliMessage produces a
+    // duplicate system pill in the parent thread.
+    const session = createSession();
+    const sink = createSink();
+
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run `echo hi` via Bash and report the output.' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+  });
+
   it('still surfaces a subagent skill load (string content with <command-name>)', async () => {
     const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
     const { tmpdir } = await import('node:os');

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -399,6 +399,14 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       //   • "[Request interrupted by user]" /
       //     "[Request interrupted by user for tool use]"
       //     (Claude source: utils/messages.ts:207-209)
+      //   • Subagent dispatch prompt: arrives here as a single text block
+      //     because normalizeMessages (CLI utils/messages.ts:782-793) converts
+      //     string-content user messages into [{type:'text', text:<string>}]
+      //     before yielding to stream-json. The text already lives in the
+      //     parent's Agent.input.prompt (rendered by the Task card), so
+      //     surfacing it via onCliMessage produces a duplicate system pill.
+      //     Skill injections from a subagent take the isSkillInjection
+      //     branch above and never reach this point, so they still surface.
       if (!isReplay && !isMeta) {
         const trimmed = text.trim();
         const isLocalCommandWrapper =
@@ -406,7 +414,8 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
             trimmed,
           );
         const isInterruptMarker = /^\[Request interrupted by user[^\]]*\]\s*$/.test(trimmed);
-        if (!isLocalCommandWrapper && !isInterruptMarker) {
+        const isSubagentDispatchPrompt = event.parent_tool_use_id != null;
+        if (!isLocalCommandWrapper && !isInterruptMarker && !isSubagentDispatchPrompt) {
           sink.onCliMessage(trimmed);
         }
       }


### PR DESCRIPTION
## Summary

PR #264 caught the subagent dispatch prompt only on the **string-content** path. Live testing showed the duplicate pill still appearing. Tracing it: the CLI's `normalizeMessages` (`claude-code/src/utils/messages.ts:782-793`) wraps any string-content user message into `[{type: 'text', text: <string>}]` **before** yielding to stream-json:

```ts
case 'user': {
  if (typeof message.message.content === 'string') {
    ...
    content: [{ type: 'text', text: message.message.content }],
    ...
```

So the daemon receives the dispatch prompt as a single text block — the previous string-only guard never fires. The event then falls through to the array-content text-block branch and `onCliMessage` produces the system pill the screenshot showed.

Repro: session `22ebe864-…` in `qlan-home-hub` — three "Run \`echo hi\` via Bash and report the output." pills next to the three `general-purpose` Task cards.

## Fix

Add a `parent_tool_use_id != null` guard inside the array-content text-block branch, alongside the existing `isLocalCommandWrapper` and `isInterruptMarker` suppressions. Skill injections still take the `isSkillInjection` branch above and surface as before; only the duplicate dispatch prompt is dropped.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/claude-events.test.ts` — 25/25 pass; new regression covers the array-of-text-blocks shape produced by `normalizeMessages`.
- [x] `pnpm --filter @qlan-ro/mainframe-core build` — clean.
- [ ] Manual: dispatch ≥1 Agent in a live chat (e.g. session `22ebe864-…` in `qlan-home-hub`). Verify no duplicate prompt pill next to the Task card; subagent skill loads and tool_use children still surface.

## Related
- PR #264 — same bug, string-content path only (the path that doesn't fire in practice because of `normalizeMessages`)
- PR #259, PR #261 — earlier surfaces of the same family of subagent → parent-thread leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)