### PR TITLE
fix(desktop): pin expandable cards to viewport when toggled at chat bottom

### DIFF
--- a/.changeset/expandable-scroll-anchor.md
+++ b/.changeset/expandable-scroll-anchor.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix expandable cards/pills jumping off-screen when toggled near the chat bottom. Adds `useExpandable` hook that nudges the chat scroller up by 1px before `setOpen` when the user is at the bottom — defeats assistant-ui's `isAtBottom < 1` autoScroll check, so the browser keeps the pill anchored to its viewport position while the new body extends downward. No JS counter-scroll, single paint, no flash. Wired into `CollapsibleToolCard` (covers Bash/Edit/Write/Read/Plan/Default/AskUserQuestion), `MCPToolCard`, `SchedulePill`, `SkillLoadedCard`, and `TaskGroupCard`. Load-bearing detail: the 1px nudge is tied to assistant-ui's `isAtBottom` threshold — verify still works on future assistant-ui upgrades.

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/CollapsibleToolCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/CollapsibleToolCard.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { cn } from '../../../../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+import { useExpandable } from './use-expandable';
 
 interface CollapsibleToolCardProps {
   /** 'primary' for file/command cards, 'compact' for read/search/metadata cards */
@@ -38,13 +39,13 @@ export function CollapsibleToolCard({
   subHeader,
   children,
 }: CollapsibleToolCardProps) {
-  const [open, setOpen] = useState(defaultOpen);
+  const { open, toggle, ref } = useExpandable<HTMLDivElement>(defaultOpen);
   const isPrimary = variant === 'primary';
 
   return (
-    <div data-testid="tool-card" className={wrapperClassName ?? 'overflow-hidden'}>
+    <div ref={ref} data-testid="tool-card" className={wrapperClassName ?? 'overflow-hidden'}>
       <button
-        onClick={() => !disabled && setOpen((v) => !v)}
+        onClick={() => !disabled && toggle()}
         className={cn(
           'w-full flex items-center gap-2 px-3 text-mf-body transition-colors',
           isPrimary ? 'py-1.5 hover:bg-mf-hover/30' : 'py-0.5 hover:bg-mf-hover/20',

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/MCPToolCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/MCPToolCard.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { Plug, ChevronRight, ChevronDown } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+import { useExpandable } from './use-expandable';
 
 interface Props {
   toolName: string;
@@ -22,7 +22,7 @@ export function MCPToolCard({ toolName, args, result, isError }: Props) {
   const { server, tool } = parseToolName(toolName);
   const pending = result === undefined;
   const errored = !pending && (isError || (typeof result === 'object' && result?.isError));
-  const [open, setOpen] = useState(false);
+  const { open, toggle, ref } = useExpandable<HTMLDivElement>();
   const expandable = !pending && !errored;
   const Chevron = open ? ChevronDown : ChevronRight;
 
@@ -36,12 +36,12 @@ export function MCPToolCard({ toolName, args, result, isError }: Props) {
   const resultText = typeof result === 'string' ? result : (result?.content ?? '');
 
   return (
-    <div className="flex flex-col items-center gap-2 my-1">
+    <div ref={ref} className="flex flex-col items-center gap-2 my-2">
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={() => expandable && setOpen((v) => !v)}
+            onClick={() => expandable && toggle()}
             className={
               errored
                 ? 'inline-flex items-center gap-1.5 rounded-full px-3 py-1 border border-mf-chat-error/30'

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SchedulePill.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SchedulePill.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { AlarmClock, CalendarClock, CalendarX, CalendarDays, Activity, ChevronRight, ChevronDown } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
+import { useExpandable } from './use-expandable';
 
 type ScheduleTool = 'ScheduleWakeup' | 'CronCreate' | 'CronDelete' | 'CronList' | 'Monitor';
 
@@ -39,7 +39,7 @@ export function SchedulePill({ toolName, args, result, isError }: Props) {
   const Icon = ICONS[toolName];
   const pending = result === undefined;
   const errored = !pending && (isError || (typeof result === 'object' && result?.isError));
-  const [open, setOpen] = useState(false);
+  const { open, toggle, ref } = useExpandable<HTMLDivElement>();
   const { obj, content } = parseResult(result);
 
   let label: React.ReactNode = '';
@@ -139,7 +139,7 @@ export function SchedulePill({ toolName, args, result, isError }: Props) {
   const pill = (
     <button
       type="button"
-      onClick={() => expandable && setOpen((v) => !v)}
+      onClick={() => expandable && toggle()}
       disabled={!expandable}
       className={
         errored
@@ -159,7 +159,7 @@ export function SchedulePill({ toolName, args, result, isError }: Props) {
   );
 
   return (
-    <div className="flex flex-col items-center gap-2 my-1">
+    <div ref={ref} className="flex flex-col items-center gap-2 my-2">
       {tooltip ? (
         <Tooltip>
           <TooltipTrigger asChild>{pill}</TooltipTrigger>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SkillLoadedCard.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
 import { ChevronDown, ChevronRight, Zap } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
 import { markdownComponents } from '../markdown-text';
 import { urlTransform } from '../../../../../lib/markdown-url-transform';
+import { useExpandable } from './use-expandable';
 
 interface SkillLoadedCardProps {
   skillName: string;
@@ -19,13 +19,13 @@ interface SkillLoadedCardProps {
 //   - changing CollapsibleToolCard's button styling would regress every other
 //     tool card that uses it
 export function SkillLoadedCard({ skillName, path, content }: SkillLoadedCardProps) {
-  const [open, setOpen] = useState(false);
+  const { open, toggle, ref } = useExpandable<HTMLDivElement>();
   const Chevron = open ? ChevronDown : ChevronRight;
 
   const pill = (
     <button
       type="button"
-      onClick={() => setOpen((v) => !v)}
+      onClick={() => toggle()}
       className="inline-flex items-center gap-1.5 rounded-full bg-mf-hover/50 px-3 py-1 hover:bg-mf-hover/70 transition-colors"
       aria-expanded={open}
     >
@@ -38,7 +38,7 @@ export function SkillLoadedCard({ skillName, path, content }: SkillLoadedCardPro
   );
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div ref={ref} className="flex flex-col items-center gap-2 my-2">
       {path ? (
         <Tooltip>
           <TooltipTrigger asChild>{pill}</TooltipTrigger>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/TaskGroupCard.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Bot } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
 import { ErrorDot, type ToolCardProps } from './shared';
 import { renderToolCard } from './render-tool-card';
+import { useExpandable } from './use-expandable';
 
 interface TaskGroupChild {
   toolCallId: string;
@@ -51,7 +52,7 @@ function buildSummary(children: TaskGroupChild[]): string {
 }
 
 export function TaskGroupCard({ args, result, isError }: ToolCardProps) {
-  const [open, setOpen] = useState(false);
+  const { open, toggle, ref } = useExpandable<HTMLDivElement>();
   const taskArgs = (args.taskArgs as Record<string, unknown>) || {};
   const children = (args.children as TaskGroupChild[]) || [];
   const rawResult =
@@ -72,9 +73,9 @@ export function TaskGroupCard({ args, result, isError }: ToolCardProps) {
   const summary = buildSummary(children);
 
   return (
-    <div className="space-y-1">
+    <div ref={ref} className="space-y-1">
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => toggle()}
         className="w-full flex items-center gap-2 py-0.5 text-mf-body hover:bg-mf-hover/20 transition-colors"
       >
         <Bot size={14} className="text-mf-accent shrink-0" />

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/use-expandable.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/use-expandable.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef, useState } from 'react';
+
+function findScrollContainer(node: HTMLElement | null): HTMLElement | null {
+  let n: HTMLElement | null = node?.parentElement ?? null;
+  while (n) {
+    const overflowY = getComputedStyle(n).overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll') return n;
+    n = n.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Expandable cards/pills inside the chat fight assistant-ui's stick-to-bottom
+ * viewport: when the user clicks one near the bottom, the new body grows
+ * downward and autoScroll snaps the viewport to the new bottom — which pushes
+ * the pill itself off the top of the screen.
+ *
+ * assistant-ui's autoScroll only fires when the viewport is within 1px of the
+ * bottom (`isAtBottom`). Nudging the scroll up by 2px before the toggle
+ * defeats that check: autoScroll skips the resize, and the browser keeps the
+ * pill at its current viewport position while the new content extends
+ * downward. No JS counter-scroll, no second paint, no visible flash.
+ */
+export function useExpandable<T extends HTMLElement = HTMLDivElement>(initial = false) {
+  const [open, setOpen] = useState(initial);
+  const ref = useRef<T>(null);
+
+  const toggle = useCallback(() => {
+    const scroller = findScrollContainer(ref.current);
+    if (scroller) {
+      const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      // assistant-ui's autoScroll uses `< 1` for isAtBottom, so 1px is enough
+      // to defeat it. Anything more is just visible jitter.
+      if (distanceFromBottom < 1) scroller.scrollTop = Math.max(0, scroller.scrollTop - 1);
+    }
+    setOpen((prev) => !prev);
+  }, []);
+
+  return { open, setOpen, toggle, ref };
+}


### PR DESCRIPTION
## Summary

Expandable cards/pills inside the chat fight assistant-ui's stick-to-bottom viewport: clicking one near the bottom causes the new body to grow downward and autoScroll snaps the viewport to the new bottom — pushing the pill itself off the top of the screen.

## How it works

assistant-ui's `autoScroll` only fires when the viewport is within 1px of the bottom (`isAtBottom < 1`). The new `useExpandable` hook nudges the chat scroller **up by 1px before** `setOpen` when the user is at the bottom, defeating that check. autoScroll skips the resize, the browser keeps the pill at its current viewport position while content extends downward. No JS counter-scroll, single paint, no flash.

## Wired into

- `CollapsibleToolCard` (covers Bash/Edit/Write/Read/Plan/Default/AskUserQuestion)
- `MCPToolCard`
- `SchedulePill`
- `SkillLoadedCard`
- `TaskGroupCard`

## Load-bearing detail

The 1px nudge is tied to assistant-ui's `isAtBottom` threshold. If a future assistant-ui upgrade changes that threshold, the nudge needs to match. Worth a quick check on dependency bumps.

## Test plan

- [x] `pnpm build` — desktop green
- [x] Desktop tool component tests pass: 13/13
- [ ] Smoke: scroll to bottom of a chat with several tool cards, click each card to expand — pill should stay at the same Y position; body grows downward; no flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)