### PR TITLE
fix(desktop): chat-rendering polish bundle

### DIFF
--- a/.changeset/render-tweaks.md
+++ b/.changeset/render-tweaks.md
@@ -1,0 +1,10 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Bundle of small chat-rendering polish:
+- `ClickableFilePath` becomes `<span role="button">` with keydown handler instead of `<button>`, fixing the React hydration warning when nested inside another button (e.g. a tool-card header).
+- Markdown code blocks render header inside the same container as the body (single border, copy icon always visible), fixing double-border and inconsistent header positioning.
+- `SyntaxHighlightedCode` strips Shiki's default `<pre>` border/radius so it inherits the outer container chrome.
+- `SearchCard` subheader aligns to 35px (icon column + padding) and the result divider is full-width.
+- `WorktreeStatusPill` uses `my-2` for vertical rhythm parity with the rest of the pill family.

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/CodeHeader.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/CodeHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { Copy, Check } from 'lucide-react';
 
 interface CodeHeaderProps {
@@ -21,20 +21,12 @@ export function CodeHeader({ language, code }: CodeHeaderProps) {
         {language && language !== 'unknown' ? language : 'text'}
       </span>
       <button
+        type="button"
         onClick={handleCopy}
-        className="flex items-center gap-1 text-mf-small text-mf-text-secondary hover:text-mf-text-primary opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        className="flex items-center text-mf-text-secondary hover:text-mf-text-primary transition-colors"
       >
-        {copied ? (
-          <>
-            <Check size={14} className="text-mf-success" />
-            <span>Copied</span>
-          </>
-        ) : (
-          <>
-            <Copy size={14} />
-            <span>Copy</span>
-          </>
-        )}
+        {copied ? <Check size={14} className="text-mf-success" /> : <Copy size={14} />}
       </button>
     </div>
   );

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/SyntaxHighlightedCode.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/SyntaxHighlightedCode.tsx
@@ -106,7 +106,7 @@ export function SyntaxHighlightedCode({ code, language }: { code: string; langua
   if (html) {
     return (
       <div
-        className="[&>pre]:!bg-transparent [&>pre]:!m-0 [&>pre]:p-3 [&>pre]:overflow-x-auto [&>pre>code]:!text-[14px] [&>pre>code]:!leading-[20px] [&>pre>code]:!font-[var(--font-mono)]"
+        className="[&>pre]:!bg-transparent [&>pre]:!border-0 [&>pre]:!rounded-none [&>pre]:!m-0 [&>pre]:p-3 [&>pre]:overflow-x-auto [&>pre>code]:!text-[14px] [&>pre>code]:!leading-[20px] [&>pre>code]:!font-[var(--font-mono)]"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/markdown-text.tsx
@@ -28,7 +28,14 @@ function Code({ className, children, ...props }: React.ComponentProps<'code'>) {
   if (isCodeBlock) {
     const lang = className?.match(/language-(\w+)/)?.[1];
     const code = extractText(children);
-    return <SyntaxHighlightedCode code={code} language={lang} />;
+    return (
+      <div className="rounded-mf-card border border-mf-divider bg-mf-hover/20 overflow-hidden my-3">
+        <CodeHeader language={lang} code={code} />
+        <div className="border-t border-mf-divider">
+          <SyntaxHighlightedCode code={code} language={lang} />
+        </div>
+      </div>
+    );
   }
   return (
     <code className={cn('aui-md-inline-code', className)} {...props}>
@@ -170,9 +177,8 @@ export const markdownComponents = unstable_memoizeMarkdownComponents({
   tr: MarkdownTr,
   strong: ({ className, ...props }) => <strong className={cn('aui-md-strong', className)} {...props} />,
   del: ({ className, ...props }) => <del className={cn('aui-md-del', className)} {...props} />,
-  pre: ({ className, ...props }) => <pre className={cn('aui-md-pre', className)} {...props} />,
+  pre: ({ children }) => <>{children}</>,
   code: Code,
-  CodeHeader,
 });
 
 const REMARK_PLUGINS = [remarkGfm, remarkAppLinks];

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SearchCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SearchCard.tsx
@@ -36,14 +36,14 @@ export function SearchCard({
       trailing={<StatusDot result={result} isError={isError} />}
       subHeader={
         subHeaderText ? (
-          <div className="px-3 pb-0.5">
+          <div className="px-3 pb-0.5 pl-[35px]">
             <span className="font-mono text-mf-small text-mf-text-secondary/60 truncate block">{subHeaderText}</span>
           </div>
         ) : undefined
       }
     >
       {resultText && (
-        <div className="border-t border-mf-divider/50 ml-5">
+        <div className="border-t border-mf-divider/50">
           <pre
             className={cn(
               'text-mf-small font-mono overflow-x-auto whitespace-pre-wrap px-3 py-2 max-h-[300px] overflow-y-auto',

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/WorktreeStatusPill.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/WorktreeStatusPill.tsx
@@ -63,7 +63,7 @@ export function WorktreeStatusPill({ toolName, args, result, isError }: Props) {
   );
 
   return (
-    <div className="flex justify-center my-1">
+    <div className="flex justify-center my-2">
       {tooltip ? (
         <Tooltip>
           <TooltipTrigger asChild>{pill}</TooltipTrigger>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/shared.tsx
@@ -60,16 +60,27 @@ export function ClickableFilePath({ filePath }: { filePath: string }) {
     revealFileInTree(filePath);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      openEditorTab(filePath);
+      revealFileInTree(filePath);
+    }
+  };
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          onClick={handleClick}
-          className="font-mono text-mf-accent truncate text-mf-body hover:underline cursor-pointer"
+        <span
+          role="button"
           tabIndex={0}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          className="font-mono text-mf-accent truncate text-mf-body hover:underline cursor-pointer"
         >
           {shortFilename(filePath)}
-        </button>
+        </span>
       </TooltipTrigger>
       <TooltipContent side="top">{filePath}</TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Summary

Bundle of small chat-rendering polish recovered from the orphaned `feat/tool-cards` worktree.

| Change | Why |
|---|---|
| `ClickableFilePath`: `<button>` → `<span role="button">` + keydown handler | Fixes React hydration warning when nested inside another button (tool-card headers) |
| Markdown code block: header moved **inside** the same container as the body | Single border instead of double; copy icon always visible; consistent header positioning |
| `SyntaxHighlightedCode`: strip Shiki's default `<pre>` border/radius | So it inherits the outer container chrome |
| `SearchCard`: subheader `pl-[35px]` + full-width result divider | Aligns subheader text under the search query column; divider extends to card edge |
| `WorktreeStatusPill`: `my-1` → `my-2` | Vertical rhythm parity with the rest of the pill family |

## Test plan

- [x] `pnpm build` — desktop green
- [x] Desktop component tests pass: 16/16
- [ ] Smoke: open a chat with markdown code blocks, search results, and worktree pills — visually confirm each tweak

🤖 Generated with [Claude Code](https://claude.com/claude-code)