### PR TITLE
chore: bump packages/mobile submodule

### DIFF
--- a/.changeset/bump-mobile-submodule.md
+++ b/.changeset/bump-mobile-submodule.md
@@ -1,0 +1,4 @@
+---
+---
+
+Bump `packages/mobile` submodule to `eec0b48` (mobile/main HEAD after mobile#7 squash-merge). Brings in the mobile tool-card refresh: U1–U16 unified card system, CompactionPill, SearchCard/BashCard alignment, unified Edit/Write headers, normalized pill spacing.


### PR DESCRIPTION
## Summary
- Bumps `packages/mobile` from `03f54dc1` → `eec0b48` (mobile/main HEAD after mobile#7 squash-merge).
- Mirrors the desktop tool-card refresh that landed in #262: brings U1–U16 unified card system, CompactionPill (mobile counterpart of #270), SearchCard/BashCard alignment, unified Edit/Write headers, normalized pill spacing.

## Test plan
- [x] Pointer change is the only diff (plus changeset)
- [x] Target SHA verified on mobile/main (`eec0b48` is the squash-merge commit of mobile#7)
- [x] Mobile-side smoke verified independently — pointer bumps don't run desktop tests