### PR TITLE
fix(desktop): polish BashCard and SearchCard layouts

### DIFF
--- a/.changeset/tricky-cats-tickle.md
+++ b/.changeset/tricky-cats-tickle.md
@@ -1,0 +1,8 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+fix(desktop): polish BashCard and SearchCard layouts
+
+- BashCard: drop the JS-level 80-char hard truncation; let CSS `truncate` handle overflow responsively so commands fill the available row width before getting an ellipsis. Tooltip still shows the full command on hover.
+- SearchCard: header now renders `Grep · "pattern"` (toolName plus pattern, monospaced and truncatable). The path moves to its own subheader line wrapped in a Radix tooltip showing the full path on hover.

--- a/packages/desktop/src/__tests__/components/tools/BashCard.test.tsx
+++ b/packages/desktop/src/__tests__/components/tools/BashCard.test.tsx
@@ -23,16 +23,16 @@ describe('BashCard', () => {
     expect(screen.getByText(/npm install/)).toBeInTheDocument();
   });
 
-  it('truncates long commands to 80 characters with ellipsis', () => {
+  it('renders the full command and lets CSS truncate based on available width', () => {
     const longCmd = 'x'.repeat(100);
     render(
       <TooltipProvider>
         <BashCard args={{ command: longCmd }} result={undefined} isError={undefined} />
       </TooltipProvider>,
     );
-    // truncated version shows in the header span
-    const truncated = longCmd.slice(0, 80) + '...';
-    expect(screen.getByText(truncated)).toBeInTheDocument();
+    const span = screen.getByText(longCmd);
+    expect(span).toBeInTheDocument();
+    expect(span.className).toMatch(/truncate/);
   });
 
   it('shows pulsing status dot when result is undefined (running)', () => {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/BashCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/BashCard.tsx
@@ -7,7 +7,6 @@ import { StatusDot, cardStyle, stripErrorXml, type ToolCardProps } from './share
 export function BashCard({ args, result, isError }: ToolCardProps) {
   const command = (args.command as string) || (args.input as string) || '';
   const description = args.description as string | undefined;
-  const truncatedCmd = command.length > 80 ? command.slice(0, 80) + '...' : command;
   const rawResultText =
     typeof result === 'string' ? result : result !== undefined ? JSON.stringify(result, null, 2) : undefined;
   const resultText = rawResultText ? stripErrorXml(rawResultText) : undefined;
@@ -21,8 +20,8 @@ export function BashCard({ args, result, isError }: ToolCardProps) {
           <Terminal size={15} className="text-mf-text-secondary shrink-0" />
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="font-mono text-mf-body text-mf-text-primary truncate" tabIndex={0}>
-                {truncatedCmd}
+              <span className="font-mono text-mf-body text-mf-text-primary truncate min-w-0" tabIndex={0}>
+                {command}
               </span>
             </TooltipTrigger>
             <TooltipContent>{command}</TooltipContent>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SearchCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/tools/SearchCard.tsx
@@ -1,5 +1,6 @@
 import { Search } from 'lucide-react';
 import { cn } from '../../../../../lib/utils';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../../../../ui/tooltip';
 import { CollapsibleToolCard } from './CollapsibleToolCard';
 import { StatusDot, stripErrorXml } from './shared';
 
@@ -20,8 +21,6 @@ export function SearchCard({
     typeof result === 'string' ? result : result !== undefined ? JSON.stringify(result, null, 2) : undefined;
   const resultText = rawResultText ? stripErrorXml(rawResultText) : undefined;
 
-  const subHeaderText = pattern ? `"${pattern}"${path ? ` · in ${path}` : ''}` : undefined;
-
   return (
     <CollapsibleToolCard
       variant="compact"
@@ -30,14 +29,27 @@ export function SearchCard({
       header={
         <>
           <Search size={15} className="text-mf-text-secondary/40 shrink-0" />
-          <span className="text-mf-body text-mf-text-secondary/60">{toolName}</span>
+          <span className="text-mf-body text-mf-text-secondary/60 shrink-0">{toolName}</span>
+          {pattern ? (
+            <>
+              <span className="text-mf-text-secondary/40 shrink-0">·</span>
+              <span className="font-mono text-mf-body text-mf-text-secondary/60 truncate min-w-0">"{pattern}"</span>
+            </>
+          ) : null}
         </>
       }
       trailing={<StatusDot result={result} isError={isError} />}
       subHeader={
-        subHeaderText ? (
-          <div className="px-3 pb-0.5 pl-[35px]">
-            <span className="font-mono text-mf-small text-mf-text-secondary/60 truncate block">{subHeaderText}</span>
+        path ? (
+          <div className="px-3 pb-0.5 pl-[35px] min-w-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={0} className="font-mono text-mf-small text-mf-text-secondary/60 truncate block">
+                  in {path}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{path}</TooltipContent>
+            </Tooltip>
           </div>
         ) : undefined
       }


### PR DESCRIPTION
## Summary

Two small desktop chat-card polish fixes.

- **BashCard**: removed the JS-level 80-char hard truncation. Long commands now fill the available row width and CSS `truncate` handles overflow responsively (with `min-w-0`). Radix tooltip continues to show the full command on hover.
- **SearchCard**: header is now `Grep · "pattern"` — toolName plus the searched pattern on one line (pattern monospaced, truncatable). The path moves to its own subheader line wrapped in a Radix tooltip showing the full path on hover.

A companion mobile PR with equivalent changes (and several other chat-UX fixes): qlan-ro/mainframe-mobile#8 — submodule bump can land in a follow-up after that PR merges.

## Test plan

- [ ] Bash card with a long command: text fills the card width before truncating; tooltip shows full command on hover
- [ ] Bash card with a short command: no truncation, tooltip still works
- [ ] Grep tool call: header shows `Grep · "pattern"`, path on second line with tooltip on hover
- [ ] Long path: subheader truncates with ellipsis; tooltip reveals full path
- [ ] `pnpm --filter @qlan-ro/mainframe-desktop test -- BashCard SearchCard` passes