### PR TITLE
fix(desktop): force assistant-ui isAtBottom flag to false before resize

### DIFF
--- a/.changeset/expandable-scroll-anchor-v2.md
+++ b/.changeset/expandable-scroll-anchor-v2.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Follow-up to #271: the original 1px nudge did not actually defeat assistant-ui's autoScroll. Tracing `useThreadViewportAutoScroll.js`: the ResizeObserver callback reads `isAtBottom` from a Zustand store, and the store is only updated by the scroll event handler. Programmatic `scrollTop = X` queues the scroll event asynchronously — so the resize fires first with the stale `isAtBottom = true`, autoScroll snaps to bottom, and the just-expanded pill flies off-screen anyway. Live repro: pill viewport top went 482.5 → -5.5 (-488 px). Fix: nudge 2px (safer than 1px against sub-pixel scrollTop) AND synchronously dispatch a `scroll` event so assistant-ui's handler updates the store BEFORE the resize callback consults it. After fix: pill top 482.5 → 484.5 (+2 px, just the nudge), scrollTop 207.5 → 205.5, autoScroll skipped.

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/use-expandable.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/use-expandable.ts
@@ -16,11 +16,22 @@ function findScrollContainer(node: HTMLElement | null): HTMLElement | null {
  * downward and autoScroll snaps the viewport to the new bottom — which pushes
  * the pill itself off the top of the screen.
  *
- * assistant-ui's autoScroll only fires when the viewport is within 1px of the
- * bottom (`isAtBottom`). Nudging the scroll up by 2px before the toggle
- * defeats that check: autoScroll skips the resize, and the browser keeps the
- * pill at its current viewport position while the new content extends
- * downward. No JS counter-scroll, no second paint, no visible flash.
+ * assistant-ui (`useThreadViewportAutoScroll`) reads `isAtBottom` from a
+ * Zustand store inside its ResizeObserver callback. The store is updated by
+ * the scroll event handler. Since programmatic `scrollTop = X` queues the
+ * scroll event asynchronously, the order on a click is:
+ *
+ *   1. nudge scrollTop  (queues async scroll event)
+ *   2. setOpen(true)    (schedules React render)
+ *   3. React renders, ResizeObserver fires
+ *   4. autoScroll reads isAtBottom — still TRUE — and snaps to bottom
+ *   5. scroll event finally fires (too late)
+ *
+ * Fix: nudge by 2px and SYNCHRONOUSLY dispatch a `scroll` event on the
+ * scroller so assistant-ui's handler runs immediately and writes
+ * `isAtBottom = false` to the store. Then on resize, autoScroll reads the
+ * fresh `false` and skips. Browser keeps the pill at its viewport position
+ * while content extends downward. No JS counter-scroll, no visible flash.
  */
 export function useExpandable<T extends HTMLElement = HTMLDivElement>(initial = false) {
   const [open, setOpen] = useState(initial);
@@ -30,9 +41,16 @@ export function useExpandable<T extends HTMLElement = HTMLDivElement>(initial = 
     const scroller = findScrollContainer(ref.current);
     if (scroller) {
       const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
-      // assistant-ui's autoScroll uses `< 1` for isAtBottom, so 1px is enough
-      // to defeat it. Anything more is just visible jitter.
-      if (distanceFromBottom < 1) scroller.scrollTop = Math.max(0, scroller.scrollTop - 1);
+      // assistant-ui's isAtBottom check is `Math.abs(...) < 1`, so we need
+      // the nudge to land at strictly >= 1. 2px is the safe minimum given
+      // sub-pixel scrollTop values (some browsers report fractional values).
+      if (distanceFromBottom < 1 && scroller.scrollTop > 0) {
+        scroller.scrollTop = Math.max(0, scroller.scrollTop - 2);
+        // Force the scroll handler to run synchronously so the cached
+        // `isAtBottom` flag in assistant-ui's store flips to false BEFORE
+        // setOpen triggers the resize that consults that flag.
+        scroller.dispatchEvent(new Event('scroll'));
+      }
     }
     setOpen((prev) => !prev);
   }, []);


### PR DESCRIPTION
## Summary

Follow-up to #271. The 1px scrollTop nudge **did not actually defeat** assistant-ui's autoScroll.

## Root cause

Tracing `useThreadViewportAutoScroll.js`:

```js
const resizeRef = useOnResizeContent(() => {
  ...
  else if (autoScroll && threadViewportStore.getState().isAtBottom) {
    scrollToBottom("instant");  // ← snaps to bottom
  }
  handleScroll();  // ← updates isAtBottom AFTER
});
```

`isAtBottom` is read from a **Zustand store** inside the `ResizeObserver` callback, and that store is only written by `handleScroll` on the scroll event. Programmatic `scrollTop = X` queues the scroll event **asynchronously**, so the order on a click is:

1. nudge `scrollTop` (queues async scroll event)
2. `setOpen(true)` (schedules React render)
3. React renders, ResizeObserver fires
4. autoScroll reads `isAtBottom` — **still `true`** — and snaps to bottom
5. scroll event finally fires (too late)

## Live repro

Project Structure Overview chat, "Using skill: todos" pill:

| | scrollTop | scrollHeight | pill top |
|---|---|---|---|
| Before click | 207.5 | 866 | 482.5 |
| After (broken) | 695.5 | 1354 | **-5.5** ← off-screen |

## Fix

Nudge by **2px** (safer than 1px against sub-pixel scrollTop values some browsers report) AND synchronously `dispatchEvent(new Event('scroll'))` on the scroller so assistant-ui's handler runs immediately and writes `isAtBottom = false` to the store BEFORE the resize callback consults it.

## After fix (verified live)

| | scrollTop | pill top |
|---|---|---|
| Before click | 207.5 | 482.5 |
| After (fixed) | **205.5** | **484.5** ← anchored |

scrollTop moved by exactly the -2 nudge. Pill viewport position moved by exactly +2. autoScroll skipped.

## Test plan

- [x] `pnpm build` — desktop green
- [x] Desktop tool component tests pass: 13/13
- [x] Live verified via electron-mcp: scroll/pill measurements above

🤖 Generated with [Claude Code](https://claude.com/claude-code)