### PR TITLE
feat: nest subagent activity inside the parent Task card

### DIFF
--- a/.changeset/floppy-birds-sneeze.md
+++ b/.changeset/floppy-birds-sneeze.md
@@ -1,0 +1,13 @@
+---
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Nest subagent activity inside the parent's Task card on both live stream and history reload.
+
+Replaces the prompt-suppression patches in PRs #264 and #267 with a uniform rule: every Claude CLI stream-json event with `parent_tool_use_id != null` is **inlined** into the parent assistant message that owns the matching `Agent`/`Task` `tool_use`, and each inlined block is **tagged** with `parentToolUseId`. The display pipeline's `groupTaskChildren` then wraps anything tagged with the Agent's id into a `_TaskGroup`, and `TaskGroupCard` renders the new child kinds (text, thinking, skill_loaded) alongside the existing tool_call children. The dispatch prompt renders as an intro line at the top of the expanded card body.
+
+History reload mirrors the live behavior: the subagent JSONL collectors now also extract text and thinking blocks (in addition to tool_use and tool_result), and every inlined block carries `parentToolUseId` so the same display pipeline produces identical output. Parent-level skill loads continue to surface at the chat root; subagent-context skill loads render as inner pills inside the Task card.
+
+New `SessionSink.onSubagentChild(parentToolUseId, blocks)` method in `@qlan-ro/mainframe-types` is the entry point for subagent-tagged blocks. Internal-only API; no migration needed for adapters that don't emit subagent events.

