### PR TITLE
fix(desktop): four UX polish items (#136 #138 #139 #140)

### DIFF
--- a/.changeset/desktop-ux-fixes.md
+++ b/.changeset/desktop-ux-fixes.md
@@ -1,0 +1,10 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+fix(desktop): four UX fixes — transient update errors, sessions sidebar header layout, long user message collapsing, and composer double scrollbar
+
+- #136: Transient auto-updater errors (network loss, DNS, 5xx, rate limits) no longer surface as a persistent error banner; logged at warn instead.
+- #138: Sessions sidebar project group header row now uses a fixed-width right cluster so the project name never reflows when action buttons appear on hover.
+- #139: User message bubbles longer than 600 characters are clamped to 6 lines with a "Read more / Show less" toggle.
+- #140: Composer card caps at 14 lines via `maxHeight: 14lh`, uses `overflow-hidden` on the outer card to eliminate the double scrollbar, and sets explicit `lineHeight`/`padding` on the textarea to fix cursor offset on paste.

--- a/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
+++ b/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import React from 'react';
+
+// Mock stores and client before component import
+vi.mock('../../renderer/store/index.js', () => ({
+  useChatsStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      activeChatId: null,
+      setActiveChat: vi.fn(),
+      removeChat: vi.fn(),
+      unreadChatIds: new Set(),
+      detectedPrs: new Map(),
+    }),
+}));
+vi.mock('../../renderer/store/tabs.js', () => ({
+  useTabsStore: { getState: () => ({ openChatTab: vi.fn(), closeTab: vi.fn(), updateTabLabel: vi.fn() }) },
+}));
+vi.mock('../../renderer/store/adapters.js', () => ({
+  useAdaptersStore: (selector: (s: unknown) => unknown) => selector({ adapters: [] }),
+}));
+vi.mock('../../renderer/lib/client.js', () => ({
+  daemonClient: { createChat: vi.fn(), resumeChat: vi.fn() },
+}));
+vi.mock('../../renderer/lib/adapters.js', () => ({
+  getDefaultModelForAdapter: vi.fn(() => 'claude-sonnet-4-6'),
+  getAdapterLabel: vi.fn(() => 'Claude CLI'),
+}));
+vi.mock('../../renderer/lib/api.js', () => ({
+  archiveChat: vi.fn(() => Promise.resolve()),
+  renameChat: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../renderer/lib/delete-project.js', () => ({
+  deleteProjectWithCleanup: vi.fn(),
+}));
+vi.mock('../../renderer/components/chat/assistant-ui/composer/composer-drafts.js', () => ({
+  deleteDraft: vi.fn(),
+}));
+
+import { ProjectGroup } from '../../renderer/components/panels/ProjectGroup.js';
+import { TooltipProvider } from '../../renderer/components/ui/tooltip.js';
+import { daemonClient } from '../../renderer/lib/client.js';
+import type { Project, Chat } from '@qlan-ro/mainframe-types';
+
+const mockProject: Project = {
+  id: 'proj-1',
+  name: 'my-app',
+  path: '/home/user/my-app',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const mockChat: Chat = {
+  id: 'chat-1',
+  projectId: 'proj-1',
+  title: 'Session 1',
+  adapterId: 'claude',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  displayStatus: 'idle',
+};
+
+function renderGroup(collapsed = false) {
+  return render(
+    <TooltipProvider>
+      <ProjectGroup project={mockProject} chats={[mockChat]} collapsed={collapsed} onToggleCollapse={vi.fn()} />
+    </TooltipProvider>,
+  );
+}
+
+describe('ProjectGroup header layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the project name in the header', () => {
+    renderGroup();
+    expect(screen.getByText('my-app')).toBeInTheDocument();
+  });
+
+  it('renders a count badge with the number of chats', () => {
+    renderGroup();
+    // There is 1 chat; the badge should contain "1"
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('has a new session button with tooltip label referencing the project name', () => {
+    renderGroup();
+    const btn = screen.getByRole('button', { name: /new session in my-app/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('calls daemonClient.createChat when the new-session button is clicked', async () => {
+    renderGroup();
+    const btn = screen.getByRole('button', { name: /new session in my-app/i });
+    await userEvent.click(btn);
+    expect(daemonClient.createChat).toHaveBeenCalledWith('proj-1', 'claude', 'claude-sonnet-4-6');
+  });
+
+  it('new-session button click does not bubble to toggle-collapse', async () => {
+    const onToggleCollapse = vi.fn();
+    render(
+      <TooltipProvider>
+        <ProjectGroup project={mockProject} chats={[mockChat]} collapsed={false} onToggleCollapse={onToggleCollapse} />
+      </TooltipProvider>,
+    );
+    const btn = screen.getByRole('button', { name: /new session in my-app/i });
+    await userEvent.click(btn);
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+  });
+
+  it('header row has a fixed-width right cluster so left content never reflows', () => {
+    renderGroup();
+    const btn = screen.getByRole('button', { name: /new session in my-app/i });
+    // The right cluster (parent of + button and delete button) should be shrink-0
+    const rightCluster = btn.parentElement;
+    expect(rightCluster?.className).toMatch(/shrink-0/);
+  });
+});

--- a/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
+++ b/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
@@ -111,11 +111,11 @@ describe('ProjectGroup header layout', () => {
     expect(onToggleCollapse).not.toHaveBeenCalled();
   });
 
-  it('header row has a fixed-width right cluster so left content never reflows', () => {
+  it('action buttons cluster is hidden until hover/focus, matching session-row pattern', () => {
     renderGroup();
-    const btn = screen.getByRole('button', { name: /new session in my-app/i });
-    // The right cluster (parent of + button and delete button) should be shrink-0
-    const rightCluster = btn.parentElement;
-    expect(rightCluster?.className).toMatch(/shrink-0/);
+    const btn = screen.getByRole('button', { name: /new session in my-app/i, hidden: true });
+    const cluster = btn.parentElement;
+    expect(cluster?.className).toMatch(/\bhidden\b/);
+    expect(cluster?.className).toMatch(/group-hover:flex/);
   });
 });

--- a/packages/desktop/src/__tests__/components/UserMessageReadMore.test.tsx
+++ b/packages/desktop/src/__tests__/components/UserMessageReadMore.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { ReadMoreBubble } from '../../renderer/components/chat/assistant-ui/messages/ReadMoreBubble.js';
+
+const SHORT_TEXT = 'Short message.';
+const LONG_TEXT = 'a'.repeat(601); // > 600 chars threshold
+
+describe('ReadMoreBubble', () => {
+  it('renders short text without a read-more toggle', () => {
+    render(<ReadMoreBubble>{SHORT_TEXT}</ReadMoreBubble>);
+    expect(screen.queryByRole('button', { name: /read more/i })).not.toBeInTheDocument();
+    expect(screen.getByText(SHORT_TEXT)).toBeInTheDocument();
+  });
+
+  it('renders long text clamped with a "Read more" button', () => {
+    render(<ReadMoreBubble>{LONG_TEXT}</ReadMoreBubble>);
+    expect(screen.getByRole('button', { name: /read more/i })).toBeInTheDocument();
+  });
+
+  it('expands to show full text when "Read more" is clicked', async () => {
+    render(<ReadMoreBubble>{LONG_TEXT}</ReadMoreBubble>);
+    const btn = screen.getByRole('button', { name: /read more/i });
+    await userEvent.click(btn);
+    expect(screen.queryByRole('button', { name: /read more/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
+  });
+
+  it('collapses back when "Show less" is clicked', async () => {
+    render(<ReadMoreBubble>{LONG_TEXT}</ReadMoreBubble>);
+    await userEvent.click(screen.getByRole('button', { name: /read more/i }));
+    await userEvent.click(screen.getByRole('button', { name: /show less/i }));
+    expect(screen.getByRole('button', { name: /read more/i })).toBeInTheDocument();
+  });
+
+  it('applies line-clamp class when collapsed', () => {
+    const { container } = render(<ReadMoreBubble>{LONG_TEXT}</ReadMoreBubble>);
+    const contentDiv = container.querySelector('[data-clamp]');
+    expect(contentDiv?.className).toMatch(/line-clamp/);
+  });
+
+  it('removes line-clamp class when expanded', async () => {
+    const { container } = render(<ReadMoreBubble>{LONG_TEXT}</ReadMoreBubble>);
+    await userEvent.click(screen.getByRole('button', { name: /read more/i }));
+    const contentDiv = container.querySelector('[data-clamp]');
+    expect(contentDiv?.className).not.toMatch(/line-clamp/);
+  });
+});

--- a/packages/desktop/src/__tests__/components/composer/ComposerScrollConstraint.test.ts
+++ b/packages/desktop/src/__tests__/components/composer/ComposerScrollConstraint.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Structural tests for the ComposerCard overflow/scroll constraint rules.
+ *
+ * We import and inspect a snapshot of the source string inlined via a vitest
+ * virtual module / raw import. Because jsdom has no layout engine, we verify
+ * the required CSS tokens appear in the component source (reliable proxy that
+ * the double-scrollbar and cursor-offset fixes are present).
+ */
+import { describe, it, expect } from 'vitest';
+
+// Raw import of the TSX source as a string — vitest + Vite support ?raw query.
+import composerSource from '../../../renderer/components/chat/assistant-ui/composer/ComposerCard.tsx?raw';
+
+describe('ComposerCard scroll constraints', () => {
+  it('caps textarea scroll region at 14lh via maxHeight style', () => {
+    expect(composerSource).toMatch(/14lh/);
+  });
+
+  it('inner scroll wrapper uses overflow-y-auto', () => {
+    expect(composerSource).toMatch(/overflow-y-auto/);
+  });
+
+  it('outer card does not allow a second scrollbar (overflow-hidden on root)', () => {
+    expect(composerSource).toMatch(/overflow-hidden/);
+  });
+
+  it('sets explicit lineHeight on the textarea for cursor alignment', () => {
+    expect(composerSource).toMatch(/lineHeight/);
+  });
+
+  it('uses box-sizing border-box in the composer tree', () => {
+    expect(composerSource).toMatch(/box-sizing.*border-box|boxSizing.*border-box/);
+  });
+});

--- a/packages/desktop/src/__tests__/components/composer/ComposerScrollConstraint.test.ts
+++ b/packages/desktop/src/__tests__/components/composer/ComposerScrollConstraint.test.ts
@@ -12,8 +12,8 @@ import { describe, it, expect } from 'vitest';
 import composerSource from '../../../renderer/components/chat/assistant-ui/composer/ComposerCard.tsx?raw';
 
 describe('ComposerCard scroll constraints', () => {
-  it('caps textarea scroll region at 14lh via maxHeight style', () => {
-    expect(composerSource).toMatch(/14lh/);
+  it('caps textarea scroll region at 14 lines (308px = 14 × 22px line-height) via maxHeight style', () => {
+    expect(composerSource).toMatch(/maxHeight:\s*'308px'/);
   });
 
   it('inner scroll wrapper uses overflow-y-auto', () => {

--- a/packages/desktop/src/__tests__/lib/auto-updater-error-classifier.test.ts
+++ b/packages/desktop/src/__tests__/lib/auto-updater-error-classifier.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { classifyUpdateError, type UpdateErrorKind } from '../../main/auto-updater-error-classifier.js';
+
+describe('classifyUpdateError', () => {
+  it('classifies ENOTFOUND as transient', () => {
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND github.com'), { code: 'ENOTFOUND' });
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies ETIMEDOUT as transient', () => {
+    const err = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies ECONNRESET as transient', () => {
+    const err = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies ECONNREFUSED as transient', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies HTTP 503 as transient via message', () => {
+    const err = new Error('Got status 503 from https://github.com/releases');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies HTTP 500 as transient via message', () => {
+    const err = new Error('Error: Got status 500');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies GitHub rate limit HTTP 403 as transient', () => {
+    const err = new Error('Got status 403 from https://api.github.com/repos');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies HTTP 429 as transient', () => {
+    const err = new Error('Got status 429');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies network unavailable message as transient', () => {
+    const err = new Error('net::ERR_NETWORK_CHANGED');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies DNS failure message as transient', () => {
+    const err = new Error('net::ERR_NAME_NOT_RESOLVED');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('transient');
+  });
+
+  it('classifies signature mismatch as persistent', () => {
+    const err = new Error('signature verification failed for update');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('persistent');
+  });
+
+  it('classifies disk full as persistent', () => {
+    const err = Object.assign(new Error('ENOSPC: no space left on device'), { code: 'ENOSPC' });
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('persistent');
+  });
+
+  it('classifies manifest parse error as persistent', () => {
+    const err = new Error('Cannot parse latest.yml: unexpected token');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('persistent');
+  });
+
+  it('classifies HTTP 404 as persistent', () => {
+    const err = new Error('Got status 404');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('persistent');
+  });
+
+  it('classifies generic unknown error as persistent', () => {
+    const err = new Error('Something completely unknown went wrong');
+    expect(classifyUpdateError(err)).toBe<UpdateErrorKind>('persistent');
+  });
+});

--- a/packages/desktop/src/main/auto-updater-error-classifier.ts
+++ b/packages/desktop/src/main/auto-updater-error-classifier.ts
@@ -1,0 +1,55 @@
+/**
+ * Classifies auto-updater errors as transient or persistent.
+ *
+ * Transient errors (network unavailability, rate limits, server errors) are
+ * expected to resolve on the next check cycle and should not surface as a
+ * permanent error banner in the UI. Persistent errors (signature mismatch,
+ * disk full, parse errors) indicate a real problem that needs user attention.
+ */
+
+export type UpdateErrorKind = 'transient' | 'persistent';
+
+/** System-level network error codes that indicate temporary connectivity loss. */
+const TRANSIENT_CODES = new Set([
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+]);
+
+/** System-level error codes that indicate a real, non-network problem. */
+const PERSISTENT_CODES = new Set(['ENOSPC', 'EPERM', 'EACCES']);
+
+/** Patterns in error messages that indicate transient HTTP or network conditions. */
+const TRANSIENT_MESSAGE_PATTERNS: RegExp[] = [
+  // HTTP 5xx server errors
+  /\bstatus\s+5\d{2}\b/i,
+  // HTTP 429 Too Many Requests
+  /\bstatus\s+429\b/i,
+  // GitHub API rate limit returns 403 with a recognizable URL/message
+  /\bstatus\s+403\b.*api\.github\.com/i,
+  /api\.github\.com.*\bstatus\s+403\b/i,
+  // Electron/Chromium network error strings
+  /net::ERR_/i,
+  // Generic "network" in message
+  /network\s+(is\s+)?unavailable/i,
+  /dns\s+(lookup\s+)?fail/i,
+];
+
+export function classifyUpdateError(err: Error): UpdateErrorKind {
+  const code = (err as NodeJS.ErrnoException).code;
+
+  if (code) {
+    if (TRANSIENT_CODES.has(code)) return 'transient';
+    if (PERSISTENT_CODES.has(code)) return 'persistent';
+  }
+
+  const msg = err.message ?? '';
+  for (const pattern of TRANSIENT_MESSAGE_PATTERNS) {
+    if (pattern.test(msg)) return 'transient';
+  }
+
+  return 'persistent';
+}

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -1,6 +1,7 @@
 import { autoUpdater } from 'electron-updater';
 import { BrowserWindow, ipcMain } from 'electron';
 import { createMainLogger } from './logger.js';
+import { classifyUpdateError } from './auto-updater-error-classifier.js';
 
 const log = createMainLogger('electron:auto-updater');
 
@@ -20,6 +21,7 @@ function send(mainWindow: BrowserWindow, status: UpdateStatus): void {
 function registerListeners(mainWindow: BrowserWindow): void {
   autoUpdater.on('checking-for-update', () => {
     log.info('checking for update');
+    // Clear any prior persistent error so stale banners don't persist across cycles.
     send(mainWindow, { state: 'checking' });
   });
 
@@ -43,7 +45,14 @@ function registerListeners(mainWindow: BrowserWindow): void {
   });
 
   autoUpdater.on('error', (err) => {
-    log.warn({ message: err.message }, 'update error');
+    const kind = classifyUpdateError(err);
+    if (kind === 'transient') {
+      // Transient errors (network unavailability, rate limits, server errors) are
+      // expected to resolve on the next check cycle — do not surface as an error banner.
+      log.warn({ message: err.message, kind }, 'transient update check error (suppressed from UI)');
+      return;
+    }
+    log.error({ message: err.message, kind }, 'persistent update error');
     send(mainWindow, { state: 'error', message: err.message });
   });
 }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -381,7 +381,10 @@ export function ComposerCard() {
         lines — beyond that the textarea scrolls internally. The outer card uses
         overflow-hidden so no second scrollbar can appear.
       */}
-      <div className="relative overflow-y-auto" style={{ maxHeight: '14lh', boxSizing: 'border-box' }}>
+      <div
+        className="relative overflow-y-auto"
+        style={{ maxHeight: '308px', lineHeight: '22px', boxSizing: 'border-box' }}
+      >
         <div className="relative">
           <ComposerHighlight />
           <ComposerPrimitive.Input
@@ -392,7 +395,7 @@ export function ComposerCard() {
             disabled={chat?.worktreeMissing}
             placeholder="Type @ to search files, / for skills… (Enter to send)"
             className="block w-full bg-transparent border-none font-sans text-mf-chat text-transparent caret-mf-text-primary selection:text-mf-text-primary resize-none placeholder:text-mf-text-secondary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-            style={{ lineHeight: '1.5', padding: '8px 12px', boxSizing: 'border-box' }}
+            style={{ lineHeight: '22px', padding: '8px 12px', boxSizing: 'border-box' }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey && chat?.isRunning) {
                 e.preventDefault();

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -278,7 +278,7 @@ export function ComposerCard() {
   return (
     <ComposerPrimitive.Root
       data-tutorial="step-3"
-      className="relative border border-mf-border rounded-mf-card bg-transparent"
+      className="relative border border-mf-border rounded-mf-card bg-transparent overflow-hidden"
     >
       <ContextPickerMenu forceOpen={pickerOpen} onClose={() => setPickerOpen(false)} />
       <div className="flex items-center gap-1 px-2 pt-2">
@@ -374,7 +374,14 @@ export function ComposerCard() {
         own scrollbar would shave 8px off its content width, making it wrap at a narrower
         width than the overlay and drift the caret away from the visible text.
       */}
-      <div className="relative max-h-[200px] overflow-y-auto">
+      {/*
+        Scroll wrapper (outer) owns max-h + overflow-y-auto. The textarea grows
+        naturally inside; both textarea and overlay share the same wrapping width
+        under a single scrollbar. Cap at 14lh so the card never grows beyond 14
+        lines — beyond that the textarea scrolls internally. The outer card uses
+        overflow-hidden so no second scrollbar can appear.
+      */}
+      <div className="relative overflow-y-auto" style={{ maxHeight: '14lh', boxSizing: 'border-box' }}>
         <div className="relative">
           <ComposerHighlight />
           <ComposerPrimitive.Input
@@ -384,7 +391,8 @@ export function ComposerCard() {
             spellCheck={false}
             disabled={chat?.worktreeMissing}
             placeholder="Type @ to search files, / for skills… (Enter to send)"
-            className="block w-full bg-transparent border-none px-3 py-2 font-sans text-mf-chat text-transparent caret-mf-text-primary selection:text-mf-text-primary resize-none placeholder:text-mf-text-secondary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+            className="block w-full bg-transparent border-none font-sans text-mf-chat text-transparent caret-mf-text-primary selection:text-mf-text-primary resize-none placeholder:text-mf-text-secondary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ lineHeight: '1.5', padding: '8px 12px', boxSizing: 'border-box' }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey && chat?.isRunning) {
                 e.preventDefault();

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/ReadMoreBubble.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/ReadMoreBubble.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { cn } from '../../../../lib/utils.js';
+
+const CHAR_THRESHOLD = 600;
+
+interface ReadMoreBubbleProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Wraps user-message bubble content with a WhatsApp-style "Read more / Show less"
+ * toggle when the text exceeds CHAR_THRESHOLD characters. The bubble is clamped to
+ * 6 lines via Tailwind's line-clamp-6, with a fade-out gradient.
+ *
+ * Only the character-length heuristic is used here because jsdom has no layout
+ * engine to measure rendered line height. The component falls through to the
+ * untruncated path for short content.
+ */
+export function ReadMoreBubble({ children, className }: ReadMoreBubbleProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Derive text length from the children for the threshold check.
+  const textLength = extractTextLength(children);
+  const needsToggle = textLength > CHAR_THRESHOLD;
+
+  if (!needsToggle) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className={cn('relative', className)}>
+      {/* Content area with optional line-clamp */}
+      <div data-clamp className={cn('aui-md text-mf-chat text-mf-text-primary', !expanded && 'line-clamp-6')}>
+        {children}
+      </div>
+
+      {/* Fade-out gradient when collapsed */}
+      {!expanded && (
+        <div className="pointer-events-none absolute bottom-6 left-0 right-0 h-8 bg-gradient-to-b from-transparent to-mf-hover" />
+      )}
+
+      {/* Toggle button */}
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="mt-1 text-mf-accent text-mf-small font-medium hover:underline"
+        aria-label={expanded ? 'Show less' : 'Read more'}
+      >
+        {expanded ? 'Show less' : 'Read more'}
+      </button>
+    </div>
+  );
+}
+
+function extractTextLength(node: React.ReactNode): number {
+  if (typeof node === 'string') return node.length;
+  if (typeof node === 'number') return String(node).length;
+  if (Array.isArray(node)) return node.reduce<number>((acc, child) => acc + extractTextLength(child), 0);
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: React.ReactNode };
+    return extractTextLength(props.children);
+  }
+  return 0;
+}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/ReadMoreBubble.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/ReadMoreBubble.tsx
@@ -20,35 +20,33 @@ interface ReadMoreBubbleProps {
 export function ReadMoreBubble({ children, className }: ReadMoreBubbleProps) {
   const [expanded, setExpanded] = useState(false);
 
-  // Derive text length from the children for the threshold check.
   const textLength = extractTextLength(children);
   const needsToggle = textLength > CHAR_THRESHOLD;
-
-  if (!needsToggle) {
-    return <>{children}</>;
-  }
+  const collapsed = needsToggle && !expanded;
 
   return (
     <div className={cn('relative', className)}>
-      {/* Content area with optional line-clamp */}
-      <div data-clamp className={cn('aui-md text-mf-chat text-mf-text-primary', !expanded && 'line-clamp-6')}>
+      <div
+        data-clamp={needsToggle ? '' : undefined}
+        className={cn('aui-md text-mf-chat text-mf-text-primary', collapsed && 'line-clamp-6')}
+      >
         {children}
       </div>
 
-      {/* Fade-out gradient when collapsed */}
-      {!expanded && (
+      {collapsed && (
         <div className="pointer-events-none absolute bottom-6 left-0 right-0 h-8 bg-gradient-to-b from-transparent to-mf-hover" />
       )}
 
-      {/* Toggle button */}
-      <button
-        type="button"
-        onClick={() => setExpanded((e) => !e)}
-        className="mt-1 text-mf-accent text-mf-small font-medium hover:underline"
-        aria-label={expanded ? 'Show less' : 'Read more'}
-      >
-        {expanded ? 'Show less' : 'Read more'}
-      </button>
+      {needsToggle && (
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="mt-1 text-mf-accent text-mf-small font-medium hover:underline"
+          aria-label={expanded ? 'Show less' : 'Read more'}
+        >
+          {expanded ? 'Show less' : 'Read more'}
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -12,6 +12,7 @@ import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 import { urlTransform, remarkAppLinks } from '../../../../lib/markdown-url-transform';
 import { PLAN_PREFIX, highlightMentions, resolveSkillName, parseRawCommand } from '../message-parsing';
 import { ImageThumbs, FileAttachmentThumbs } from './ImageThumbs';
+import { ReadMoreBubble } from './ReadMoreBubble.js';
 
 // remarkBreaks converts single newlines into <br> elements so user-typed line breaks
 // are preserved in rendered output (CommonMark collapses them to spaces by default).
@@ -129,11 +130,11 @@ export function UserMessage() {
       {queuedBadge}
       {hasTextContent && (
         <div className="max-w-[75%] bg-mf-hover rounded-[12px_12px_4px_12px] px-4 py-2.5">
-          <div className="aui-md text-mf-chat text-mf-text-primary">
+          <ReadMoreBubble>
             <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={urlTransform} components={userComponents}>
               {cleanText}
             </Markdown>
-          </div>
+          </ReadMoreBubble>
         </div>
       )}
       <FileAttachmentThumbs attachments={mergedFileAttachments} />

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -111,11 +111,11 @@ export function UserMessage() {
           data-testid={parsed.isCommand ? 'user-command-bubble' : 'user-skill-bubble'}
           className="max-w-[75%] bg-mf-hover rounded-[12px_12px_4px_12px] px-4 py-2.5"
         >
-          <div className="aui-md text-mf-chat text-mf-text-primary">
+          <ReadMoreBubble>
             <Icon size={14} className="text-mf-accent inline-block align-[-2px] mr-0.5" />
             <span className="font-mono text-mf-chat text-mf-accent mr-1.5">/{parsed.commandName}</span>
             {parsed.userText}
-          </div>
+          </ReadMoreBubble>
         </div>
         <FileAttachmentThumbs attachments={mergedFileAttachments} />
         <ImageThumbs imageBlocks={imageBlocks} openLightbox={openLightbox} />

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -382,47 +382,53 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             onToggleCollapse();
           }
         }}
-        className="group w-full flex items-center gap-2 px-2 py-1.5 rounded-mf-input text-mf-label hover:bg-mf-hover/50 transition-colors cursor-pointer"
+        className="group flex items-center h-7 px-2 gap-2 min-w-0 w-full rounded-mf-input text-mf-label hover:bg-mf-hover/50 transition-colors cursor-pointer"
       >
-        {collapsed ? <ChevronRight size={12} className="shrink-0" /> : <ChevronDown size={12} className="shrink-0" />}
-        <div className="flex-1 min-w-0 text-left">
-          <span className="text-mf-text-primary truncate block text-mf-small font-medium">{project.name}</span>
+        {/* Left cluster: chevron + name */}
+        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+          <span className="inline-flex w-4 items-center justify-center shrink-0">
+            {collapsed ? <ChevronRight size={16} /> : <ChevronDown size={16} />}
+          </span>
+          <span className="truncate text-sm text-mf-text-primary font-medium">{project.name}</span>
           {parentName && (
-            <span className="text-mf-status text-mf-text-secondary truncate block">
-              {'↳ branch of '}
+            <span className="text-mf-status text-mf-text-secondary truncate ml-1">
+              {'↳ '}
               {parentName}
             </span>
           )}
         </div>
-        <span className="text-mf-status bg-mf-hover text-mf-text-secondary px-1.5 py-0.5 rounded-full shrink-0">
-          {chats.length}
-        </span>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleNewSession}
-              className="w-6 h-6 rounded-mf-input flex items-center justify-center text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors shrink-0"
-              aria-label={`New session in ${project.name}`}
-            >
-              <Plus size={12} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>New Session</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleDeleteProject}
-              className="w-6 h-6 rounded-mf-input flex items-center justify-center text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
-              aria-label={`Delete project ${project.name}`}
-            >
-              <Trash2 size={12} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Delete Project</TooltipContent>
-        </Tooltip>
+        {/* Right cluster: count badge + action buttons — fixed width so left never reflows */}
+        <div className="flex items-center gap-1 shrink-0 w-14 justify-end">
+          <span className="h-5 px-1.5 text-[10px] tabular-nums rounded-full bg-mf-hover text-mf-text-secondary flex items-center">
+            {chats.length}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleNewSession}
+                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                aria-label={`New session in ${project.name}`}
+              >
+                <Plus size={12} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{`New session in ${project.name}`}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleDeleteProject}
+                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                aria-label={`Delete project ${project.name}`}
+              >
+                <Trash2 size={12} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Delete Project</TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       {/* Chat list */}

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -397,17 +397,16 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             </span>
           )}
         </div>
-        {/* Right cluster: count badge + action buttons — fixed width so left never reflows */}
-        <div className="flex items-center gap-1 shrink-0 w-14 justify-end">
-          <span className="h-5 px-1.5 text-[10px] tabular-nums rounded-full bg-mf-hover text-mf-text-secondary flex items-center">
-            {chats.length}
-          </span>
+        <span className="h-5 px-1.5 text-[10px] tabular-nums rounded-full bg-mf-hover text-mf-text-secondary flex items-center shrink-0">
+          {chats.length}
+        </span>
+        <div className="shrink-0 hidden group-hover:flex items-center gap-0.5">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 type="button"
                 onClick={handleNewSession}
-                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
                 aria-label={`New session in ${project.name}`}
               >
                 <Plus size={12} />
@@ -420,7 +419,7 @@ export const ProjectGroup = React.memo(function ProjectGroup({
               <button
                 type="button"
                 onClick={handleDeleteProject}
-                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                className="h-7 w-6 inline-flex items-center justify-center rounded-mf-input text-mf-text-secondary hover:text-mf-destructive hover:bg-mf-hover transition-colors"
                 aria-label={`Delete project ${project.name}`}
               >
                 <Trash2 size={12} />


### PR DESCRIPTION
## Summary
Four small desktop UX fixes:

- **#136** — Transient auto-updater errors (network loss, DNS, 5xx, rate limits) are now classified and logged at warn instead of surfacing as a persistent error banner. New `auto-updater-error-classifier.ts` covers ENOTFOUND/ETIMEDOUT/ECONNRESET/ECONNREFUSED + 5xx/429/`net::ERR_*`/GitHub-403; signature/disk/parse errors still surface.
- **#138** — Sessions sidebar project group header: count badge now sits flush at row end, action buttons (`+`, trash) appear only on real mouse hover (no reserved trailing space, no focus-sticky reveal). Mirrors the existing session-row pattern.
- **#139** — User-message bubbles longer than 600 chars are clamped to 6 lines via `line-clamp-6` with a fade gradient and an inline "Read more / Show less" toggle. Applies to both plain-text and slash-command bubble paths.
- **#140** — Composer card capped at 14 lines via explicit `308px` (= 14 × 22), `overflow-hidden` on the outer card to remove the double scrollbar, and explicit `lineHeight: 22px` (matching `--text-mf-chat--line-height`) on both the textarea and scroll wrapper to remove a 0.5px-per-line drift between the textarea caret and the highlight overlay.

A companion mobile PR mirrors the #139 affordance for React Native: qlan-ro/mainframe-mobile#10. Submodule pointer will bump after that merges.

## Test plan
- [ ] **#136** — `pnpm --filter @qlan-ro/mainframe-desktop test src/__tests__/lib/auto-updater-error-classifier.test.ts` passes 15/15.
- [ ] **#138** — Hover a project group row: only then do `+` and trash appear; click the row, move cursor away — buttons hide immediately. Badge stays flush at row end in both states.
- [ ] **#139 (plain)** — Send a plain user message > 600 chars: bubble clamps to 6 lines + fade + Read more. Toggle works both ways.
- [ ] **#139 (slash)** — Send `/<skill> <long body>` > 600 chars: same affordance, slash command icon and name still rendered.
- [ ] **#140** — Type / paste 30+ lines into the composer: card grows up to 14 lines then a single inner scrollbar appears (no second scrollbar on the outer card). Caret stays aligned with the highlighted text on every line.
- [ ] **Regression** — Existing slash-command, plan, queued-badge, image and file-attachment user-message rendering still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)