### PR TITLE
feat: render context-compaction events as a centered pill

### DIFF
--- a/.changeset/compaction-pill.md
+++ b/.changeset/compaction-pill.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Render context-compaction events as a centered "Context compacted" pill instead of a plain system text bubble. Adds `{ type: 'compaction' }` to MessageContent / DisplayContent and a `CompactionPill` component used by `SystemMessage`. Live and history-replay paths both emit the new shape. As a small parallel change, `AssistantMessage.Fallback` now routes through the shared `renderToolCard` registry so tools without an explicit Tool UI registration still get their proper card.

--- a/packages/core/src/__tests__/adapter-events-flow.test.ts
+++ b/packages/core/src/__tests__/adapter-events-flow.test.ts
@@ -180,7 +180,7 @@ describe('adapter events flow', () => {
     expect((e as any).message.content[0].type).toBe('tool_result');
   }, 10_000);
 
-  it('compact event emits message.added with Context compacted text', async () => {
+  it('compact event emits message.added with compaction content block', async () => {
     const adapter = new MockAdapter();
     const events = await setup(adapter);
 
@@ -190,7 +190,7 @@ describe('adapter events flow', () => {
     const e = events.find((e) => e.type === 'message.added');
     expect(e).toBeDefined();
     const content = (e as any).message.content;
-    expect(content.some((b: any) => b.type === 'text' && b.text === 'Context compacted')).toBe(true);
+    expect(content.some((b: any) => b.type === 'compaction')).toBe(true);
   }, 10_000);
 
   it('plan_file event emits context.updated when file is new', async () => {

--- a/packages/core/src/__tests__/message-loading.test.ts
+++ b/packages/core/src/__tests__/message-loading.test.ts
@@ -713,7 +713,7 @@ describe('loadHistory', () => {
     expect(types).toEqual(['user', 'assistant', 'assistant']);
   });
 
-  it('converts system:compact_boundary to a visible "Context compacted" system message', async () => {
+  it('converts system:compact_boundary to a visible compaction system message', async () => {
     writeJsonl(SESSION_ID, [
       userTextEntry('Do a lot of work'),
       assistantTextEntry('Working...'),
@@ -731,7 +731,7 @@ describe('loadHistory', () => {
 
     expect(messages).toHaveLength(4);
     expect(messages[2].type).toBe('system');
-    expect(messages[2].content[0]).toMatchObject({ type: 'text', text: 'Context compacted' });
+    expect(messages[2].content[0]).toMatchObject({ type: 'compaction' });
   });
 
   it('skips isCompactSummary=true entries (context compaction messages)', async () => {

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -365,7 +365,7 @@ function buildSessionSink(
     },
 
     onCompact() {
-      const message = messages.createTransientMessage(chatId, 'system', [{ type: 'text', text: 'Context compacted' }]);
+      const message = messages.createTransientMessage(chatId, 'system', [{ type: 'compaction' }]);
       messages.append(chatId, message);
       emitEvent({ type: 'message.added', chatId, message });
       emitEvent({ type: 'chat.compactDone', chatId });

--- a/packages/core/src/messages/display-pipeline.ts
+++ b/packages/core/src/messages/display-pipeline.ts
@@ -95,6 +95,7 @@ function convertGroupedToDisplay(
           if (c.type === 'text') return { type: 'text' as const, text: c.text };
           if (c.type === 'skill_loaded')
             return { type: 'skill_loaded' as const, skillName: c.skillName, path: c.path, content: c.content };
+          if (c.type === 'compaction') return { type: 'compaction' as const };
           return { type: 'text' as const, text: '' };
         }),
         ...(msg.metadata && { metadata: { ...msg.metadata } }),

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -246,7 +246,7 @@ export function convertHistoryEntry(entry: Record<string, unknown>, chatId: stri
       id: (entry.uuid as string) || nanoid(),
       chatId,
       type: 'system',
-      content: [{ type: 'text', text: 'Context compacted' }],
+      content: [{ type: 'compaction' }],
       timestamp: (entry.timestamp as string) || new Date().toISOString(),
       metadata: { source: 'history', internal: true },
     };

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/AssistantMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/AssistantMessage.tsx
@@ -3,7 +3,7 @@ import { Bot } from 'lucide-react';
 import { MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { MainframeText } from '../parts/MainframeText';
-import { DefaultToolCard } from '../parts/tools/DefaultToolCard';
+import { renderToolCard } from '../parts/tools/render-tool-card';
 import { TurnFooter } from './TurnFooter';
 import { ImageThumbs } from './ImageThumbs';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
@@ -29,15 +29,8 @@ export function AssistantMessage() {
               Text: MainframeText,
               Reasoning: () => null,
               tools: {
-                Fallback: ({ toolName, args, argsText, result, isError }) => (
-                  <DefaultToolCard
-                    toolName={toolName}
-                    args={(args || {}) as Record<string, unknown>}
-                    argsText={argsText}
-                    result={result}
-                    isError={isError}
-                  />
-                ),
+                Fallback: ({ toolName, args, argsText, result, isError }) =>
+                  renderToolCard(toolName, (args || {}) as Record<string, unknown>, argsText, result, isError),
               },
             }}
           />

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, Zap } from 'lucide-react';
 import { MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
+import { CompactionPill } from '../parts/tools/CompactionPill';
 import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 const CLI_ERROR_PREFIXES = [/^Unknown (?:command|skill):/i];
@@ -21,6 +22,14 @@ export function SystemMessage() {
     return (
       <MessagePrimitive.Root>
         <SkillLoadedCard skillName={skillBlock.skillName} path={skillBlock.path} content={skillBlock.content} />
+      </MessagePrimitive.Root>
+    );
+  }
+
+  if (original?.content?.some((c) => c.type === 'compaction')) {
+    return (
+      <MessagePrimitive.Root>
+        <CompactionPill />
       </MessagePrimitive.Root>
     );
   }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/CompactionPill.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/CompactionPill.tsx
@@ -1,0 +1,12 @@
+import { Layers } from 'lucide-react';
+
+export function CompactionPill() {
+  return (
+    <div className="flex justify-center my-2">
+      <div className="inline-flex items-center gap-2 rounded-full px-3 py-1 bg-mf-hover/50">
+        <Layers size={12} className="text-mf-text-secondary shrink-0" />
+        <span className="font-mono text-[11px] text-mf-text-secondary">Context compacted</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -81,7 +81,8 @@ export type MessageContent =
     }
   | { type: 'permission_request'; request: import('./adapter.js').ControlRequest }
   | { type: 'error'; message: string }
-  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string }
+  | { type: 'compaction' };
 
 export type ToolResultMessageContent = Extract<MessageContent, { type: 'tool_result' }>;
 

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -37,7 +37,8 @@ export type DisplayContent =
     }
   | { type: 'permission_request'; request: unknown }
   | { type: 'error'; message: string }
-  | { type: 'skill_loaded'; skillName: string; path: string; content: string };
+  | { type: 'skill_loaded'; skillName: string; path: string; content: string }
+  | { type: 'compaction' };
 
 export interface DisplayMessage {
   id: string;


### PR DESCRIPTION
## Summary

Replaces the plain "Context compacted" system text bubble with a dedicated `CompactionPill` component.

- Adds `{ type: 'compaction' }` to `MessageContent` / `DisplayContent`.
- `onCompact` (live event path) and `convertHistoryEntry` (history replay) both emit the new shape.
- `SystemMessage` detects the new content type and renders the pill instead of the text bubble.

## Parallel change in the same area

`AssistantMessage`'s tools `Fallback` now routes through the shared `renderToolCard` registry instead of hardcoding `DefaultToolCard`. Tools without an explicit Tool UI registration now get their proper card (mirrors how `_TaskGroup` / `_ToolGroup` already worked).

## Notes

- This work was orphaned on a stale `feat/tool-cards` worktree and never made it into any PR. Recovering it now.
- The `packages/mobile` submodule pointer was bumped on that worktree alongside this work, but I left it out of this PR — bumping it requires the corresponding mobile-side change to be merged first. Open as a separate concern.
- `pnpm-lock.yaml` was also touched on the source worktree; left out per instruction (it gets re-altered by local mobile builds).

## Test plan

- [x] `pnpm build` — all packages green
- [x] Touched tests pass: `pnpm vitest run src/__tests__/adapter-events-flow.test.ts src/__tests__/message-loading.test.ts` → 40/40
- [ ] Smoke: trigger a context compaction live and confirm the pill renders centered, then reload chat and confirm the pill persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)