--- a/docs/plans/2026-04-30-subagent-blocks-nesting.md
+++ b/docs/plans/2026-04-30-subagent-blocks-nesting.md
@@ -1,0 +1,1252 @@
+# Subagent Blocks Nesting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render every subagent activity (dispatch prompt, text, thinking, skill loads, tool_use, tool_result) **inside** the parent's Task card instead of leaking into the main chat thread, on both live stream and history reload.
+
+**Architecture:** When the Claude CLI emits a stream-json event with `parent_tool_use_id != null`, treat it as a child of the parent assistant message that contains the matching `Agent`/`Task` `tool_use` block. Inline the event's content blocks into that parent assistant message's `content[]` and tag each block with `parentToolUseId`. The display pipeline already groups consecutive blocks under an `Agent` tool_use into a `_TaskGroup` virtual entry; we extend `groupTaskChildren` to keep walking past text/thinking/skill_loaded as long as the block's `parentToolUseId` matches the Agent's id, and we update `TaskGroupCard` to render those non-tool child kinds. History does the same via `injectAgentChildren`, extended to also inline subagent text/thinking/skill_loaded from subagent JSONLs.
+
+**Tech Stack:** TypeScript (strict, NodeNext), pnpm workspaces, vitest, React (`packages/desktop`), pino logger.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `packages/types/src/chat.ts` | `MessageContent` union + `ChatMessage` | Add optional `parentToolUseId` to `text`, `thinking`, `tool_use`, `tool_result`, `skill_loaded` variants |
+| `packages/types/src/adapter.ts` | `SessionSink` interface | Add `onSubagentChild(parentToolUseId, blocks)` method |
+| `packages/core/src/plugins/builtin/claude/events.ts` | Live stream → sink | Route `parent_tool_use_id != null` events through `onSubagentChild`; remove the prompt-suppression guard added by PRs #264/#267 (no longer needed — prompt is inlined) |
+| `packages/core/src/chat/event-handler.ts` | Sink → message cache | Implement `onSubagentChild`: append blocks to the existing parent assistant message that owns the matching Agent tool_use; emit `message.updated` |
+| `packages/core/src/plugins/builtin/claude/history.ts` | History reconstruction | Extend `collectAgentProgressTools` to capture text/thinking; in `injectAgentChildren` tag inlined blocks with `parentToolUseId`; collect subagent assistant text/thinking from subagent JSONLs (same pattern as the current tool_result collection) and inline them via `injectAgentChildren` |
+| `packages/core/src/messages/tool-grouping.ts` | `PartEntry` + `groupTaskChildren` | Add `parentToolUseId` to `PartEntry`; replace the "stop on text" rule with "include while parentToolUseId matches Agent.id, stop otherwise" |
+| `packages/core/src/messages/display-helpers.ts` | Block → PartEntry | Propagate `parentToolUseId` from `MessageContent` blocks to `PartEntry` and from `PartEntry` back to `DisplayContent` for rendering |
+| `packages/types/src/display.ts` | `DisplayContent` (if separate) | Mirror `parentToolUseId` on rendered child kinds the Task card needs |
+| `packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx` | Task card rendering | Render `text`, `thinking`, `skill_loaded` child kinds in addition to `tool_call`. Drop the dispatch prompt's redundant text child since the parent's `taskArgs.prompt` already lives in the card header tooltip — render it instead as a small intro line at the top of the expanded body |
+| `packages/core/src/__tests__/claude-events.test.ts` | Live event tests | Replace the prompt-drop tests with `onSubagentChild` tests |
+| `packages/core/src/__tests__/event-handler.test.ts` | Sink behaviour | New: `onSubagentChild` appends to the matching parent message and no-ops when no match |
+| `packages/core/src/__tests__/message-grouping.test.ts` | Grouping | New: parts with matching `parentToolUseId` get nested under `_TaskGroup`; mismatched parts terminate the group |
+| `packages/core/src/__tests__/message-loading.test.ts` | History tests | New: subagent assistant text/thinking from a subagent JSONL gets inlined into the parent assistant message's content with `parentToolUseId` tag |
+
+---
+
+## Task 0: Read context, branch, dependency check
+
+**Files:**
+- Read: `packages/core/src/messages/message-grouping.ts`, `packages/core/src/messages/tool-grouping.ts`, `packages/core/src/messages/display-helpers.ts`, `packages/core/src/messages/display-pipeline.ts`, `packages/core/src/plugins/builtin/claude/events.ts`, `packages/core/src/plugins/builtin/claude/history.ts`, `packages/core/src/chat/event-handler.ts`
+- Read: `packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx`, `packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskCard.tsx`
+- Read sample JSONL: `~/.claude/projects/<encoded>/<sessionId>.jsonl` and a subagent JSONL under `<sessionId>/subagents/agent-<id>.jsonl` to confirm the shape of `parentToolUseID`/`parent_tool_use_id` and that the dispatch prompt arrives as `[{type:'text', text:<prompt>}]` post-`normalizeMessages`.
+
+- [ ] **Step 1: Pull main**
+
+```bash
+cd /Users/doruchiulan/Projects/qlan/mainframe
+git fetch origin
+git checkout main
+git pull --ff-only
+```
+
+- [ ] **Step 2: Create the worktree branch**
+
+```bash
+git checkout -b feat/subagent-blocks-nesting origin/main
+```
+
+- [ ] **Step 3: Install deps and confirm baseline build**
+
+Run:
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @qlan-ro/mainframe-types build
+pnpm --filter @qlan-ro/mainframe-core build
+```
+Expected: clean build, no errors.
+
+- [ ] **Step 4: Confirm baseline test suite passes (excluding the known-flake `routes/search.test.ts` when run in parallel)**
+
+Run:
+```bash
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/claude-events.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/event-handler.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-grouping.test.ts
+pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-loading.test.ts
+```
+Expected: all pass.
+
+---
+
+## Task 1: Type field — `parentToolUseId` on `MessageContent`
+
+**Files:**
+- Modify: `packages/types/src/chat.ts:68-84`
+- Test: type-only change verified by build + downstream tests
+
+- [ ] **Step 1: Edit `packages/types/src/chat.ts:68-84` — add `parentToolUseId?: string` to the variants we'll inline**
+
+Before:
+```ts
+export type MessageContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; mediaType: string; data: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | {
+      type: 'tool_result';
+      toolUseId: string;
+      content: string;
+      isError: boolean;
+      structuredPatch?: DiffHunk[];
+      originalFile?: string;
+      modifiedFile?: string;
+    }
+  | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
+  | { type: 'error'; message: string }
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
+```
+
+After:
+```ts
+export type MessageContent =
+  | { type: 'text'; text: string; parentToolUseId?: string }
+  | { type: 'image'; mediaType: string; data: string }
+  | { type: 'thinking'; thinking: string; parentToolUseId?: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown>; parentToolUseId?: string }
+  | {
+      type: 'tool_result';
+      toolUseId: string;
+      content: string;
+      isError: boolean;
+      structuredPatch?: DiffHunk[];
+      originalFile?: string;
+      modifiedFile?: string;
+      parentToolUseId?: string;
+    }
+  | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
+  | { type: 'error'; message: string }
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string; parentToolUseId?: string };
+```
+
+- [ ] **Step 2: Build types package**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
+Expected: clean.
+
+- [ ] **Step 3: Build core to surface any consumer breakage**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
+Expected: clean (the field is optional; no existing call site is broken).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/types/src/chat.ts
+git commit -m "feat(types): add optional parentToolUseId to MessageContent variants"
+```
+
+---
+
+## Task 2: Sink method — `onSubagentChild`
+
+**Files:**
+- Modify: `packages/types/src/adapter.ts:114-134`
+- Modify: every `SessionSink` mock and stub (search via `grep -rn "onSkillLoaded:" packages/core/src` to find them)
+
+- [ ] **Step 1: Edit `packages/types/src/adapter.ts` — add `onSubagentChild` after `onSkillLoaded`**
+
+```ts
+  /** A skill was loaded via slash-command; show a collapsible skill card instead of raw text. */
+  onSkillLoaded(entry: { skillName: string; path: string; content: string }): void;
+  /**
+   * Inline content blocks from a subagent stream event under the parent assistant
+   * message that owns the matching Agent/Task tool_use. Caller must have stamped
+   * each block with `parentToolUseId === parentToolUseId` argument so the display
+   * pipeline can group them under the matching Task card.
+   */
+  onSubagentChild(parentToolUseId: string, blocks: import('./chat.js').MessageContent[]): void;
+}
+```
+
+- [ ] **Step 2: Build types**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types build`
+Expected: clean.
+
+- [ ] **Step 3: Build core — expect failures at every `SessionSink` mock that is missing `onSubagentChild`**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
+Expected: type errors listing each mock.
+
+- [ ] **Step 4: Add `onSubagentChild: () => {}` to every fixture sink and `onSubagentChild: vi.fn()` to every test sink. Use grep to find them**
+
+Run:
+```bash
+grep -rln "onSkillLoaded:" packages/core/src
+```
+
+For each match, add the new method right under `onSkillLoaded`. Concrete locations to confirm at edit time:
+- `packages/core/src/plugins/builtin/claude/session.ts` (default no-op sink)
+- `packages/core/src/plugins/builtin/codex/session.ts` (default no-op sink — codex doesn't emit subagent events but the sink shape must match)
+- `packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts`
+- `packages/core/src/__tests__/claude-events.test.ts` (`createSink()`)
+- `packages/core/src/__tests__/codex-event-mapper.test.ts`
+- `packages/core/src/__tests__/codex-session.test.ts`
+- `packages/core/src/__tests__/codex-approval-handler.test.ts`
+- `packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts`
+- `packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts`
+- `packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts`
+- `packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts`
+- `packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts`
+- `packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts`
+
+(If grep turns up additional sites, edit them too — same one-line addition.)
+
+- [ ] **Step 5: Build core**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core build`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/types/src/adapter.ts packages/core/src
+git commit -m "feat(adapter): add SessionSink.onSubagentChild for inlining subagent blocks"
+```
+
+---
+
+## Task 3: Event handler — implement `onSubagentChild`
+
+**Files:**
+- Modify: `packages/core/src/chat/event-handler.ts`
+- Test: `packages/core/src/__tests__/event-handler.test.ts`
+
+The handler must:
+1. Find the parent assistant message in the chat's message cache that contains a `tool_use` block whose `id === parentToolUseId`.
+2. Append the `blocks` argument to that message's `content[]`.
+3. Emit `message.updated` so the renderer re-grouping is triggered.
+4. If no such parent exists (race/restart), no-op + warn-log via the child logger.
+
+- [ ] **Step 1: Write the failing test in `packages/core/src/__tests__/event-handler.test.ts`**
+
+```ts
+describe('EventHandler onSubagentChild', () => {
+  it('appends blocks to the parent assistant message that owns the matching tool_use', () => {
+    const { sink, db, messages, emitted } = createHandlerHarness({ chatId: 'chat-1' });
+    // Seed an assistant message with an Agent tool_use
+    sink.onMessage(
+      [
+        { type: 'text', text: 'Dispatching subagent.' },
+        { type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: { description: 'Echo hi 1' } },
+      ],
+      { model: 'claude-opus-4-7' },
+    );
+
+    sink.onSubagentChild('toolu_agent_1', [
+      { type: 'text', text: 'Run echo hi via Bash and report the output.', parentToolUseId: 'toolu_agent_1' },
+      { type: 'tool_use', id: 'toolu_sub_bash', name: 'Bash', input: { command: 'echo hi' }, parentToolUseId: 'toolu_agent_1' },
+    ]);
+
+    const cached = messages.get('chat-1') ?? [];
+    const assistant = cached.find((m) => m.type === 'assistant');
+    expect(assistant).toBeDefined();
+    const types = assistant!.content.map((c) => c.type);
+    expect(types).toEqual(['text', 'tool_use', 'text', 'tool_use']);
+    const last = assistant!.content[3] as { parentToolUseId?: string; name?: string };
+    expect(last.parentToolUseId).toBe('toolu_agent_1');
+    expect(last.name).toBe('Bash');
+    expect(emitted.some((e: { type: string }) => e.type === 'message.updated')).toBe(true);
+  });
+
+  it('no-ops with a warn log when no parent assistant message owns the tool_use', () => {
+    const { sink, messages, warnings } = createHandlerHarness({ chatId: 'chat-1' });
+
+    sink.onSubagentChild('toolu_unknown', [
+      { type: 'text', text: 'orphaned', parentToolUseId: 'toolu_unknown' },
+    ]);
+
+    expect(messages.get('chat-1') ?? []).toEqual([]);
+    expect(warnings.some((w) => w.includes('parent tool_use not found'))).toBe(true);
+  });
+});
+```
+
+If `createHandlerHarness` doesn't exist yet, add a tiny helper at the top of the file that returns `{ sink, db, messages, emitted, warnings }` and seeds the chat. The existing test file's existing setup pattern must be reused — read the file first to copy its style.
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/event-handler.test.ts -t "onSubagentChild"`
+Expected: FAIL — `onSubagentChild is not a function` (or similar).
+
+- [ ] **Step 3: Implement `onSubagentChild` in `packages/core/src/chat/event-handler.ts`**
+
+Add inside the sink object next to the existing methods (right after `onSkillLoaded`):
+
+```ts
+    onSubagentChild(parentToolUseId: string, blocks: import('@qlan-ro/mainframe-types').MessageContent[]) {
+      const cache = messages.get(chatId) ?? [];
+      // Newest-first: a subagent's events typically belong to the most recent
+      // assistant message that contains the parent tool_use.
+      for (let i = cache.length - 1; i >= 0; i--) {
+        const msg = cache[i]!;
+        if (msg.type !== 'assistant') continue;
+        const owns = msg.content.some((b) => b.type === 'tool_use' && b.id === parentToolUseId);
+        if (!owns) continue;
+        msg.content = [...msg.content, ...blocks];
+        emitEvent({ type: 'message.updated', chatId, messageId: msg.id });
+        emitDisplay();
+        return;
+      }
+      log.warn(
+        { chatId, parentToolUseId, blockCount: blocks.length },
+        'onSubagentChild: parent tool_use not found in cache; dropping blocks',
+      );
+    },
+```
+
+(Use the existing `log` child logger if there is one; if not, mirror the convention you see at the top of the file.)
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/event-handler.test.ts -t "onSubagentChild"`
+Expected: PASS for both cases.
+
+- [ ] **Step 5: Run the rest of the event-handler tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/event-handler.test.ts`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/chat/event-handler.ts packages/core/src/__tests__/event-handler.test.ts
+git commit -m "feat(chat/event-handler): implement onSubagentChild — inline subagent blocks under parent tool_use"
+```
+
+---
+
+## Task 4: events.ts — route subagent events through `onSubagentChild`
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/events.ts` (handleAssistantEvent + handleUserEvent)
+- Test: `packages/core/src/__tests__/claude-events.test.ts`
+
+We replace the prompt-suppression guards from PRs #264 and #267 with: "if `event.parent_tool_use_id != null`, tag every block with that id and route via `onSubagentChild`". Skill loads from a subagent are tagged the same way and bubble through `onSubagentChild` as a `skill_loaded` block — they nest in the Task card per the user's "inner pill" decision.
+
+- [ ] **Step 1: Update tests in `packages/core/src/__tests__/claude-events.test.ts`**
+
+Replace the existing `describe('subagent dispatch prompt …', …)` block with this:
+
+```ts
+describe('subagent events (parent_tool_use_id != null)', () => {
+  // Background: CLI 2.1.118+ normalizes agent_progress into top-level SDK
+  // user/assistant events with parent_tool_use_id set to the parent's
+  // Agent/Task tool_use_id. We route every such event through
+  // onSubagentChild, tagging blocks with parentToolUseId so the display
+  // pipeline groups them under the parent Task card.
+
+  it('routes subagent assistant events to onSubagentChild with tagged blocks', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'assistant',
+        model: 'claude-opus-4-7',
+        content: [
+          { type: 'thinking', thinking: 'subagent inner thought' },
+          { type: 'text', text: 'Let me run a command.' },
+          { type: 'tool_use', id: 'toolu_subagent_bash', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onMessage).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect(blocks).toHaveLength(3);
+    for (const b of blocks) expect((b as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
+  });
+
+  it('routes the dispatch prompt (string content normalized to text block) to onSubagentChild', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run `echo hi` via Bash and report the output.' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect(blocks).toEqual([
+      { type: 'text', text: 'Run `echo hi` via Bash and report the output.', parentToolUseId: 'toolu_parent_agent' },
+    ]);
+  });
+
+  it('routes raw string-content (pre-normalize edge case) to onSubagentChild', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: { role: 'user', content: 'raw string body' },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSubagentChild).toHaveBeenCalledWith('toolu_parent_agent', [
+      { type: 'text', text: 'raw string body', parentToolUseId: 'toolu_parent_agent' },
+    ]);
+  });
+
+  it('routes subagent tool_result blocks via onSubagentChild (not onToolResult)', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_subagent_bash', content: 'hi' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onToolResult).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect((blocks[0] as { type: string }).type).toBe('tool_result');
+    expect((blocks[0] as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
+  });
+
+  it('routes subagent skill loads through onSubagentChild as skill_loaded blocks (inner pill)', async () => {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const pathMod = await import('node:path');
+    const tmp = await mkdtemp(pathMod.join(tmpdir(), 'mf-subagent-skill-'));
+    try {
+      const skillDir = pathMod.join(tmp, '.claude', 'skills', 'pencil');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(pathMod.join(skillDir, 'SKILL.md'), '# Pencil\nbody');
+
+      const session = createSession(tmp);
+      const sink = createSink();
+      const event = JSON.stringify({
+        type: 'user',
+        parent_tool_use_id: 'toolu_parent_agent',
+        message: { role: 'user', content: '<command-name>pencil</command-name>' },
+      });
+      handleStdout(session, Buffer.from(event + '\n'), sink);
+
+      expect(sink.onSkillLoaded).not.toHaveBeenCalled();
+      expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+      const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(parentId).toBe('toolu_parent_agent');
+      expect((blocks[0] as { type: string }).type).toBe('skill_loaded');
+      expect((blocks[0] as { skillName: string }).skillName).toBe('pencil');
+      expect((blocks[0] as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('parent-level events (parent_tool_use_id null) take the existing path', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: null,
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Unknown command: /typo' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown command: /typo');
+    expect(sink.onSubagentChild).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests, confirm they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/claude-events.test.ts -t "subagent events"`
+Expected: FAIL — sink methods called as before, not via `onSubagentChild`.
+
+- [ ] **Step 3: Implement subagent routing in `handleUserEvent`**
+
+Replace the current `parent_tool_use_id` guard inside `handleUserEvent` (lines that drop the dispatch prompt) with this branch placed **right after** the `if (!message?.content) return;` line and **before** the existing string/array branches:
+
+```ts
+  // Subagent activity: every block in this event belongs inside the parent's
+  // Agent/Task tool_use card. Tag each block with parentToolUseId and forward
+  // via onSubagentChild — the event-handler appends them to the parent's
+  // assistant message and the display pipeline groups them under _TaskGroup.
+  if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+    const parentToolUseId = event.parent_tool_use_id;
+    const collected: import('@qlan-ro/mainframe-types').MessageContent[] = [];
+
+    if (typeof message.content === 'string') {
+      // Pre-normalize edge case (model-switch breadcrumbs etc.). Treat as text.
+      collected.push({ type: 'text', text: message.content, parentToolUseId });
+    } else {
+      const tur = (event.tool_use_result ?? event.toolUseResult) as Record<string, unknown> | undefined;
+      const toolResults = buildToolResultBlocks(message as Record<string, unknown>, tur);
+      for (const r of toolResults) collected.push({ ...r, parentToolUseId });
+
+      for (const block of message.content) {
+        if (block.type === 'tool_result') continue; // already handled by buildToolResultBlocks
+        if (block.type === 'text') {
+          const text = (block.text as string) || '';
+          if (!text.trim()) continue;
+          // Skill load shape: surface as a skill_loaded child (inner pill) using
+          // the same extraction logic as the parent-level path below.
+          const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
+          const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
+          const isSkillInjection = hasSkillFormat || Boolean(baseDirMatch);
+          if (isSkillInjection) {
+            const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
+            const rawDir = baseDirMatch?.[1]?.trim() ?? '';
+            const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
+            const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
+            const finalPath =
+              resolvedPath ||
+              (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
+            const content = text
+              .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
+              .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
+              .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
+              .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
+              .trim();
+            if (skillName && finalPath) {
+              session.state.skillPathCache.set(skillName, finalPath);
+            }
+            if (skillName) {
+              collected.push({ type: 'skill_loaded', skillName, path: finalPath, content, parentToolUseId });
+              continue;
+            }
+          }
+          collected.push({ type: 'text', text, parentToolUseId });
+        } else if (block.type === 'image') {
+          collected.push({
+            type: 'image',
+            mediaType: (block.source as { media_type?: string } | undefined)?.media_type ?? 'image/png',
+            data: (block.source as { data?: string } | undefined)?.data ?? '',
+          } as import('@qlan-ro/mainframe-types').MessageContent);
+        }
+      }
+    }
+
+    // Also handle the string-content `<command-name>` shape inside subagent
+    // (e.g. user-typed slash that surfaces as a string event).
+    if (
+      typeof message.content === 'string' &&
+      /<command-name>\/?([^<]+)<\/command-name>/.test(message.content)
+    ) {
+      const nameMatch = /<command-name>\/?([^<]+)<\/command-name>/.exec(message.content);
+      if (nameMatch?.[1]) {
+        const skillName = nameMatch[1].trim();
+        const cached = session.state.skillPathCache.get(skillName);
+        const skillPath = cached ?? resolveExistingSkillPath(session.projectPath, skillName);
+        if (skillPath) {
+          session.state.skillPathCache.set(skillName, skillPath);
+          const content = readSkillContent(skillPath) ?? '';
+          // Replace the plain text we collected above with a skill_loaded block.
+          collected.length = 0;
+          collected.push({ type: 'skill_loaded', skillName, path: skillPath, content, parentToolUseId });
+        }
+      }
+    }
+
+    if (collected.length > 0) sink.onSubagentChild(parentToolUseId, collected);
+    return;
+  }
+```
+
+- [ ] **Step 4: Implement subagent routing in `handleAssistantEvent`**
+
+Add this branch at the top of `handleAssistantEvent` (after the `if (!message?.content) return;`):
+
+```ts
+  if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+    const parentToolUseId = event.parent_tool_use_id;
+    const tagged = message.content.map((b) => ({ ...b, parentToolUseId })) as import(
+      '@qlan-ro/mainframe-types'
+    ).MessageContent[];
+    sink.onSubagentChild(parentToolUseId, tagged);
+    return;
+  }
+```
+
+This skips the parent-level bookkeeping (TodoWrite/PR/Skill registration) for subagent events on purpose: those tools belong to the subagent's own context, not the parent's PR/Todo state. (The previous implementation already did this for the wide-blanket version of the fix.)
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/claude-events.test.ts -t "subagent events"`
+Expected: all pass.
+
+- [ ] **Step 6: Run the rest of the events tests to confirm no regression**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/claude-events.test.ts`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/events.ts packages/core/src/__tests__/claude-events.test.ts
+git commit -m "feat(claude/events): route subagent events through onSubagentChild with tagged blocks"
+```
+
+---
+
+## Task 5: Display pipeline — propagate `parentToolUseId` through `PartEntry`
+
+**Files:**
+- Modify: `packages/core/src/messages/tool-grouping.ts:25-34` (PartEntry shape)
+- Modify: `packages/core/src/messages/display-helpers.ts` (where `PartEntry`s are constructed and where they're converted back to `DisplayContent`)
+- Test: `packages/core/src/__tests__/message-grouping.test.ts` (new)
+
+- [ ] **Step 1: Extend `PartEntry`**
+
+In `packages/core/src/messages/tool-grouping.ts:25-34`, add the field on both variants:
+
+```ts
+export type PartEntry =
+  | {
+      type: 'tool-call';
+      toolCallId: string;
+      toolName: string;
+      args: Record<string, unknown>;
+      result?: unknown;
+      isError?: boolean;
+      parentToolUseId?: string;
+    }
+  | { type: 'text'; text: string; parentToolUseId?: string };
+```
+
+- [ ] **Step 2: Carry `parentToolUseId` from `MessageContent` into the `PartEntry` array in `display-helpers.ts`**
+
+Find the part-construction call site in `applyToolGrouping` and `convertGroupedPartsToDisplay` (read `display-helpers.ts` to confirm exact lines) and copy `parentToolUseId` through. Example for the construction loop:
+
+```ts
+const parts: PartEntry[] = content.map((c) => {
+  if (c.type === 'tool_call') {
+    return {
+      type: 'tool-call' as const,
+      toolCallId: c.id,
+      toolName: c.name,
+      args: c.input,
+      result: c.result,
+      isError: c.result?.isError,
+      parentToolUseId: c.parentToolUseId,
+    };
+  }
+  if (c.type === 'text') return { type: 'text' as const, text: c.text, parentToolUseId: c.parentToolUseId };
+  // sentinel-encoding for non-groupable content (existing behavior) — already preserves parentToolUseId via the original DisplayContent so no extra change here.
+  ...
+});
+```
+
+When converting back (`convertGroupedPartsToDisplay`), if a `tool-call` part has `parentToolUseId`, mirror it onto the resulting `DisplayContent` `tool_call`.
+
+- [ ] **Step 3: Mirror `parentToolUseId` on `DisplayContent` where needed**
+
+`packages/types/src/display.ts` (or wherever `DisplayContent` is defined): add optional `parentToolUseId?: string` to `tool_call`, `text`, `thinking`, `skill_loaded` variants. Build types.
+
+- [ ] **Step 4: Build core; fix any cascading type errors**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/types packages/core/src/messages
+git commit -m "feat(messages): propagate parentToolUseId through PartEntry and DisplayContent"
+```
+
+---
+
+## Task 6: Grouping — `groupTaskChildren` matches by `parentToolUseId`
+
+**Files:**
+- Modify: `packages/core/src/messages/tool-grouping.ts` (`groupTaskChildren`)
+- Test: `packages/core/src/__tests__/message-grouping.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/core/src/__tests__/message-grouping.test.ts`:
+
+```ts
+it('groupTaskChildren includes text/thinking/skill_loaded children whose parentToolUseId matches the Agent', () => {
+  const cats = makeTestCategories(); // helper that already exists in this file; if not, copy from a sibling test
+  const parts: PartEntry[] = [
+    { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+    { type: 'text', text: 'Run echo hi via Bash and report the output.', parentToolUseId: 'toolu_agent_1' },
+    { type: 'tool-call', toolCallId: 'toolu_sub_bash', toolName: 'Bash', args: { command: 'echo hi' }, result: 'hi', parentToolUseId: 'toolu_agent_1' },
+  ];
+  const grouped = groupTaskChildren(parts, cats);
+  expect(grouped).toHaveLength(1);
+  const g = grouped[0]!;
+  expect(g.type).toBe('tool-call');
+  expect((g as { toolName: string }).toolName).toBe('_TaskGroup');
+  const args = (g as { args: { children: PartEntry[] } }).args;
+  expect(args.children.map((c) => (c.type === 'text' ? 'text' : c.toolName))).toEqual(['text', 'Bash']);
+});
+
+it('groupTaskChildren stops collecting when a part has no parentToolUseId or a different one', () => {
+  const cats = makeTestCategories();
+  const parts: PartEntry[] = [
+    { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+    { type: 'text', text: 'subagent text', parentToolUseId: 'toolu_agent_1' },
+    { type: 'tool-call', toolCallId: 'toolu_sub_bash', toolName: 'Bash', args: {}, parentToolUseId: 'toolu_agent_1' },
+    { type: 'text', text: 'parent thread text' }, // no parentToolUseId — terminates
+    { type: 'tool-call', toolCallId: 'toolu_parent_read', toolName: 'Read', args: {} },
+  ];
+  const grouped = groupTaskChildren(parts, cats);
+  expect(grouped).toHaveLength(3);
+  expect((grouped[0] as { toolName: string }).toolName).toBe('_TaskGroup');
+  expect((grouped[1] as { type: string }).type).toBe('text');
+  expect((grouped[2] as { toolName: string }).toolName).toBe('Read');
+});
+```
+
+If `makeTestCategories` doesn't exist, write a minimal helper at the top of the test file:
+
+```ts
+function makeTestCategories() {
+  return {
+    explore: new Set<string>(['Read', 'Glob', 'Grep', 'LS']),
+    hidden: new Set<string>(['TodoWrite']),
+    progress: new Set<string>(['_TaskProgress']),
+    subagent: new Set<string>(['Agent', 'Task']),
+  } as const;
+}
+```
+
+- [ ] **Step 2: Run the tests, confirm they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-grouping.test.ts -t "groupTaskChildren"`
+Expected: FAIL — current code breaks on the first text part.
+
+- [ ] **Step 3: Update `groupTaskChildren` in `packages/core/src/messages/tool-grouping.ts:143-188`**
+
+Replace the inner loop with the parent-id match rule. Concrete diff:
+
+```ts
+export function groupTaskChildren(parts: PartEntry[], categories: ToolCategories): PartEntry[] {
+  const result: PartEntry[] = [];
+  let i = 0;
+
+  while (i < parts.length) {
+    const part = parts[i]!;
+
+    if (part.type === 'tool-call' && isSubagentTool(part.toolName, categories)) {
+      const agentToolUseId = part.toolCallId;
+      const children: PartEntry[] = [];
+      let j = i + 1;
+      while (j < parts.length) {
+        const next = parts[j]!;
+        // sentinel placeholder for thinking/image — must keep the same as before
+        if (next.type === 'text' && next.text.startsWith('\0ng:')) { j++; continue; }
+        // Only collect parts tagged as belonging to THIS Agent.
+        if (next.parentToolUseId !== agentToolUseId) break;
+        children.push(next);
+        j++;
+      }
+
+      if (children.length > 0) {
+        result.push({
+          type: 'tool-call',
+          toolCallId: part.toolCallId,
+          toolName: '_TaskGroup',
+          args: { taskArgs: part.args, children },
+          result: part.result,
+          isError: part.isError,
+        });
+        i = j;
+      } else {
+        result.push(part);
+        i++;
+      }
+    } else {
+      result.push(part);
+      i++;
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the tests, confirm they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-grouping.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/messages/tool-grouping.ts packages/core/src/__tests__/message-grouping.test.ts
+git commit -m "feat(messages): group Task children by parentToolUseId tag"
+```
+
+---
+
+## Task 7: TaskGroupCard — render text/thinking/skill_loaded children
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx`
+- (Possibly) Modify: `packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/render-tool-card.tsx` if it dispatches by name
+
+The current `TaskGroupCard` body iterates `children` and calls `renderToolCard`. We extend it to handle the three new child kinds.
+
+- [ ] **Step 1: Read the existing component to confirm the props shape**
+
+```bash
+cat packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
+```
+
+- [ ] **Step 2: Add child kind discriminator**
+
+`children` was previously typed as `TaskGroupChild[]` (only tool calls). Update the type to allow the new shapes:
+
+```tsx
+type TaskGroupChild =
+  | { kind: 'tool'; toolCallId: string; toolName: string; args: Record<string, unknown>; result?: unknown; isError?: boolean }
+  | { kind: 'text'; text: string }
+  | { kind: 'thinking'; thinking: string }
+  | { kind: 'skill_loaded'; skillName: string; path: string; content: string };
+```
+
+The `args.children` we push from `groupTaskChildren` must be normalized into this shape. Do that in the `_TaskGroup` builder in `groupTaskChildren` (Task 6) — easier than translating in the React component.
+
+If you prefer keeping `PartEntry` in `args.children`, then translate in the component instead — same idea, different boundary.
+
+- [ ] **Step 3: Render each kind**
+
+```tsx
+{open && (
+  <>
+    <div className="pl-6 pr-2 pb-1 text-mf-small text-mf-text-secondary/70 italic whitespace-pre-wrap">
+      {(taskArgs.prompt as string | undefined) ?? ''}
+    </div>
+    {children.map((child, idx) => {
+      switch (child.kind) {
+        case 'tool':
+          return (
+            <React.Fragment key={child.toolCallId}>
+              {renderToolCard(child.toolName, child.args, '', child.result, child.isError)}
+            </React.Fragment>
+          );
+        case 'text':
+          return (
+            <div key={`text-${idx}`} className="pl-6 pr-2 py-1 text-mf-body text-mf-text-primary whitespace-pre-wrap select-text">
+              {child.text}
+            </div>
+          );
+        case 'thinking':
+          return (
+            <details key={`think-${idx}`} className="pl-6 pr-2 py-1 text-mf-small text-mf-text-secondary">
+              <summary className="cursor-pointer">Reasoning</summary>
+              <div className="whitespace-pre-wrap pl-3 pt-1">{child.thinking}</div>
+            </details>
+          );
+        case 'skill_loaded':
+          return (
+            <div key={`skill-${idx}`} className="pl-6">
+              <SkillLoadedCard skillName={child.skillName} path={child.path} content={child.content} />
+            </div>
+          );
+      }
+    })}
+    {resultText && (
+      <div className="pl-6 text-mf-small text-mf-text-secondary whitespace-pre-wrap select-text">{resultText}</div>
+    )}
+  </>
+)}
+```
+
+The intro line at the top is the prompt straight from `taskArgs.prompt` — that solves "trim the prompt so it doesn't look bad" by simply not duplicating it (the inlined first text child IS the prompt, but we render it from `taskArgs.prompt` instead because that's authoritative and never affected by streaming order).
+
+If you want to deduplicate: when the first text child equals `taskArgs.prompt`, skip rendering it.
+
+- [ ] **Step 4: Manual smoke**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-core build
+pnpm --filter @qlan-ro/mainframe-desktop dev
+```
+
+Open a chat, dispatch an Agent (e.g. "Run `echo hi` via Bash"), expand the Task card. Confirm:
+- prompt appears once at the top (intro line)
+- subagent text appears as a left-indented body line
+- Bash command appears as `BashCard` child
+- no system pill at root
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
+git commit -m "feat(desktop/TaskGroupCard): render text/thinking/skill_loaded children"
+```
+
+---
+
+## Task 8: History — extend `injectAgentChildren` with subagent text/thinking + tag
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/history.ts`
+- Test: `packages/core/src/__tests__/message-loading.test.ts`
+
+History today only inlines subagent **tool_use** blocks (from `agent_progress` events) and attaches subagent **tool_result** blocks. We extend it to also inline subagent text/thinking/skill_loaded from subagent JSONLs, and we tag every inlined block with `parentToolUseId = parent Agent tool_use_id`.
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `packages/core/src/__tests__/message-loading.test.ts`:
+
+```ts
+it('inlines subagent assistant text/thinking from subagent JSONLs into the parent assistant message with parentToolUseId tag', async () => {
+  // Parent JSONL: assistant with Agent tool_use, then parent's tool_result.
+  const agentToolUseId = 'toolu_agent_1';
+  writeJsonl(SESSION_ID, [
+    userTextEntry('dispatch please'),
+    assistantToolUseEntry('Agent', { description: 'Echo hi', subagent_type: 'general-purpose', prompt: 'Run echo hi' }, agentToolUseId),
+    toolResultEntry(agentToolUseId, 'Output of `echo hi`: `hi`'),
+  ]);
+
+  // Subagent JSONL with one assistant turn (text + Bash tool_use) and tool_result.
+  const subagentDir = join(PROJECT_DIR, SESSION_ID, 'subagents');
+  mkdirSync(subagentDir, { recursive: true });
+  writeFileSync(
+    join(subagentDir, `agent-sub.jsonl`),
+    [
+      jsonlEntry({
+        type: 'user',
+        isSidechain: true,
+        agentId: 'sub',
+        message: { role: 'user', content: 'Run echo hi' },
+      }),
+      jsonlEntry({
+        type: 'assistant',
+        isSidechain: true,
+        agentId: 'sub',
+        parentToolUseID: agentToolUseId,
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'subagent inner' },
+            { type: 'text', text: 'Running it.' },
+            { type: 'tool_use', id: 'toolu_sub_bash', name: 'Bash', input: { command: 'echo hi' } },
+          ],
+        },
+      }),
+      jsonlEntry({
+        type: 'user',
+        isSidechain: true,
+        agentId: 'sub',
+        parentToolUseID: agentToolUseId,
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_sub_bash', content: 'hi' }],
+        },
+      }),
+    ].join('\n') + '\n',
+  );
+
+  const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+  // Find the parent assistant message and assert its content[] now includes the subagent blocks.
+  const assistant = messages.find((m) => m.type === 'assistant');
+  expect(assistant).toBeDefined();
+  const contentTypes = assistant!.content.map((c) => c.type);
+  expect(contentTypes).toContain('thinking');
+  expect(contentTypes.filter((t) => t === 'text').length).toBeGreaterThanOrEqual(1);
+  // Every inlined block carries the parentToolUseId tag pointing to the Agent tool_use.
+  for (const c of assistant!.content) {
+    if (c.type === 'tool_use' && c.name === 'Agent') continue;
+    if ((c as { parentToolUseId?: string }).parentToolUseId !== undefined) {
+      expect((c as { parentToolUseId?: string }).parentToolUseId).toBe(agentToolUseId);
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-loading.test.ts -t "inlines subagent assistant text/thinking"`
+Expected: FAIL.
+
+- [ ] **Step 3: Extend `collectAgentProgressTools` (rename mentally — it now also collects text/thinking)**
+
+In `packages/core/src/plugins/builtin/claude/history.ts`, locate `collectAgentProgressTools` (around line 277) and extend it to push `text` and `thinking` blocks too:
+
+```ts
+function collectAgentProgressTools(entry: Record<string, unknown>, agentTools: Map<string, MessageContent[]>): void {
+  const parentId = entry.parentToolUseID as string | undefined;
+  if (!parentId) return;
+  const data = entry.data as Record<string, unknown>;
+  const msg = data.message as Record<string, unknown> | undefined;
+  const inner = msg?.message as Record<string, unknown> | undefined;
+  if (!inner || inner.role !== 'assistant') return;
+  const content = inner.content as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(content)) return;
+
+  for (const block of content) {
+    const existing = agentTools.get(parentId) ?? [];
+    if (block.type === 'tool_use') {
+      existing.push({
+        type: 'tool_use',
+        id: (block.id as string) || nanoid(),
+        name: block.name as string,
+        input: (block.input as Record<string, unknown>) ?? {},
+        parentToolUseId: parentId,
+      });
+    } else if (block.type === 'text') {
+      const text = (block.text as string) || '';
+      if (text.trim()) existing.push({ type: 'text', text, parentToolUseId: parentId });
+    } else if (block.type === 'thinking') {
+      const t = (block.thinking as string) || '';
+      if (t.trim()) existing.push({ type: 'thinking', thinking: t, parentToolUseId: parentId });
+    }
+    if (existing.length > 0) agentTools.set(parentId, existing);
+  }
+}
+```
+
+- [ ] **Step 4: Add a sibling helper to collect from subagent JSONL files (current CLI doesn't write `agent_progress` to the parent JSONL)**
+
+Add a function that walks subagent JSONL files and pushes their assistant text/thinking/tool_use blocks plus user tool_results into the same `agentTools` map keyed by the parent agent tool_use id (which on subagent JSONL entries is `parentToolUseID`).
+
+```ts
+function collectSubagentAssistantBlocks(
+  entry: Record<string, unknown>,
+  agentTools: Map<string, MessageContent[]>,
+): void {
+  const parentId = entry.parentToolUseID as string | undefined;
+  if (!parentId) return;
+  if (entry.type !== 'assistant') return;
+  const message = entry.message as Record<string, unknown> | undefined;
+  const content = message?.content as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(content)) return;
+
+  const existing = agentTools.get(parentId) ?? [];
+  for (const block of content) {
+    if (block.type === 'tool_use') {
+      existing.push({
+        type: 'tool_use',
+        id: (block.id as string) || nanoid(),
+        name: block.name as string,
+        input: (block.input as Record<string, unknown>) ?? {},
+        parentToolUseId: parentId,
+      });
+    } else if (block.type === 'text') {
+      const text = (block.text as string) || '';
+      if (text.trim()) existing.push({ type: 'text', text, parentToolUseId: parentId });
+    } else if (block.type === 'thinking') {
+      const t = (block.thinking as string) || '';
+      if (t.trim()) existing.push({ type: 'thinking', thinking: t, parentToolUseId: parentId });
+    }
+  }
+  agentTools.set(parentId, existing);
+}
+```
+
+- [ ] **Step 5: Wire the new collector inside `loadHistory`**
+
+In `loadHistory`, where the current `if (isSubagentFile) { collectSubagentToolResults(entry, subagentToolResults); continue; }` sits, also call `collectSubagentAssistantBlocks(entry, agentTools)`:
+
+```ts
+          if (isSubagentFile) {
+            collectSubagentToolResults(entry, subagentToolResults);
+            collectSubagentAssistantBlocks(entry, agentTools);
+            continue;
+          }
+```
+
+- [ ] **Step 6: Tag tool_results when attaching them to the inlined tool_use**
+
+In `attachSubagentToolResults`, set `parentToolUseId` on the result block so it lines up with the inlined tool_use it pairs with. Find the matching parent agent id by walking the parent assistant message's content for the tool_use that owns the result:
+
+```ts
+function attachSubagentToolResults(
+  messages: ChatMessage[],
+  results: Map<string, MessageContent & { type: 'tool_result' }>,
+): void {
+  for (const msg of messages) {
+    if (msg.type !== 'assistant') continue;
+    const newContent: MessageContent[] = [];
+    for (const block of msg.content) {
+      newContent.push(block);
+      if (block.type === 'tool_use') {
+        const toolResult = results.get(block.id);
+        if (toolResult) {
+          newContent.push({ ...toolResult, parentToolUseId: block.parentToolUseId });
+        }
+      }
+    }
+    msg.content = newContent;
+  }
+}
+```
+
+- [ ] **Step 7: `injectAgentChildren` is unchanged — it already uses `agentTools` which now contains the broader block kinds. Confirm by reading the function**
+
+```bash
+sed -n '/^function injectAgentChildren/,/^}/p' packages/core/src/plugins/builtin/claude/history.ts
+```
+
+(The function as-is appends whatever is in `agentTools.get(block.id)` — that's now the right thing.)
+
+- [ ] **Step 8: Run the failing test from Step 1**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-loading.test.ts -t "inlines subagent assistant text/thinking"`
+Expected: PASS.
+
+- [ ] **Step 9: Run the full message-loading suite**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/message-loading.test.ts`
+Expected: all pass. The two regressions added by PRs #259 and #261 still hold (subagent isMeta skill loads from subagent JSONLs are no longer promoted to top-level cards — they now flow through the inlined-blocks path and the existing skill-synthesis filter for subagent files in #261 is still correct).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/history.ts packages/core/src/__tests__/message-loading.test.ts
+git commit -m "feat(claude/history): inline subagent text/thinking/tool_results with parentToolUseId tag"
+```
+
+---
+
+## Task 9: End-to-end manual verification
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Build everything**
+
+```bash
+pnpm install
+pnpm -r build
+```
+
+- [ ] **Step 2: Start the dev daemon and renderer**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-core dev &
+pnpm --filter @qlan-ro/mainframe-desktop dev
+```
+
+- [ ] **Step 3: Live test**
+
+Open a chat in `qlan-home-hub` (or any project). Send a prompt like: "Dispatch 3 general-purpose subagents — each runs `echo hi` via Bash."
+
+Verify:
+- No system pill with the dispatch prompt at root.
+- Each Task card collapses by default; expanding reveals: prompt at top, subagent text/thinking inline, Bash child with its result.
+- Skill loads triggered inside a subagent appear as `SkillLoadedCard`s **inside** the Task card.
+- Skill loads triggered at parent level still appear at root.
+
+- [ ] **Step 4: History test**
+
+Restart the daemon. Reopen the same chat. Verify the same nesting persists from the JSONL replay path.
+
+- [ ] **Step 5: Cross-check against existing PR's regressions**
+
+Open a chat that has historical Agent dispatches recorded with the older protocol (no subagent text in subagent JSONLs). Confirm Task cards still render correctly — empty children are fine, no errors.
+
+- [ ] **Step 6: Commit a changeset**
+
+```bash
+pnpm changeset
+# choose @qlan-ro/mainframe-core, @qlan-ro/mainframe-types, @qlan-ro/mainframe-desktop
+# bump: minor
+```
+
+Changeset summary:
+
+```markdown
+Nest subagent activity (dispatch prompt, text, thinking, skill loads, tool calls) **inside** the parent's Task card on both live stream and history reload. Replaces the prompt-suppression patches in PRs #264/#267 with a uniform rule: every event with `parent_tool_use_id != null` is inlined into the parent assistant message that owns the matching `Agent`/`Task` `tool_use`, and tagged with `parentToolUseId` so `groupTaskChildren` can wrap text/thinking/skill_loaded under `_TaskGroup` alongside tool calls. Parent-level skill loads continue to surface at the chat root.
+```
+
+```bash
+git add .changeset
+git commit -m "chore: changeset for subagent-blocks-nesting"
+```
+
+---
+
+## Task 10: Open the PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/subagent-blocks-nesting
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "feat: nest subagent activity inside the parent Task card" --body "$(cat <<'EOF'
+## Summary
+
+Replaces the prompt-suppression patches in #264 and #267 with the right architectural fix: every Claude CLI stream-json event with `parent_tool_use_id != null` is **inlined** into the parent's assistant message that owns the matching `Agent`/`Task` tool_use, and each inlined block is **tagged** with `parentToolUseId`. The display pipeline's `groupTaskChildren` then wraps anything tagged with the Agent's id into a `_TaskGroup`, so the dispatch prompt, subagent text/thinking, subagent skill loads, subagent tool_use and subagent tool_results all render **inside** the Task card.
+
+## Why
+
+CLI 2.1.118+ normalizes `agent_progress` events into top-level user/assistant SDK messages with `parent_tool_use_id` set. Mainframe used to handle these at the parent level, leaking subagent chatter as ghost system pills/bubbles into the main thread and breaking `_TaskGroup` grouping (which previously stopped at the first text block).
+
+## Behaviour change
+
+Before: subagent prompt → root pill, subagent text → root assistant bubble, Task card empty.
+After: everything subagent-origin lives inside the Task card. Skill loads from inside a subagent become an "inner pill" (`SkillLoadedCard`) inside the Task card body. Skill loads from the parent thread still render at the chat root.
+
+## Test plan
+
+- [x] Unit: `claude-events.test.ts` (`onSubagentChild` routing for assistant/user/text/string/skill/tool_result shapes)
+- [x] Unit: `event-handler.test.ts` (`onSubagentChild` appends to parent message; warns on missing parent)
+- [x] Unit: `message-grouping.test.ts` (`groupTaskChildren` collects by `parentToolUseId`, terminates on mismatch)
+- [x] Unit: `message-loading.test.ts` (history reload inlines subagent text/thinking with tag)
+- [ ] Manual live: dispatch 3 parallel subagents; expand the Task card; expect prompt + subagent text + Bash child with result; no root pill.
+- [ ] Manual history: restart daemon, reopen chat; expect same nesting.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Skill loads at root vs. nested → Task 4 (parent-level path unchanged) + Task 7 (`SkillLoadedCard` rendered inside Task card body for subagent-origin)
+- Prompt nested + trimmed/styled → Task 7 (intro line in Task card body)
+- Subagent text/thinking nested → Tasks 4, 6, 7
+- Subagent tool_use/tool_result nested → Tasks 4, 6, 7 (already worked for tool_use; now via tag, no regression)
+- History parity → Task 8
+- Replaces #264/#267 → Task 4 (drops the prompt-suppression branches)
+
+**Placeholder scan:** None. Every code step has full bodies.
+
+**Type consistency:** `parentToolUseId` field name used consistently across `MessageContent` (Task 1), `SessionSink.onSubagentChild` (Task 2), event-handler implementation (Task 3), `events.ts` block tagging (Task 4), `PartEntry` (Task 5), `DisplayContent` (Task 5), `groupTaskChildren` (Task 6), `TaskGroupCard` (Task 7), history collectors and `attachSubagentToolResults` (Task 8). The runtime field name from the CLI's stream-json (`parent_tool_use_id`, snake_case) is read in `events.ts` only and translated to `parentToolUseId` (camelCase) at the boundary.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-04-30-subagent-blocks-nesting.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using the `executing-plans` skill, batch execution with checkpoints.
+
+Which approach?

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -26,6 +26,7 @@ function createSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -341,31 +341,98 @@ describe('handleStdout', () => {
   });
 });
 
-describe('subagent dispatch prompt (parent_tool_use_id != null)', () => {
+describe('subagent events (parent_tool_use_id != null)', () => {
   // Background: CLI 2.1.118+ normalizes agent_progress into top-level SDK
   // user/assistant events with parent_tool_use_id set to the parent's
-  // Agent/Task tool_use_id. The first event is a string-content user message
-  // restating the dispatch prompt — that text already lives in the parent's
-  // `Agent.input.prompt` (rendered by the Task card), so re-emitting it as
-  // a system pill produces a duplicate. Everything else from the subagent
-  // (text/thinking, skill loads, tool_use, tool_result) is left untouched.
+  // Agent/Task tool_use_id. We route every such event through
+  // onSubagentChild, tagging blocks with parentToolUseId so the display
+  // pipeline groups them under the parent Task card.
 
-  it('drops the dispatch prompt (string content, no CLI-internal tags)', () => {
+  it('routes subagent assistant events to onSubagentChild with tagged blocks', () => {
     const session = createSession();
     const sink = createSink();
+    const event = JSON.stringify({
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'assistant',
+        model: 'claude-opus-4-7',
+        content: [
+          { type: 'thinking', thinking: 'subagent inner thought' },
+          { type: 'text', text: 'Let me run a command.' },
+          { type: 'tool_use', id: 'toolu_subagent_bash', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
 
+    expect(sink.onMessage).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect(blocks).toHaveLength(3);
+    for (const b of blocks) expect((b as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
+  });
+
+  it('routes the dispatch prompt (string content normalized to text block) to onSubagentChild', () => {
+    const session = createSession();
+    const sink = createSink();
     const event = JSON.stringify({
       type: 'user',
       parent_tool_use_id: 'toolu_parent_agent',
-      message: { role: 'user', content: 'Create a PR for the current branch...' },
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run `echo hi` via Bash and report the output.' }],
+      },
     });
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
     expect(sink.onCliMessage).not.toHaveBeenCalled();
-    expect(sink.onSkillLoaded).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect(blocks).toEqual([
+      { type: 'text', text: 'Run `echo hi` via Bash and report the output.', parentToolUseId: 'toolu_parent_agent' },
+    ]);
   });
 
-  it('still surfaces a subagent skill load (string content with <command-name>)', async () => {
+  it('routes raw string-content (pre-normalize edge case) to onSubagentChild', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: { role: 'user', content: 'raw string body' },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onSubagentChild).toHaveBeenCalledWith('toolu_parent_agent', [
+      { type: 'text', text: 'raw string body', parentToolUseId: 'toolu_parent_agent' },
+    ]);
+  });
+
+  it('routes subagent tool_result blocks via onSubagentChild (not onToolResult)', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      parent_tool_use_id: 'toolu_parent_agent',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_subagent_bash', content: 'hi' }],
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onToolResult).not.toHaveBeenCalled();
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
+    expect((blocks[0] as { type: string }).type).toBe('tool_result');
+    expect((blocks[0] as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
+  });
+
+  it('routes subagent skill loads through onSubagentChild as skill_loaded blocks (inner pill)', async () => {
     const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
     const { tmpdir } = await import('node:os');
     const pathMod = await import('node:path');
@@ -384,87 +451,57 @@ describe('subagent dispatch prompt (parent_tool_use_id != null)', () => {
       });
       handleStdout(session, Buffer.from(event + '\n'), sink);
 
-      expect(sink.onSkillLoaded).toHaveBeenCalledTimes(1);
-      const loaded = (sink.onSkillLoaded as ReturnType<typeof vi.fn>).mock.calls[0]![0];
-      expect(loaded.skillName).toBe('pencil');
+      expect(sink.onSkillLoaded).not.toHaveBeenCalled();
+      expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+      const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(parentId).toBe('toolu_parent_agent');
+      expect((blocks[0] as { type: string }).type).toBe('skill_loaded');
+      expect((blocks[0] as { skillName: string }).skillName).toBe('pencil');
+      expect((blocks[0] as { parentToolUseId?: string }).parentToolUseId).toBe('toolu_parent_agent');
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }
   });
 
-  it('still surfaces a subagent isMeta skill-content (Base directory for this skill: …)', () => {
+  it('extracts a skill_loaded block from a subagent array-content event with skill-format markers', () => {
     const session = createSession();
     const sink = createSink();
-    const skillContent = '# brainstorming\n\nThink broadly.';
-    const text = ['Base directory for this skill: /home/user/.claude/skills/brainstorming', skillContent].join('\n');
+    const text = [
+      '<command-name>brainstorming</command-name>',
+      '<skill-format>true</skill-format>',
+      'Base directory for this skill: /home/user/.claude/skills/brainstorming',
+      '# Brainstorming\n\nThink broadly.',
+    ].join('\n');
 
     const event = JSON.stringify({
       type: 'user',
       parent_tool_use_id: 'toolu_parent_agent',
-      message: { role: 'user', content: text },
+      message: { role: 'user', content: [{ type: 'text', text }] },
     });
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
-    // The string-content path does not synthesize SkillLoadedCard for the
-    // "Base directory" shape (that's an array-content concern). What matters
-    // here is that we did NOT silently drop the event — it falls through to
-    // the existing onCliMessage path, where downstream code can react.
-    expect(sink.onCliMessage).toHaveBeenCalledWith(text.trim());
-  });
-
-  it('forwards tool_result blocks from a subagent user event', () => {
-    const session = createSession();
-    const sink = createSink();
-
-    const event = JSON.stringify({
-      type: 'user',
-      parent_tool_use_id: 'toolu_parent_agent',
-      message: {
-        role: 'user',
-        content: [{ type: 'tool_result', tool_use_id: 'toolu_subagent_bash', content: 'ls output' }],
-      },
-    });
-    handleStdout(session, Buffer.from(event + '\n'), sink);
-
-    expect(sink.onToolResult).toHaveBeenCalledTimes(1);
-    const blocks = (sink.onToolResult as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(sink.onSubagentChild).toHaveBeenCalledTimes(1);
+    const [parentId, blocks] = (sink.onSubagentChild as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(parentId).toBe('toolu_parent_agent');
     expect(blocks).toHaveLength(1);
-    expect(blocks[0]).toMatchObject({
-      type: 'tool_result',
-      toolUseId: 'toolu_subagent_bash',
-      content: 'ls output',
-    });
+    const skill = blocks[0] as {
+      type: string;
+      skillName: string;
+      path: string;
+      parentToolUseId?: string;
+      content: string;
+    };
+    expect(skill.type).toBe('skill_loaded');
+    expect(skill.skillName).toBe('brainstorming');
+    expect(skill.path).toBe('/home/user/.claude/skills/brainstorming/SKILL.md');
+    expect(skill.parentToolUseId).toBe('toolu_parent_agent');
+    expect(skill.content).not.toContain('<skill-format>');
+    expect(skill.content).not.toContain('Base directory for this skill:');
   });
 
-  it('forwards subagent assistant turns unchanged (text + tool_use both flow)', () => {
+  it('parent-level events (parent_tool_use_id null) take the existing path', () => {
     const session = createSession();
     const sink = createSink();
-
-    const event = JSON.stringify({
-      type: 'assistant',
-      parent_tool_use_id: 'toolu_parent_agent',
-      message: {
-        role: 'assistant',
-        model: 'claude-opus-4-7',
-        content: [
-          { type: 'thinking', thinking: 'subagent inner thought' },
-          { type: 'text', text: 'Let me run a command.' },
-          { type: 'tool_use', id: 'toolu_subagent_bash', name: 'Bash', input: { command: 'ls' } },
-        ],
-      },
-    });
-    handleStdout(session, Buffer.from(event + '\n'), sink);
-
-    expect(sink.onMessage).toHaveBeenCalledTimes(1);
-    const [content] = (sink.onMessage as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(content).toHaveLength(3);
-    expect(content.map((b: Record<string, unknown>) => b.type)).toEqual(['thinking', 'text', 'tool_use']);
-  });
-
-  it('parent-level events (parent_tool_use_id null) take the normal path', () => {
-    const session = createSession();
-    const sink = createSink();
-
     const event = JSON.stringify({
       type: 'user',
       parent_tool_use_id: null,
@@ -476,6 +513,7 @@ describe('subagent dispatch prompt (parent_tool_use_id != null)', () => {
     handleStdout(session, Buffer.from(event + '\n'), sink);
 
     expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown command: /typo');
+    expect(sink.onSubagentChild).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/__tests__/codex-approval-handler.test.ts
+++ b/packages/core/src/__tests__/codex-approval-handler.test.ts
@@ -22,6 +22,7 @@ function createSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -23,6 +23,7 @@ function createSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/codex-session.test.ts
+++ b/packages/core/src/__tests__/codex-session.test.ts
@@ -56,6 +56,7 @@ function createSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/__tests__/event-handler-display.test.ts
+++ b/packages/core/src/__tests__/event-handler-display.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventHandler } from '../chat/event-handler.js';
 import { MessageCache } from '../chat/message-cache.js';
 import { PermissionManager } from '../chat/permission-manager.js';
+import { convertAssistantContent } from '../messages/display-helpers.js';
 import type { DaemonEvent, SessionSink } from '@qlan-ro/mainframe-types';
+import type { GroupedMessage } from '../messages/message-grouping.js';
 
 function createRespondToPermission() {
   return vi.fn().mockResolvedValue(undefined);
@@ -155,5 +157,41 @@ describe('EventHandler display event emission', () => {
     expect(updatedEvents).toHaveLength(1);
     const updated = updatedEvents[0] as Extract<DaemonEvent, { type: 'display.message.updated' }>;
     expect(updated.message.type).toBe('assistant');
+  });
+});
+
+describe('display-pipeline parentToolUseId propagation', () => {
+  it('preserves parentToolUseId on text blocks through convertAssistantContent', () => {
+    const grouped: GroupedMessage = {
+      id: 'm1',
+      chatId: 'c1',
+      type: 'assistant',
+      content: [{ type: 'text', text: 'hello', parentToolUseId: 'toolu_agent_1' }],
+      timestamp: '2026-04-30T00:00:00Z',
+    };
+    const out = convertAssistantContent(grouped);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { type: string; parentToolUseId?: string }).parentToolUseId).toBe('toolu_agent_1');
+  });
+
+  it('preserves parentToolUseId on tool_call blocks through convertAssistantContent', () => {
+    const grouped: GroupedMessage = {
+      id: 'm2',
+      chatId: 'c1',
+      type: 'tool_use',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'Read',
+          input: { path: '/tmp/x' },
+          parentToolUseId: 'toolu_agent_1',
+        },
+      ],
+      timestamp: '2026-04-30T00:00:00Z',
+    };
+    const out = convertAssistantContent(grouped);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { type: string; parentToolUseId?: string }).parentToolUseId).toBe('toolu_agent_1');
   });
 });

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -340,6 +340,99 @@ describe('EventHandler onSkillLoaded', () => {
   });
 });
 
+describe('EventHandler onSubagentChild', () => {
+  let db: any;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+  const chatId = 'chat-1';
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    messages = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    activeChats = new Map();
+  });
+
+  it('appends blocks to the parent assistant message that owns the matching tool_use and emits message.updated', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    // Seed: an assistant message that contains an Agent tool_use with id 'toolu_agent_1'.
+    sink.onMessage(
+      [
+        { type: 'text', text: 'Dispatching subagent.' },
+        { type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: { description: 'Echo hi 1' } },
+      ],
+      { model: 'claude-opus-4-7' },
+    );
+
+    // Act: subagent forwards two blocks tagged with parentToolUseId.
+    sink.onSubagentChild('toolu_agent_1', [
+      { type: 'text', text: 'Run echo hi via Bash and report the output.', parentToolUseId: 'toolu_agent_1' },
+      {
+        type: 'tool_use',
+        id: 'toolu_sub_bash',
+        name: 'Bash',
+        input: { command: 'echo hi' },
+        parentToolUseId: 'toolu_agent_1',
+      },
+    ]);
+
+    const cached = messages.get(chatId);
+    const assistant = cached?.find((m) => m.type === 'assistant');
+    expect(assistant).toBeDefined();
+    const types = assistant!.content.map((c: any) => c.type);
+    expect(types).toEqual(['text', 'tool_use', 'text', 'tool_use']);
+    const last = assistant!.content[3] as any;
+    expect(last.parentToolUseId).toBe('toolu_agent_1');
+    expect(last.name).toBe('Bash');
+    const updateEvents = emitEvent.mock.calls.filter(([e]: [any]) => e.type === 'message.updated');
+    expect(updateEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('no-ops with a warn log when no parent assistant message owns the tool_use', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    sink.onSubagentChild('toolu_unknown', [{ type: 'text', text: 'orphaned', parentToolUseId: 'toolu_unknown' }]);
+
+    expect(messages.get(chatId)).toBeUndefined();
+  });
+
+  it('picks the assistant message that owns the matching tool_use id, skipping non-matching ones', () => {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    const sink: SessionSink = handler.buildSink(chatId, createRespondToPermission());
+
+    sink.onMessage([{ type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: { description: 'a' } }], {
+      model: 'claude-opus-4-7',
+    });
+    sink.onMessage([{ type: 'tool_use', id: 'toolu_agent_2', name: 'Agent', input: { description: 'b' } }], {
+      model: 'claude-opus-4-7',
+    });
+
+    sink.onSubagentChild('toolu_agent_1', [{ type: 'text', text: 'from agent 1', parentToolUseId: 'toolu_agent_1' }]);
+
+    const cached = messages.get(chatId);
+    const owningAgent1 = cached?.find(
+      (m) => m.type === 'assistant' && m.content.some((b: any) => b.type === 'tool_use' && b.id === 'toolu_agent_1'),
+    );
+    const owningAgent2 = cached?.find(
+      (m) => m.type === 'assistant' && m.content.some((b: any) => b.type === 'tool_use' && b.id === 'toolu_agent_2'),
+    );
+    expect(owningAgent1).toBeDefined();
+    expect(owningAgent2).toBeDefined();
+    expect(owningAgent1!.content).toHaveLength(2); // original tool_use + inlined text
+    expect(owningAgent2!.content).toHaveLength(1); // untouched
+  });
+});
+
 describe('EventHandler onPermission — yolo no longer auto-approves', () => {
   let db: any;
   let messages: MessageCache;

--- a/packages/core/src/__tests__/message-grouping.test.ts
+++ b/packages/core/src/__tests__/message-grouping.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { groupTaskChildren, type PartEntry } from '../messages/tool-grouping.js';
+import type { ToolCategories } from '@qlan-ro/mainframe-types';
+
+function makeCategories(): ToolCategories {
+  return {
+    explore: new Set(['Read', 'Glob', 'Grep', 'LS']),
+    hidden: new Set(['TodoWrite']),
+    progress: new Set(['_TaskProgress']),
+    subagent: new Set(['Agent', 'Task']),
+  };
+}
+
+describe('groupTaskChildren', () => {
+  it('includes text/thinking-sentinel/tool_call/skill_loaded children whose parentToolUseId matches the Agent id', () => {
+    const cats = makeCategories();
+    const parts: PartEntry[] = [
+      { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+      { type: 'text', text: 'Run echo hi via Bash and report the output.', parentToolUseId: 'toolu_agent_1' },
+      // Thinking arrives as a sentinel; the sentinel itself now carries the tag.
+      { type: 'text', text: '\0ng:0', parentToolUseId: 'toolu_agent_1' },
+      {
+        type: 'tool-call',
+        toolCallId: 'toolu_sub_bash',
+        toolName: 'Bash',
+        args: { command: 'echo hi' },
+        result: 'hi',
+        parentToolUseId: 'toolu_agent_1',
+      },
+    ];
+    const grouped = groupTaskChildren(parts, cats);
+    expect(grouped).toHaveLength(1);
+    const g = grouped[0]!;
+    expect(g.type).toBe('tool-call');
+    expect((g as { toolName: string }).toolName).toBe('_TaskGroup');
+    const args = (g as unknown as { args: { children: PartEntry[] } }).args;
+    expect(args.children).toHaveLength(3);
+    // First child is the dispatch prompt text
+    expect(args.children[0]!.type).toBe('text');
+    expect((args.children[0]! as { text: string }).text).toContain('Run echo hi');
+    // Second child is the thinking sentinel — preserved for downstream decode
+    expect((args.children[1]! as { text: string }).text).toBe('\0ng:0');
+    // Third child is the Bash tool_call
+    expect((args.children[2]! as { toolName?: string }).toolName).toBe('Bash');
+  });
+
+  it('stops collecting when a part has no parentToolUseId or a different one', () => {
+    const cats = makeCategories();
+    const parts: PartEntry[] = [
+      { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+      { type: 'text', text: 'subagent text', parentToolUseId: 'toolu_agent_1' },
+      { type: 'tool-call', toolCallId: 'toolu_sub_bash', toolName: 'Bash', args: {}, parentToolUseId: 'toolu_agent_1' },
+      { type: 'text', text: 'parent thread text' }, // no parentToolUseId — terminates the group
+      { type: 'tool-call', toolCallId: 'toolu_parent_read', toolName: 'Read', args: {} },
+    ];
+    const grouped = groupTaskChildren(parts, cats);
+    expect(grouped).toHaveLength(3);
+    expect((grouped[0] as { toolName: string }).toolName).toBe('_TaskGroup');
+    expect(grouped[1]!.type).toBe('text');
+    expect((grouped[1]! as { text: string }).text).toBe('parent thread text');
+    expect((grouped[2] as { toolName: string }).toolName).toBe('Read');
+  });
+
+  it('still groups tool_call children when no text parts intervene (back-compat with existing flow)', () => {
+    const cats = makeCategories();
+    const parts: PartEntry[] = [
+      { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+      { type: 'tool-call', toolCallId: 'toolu_sub_bash', toolName: 'Bash', args: {}, parentToolUseId: 'toolu_agent_1' },
+      { type: 'tool-call', toolCallId: 'toolu_sub_read', toolName: 'Read', args: {}, parentToolUseId: 'toolu_agent_1' },
+    ];
+    const grouped = groupTaskChildren(parts, cats);
+    expect(grouped).toHaveLength(1);
+    const args = (grouped[0] as unknown as { args: { children: PartEntry[] } }).args;
+    expect(args.children).toHaveLength(2);
+  });
+
+  it('terminates on a second Agent tool_call (parallel subagents)', () => {
+    const cats = makeCategories();
+    const parts: PartEntry[] = [
+      { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+      { type: 'text', text: 'first prompt', parentToolUseId: 'toolu_agent_1' },
+      { type: 'tool-call', toolCallId: 'toolu_agent_2', toolName: 'Agent', args: {}, result: 'ok2' },
+      { type: 'text', text: 'second prompt', parentToolUseId: 'toolu_agent_2' },
+    ];
+    const grouped = groupTaskChildren(parts, cats);
+    expect(grouped).toHaveLength(2);
+    expect((grouped[0] as { toolName: string }).toolName).toBe('_TaskGroup');
+    expect((grouped[1] as { toolName: string }).toolName).toBe('_TaskGroup');
+    const firstArgs = (grouped[0] as unknown as { args: { children: PartEntry[] } }).args;
+    const secondArgs = (grouped[1] as unknown as { args: { children: PartEntry[] } }).args;
+    expect(firstArgs.children).toHaveLength(1);
+    expect((firstArgs.children[0] as { text: string }).text).toBe('first prompt');
+    expect(secondArgs.children).toHaveLength(1);
+    expect((secondArgs.children[0] as { text: string }).text).toBe('second prompt');
+  });
+
+  it('Agent with no matching children renders as a plain tool-call (not _TaskGroup)', () => {
+    const cats = makeCategories();
+    const parts: PartEntry[] = [
+      { type: 'tool-call', toolCallId: 'toolu_agent_1', toolName: 'Agent', args: {}, result: 'ok' },
+      { type: 'text', text: 'untagged' /* no parentToolUseId */ },
+    ];
+    const grouped = groupTaskChildren(parts, cats);
+    expect(grouped).toHaveLength(2);
+    expect((grouped[0] as { toolName: string }).toolName).toBe('Agent');
+    expect(grouped[1]!.type).toBe('text');
+  });
+});

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -867,6 +867,71 @@ describe('loadHistory', () => {
     }
   });
 
+  it('links subagent JSONL entries via toolUseResult.agentId when parentToolUseID is absent (CLI 2.1.118+)', async () => {
+    // CLI 2.1.118+ writes subagent JSONL entries with `agentId` but without
+    // `parentToolUseID` on each line. The link to the parent's tool_use lives
+    // on the parent tool_result's `toolUseResult.agentId`. Without the lookup,
+    // history reload drops every subagent block and the Task card renders empty.
+    const agentToolUseId = 'toolu_agent_2118';
+    const subAgentId = 'ac1059642ea2fac5f';
+
+    writeJsonl(SESSION_ID, [
+      userTextEntry('use an explore agent'),
+      assistantToolUseEntry(
+        'Agent',
+        { description: 'Quick project overview', subagent_type: 'Explore', prompt: 'overview' },
+        agentToolUseId,
+      ),
+      // Parent tool_result carries `toolUseResult.agentId` — the only link to the subagent file.
+      jsonlEntry({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: agentToolUseId, content: 'agent done' }],
+        },
+        toolUseResult: { status: 'completed', agentId: subAgentId, agentType: 'Explore' },
+      }),
+    ]);
+
+    const subagentDir = join(PROJECT_DIR, SESSION_ID, 'subagents');
+    mkdirSync(subagentDir, { recursive: true });
+    writeFileSync(
+      join(subagentDir, `agent-${subAgentId}.jsonl`),
+      [
+        // Subagent entries carry `agentId` but NOT `parentToolUseID` — matches CLI 2.1.118+ shape.
+        jsonlEntry({
+          type: 'assistant',
+          isSidechain: true,
+          agentId: subAgentId,
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Looking around.' },
+              { type: 'tool_use', id: 'toolu_sub_read', name: 'Read', input: { file_path: '/a.ts' } },
+            ],
+          },
+        }),
+        jsonlEntry({
+          type: 'user',
+          isSidechain: true,
+          agentId: subAgentId,
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_sub_read', content: 'file body' }],
+          },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    const assistant = messages.find((m) => m.type === 'assistant');
+    expect(assistant).toBeDefined();
+    const tagged = assistant!.content.filter((c) => 'parentToolUseId' in c && c.parentToolUseId === agentToolUseId);
+    // Subagent text + tool_use + tool_result should all be inlined and tagged.
+    expect(tagged.map((c) => c.type).sort()).toEqual(['text', 'tool_result', 'tool_use']);
+  });
+
   it('handles tool_result with error flag', async () => {
     const toolUseId = 'toolu_err';
     writeJsonl(SESSION_ID, [

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -794,6 +794,79 @@ describe('loadHistory', () => {
     expect(messages[0].content[0]).toMatchObject({ type: 'text', text: '' });
   });
 
+  it('inlines subagent assistant text/thinking and tool_results from subagent JSONLs into the parent assistant message with parentToolUseId tag', async () => {
+    const agentToolUseId = 'toolu_agent_1';
+    // Parent JSONL: assistant with Agent tool_use, then parent's tool_result.
+    writeJsonl(SESSION_ID, [
+      userTextEntry('dispatch please'),
+      assistantToolUseEntry(
+        'Agent',
+        { description: 'Echo hi', subagent_type: 'general-purpose', prompt: 'Run echo hi' },
+        agentToolUseId,
+      ),
+      toolResultEntry(agentToolUseId, 'Output of `echo hi`: `hi`'),
+    ]);
+
+    // Subagent JSONL: text/thinking/tool_use as one assistant turn, then tool_result.
+    const subagentDir = join(PROJECT_DIR, SESSION_ID, 'subagents');
+    mkdirSync(subagentDir, { recursive: true });
+    writeFileSync(
+      join(subagentDir, `agent-sub.jsonl`),
+      [
+        jsonlEntry({
+          type: 'user',
+          isSidechain: true,
+          agentId: 'sub',
+          message: { role: 'user', content: 'Run echo hi' },
+        }),
+        jsonlEntry({
+          type: 'assistant',
+          isSidechain: true,
+          agentId: 'sub',
+          parentToolUseID: agentToolUseId,
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'subagent inner' },
+              { type: 'text', text: 'Running it.' },
+              { type: 'tool_use', id: 'toolu_sub_bash', name: 'Bash', input: { command: 'echo hi' } },
+            ],
+          },
+        }),
+        jsonlEntry({
+          type: 'user',
+          isSidechain: true,
+          agentId: 'sub',
+          parentToolUseID: agentToolUseId,
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_sub_bash', content: 'hi' }],
+          },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const messages = await loadHistory(SESSION_ID, PROJECT_PATH);
+
+    // Find the parent assistant message and assert its content[] now includes the subagent blocks.
+    const assistant = messages.find((m) => m.type === 'assistant');
+    expect(assistant).toBeDefined();
+    const types = assistant!.content.map((c) => c.type);
+    // Must include the original Agent tool_use, plus inlined thinking + text + tool_use + tool_result.
+    expect(types).toContain('thinking');
+    expect(types.filter((t) => t === 'text').length).toBeGreaterThanOrEqual(1);
+    expect(types.filter((t) => t === 'tool_use').length).toBeGreaterThanOrEqual(2); // Agent + Bash
+    expect(types).toContain('tool_result');
+
+    // Every inlined block carries the parentToolUseId tag pointing to the Agent tool_use id.
+    for (const c of assistant!.content) {
+      if (c.type === 'tool_use' && c.name === 'Agent') continue; // the parent's own Agent tool_use is untagged
+      if ('parentToolUseId' in c && c.parentToolUseId !== undefined) {
+        expect(c.parentToolUseId).toBe(agentToolUseId);
+      }
+    }
+  });
+
   it('handles tool_result with error flag', async () => {
     const toolUseId = 'toolu_err';
     writeJsonl(SESSION_ID, [

--- a/packages/core/src/__tests__/messages/display-pipeline.test.ts
+++ b/packages/core/src/__tests__/messages/display-pipeline.test.ts
@@ -359,9 +359,12 @@ describe('prepareMessagesForClient', () => {
       expect(groups).toHaveLength(1);
     });
 
-    it('wraps subagent tool + children into a task_group', () => {
+    it('wraps subagent tool + tagged children into a task_group', () => {
       const messages = [
-        rawMsg('assistant', [tu('tu1', 'Task', { description: 'do something' }), tu('tu2', 'Bash', { command: 'ls' })]),
+        rawMsg('assistant', [
+          tu('tu1', 'Task', { description: 'do something' }),
+          { ...tu('tu2', 'Bash', { command: 'ls' }), parentToolUseId: 'tu1' } as MessageContent,
+        ]),
         rawMsg('tool_result', [tr('tu1', 'task-result'), tr('tu2', 'bash-result')]),
       ];
       const result = prepareMessagesForClient(messages, TEST_CATEGORIES);

--- a/packages/core/src/__tests__/messages/tool-grouping.test.ts
+++ b/packages/core/src/__tests__/messages/tool-grouping.test.ts
@@ -46,6 +46,17 @@ function tc(toolName: string, id?: string, result?: unknown, isError?: boolean):
   };
 }
 
+function tcTagged(toolName: string, id: string, parentToolUseId: string, result?: unknown): PartEntry {
+  return {
+    type: 'tool-call',
+    toolCallId: id,
+    toolName,
+    args: { some: 'arg' },
+    result,
+    parentToolUseId,
+  };
+}
+
 function text(t: string): PartEntry {
   return { type: 'text', text: t };
 }
@@ -293,8 +304,12 @@ describe('groupTaskChildren', () => {
     expect(result).toEqual(parts);
   });
 
-  it('wraps a Task + subsequent tool calls into a _TaskGroup', () => {
-    const parts = [tc('Task', 't1', undefined), tc('Bash', 'b1', 'output'), tc('Read', 'r1', 'file')];
+  it('wraps a Task + tagged subsequent tool calls into a _TaskGroup', () => {
+    const parts = [
+      tc('Task', 't1', undefined),
+      tcTagged('Bash', 'b1', 't1', 'output'),
+      tcTagged('Read', 'r1', 't1', 'file'),
+    ];
     const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
 
     expect(result).toHaveLength(1);
@@ -305,22 +320,23 @@ describe('groupTaskChildren', () => {
 
     const children = group.args.children as PartEntry[];
     expect(children).toHaveLength(2);
-    expect(children[0]!).toEqual(tc('Bash', 'b1', 'output'));
-    expect(children[1]!).toEqual(tc('Read', 'r1', 'file'));
+    expect(children[0]!).toEqual(tcTagged('Bash', 'b1', 't1', 'output'));
+    expect(children[1]!).toEqual(tcTagged('Read', 'r1', 't1', 'file'));
   });
 
   it('preserves Task args in taskArgs', () => {
     const parts = [
       { type: 'tool-call' as const, toolCallId: 't1', toolName: 'Task', args: { description: 'do stuff' } },
-      tc('Bash', 'b1'),
+      tcTagged('Bash', 'b1', 't1'),
     ];
     const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
     const group = result[0] as PartEntry & { type: 'tool-call' };
     expect(group.args.taskArgs).toEqual({ description: 'do stuff' });
   });
 
-  it('stops grouping at a text entry', () => {
-    const parts = [tc('Task', 't1'), tc('Bash', 'b1'), text('middle'), tc('Edit', 'e1')];
+  it('stops grouping at an untagged entry', () => {
+    // Bash is tagged for t1; the untagged Edit terminates the run.
+    const parts = [tc('Task', 't1'), tcTagged('Bash', 'b1', 't1'), text('middle'), tc('Edit', 'e1')];
     const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
 
     // _TaskGroup(Task+Bash), text, Edit
@@ -331,11 +347,11 @@ describe('groupTaskChildren', () => {
 
     const children = (result[0] as PartEntry & { type: 'tool-call' }).args.children as PartEntry[];
     expect(children).toHaveLength(1);
-    expect(children[0]!).toEqual(tc('Bash', 'b1'));
+    expect(children[0]!).toEqual(tcTagged('Bash', 'b1', 't1'));
   });
 
-  it('stops grouping at another Task tool call', () => {
-    const parts = [tc('Task', 't1'), tc('Bash', 'b1'), tc('Task', 't2'), tc('Read', 'r1')];
+  it('stops grouping at a child tagged for a different parent', () => {
+    const parts = [tc('Task', 't1'), tcTagged('Bash', 'b1', 't1'), tc('Task', 't2'), tcTagged('Read', 'r1', 't2')];
     const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
 
     expect(result).toHaveLength(2);
@@ -346,11 +362,11 @@ describe('groupTaskChildren', () => {
 
     const children1 = (result[0] as PartEntry & { type: 'tool-call' }).args.children as PartEntry[];
     expect(children1).toHaveLength(1);
-    expect(children1[0]!).toEqual(tc('Bash', 'b1'));
+    expect(children1[0]!).toEqual(tcTagged('Bash', 'b1', 't1'));
 
     const children2 = (result[1] as PartEntry & { type: 'tool-call' }).args.children as PartEntry[];
     expect(children2).toHaveLength(1);
-    expect(children2[0]!).toEqual(tc('Read', 'r1'));
+    expect(children2[0]!).toEqual(tcTagged('Read', 'r1', 't2'));
   });
 
   it('leaves a Task with no children as a plain Task entry', () => {
@@ -374,11 +390,39 @@ describe('groupTaskChildren', () => {
   it('preserves result and isError on _TaskGroup', () => {
     const parts = [
       { type: 'tool-call' as const, toolCallId: 't1', toolName: 'Task', args: {}, result: 'task done', isError: false },
-      tc('Bash', 'b1'),
+      tcTagged('Bash', 'b1', 't1'),
     ];
     const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
     const group = result[0] as PartEntry & { type: 'tool-call' };
     expect(group.result).toBe('task done');
     expect(group.isError).toBe(false);
+  });
+
+  // Reproduces the screenshot bug: a subagent that runs an explore burst
+  // (Read/Glob/Grep) gets its tool calls collapsed into a `_ToolGroup` by
+  // groupToolCallParts. groupTaskChildren then needs that wrapper to carry
+  // the subagent's parentToolUseId, otherwise the wrapper falls outside the
+  // _TaskGroup and renders at chat root.
+  it('nests a tagged _ToolGroup inside the parent _TaskGroup', () => {
+    const taskId = 't-agent';
+    const exploreItems = [
+      tcTagged('Read', 'r1', taskId),
+      tcTagged('Grep', 'g1', taskId),
+      tcTagged('Glob', 'gl1', taskId),
+    ];
+    const grouped = groupToolCallParts(exploreItems, CLAUDE_CATEGORIES);
+    expect(grouped).toHaveLength(1);
+    expect((grouped[0] as PartEntry & { type: 'tool-call' }).toolName).toBe('_ToolGroup');
+
+    const parts = [tc('Task', taskId), ...grouped];
+    const result = groupTaskChildren(parts, CLAUDE_CATEGORIES);
+
+    expect(result).toHaveLength(1);
+    const group = result[0] as PartEntry & { type: 'tool-call' };
+    expect(group.toolName).toBe('_TaskGroup');
+
+    const children = group.args.children as PartEntry[];
+    expect(children).toHaveLength(1);
+    expect((children[0] as PartEntry & { type: 'tool-call' }).toolName).toBe('_ToolGroup');
   });
 });

--- a/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
+++ b/packages/core/src/__tests__/plugins/claude-sdk/test-utils.ts
@@ -20,5 +20,6 @@ export function createMockSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -421,6 +421,10 @@ function buildSessionSink(
       emitDisplay();
     },
 
+    onSubagentChild(_parentToolUseId: string, _blocks: import('@qlan-ro/mainframe-types').MessageContent[]) {
+      // Wired in Task 3 — intentional no-op here until event-handler.ts gains full subagent-nesting support.
+    },
+
     onError(error: Error) {
       emitEvent({ type: 'error', chatId, error: error.message });
     },

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -421,8 +421,31 @@ function buildSessionSink(
       emitDisplay();
     },
 
-    onSubagentChild(_parentToolUseId: string, _blocks: import('@qlan-ro/mainframe-types').MessageContent[]) {
-      // Wired in Task 3 — intentional no-op here until event-handler.ts gains full subagent-nesting support.
+    onSubagentChild(parentToolUseId: string, blocks: import('@qlan-ro/mainframe-types').MessageContent[]) {
+      const cached = messages.get(chatId);
+      if (!cached) {
+        log.warn(
+          { chatId, parentToolUseId, blockCount: blocks.length },
+          'onSubagentChild: no messages in cache; dropping blocks',
+        );
+        return;
+      }
+      // Walk newest-first: subagent events belong to the most recent assistant
+      // message that contains the parent tool_use.
+      for (let i = cached.length - 1; i >= 0; i--) {
+        const msg = cached[i]!;
+        if (msg.type !== 'assistant') continue;
+        const owns = msg.content.some((b) => b.type === 'tool_use' && b.id === parentToolUseId);
+        if (!owns) continue;
+        msg.content = [...msg.content, ...blocks];
+        emitEvent({ type: 'message.updated', chatId, message: msg });
+        emitDisplay();
+        return;
+      }
+      log.warn(
+        { chatId, parentToolUseId, blockCount: blocks.length },
+        'onSubagentChild: parent tool_use not found in cache; dropping blocks',
+      );
     },
 
     onError(error: Error) {

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -6,6 +6,11 @@ import { groupToolCallParts, groupTaskChildren } from './tool-grouping.js';
 
 const INTERNAL_USER_RE = /<mainframe-command[\s>]/;
 
+/** Returns `{ parentToolUseId: id }` when `id` is set, an empty object otherwise. */
+export function withParentId(id: string | undefined): { parentToolUseId: string } | Record<string, never> {
+  return id ? { parentToolUseId: id } : {};
+}
+
 /** Returns true if a user message is internal (mainframe commands or skill invocations). */
 export function isInternalUserMessage(content: MessageContent[]): boolean {
   return content.some((block) => block.type === 'text' && INTERNAL_USER_RE.test(block.text));
@@ -43,9 +48,18 @@ export function convertAssistantContent(grouped: GroupedMessage, categories?: To
   for (const block of grouped.content) {
     if (block.type === 'text') {
       const stripped = stripMainframeCommandTags(block.text);
-      if (stripped) content.push({ type: 'text', text: stripped });
+      if (stripped)
+        content.push({
+          type: 'text',
+          text: stripped,
+          ...withParentId(block.parentToolUseId),
+        });
     } else if (block.type === 'thinking') {
-      content.push({ type: 'thinking', thinking: block.thinking });
+      content.push({
+        type: 'thinking',
+        thinking: block.thinking,
+        ...withParentId(block.parentToolUseId),
+      });
     } else if (block.type === 'tool_use') {
       if (seenToolIds.has(block.id)) continue;
       seenToolIds.add(block.id);
@@ -57,6 +71,7 @@ export function convertAssistantContent(grouped: GroupedMessage, categories?: To
         name: block.name,
         input: block.input,
         category: categorizeToolCall(block.name, categories),
+        ...withParentId(block.parentToolUseId),
       };
       if (resultBlock) call.result = toToolCallResult(resultBlock);
       content.push(call);
@@ -94,7 +109,11 @@ export function convertUserContent(content: MessageContent[]): {
         // echo. The raw XML is pure CLI metadata — users want to see what they typed.
         const args = cmdInfo.userText.trim();
         const rendered = args ? `/${cmdInfo.commandName} ${args}` : `/${cmdInfo.commandName}`;
-        displayContent.push({ type: 'text', text: rendered });
+        displayContent.push({
+          type: 'text',
+          text: rendered,
+          ...withParentId(block.parentToolUseId),
+        });
         continue;
       }
 
@@ -103,7 +122,12 @@ export function convertUserContent(content: MessageContent[]): {
 
       const textToStore = files.length > 0 ? cleanText : block.text;
 
-      if (textToStore) displayContent.push({ type: 'text', text: textToStore });
+      if (textToStore)
+        displayContent.push({
+          type: 'text',
+          text: textToStore,
+          ...withParentId(block.parentToolUseId),
+        });
     } else if (block.type === 'image') {
       displayContent.push({ type: 'image', mediaType: block.mediaType, data: block.data });
     }
@@ -128,9 +152,10 @@ export function applyToolGrouping(content: DisplayContent[], categories: ToolCat
         args: c.input,
         result: c.result,
         isError: c.result?.isError,
+        ...withParentId(c.parentToolUseId),
       };
     }
-    if (c.type === 'text') return { type: 'text' as const, text: c.text };
+    if (c.type === 'text') return { type: 'text' as const, text: c.text, ...withParentId(c.parentToolUseId) };
     // Encode non-groupable content as sentinel text so it survives grouping in-place
     const idx = nonGroupable.length;
     nonGroupable.push(c);
@@ -162,7 +187,11 @@ function convertGroupedPartsToDisplay(
         const item = nonGroupable[Number(match[1])];
         if (item) result.push(item);
       } else if (part.text) {
-        result.push({ type: 'text', text: part.text });
+        result.push({
+          type: 'text',
+          text: part.text,
+          ...withParentId(part.parentToolUseId),
+        });
       }
       continue;
     }
@@ -174,6 +203,7 @@ function convertGroupedPartsToDisplay(
         args: Record<string, unknown>;
         result: unknown;
         isError: boolean | undefined;
+        parentToolUseId?: string;
       }>;
       result.push({
         type: 'tool_group',
@@ -183,9 +213,8 @@ function convertGroupedPartsToDisplay(
           name: item.toolName,
           input: item.args,
           category: categorizeToolCall(item.toolName, categories),
-          ...(item.result != null && {
-            result: item.result as ToolCallResult,
-          }),
+          ...(item.result != null && { result: item.result as ToolCallResult }),
+          ...withParentId(item.parentToolUseId),
         })),
       });
     } else if (part.toolName === '_TaskGroup') {
@@ -197,16 +226,17 @@ function convertGroupedPartsToDisplay(
         agentId,
         taskArgs: taskArgs ?? {},
         calls: children.map((child) => {
-          if (child.type !== 'tool-call') return { type: 'text' as const, text: child.text };
+          if (child.type === 'text') {
+            return { type: 'text' as const, text: child.text, ...withParentId(child.parentToolUseId) };
+          }
           return {
             type: 'tool_call' as const,
             id: child.toolCallId,
             name: child.toolName,
             input: child.args,
             category: categorizeToolCall(child.toolName, categories),
-            ...(child.result != null && {
-              result: child.result as ToolCallResult,
-            }),
+            ...(child.result != null && { result: child.result as ToolCallResult }),
+            ...withParentId(child.parentToolUseId),
           };
         }),
         ...(part.result != null && { result: part.result as ToolCallResult }),
@@ -232,6 +262,7 @@ function convertGroupedPartsToDisplay(
         input: part.args,
         category: categorizeToolCall(part.toolName, categories),
         ...(orig?.result && { result: orig.result }),
+        ...withParentId(part.parentToolUseId),
       });
     }
   }

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -232,6 +232,14 @@ function convertGroupedPartsToDisplay(
         taskArgs: taskArgs ?? {},
         calls: children.map((child) => {
           if (child.type === 'text') {
+            const m = NG_SENTINEL_RE.exec(child.text);
+            if (m) {
+              const original = nonGroupable[Number(m[1])];
+              // The original DisplayContent already carries parentToolUseId from
+              // applyToolGrouping's encoding step; pass it through unchanged.
+              if (original) return original;
+              return { type: 'text' as const, text: '', ...withParentId(child.parentToolUseId) };
+            }
             return { type: 'text' as const, text: child.text, ...withParentId(child.parentToolUseId) };
           }
           return {

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -156,10 +156,15 @@ export function applyToolGrouping(content: DisplayContent[], categories: ToolCat
       };
     }
     if (c.type === 'text') return { type: 'text' as const, text: c.text, ...withParentId(c.parentToolUseId) };
-    // Encode non-groupable content as sentinel text so it survives grouping in-place
+    // Encode non-groupable content as sentinel text so it survives grouping in-place.
+    // Carry parentToolUseId so groupTaskChildren can include sentinels belonging to a subagent.
     const idx = nonGroupable.length;
     nonGroupable.push(c);
-    return { type: 'text' as const, text: `\0ng:${idx}` };
+    return {
+      type: 'text' as const,
+      text: `\0ng:${idx}`,
+      ...withParentId('parentToolUseId' in c ? c.parentToolUseId : undefined),
+    };
   });
 
   let grouped = groupToolCallParts(parts, categories);

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -5,6 +5,7 @@ import {
   convertAssistantContent,
   convertUserContent,
   applyToolGrouping,
+  withParentId,
 } from './display-helpers.js';
 
 /**
@@ -92,9 +93,20 @@ function convertGroupedToDisplay(
         ...base,
         type: 'system',
         content: msg.content.map((c) => {
-          if (c.type === 'text') return { type: 'text' as const, text: c.text };
+          if (c.type === 'text')
+            return {
+              type: 'text' as const,
+              text: c.text,
+              ...withParentId(c.parentToolUseId),
+            };
           if (c.type === 'skill_loaded')
-            return { type: 'skill_loaded' as const, skillName: c.skillName, path: c.path, content: c.content };
+            return {
+              type: 'skill_loaded' as const,
+              skillName: c.skillName,
+              path: c.path,
+              content: c.content,
+              ...withParentId(c.parentToolUseId),
+            };
           return { type: 'text' as const, text: '' };
         }),
         ...(msg.metadata && { metadata: { ...msg.metadata } }),

--- a/packages/core/src/messages/tool-grouping.ts
+++ b/packages/core/src/messages/tool-grouping.ts
@@ -12,6 +12,7 @@ export interface ToolGroupItem {
   args: Record<string, unknown>;
   result: unknown;
   isError: boolean | undefined;
+  parentToolUseId?: string;
 }
 
 export interface TaskProgressItem {
@@ -30,8 +31,9 @@ export type PartEntry =
       args: Record<string, unknown>;
       result?: unknown;
       isError?: boolean;
+      parentToolUseId?: string;
     }
-  | { type: 'text'; text: string };
+  | { type: 'text'; text: string; parentToolUseId?: string };
 
 /**
  * Post-processes parts to group consecutive explore tools, suppress hidden tools,
@@ -98,6 +100,7 @@ export function groupToolCallParts(parts: PartEntry[], categories: ToolCategorie
             args: tc.args,
             result: tc.result,
             isError: tc.isError,
+            ...(tc.parentToolUseId && { parentToolUseId: tc.parentToolUseId }),
           };
         });
         result.push({

--- a/packages/core/src/messages/tool-grouping.ts
+++ b/packages/core/src/messages/tool-grouping.ts
@@ -21,6 +21,18 @@ export interface TaskProgressItem {
   args: Record<string, unknown>;
   result: unknown;
   isError: boolean | undefined;
+  parentToolUseId?: string;
+}
+
+/**
+ * Returns a parentToolUseId only if every item in the group shares the same
+ * non-empty value. Used to propagate the tag onto virtual wrappers
+ * (`_ToolGroup`, `_TaskProgress`) so groupTaskChildren can match them.
+ */
+function sharedParentToolUseId(items: ReadonlyArray<{ parentToolUseId?: string }>): string | undefined {
+  const first = items[0]?.parentToolUseId;
+  if (!first) return undefined;
+  return items.every((it) => it.parentToolUseId === first) ? first : undefined;
 }
 
 export type PartEntry =
@@ -70,6 +82,7 @@ export function groupToolCallParts(parts: PartEntry[], categories: ToolCategorie
         args: part.args,
         result: part.result,
         isError: part.isError,
+        ...(part.parentToolUseId && { parentToolUseId: part.parentToolUseId }),
       });
       i++;
       continue;
@@ -103,12 +116,14 @@ export function groupToolCallParts(parts: PartEntry[], categories: ToolCategorie
             ...(tc.parentToolUseId && { parentToolUseId: tc.parentToolUseId }),
           };
         });
+        const wrapperParent = sharedParentToolUseId(items);
         result.push({
           type: 'tool-call',
           toolCallId: (group[0] as PartEntry & { type: 'tool-call' }).toolCallId,
           toolName: '_ToolGroup',
           args: { items },
           result: 'grouped',
+          ...(wrapperParent && { parentToolUseId: wrapperParent }),
         });
       } else {
         result.push(group[0]!);
@@ -124,12 +139,14 @@ export function groupToolCallParts(parts: PartEntry[], categories: ToolCategorie
 
   // Insert accumulated task progress at the position of the first task tool
   if (taskItems.length > 0) {
+    const wrapperParent = sharedParentToolUseId(taskItems);
     const entry: PartEntry = {
       type: 'tool-call',
       toolCallId: taskItems[0]!.toolCallId,
       toolName: '_TaskProgress',
       args: { items: taskItems },
       result: 'accumulated',
+      ...(wrapperParent && { parentToolUseId: wrapperParent }),
     };
     result.splice(taskInsertIndex >= 0 ? taskInsertIndex : result.length, 0, entry);
   }

--- a/packages/core/src/messages/tool-grouping.ts
+++ b/packages/core/src/messages/tool-grouping.ts
@@ -138,9 +138,9 @@ export function groupToolCallParts(parts: PartEntry[], categories: ToolCategorie
 }
 
 /**
- * Wraps a subagent tool call together with all subsequent tool calls (until the next
- * text block or another subagent call) into a single _TaskGroup virtual entry so they
- * render nested under the subagent header.
+ * Wraps a subagent tool call together with all subsequent parts tagged with a matching
+ * `parentToolUseId` into a single _TaskGroup virtual entry so they render nested under
+ * the subagent header. Stops as soon as a part carries no tag or a different one.
  * Categories are adapter-declared — pass the adapter's ToolCategories instance.
  */
 export function groupTaskChildren(parts: PartEntry[], categories: ToolCategories): PartEntry[] {
@@ -151,18 +151,13 @@ export function groupTaskChildren(parts: PartEntry[], categories: ToolCategories
     const part = parts[i]!;
 
     if (part.type === 'tool-call' && isSubagentTool(part.toolName, categories)) {
+      const agentToolUseId = part.toolCallId;
       const children: PartEntry[] = [];
       let j = i + 1;
       while (j < parts.length) {
         const next = parts[j]!;
-        // Sentinel text entries (\0ng:N) are non-groupable placeholders (thinking,
-        // images) — skip over them without breaking or adding as children.
-        if (next.type === 'text' && next.text.startsWith('\0ng:')) {
-          j++;
-          continue;
-        }
-        if (next.type === 'text') break;
-        if (next.type === 'tool-call' && isSubagentTool(next.toolName, categories)) break;
+        // Only collect parts tagged as belonging to THIS Agent.
+        if (next.parentToolUseId !== agentToolUseId) break;
         children.push(next);
         j++;
       }

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -32,6 +32,7 @@ function createMockSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
@@ -22,6 +22,7 @@ function createMockSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
@@ -22,6 +22,7 @@ function createMockSink(): SessionSink {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -189,6 +189,16 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
   }
   if (!message?.content) return;
 
+  if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+    const parentToolUseId = event.parent_tool_use_id;
+    const tagged = message.content.map((b) => ({
+      ...b,
+      parentToolUseId,
+    })) as import('@qlan-ro/mainframe-types').MessageContent[];
+    sink.onSubagentChild(parentToolUseId, tagged);
+    return;
+  }
+
   for (const block of message.content) {
     if (block.type === 'tool_use') {
       if (block.name === 'TodoWrite') {
@@ -235,6 +245,97 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
   });
 }
 
+/**
+ * Extract a skill_loaded block from a text block when it carries the CLI's
+ * skill-injection markers. Returns null when the text isn't a skill injection.
+ *
+ * Two shapes:
+ *   (A) <skill-format>true</skill-format> — model-initiated SkillTool output + subagent preloads
+ *   (B) Text starting with "Base directory for this skill: <path>" — user-typed /skill-name
+ */
+function extractSkillBlock(
+  text: string,
+  session: ClaudeSession,
+  parentToolUseId?: string,
+): (import('@qlan-ro/mainframe-types').MessageContent & { type: 'skill_loaded' }) | null {
+  const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
+  const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
+  if (!hasSkillFormat && !baseDirMatch) return null;
+
+  const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
+  const rawDir = baseDirMatch?.[1]?.trim() ?? '';
+  const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
+  if (!skillName) return null;
+
+  const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
+  const finalPath = resolvedPath || resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache);
+  session.state.skillPathCache.set(skillName, finalPath);
+
+  const content = text
+    .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
+    .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
+    .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
+    .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
+    .trim();
+
+  return parentToolUseId
+    ? { type: 'skill_loaded', skillName, path: finalPath, content, parentToolUseId }
+    : { type: 'skill_loaded', skillName, path: finalPath, content };
+}
+
+function handleSubagentUserEvent(
+  session: ClaudeSession,
+  event: Record<string, unknown>,
+  parentToolUseId: string,
+  message: { content: Array<Record<string, unknown>> | string },
+  sink: SessionSink,
+): void {
+  const collected: import('@qlan-ro/mainframe-types').MessageContent[] = [];
+
+  if (typeof message.content === 'string') {
+    // Pre-normalize edge case (model-switch breadcrumbs etc.). Treat as text,
+    // but if it's a `<command-name>...</command-name>` skill echo, surface as
+    // a skill_loaded child instead.
+    const nameMatch = /<command-name>\/?([^<]+)<\/command-name>/.exec(message.content);
+    if (nameMatch?.[1]) {
+      const skillName = nameMatch[1].trim();
+      const cached = session.state.skillPathCache.get(skillName);
+      const skillPath = cached ?? resolveExistingSkillPath(session.projectPath, skillName);
+      if (skillPath) {
+        session.state.skillPathCache.set(skillName, skillPath);
+        const content = readSkillContent(skillPath) ?? '';
+        collected.push({ type: 'skill_loaded', skillName, path: skillPath, content, parentToolUseId });
+      } else {
+        collected.push({ type: 'text', text: message.content, parentToolUseId });
+      }
+    } else {
+      collected.push({ type: 'text', text: message.content, parentToolUseId });
+    }
+  } else {
+    const tur = (event.tool_use_result ?? event.toolUseResult) as Record<string, unknown> | undefined;
+    const toolResults = buildToolResultBlocks(message as Record<string, unknown>, tur);
+    for (const r of toolResults) collected.push({ ...r, parentToolUseId });
+
+    for (const block of message.content) {
+      if (block.type === 'tool_result') continue; // already handled above
+      if (block.type === 'text') {
+        const text = (block.text as string) || '';
+        if (!text.trim()) continue;
+        // Skill-injection shape: surface as a skill_loaded child (inner pill).
+        const skillBlock = extractSkillBlock(text, session, parentToolUseId);
+        if (skillBlock) {
+          collected.push(skillBlock);
+          continue;
+        }
+        collected.push({ type: 'text', text, parentToolUseId });
+      }
+      // Image blocks intentionally skipped — same as the existing parent-level path.
+    }
+  }
+
+  if (collected.length > 0) sink.onSubagentChild(parentToolUseId, collected);
+}
+
 function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
   // Detect queued message processed by CLI (isReplay from SDK mode)
   const isReplay = event.isReplay === true || event.is_replay === true;
@@ -256,28 +357,12 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   const message = event.message as { content: Array<Record<string, unknown>> | string } | undefined;
   if (!message?.content) return;
 
-  // Subagent dispatch prompt: CLI 2.1.118+ normalizes agent_progress into
-  // top-level SDK messages (queryHelpers.ts:120-156). The subagent's first
-  // event is a string-content user message restating its prompt — that text
-  // already lives in the parent's `Agent.input.prompt` (rendered by the
-  // Task card), so re-emitting it via onCliMessage produces a duplicate
-  // system pill in the parent thread.
-  //
-  // Discriminator: parent_tool_use_id set + string content + no CLI-internal
-  // tags. Skill loads carry <command-name>; "Base directory for this skill:"
-  // is the isMeta skill-content shape. Anything tagged is real content from
-  // the subagent — let it flow through the existing string-content branches
-  // below so SkillLoadedCards still render. Array-content user events
-  // (tool_results, text blocks, image blocks) and assistant events all flow
-  // unchanged: the parent's Task card still picks up subagent tool_use /
-  // tool_result blocks, and any other intra-subagent surface we may want to
-  // show stays available.
-  if (
-    event.parent_tool_use_id != null &&
-    typeof message.content === 'string' &&
-    !message.content.includes('<command-name>') &&
-    !/^Base directory for this skill:/m.test(message.content)
-  ) {
+  // Subagent activity: every block in this event belongs inside the parent's
+  // Agent/Task tool_use card. Tag each block with parentToolUseId and forward
+  // via onSubagentChild — the event-handler appends them to the parent's
+  // assistant message and the display pipeline groups them under _TaskGroup.
+  if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+    handleSubagentUserEvent(session, event, event.parent_tool_use_id, message, sink);
     return;
   }
 
@@ -360,32 +445,10 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
       //       output + subagent preloads
       //   (B) Text starting with "Base directory for this skill: <path>" —
       //       user-typed /skill-name injection (isMeta: true, no XML tag)
-      const hasSkillFormat = text.includes('<skill-format>true</skill-format>');
-      const baseDirMatch = /^Base directory for this skill:\s*(.+?)(?:\n|$)/m.exec(text);
-      const isSkillInjection = hasSkillFormat || Boolean(baseDirMatch);
-
-      if (isSkillInjection) {
-        const nameFromTag = /<command-name>([^<]+)<\/command-name>/.exec(text)?.[1]?.replace(/^\//, '').trim();
-        const rawDir = baseDirMatch?.[1]?.trim() ?? '';
-        const skillName = nameFromTag || (rawDir ? path.basename(rawDir) : '');
-        const resolvedPath = rawDir && !path.extname(rawDir) ? path.join(rawDir, 'SKILL.md') : rawDir;
-        const finalPath =
-          resolvedPath ||
-          (skillName ? resolveSkillPath(session.projectPath, skillName, session.state.skillPathCache) : '');
-
-        if (skillName && finalPath) {
-          session.state.skillPathCache.set(skillName, finalPath);
-        }
-
-        const content = text
-          .replace(/<command-message>[^<]*<\/command-message>\n?/g, '')
-          .replace(/<command-name>[^<]*<\/command-name>\n?/g, '')
-          .replace(/<skill-format>[^<]*<\/skill-format>\n?/g, '')
-          .replace(/^Base directory for this skill:[^\n]*\n?/m, '')
-          .trim();
-
-        sink.onSkillLoaded({ skillName, path: finalPath, content });
-        sink.onSkillFile({ path: finalPath, displayName: skillName });
+      const skillBlock = extractSkillBlock(text, session);
+      if (skillBlock) {
+        sink.onSkillLoaded({ skillName: skillBlock.skillName, path: skillBlock.path, content: skillBlock.content });
+        sink.onSkillFile({ path: skillBlock.path, displayName: skillBlock.skillName });
         continue;
       }
 

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -323,12 +323,39 @@ function collectSubagentToolResults(
   }
 }
 
+/**
+ * Capture the agentId → parent tool_use_id mapping from a parent-JSONL user
+ * entry whose tool_result corresponds to a Task/Agent dispatch. CLI 2.1.118+
+ * does not write parentToolUseID into subagent JSONL entries; this map is the
+ * only way to link a subagent's blocks back to its dispatching tool_use.
+ */
+function captureAgentIdMapping(entry: Record<string, unknown>, map: Map<string, string>): void {
+  if (entry.type !== 'user') return;
+  const tur = (entry.toolUseResult ?? entry.tool_use_result) as Record<string, unknown> | undefined;
+  const agentId = typeof tur?.agentId === 'string' ? (tur.agentId as string) : undefined;
+  if (!agentId) return;
+  const message = entry.message as { content?: unknown } | undefined;
+  const content = message?.content;
+  if (!Array.isArray(content)) return;
+  for (const block of content as Array<Record<string, unknown>>) {
+    if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+      map.set(agentId, block.tool_use_id);
+      return;
+    }
+  }
+}
+
 /** Collect assistant text/thinking/tool_use blocks from subagent JSONL assistant entries. */
 function collectSubagentAssistantBlocks(
   entry: Record<string, unknown>,
   agentTools: Map<string, MessageContent[]>,
+  agentIdMap?: Map<string, string>,
 ): void {
-  const parentId = entry.parentToolUseID as string | undefined;
+  let parentId = entry.parentToolUseID as string | undefined;
+  if (!parentId && agentIdMap) {
+    const agentId = entry.agentId as string | undefined;
+    if (agentId) parentId = agentIdMap.get(agentId);
+  }
   if (!parentId) return;
   if (entry.type !== 'assistant') return;
   const message = entry.message as Record<string, unknown> | undefined;
@@ -462,6 +489,10 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
   // Map of toolUseId → tool_result block, populated from subagent JONLs
   const subagentToolResults = new Map<string, MessageContent & { type: 'tool_result' }>();
   const seenUuids = new Set<string>();
+  // CLI 2.1.118+ subagent JSONLs omit parentToolUseID. The link is kept on the
+  // parent's tool_result via toolUseResult.agentId. Build that map as we walk
+  // the parent file so subagent-file processing can resolve the parent id.
+  const agentIdToParentToolUseId = new Map<string, string>();
 
   for (const file of jsonlFiles) {
     const isSubagentFile = subagentFiles.has(file);
@@ -506,9 +537,15 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           // injectAgentChildren / attachSubagentToolResults pipeline below.
           if (isSubagentFile) {
             collectSubagentToolResults(entry, subagentToolResults);
-            collectSubagentAssistantBlocks(entry, agentTools);
+            collectSubagentAssistantBlocks(entry, agentTools, agentIdToParentToolUseId);
             continue;
           }
+
+          // Capture agentId → parent tool_use_id mapping from the parent's
+          // tool_result for any Task/Agent dispatch. discoverSessionJsonlFiles
+          // returns the parent file before subagent files, so the map is built
+          // by the time subagent processing needs it.
+          if (entry.type === 'user') captureAgentIdMapping(entry, agentIdToParentToolUseId);
 
           // Sidechain entries are subagent activity (Task/Agent tool spawns its
           // own CLI session whose messages share our sessionId but live in a

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -283,17 +283,25 @@ function collectAgentProgressTools(entry: Record<string, unknown>, agentTools: M
   const content = inner.content as Array<Record<string, unknown>> | undefined;
   if (!Array.isArray(content)) return;
 
+  const existing = agentTools.get(parentId) ?? [];
   for (const block of content) {
-    if (block.type !== 'tool_use') continue;
-    const existing = agentTools.get(parentId) ?? [];
-    existing.push({
-      type: 'tool_use',
-      id: (block.id as string) || nanoid(),
-      name: block.name as string,
-      input: (block.input as Record<string, unknown>) ?? {},
-    });
-    agentTools.set(parentId, existing);
+    if (block.type === 'tool_use') {
+      existing.push({
+        type: 'tool_use',
+        id: (block.id as string) || nanoid(),
+        name: block.name as string,
+        input: (block.input as Record<string, unknown>) ?? {},
+        parentToolUseId: parentId,
+      });
+    } else if (block.type === 'text') {
+      const text = (block.text as string) || '';
+      if (text.trim()) existing.push({ type: 'text', text, parentToolUseId: parentId });
+    } else if (block.type === 'thinking') {
+      const t = (block.thinking as string) || '';
+      if (t.trim()) existing.push({ type: 'thinking', thinking: t, parentToolUseId: parentId });
+    }
   }
+  if (existing.length > 0) agentTools.set(parentId, existing);
 }
 
 /** Extract tool_result blocks from subagent JSONL user entries. */
@@ -315,6 +323,39 @@ function collectSubagentToolResults(
   }
 }
 
+/** Collect assistant text/thinking/tool_use blocks from subagent JSONL assistant entries. */
+function collectSubagentAssistantBlocks(
+  entry: Record<string, unknown>,
+  agentTools: Map<string, MessageContent[]>,
+): void {
+  const parentId = entry.parentToolUseID as string | undefined;
+  if (!parentId) return;
+  if (entry.type !== 'assistant') return;
+  const message = entry.message as Record<string, unknown> | undefined;
+  const content = message?.content as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(content)) return;
+
+  const existing = agentTools.get(parentId) ?? [];
+  for (const block of content) {
+    if (block.type === 'tool_use') {
+      existing.push({
+        type: 'tool_use',
+        id: (block.id as string) || nanoid(),
+        name: block.name as string,
+        input: (block.input as Record<string, unknown>) ?? {},
+        parentToolUseId: parentId,
+      });
+    } else if (block.type === 'text') {
+      const text = (block.text as string) || '';
+      if (text.trim()) existing.push({ type: 'text', text, parentToolUseId: parentId });
+    } else if (block.type === 'thinking') {
+      const t = (block.thinking as string) || '';
+      if (t.trim()) existing.push({ type: 'thinking', thinking: t, parentToolUseId: parentId });
+    }
+  }
+  if (existing.length > 0) agentTools.set(parentId, existing);
+}
+
 /** Inject subagent tool_result blocks after their matching tool_use in assistant messages. */
 function attachSubagentToolResults(
   messages: ChatMessage[],
@@ -327,7 +368,7 @@ function attachSubagentToolResults(
       newContent.push(block);
       if (block.type === 'tool_use') {
         const toolResult = results.get(block.id);
-        if (toolResult) newContent.push(toolResult);
+        if (toolResult) newContent.push({ ...toolResult, parentToolUseId: block.parentToolUseId });
       }
     }
     msg.content = newContent;
@@ -459,14 +500,22 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           if (entry.isMeta === true) continue;
           if (entry.isCompactSummary === true || entry.isVisibleInTranscriptOnly === true) continue;
 
+          // Subagent JSONL files: extract tool_result and assistant blocks to
+          // inline under the parent's Agent tool_use. These entries must NOT
+          // appear as top-level chat messages — they're surfaced via the
+          // injectAgentChildren / attachSubagentToolResults pipeline below.
+          if (isSubagentFile) {
+            collectSubagentToolResults(entry, subagentToolResults);
+            collectSubagentAssistantBlocks(entry, agentTools);
+            continue;
+          }
+
           // Sidechain entries are subagent activity (Task/Agent tool spawns its
           // own CLI session whose messages share our sessionId but live in a
           // sibling JSONL). The subagent's first user message is its dispatch
           // prompt — converting it would render a ghost user bubble in the
-          // parent thread. Tool_results we still want are attached to the
-          // parent's Task tool_use via collectSubagentToolResults below.
-          // Skill-loaded synthesis above runs first so user-typed /skill
-          // invocations are preserved.
+          // parent thread. Skill-loaded synthesis above runs first so user-typed
+          // /skill invocations are preserved.
           if (entry.isSidechain === true) continue;
 
           // "Unknown command: /X" — CLI feedback for slash commands that don't
@@ -486,14 +535,6 @@ export async function loadHistory(sessionId: string, projectPath: string): Promi
           // Collect tool_use blocks from agent_progress events
           if (entry.type === 'progress' && entry.data?.type === 'agent_progress') {
             collectAgentProgressTools(entry, agentTools);
-            continue;
-          }
-
-          // Subagent JSONL files: only extract tool_result data to populate
-          // the tool_use blocks injected via agent_progress. The subagent's own
-          // assistant/user messages must NOT appear as top-level chat messages.
-          if (isSubagentFile) {
-            collectSubagentToolResults(entry, subagentToolResults);
             continue;
           }
 

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -45,6 +45,7 @@ const nullSink: SessionSink = {
   onPrDetected: () => {},
   onCliMessage: () => {},
   onSkillLoaded: () => {},
+  onSubagentChild: () => {},
 };
 
 export interface ClaudeSessionState {

--- a/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/plan-item-capture.test.ts
@@ -20,6 +20,7 @@ const NULL_SINK: SessionSink = {
   onPrDetected: vi.fn(),
   onCliMessage: vi.fn(),
   onSkillLoaded: vi.fn(),
+  onSubagentChild: vi.fn(),
 };
 
 describe('Codex plan item capture', () => {

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-resolve.test.ts
@@ -21,6 +21,7 @@ function mkSink(onPermissionSpy = vi.fn()) {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/request-user-input-routing.test.ts
@@ -20,6 +20,7 @@ function mkSink() {
     onPrDetected: vi.fn(),
     onCliMessage: vi.fn(),
     onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
   };
 }
 

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -52,6 +52,7 @@ const nullSink: SessionSink = {
   onPrDetected: () => {},
   onCliMessage: () => {},
   onSkillLoaded: () => {},
+  onSubagentChild: () => {},
 };
 
 export class CodexSession implements AdapterSession {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -109,30 +109,46 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
                   result: c.result,
                   isError: c.result?.isError,
                 })),
-              } as import('assistant-stream/utils').ReadonlyJSONObject,
+              } as unknown as import('assistant-stream/utils').ReadonlyJSONObject,
               result: 'grouped',
             });
             break;
           }
           case 'task_group': {
-            const calls = block.calls.filter(
-              (c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call',
-            );
+            const children = block.calls
+              .map((c) => {
+                if (c.type === 'tool_call') {
+                  return {
+                    kind: 'tool' as const,
+                    toolCallId: c.id,
+                    toolName: c.name,
+                    args: c.input,
+                    result: c.result,
+                    isError: c.result?.isError,
+                  };
+                }
+                if (c.type === 'text') return { kind: 'text' as const, text: c.text };
+                if (c.type === 'thinking') return { kind: 'thinking' as const, thinking: c.thinking };
+                if (c.type === 'skill_loaded') {
+                  return { kind: 'skill_loaded' as const, skillName: c.skillName, path: c.path, content: c.content };
+                }
+                if (c.type === 'image') return { kind: 'image' as const, mediaType: c.mediaType, data: c.data };
+                return null;
+              })
+              .filter((x): x is NonNullable<typeof x> => x !== null);
+
+            // Preserve the historical fallback that the agent's outer tool_result lives on the
+            // first tool child (when block.result is missing). Only consider tool children here.
+            const firstTool = children.find((c) => c.kind === 'tool') as { kind: 'tool'; result: unknown } | undefined;
             parts.push({
               type: 'tool-call',
               toolCallId: block.agentId,
               toolName: '_TaskGroup',
               args: {
                 taskArgs: block.taskArgs,
-                children: calls.map((c) => ({
-                  toolCallId: c.id,
-                  toolName: c.name,
-                  args: c.input,
-                  result: c.result,
-                  isError: c.result?.isError,
-                })),
-              } as import('assistant-stream/utils').ReadonlyJSONObject,
-              result: block.result ?? calls[0]?.result,
+                children,
+              } as unknown as import('assistant-stream/utils').ReadonlyJSONObject,
+              result: block.result ?? firstTool?.result,
             });
             break;
           }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
@@ -3,14 +3,21 @@ import { Bot, Maximize2, Minimize2 } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
 import { ErrorDot, type ToolCardProps } from './shared';
 import { renderToolCard } from './render-tool-card';
+import { SkillLoadedCard } from './SkillLoadedCard';
 
-interface TaskGroupChild {
+type ToolChild = {
+  kind: 'tool';
   toolCallId: string;
   toolName: string;
   args: Record<string, unknown>;
   result?: unknown;
   isError?: boolean;
-}
+};
+type TextChild = { kind: 'text'; text: string };
+type ThinkingChild = { kind: 'thinking'; thinking: string };
+type SkillChild = { kind: 'skill_loaded'; skillName: string; path: string; content: string };
+type ImageChild = { kind: 'image'; mediaType: string; data: string };
+type TaskGroupChild = ToolChild | TextChild | ThinkingChild | SkillChild | ImageChild;
 
 interface ToolGroupItem {
   toolName: string;
@@ -26,6 +33,7 @@ const TOOL_LABELS: Record<string, string> = {
 function buildSummary(children: TaskGroupChild[]): string {
   const counts = new Map<string, number>();
   for (const child of children) {
+    if (child.kind !== 'tool') continue;
     if (child.toolName === '_ToolGroup') {
       const items = (child.args.items as ToolGroupItem[]) || [];
       for (const item of items) {
@@ -58,7 +66,6 @@ export function TaskGroupCard({ args, result, isError }: ToolCardProps) {
     typeof result === 'object' && result !== null && 'content' in result
       ? (result as { content: string }).content
       : undefined;
-  // Strip CLI metadata: <usage> block and agentId continuation hint
   const resultText =
     rawResult
       ?.replace(/<usage>[\s\S]*<\/usage>\s*$/m, '')
@@ -68,8 +75,15 @@ export function TaskGroupCard({ args, result, isError }: ToolCardProps) {
   const agentType = (taskArgs.subagent_type as string) || 'Task';
   const model = taskArgs.model as string | undefined;
   const description = (taskArgs.description as string) || (taskArgs.prompt as string) || '';
+  const prompt = (taskArgs.prompt as string) || '';
   const truncatedDesc = description.length > 60 ? description.slice(0, 60) + '...' : description;
   const summary = buildSummary(children);
+
+  // Dedupe: if the FIRST text child equals taskArgs.prompt, skip rendering it
+  // because we render the prompt as the intro line at the top of the body.
+  const firstTextIdx = children.findIndex((c) => c.kind === 'text');
+  const promptDuplicateIdx =
+    firstTextIdx >= 0 && (children[firstTextIdx] as TextChild).text.trim() === prompt.trim() ? firstTextIdx : -1;
 
   return (
     <div className="space-y-1">
@@ -105,11 +119,48 @@ export function TaskGroupCard({ args, result, isError }: ToolCardProps) {
       </button>
       {open && (
         <>
-          {children.map((child) => (
-            <React.Fragment key={child.toolCallId}>
-              {renderToolCard(child.toolName, child.args, '', child.result, child.isError)}
-            </React.Fragment>
-          ))}
+          {prompt && (
+            <div className="pl-6 pr-2 pb-1 text-mf-small text-mf-text-secondary/70 italic whitespace-pre-wrap select-text">
+              {prompt}
+            </div>
+          )}
+          {children.map((child, idx) => {
+            if (idx === promptDuplicateIdx) return null;
+            if (child.kind === 'tool') {
+              return (
+                <React.Fragment key={`tool-${child.toolCallId}`}>
+                  {renderToolCard(child.toolName, child.args, '', child.result, child.isError)}
+                </React.Fragment>
+              );
+            }
+            if (child.kind === 'text') {
+              return (
+                <div
+                  key={`text-${idx}`}
+                  className="pl-6 pr-2 py-1 text-mf-body text-mf-text-primary whitespace-pre-wrap select-text"
+                >
+                  {child.text}
+                </div>
+              );
+            }
+            if (child.kind === 'thinking') {
+              return (
+                <details key={`think-${idx}`} className="pl-6 pr-2 py-1 text-mf-small text-mf-text-secondary">
+                  <summary className="cursor-pointer">Reasoning</summary>
+                  <div className="whitespace-pre-wrap pl-3 pt-1">{child.thinking}</div>
+                </details>
+              );
+            }
+            if (child.kind === 'skill_loaded') {
+              return (
+                <div key={`skill-${idx}`} className="pl-6">
+                  <SkillLoadedCard skillName={child.skillName} path={child.path} content={child.content} />
+                </div>
+              );
+            }
+            // image: skip for now (not surfaced in task card today)
+            return null;
+          })}
           {resultText && (
             <div className="pl-6 text-mf-small text-mf-text-secondary whitespace-pre-wrap select-text">
               {resultText}

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -54,6 +54,11 @@ export function routeEvent(event: DaemonEvent): void {
       log.debug('event:display.message.added', { chatId: event.chatId });
       chats.addMessage(event.chatId, event.message);
       break;
+    case 'message.updated':
+      // No frontend consumer needed today: emitDisplay() is paired with this and
+      // the renderer reacts to display.message.updated. Adding the explicit
+      // no-op so the switch stays exhaustive and a future consumer is easy to wire.
+      break;
     case 'display.message.updated':
       log.debug('event:display.message.updated', { chatId: event.chatId, messageId: event.message.id });
       chats.updateMessage(event.chatId, event.message);

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -131,6 +131,15 @@ export interface SessionSink {
   onCliMessage(text: string): void;
   /** A skill was loaded via slash-command; show a collapsible skill card instead of raw text. */
   onSkillLoaded(entry: { skillName: string; path: string; content: string }): void;
+  /**
+   * Inline content blocks from a subagent stream event under the parent assistant
+   * message that owns the matching Agent/Task tool_use. Caller must have stamped
+   * each block's `.parentToolUseId` field with the same value passed as the
+   * `parentToolUseId` argument so the display pipeline can group them under the
+   * matching Task card. Implementations must no-op silently if `parentToolUseId`
+   * does not match any known tool_use block.
+   */
+  onSubagentChild(parentToolUseId: string, blocks: import('./chat.js').MessageContent[]): void;
 }
 
 export interface AdapterSession {

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -66,10 +66,10 @@ export interface DiffHunk {
 }
 
 export type MessageContent =
-  | { type: 'text'; text: string }
+  | { type: 'text'; text: string; parentToolUseId?: string }
   | { type: 'image'; mediaType: string; data: string }
-  | { type: 'thinking'; thinking: string }
-  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'thinking'; thinking: string; parentToolUseId?: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown>; parentToolUseId?: string }
   | {
       type: 'tool_result';
       toolUseId: string;
@@ -78,10 +78,11 @@ export type MessageContent =
       structuredPatch?: DiffHunk[];
       originalFile?: string;
       modifiedFile?: string;
+      parentToolUseId?: string;
     }
   | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
   | { type: 'error'; message: string }
-  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string; parentToolUseId?: string };
 
 export type ToolResultMessageContent = Extract<MessageContent, { type: 'tool_result' }>;
 

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -65,9 +65,20 @@ export interface DiffHunk {
   lines: string[];
 }
 
+/**
+ * `parentToolUseId` is set on a content block to indicate it originated from a
+ * subagent stream event (CLI emits with `parent_tool_use_id`). The display
+ * pipeline groups these blocks under the parent's Agent/Task `tool_use` as
+ * `_TaskGroup` children. The field is on every variant — including `image`,
+ * `permission_request`, `error` — so the event handlers can spread the tag
+ * uniformly (`{...block, parentToolUseId}`) without per-variant filtering.
+ * The pipeline only renders the variants that have a Task-card child kind:
+ * `text`, `thinking`, `tool_use`, `tool_result`, `skill_loaded`. Other
+ * variants carrying the field are tolerated and rendered at root as usual.
+ */
 export type MessageContent =
   | { type: 'text'; text: string; parentToolUseId?: string }
-  | { type: 'image'; mediaType: string; data: string }
+  | { type: 'image'; mediaType: string; data: string; parentToolUseId?: string }
   | { type: 'thinking'; thinking: string; parentToolUseId?: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown>; parentToolUseId?: string }
   | {
@@ -80,8 +91,8 @@ export type MessageContent =
       modifiedFile?: string;
       parentToolUseId?: string;
     }
-  | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
-  | { type: 'error'; message: string }
+  | { type: 'permission_request'; request: import('./adapter.js').ControlRequest; parentToolUseId?: string }
+  | { type: 'error'; message: string; parentToolUseId?: string }
   | { type: 'skill_loaded'; skillName: string; path: string; content: string; parentToolUseId?: string };
 
 export type ToolResultMessageContent = Extract<MessageContent, { type: 'tool_result' }>;

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -16,8 +16,8 @@ export interface ToolCategories {
 }
 
 export type DisplayContent =
-  | { type: 'text'; text: string }
-  | { type: 'thinking'; thinking: string }
+  | { type: 'text'; text: string; parentToolUseId?: string }
+  | { type: 'thinking'; thinking: string; parentToolUseId?: string }
   | { type: 'image'; mediaType: string; data: string }
   | {
       type: 'tool_call';
@@ -26,6 +26,7 @@ export type DisplayContent =
       input: Record<string, unknown>;
       category: 'default' | 'explore' | 'hidden' | 'progress' | 'subagent';
       result?: ToolCallResult;
+      parentToolUseId?: string;
     }
   | { type: 'tool_group'; calls: DisplayContent[] }
   | {
@@ -37,7 +38,7 @@ export type DisplayContent =
     }
   | { type: 'permission_request'; request: unknown }
   | { type: 'error'; message: string }
-  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string; parentToolUseId?: string };
 
 export interface DisplayMessage {
   id: string;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -11,6 +11,7 @@ export type DaemonEvent =
   | { type: 'process.ready'; processId: string; claudeSessionId: string }
   | { type: 'process.stopped'; processId: string }
   | { type: 'message.added'; chatId: string; message: ChatMessage }
+  | { type: 'message.updated'; chatId: string; message: ChatMessage }
   | { type: 'display.message.added'; chatId: string; message: import('./display.js').DisplayMessage }
   | { type: 'display.message.updated'; chatId: string; message: import('./display.js').DisplayMessage }
   | { type: 'display.messages.set'; chatId: string; messages: import('./display.js').DisplayMessage[] }


### PR DESCRIPTION
## Summary

Replaces the prompt-suppression patches in PRs #264 and #267 with the right architectural fix: every Claude CLI stream-json event with `parent_tool_use_id != null` is **inlined** into the parent's assistant message that owns the matching `Agent`/`Task` tool_use, and each inlined block is **tagged** with `parentToolUseId`. The display pipeline's `groupTaskChildren` then wraps anything tagged with the Agent's id into a `_TaskGroup`, so the dispatch prompt, subagent text/thinking, subagent skill loads, subagent tool_use and subagent tool_results all render **inside** the Task card.

History reload mirrors the live behavior — same inlining + tagging — so users see identical output whether they're watching the chat live or returning to it after a daemon restart.

## Why

CLI 2.1.118+ normalizes `agent_progress` events into top-level `user`/`assistant` SDK messages with `parent_tool_use_id` set. Mainframe used to handle these at the parent level, which leaked subagent chatter as ghost system pills/bubbles into the main thread and broke `_TaskGroup` grouping (which previously stopped at the first text block). The earlier patches in #264 and #267 dropped the dispatch prompt outright; this PR keeps the prompt and the rest of the subagent activity, but renders all of it inside the Task card.

## Behaviour change

Before: subagent dispatch prompt → root system pill, subagent text → root assistant bubble, Task card empty.
After: everything subagent-origin lives inside the Task card. Skill loads from inside a subagent become an inner `SkillLoadedCard` inside the Task card body. Skill loads from the parent thread still render at the chat root.

## Plan

The work is broken across 8 commits, mirroring `docs/plans/2026-04-30-subagent-blocks-nesting.md`:

1. `feat(types): add optional parentToolUseId to MessageContent variants` — types
2. `feat(adapter): add SessionSink.onSubagentChild for inlining subagent blocks` — sink interface + fixtures
3. `feat(chat/event-handler): implement onSubagentChild — inline subagent blocks under parent tool_use` — appends tagged blocks to the parent assistant message
4. `feat(claude/events): route subagent events through onSubagentChild with tagged blocks` — replaces #264/#267 prompt-suppression with full routing
5. `feat(messages): propagate parentToolUseId through PartEntry and DisplayContent` — display-pipeline plumbing + small `withParentId` helper
6. `feat(messages): group Task children by parentToolUseId tag` — `groupTaskChildren` matches by tag instead of break-on-text
7. `feat(desktop/TaskGroupCard): render text/thinking/skill_loaded children inside the task card` — UI
8. `feat(claude/history): inline subagent text/thinking/tool_results with parentToolUseId tag` — history reload parity

## Test plan

Unit tests added across the stack (86/86 pass):
- [x] `event-handler.test.ts` — `onSubagentChild` appends to the matching parent message; warns on miss; newest-first walk picks the right parent
- [x] `claude-events.test.ts` — `subagent events` describe block, 6 cases covering assistant routing, dispatch prompt (text-block shape), raw string content, tool_result blocks, skill loads, and parent-level events still taking the original path
- [x] `message-grouping.test.ts` (new file) — `groupTaskChildren` collects by `parentToolUseId`, terminates on mismatch, parallel-subagent disambiguation, back-compat tool-call-only flow
- [x] `event-handler-display.test.ts` — propagation regression tests for text and tool_call blocks
- [x] `message-loading.test.ts` — history reload inlines subagent text/thinking with tag
- [x] All packages build clean (`@qlan-ro/mainframe-types`, `@qlan-ro/mainframe-core`, `@qlan-ro/mainframe-desktop`)

Manual verification (recommended before merge):
- [ ] Dispatch 3 parallel subagents in a live chat (e.g. "Run \`echo hi\` via Bash, three times in parallel"). Expand each Task card; expect prompt at top, subagent text below, Bash child with its result. No root pill.
- [ ] Restart the daemon, reopen the same chat. Same nesting persists from JSONL replay.

## Related

- PR #259 — sidechain entries dropped from history (still correct)
- PR #261 — duplicate "Using skill" cards from subagent JSONLs on history reload
- PR #264 — first attempt at dropping the dispatch prompt (string-content path only)
- PR #267 — array-content fallback for the same drop

This PR supersedes the suppression branches from #264 and #267 — the prompt is no longer dropped; it's surfaced inside the Task card body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)