### PR TITLE
fix(desktop): make Find-in-Chat actually work

### DIFF
--- a/.changeset/chat-and-tasks.md
+++ b/.changeset/chat-and-tasks.md
@@ -1,0 +1,11 @@
+---
+"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-desktop": minor
+---
+
+feat: chat rendering + adapter event pipeline improvements (#133 #141 #142 #144)
+
+- **#133** Add canonical `normalizeTodos` utility (`todos/normalize.ts`) supporting `todoV1` (TodoWrite), `taskV2` (TaskCreate/TaskUpdate/TaskStop), and `codexTodoList` sources. Wire V2 task events into Claude adapter's `onTodoUpdate` so `chat.todos` reflects V2 task progress. Add 17 tests covering all sources and edge cases.
+- **#141** Fix thinking indicator disappearing prematurely: Claude CLI emits `result` events for subagent (Task/Agent) turns carrying `parent_tool_use_id`; these were being routed to `onResult()` which flipped `processState` to `'idle'` while the parent session was still working. Subagent result events are now dropped at the event handler level. Add 3 regression tests.
+- **#142** Add Find-in-Chat: `Cmd+F` / `Ctrl+F` while the chat thread is focused slides down a find bar with live-filter (80ms debounce), match counter, prev/next navigation, and `Esc` to close. Implemented via `FindBar.tsx` and `find-in-chat` zustand store.
+- **#144** Fix Codex `todoList` items silently dropped: `TodoListItem` was defined in types but missing from both the `ThreadItem` union and the `item/completed` switch. Added the union member and a `todoList` case that normalizes items via `onTodoUpdate`. Add 3 tests.

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -542,3 +542,61 @@ describe('handleStderr', () => {
     expect(sink.onError).not.toHaveBeenCalled();
   });
 });
+
+describe('handleStdout — subagent result isolation (#141)', () => {
+  it('does not call onResult for a result event with parent_tool_use_id (subagent turn)', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const subagentResult = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      total_cost_usd: 0.001,
+      parent_tool_use_id: 'toolu_task_1',
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    handleStdout(session, Buffer.from(subagentResult + '\n'), sink);
+
+    expect(sink.onResult).not.toHaveBeenCalled();
+  });
+
+  it('calls onResult for a top-level result event without parent_tool_use_id', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    const topLevelResult = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      total_cost_usd: 0.002,
+      usage: { input_tokens: 200, output_tokens: 80 },
+    });
+    handleStdout(session, Buffer.from(topLevelResult + '\n'), sink);
+
+    expect(sink.onResult).toHaveBeenCalledOnce();
+  });
+
+  it('parent processState stays working when subagent result arrives before parent result', () => {
+    const session = createSession();
+    const sink = createSink();
+
+    // Subagent result arrives first
+    const subagentResult = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      total_cost_usd: 0.001,
+      parent_tool_use_id: 'toolu_task_1',
+    });
+    handleStdout(session, Buffer.from(subagentResult + '\n'), sink);
+    expect(sink.onResult).not.toHaveBeenCalled();
+
+    // Then parent result arrives
+    const parentResult = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      total_cost_usd: 0.01,
+      usage: { input_tokens: 500, output_tokens: 200 },
+    });
+    handleStdout(session, Buffer.from(parentResult + '\n'), sink);
+    expect(sink.onResult).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -603,4 +603,71 @@ describe('handleNotification', () => {
     handleNotification('thread/compacted', {}, sink, state);
     expect(sink.onCompact).toHaveBeenCalled();
   });
+
+  it('item/completed todoList calls onTodoUpdate with normalized TodoItems', () => {
+    const sink = createSink();
+    const state = createState();
+    handleNotification(
+      'item/completed',
+      {
+        threadId: 't1',
+        turnId: 'turn_1',
+        item: {
+          id: 'todo_1',
+          type: 'todoList',
+          items: [
+            { text: 'Write tests', completed: false },
+            { text: 'Fix bug', completed: true },
+            { text: 'Ship it', completed: false },
+          ],
+        },
+      },
+      sink,
+      state,
+    );
+    expect(sink.onTodoUpdate).toHaveBeenCalledWith([
+      { content: 'Write tests', status: 'pending', activeForm: 'Write tests' },
+      { content: 'Fix bug', status: 'completed', activeForm: 'Fix bug' },
+      { content: 'Ship it', status: 'pending', activeForm: 'Ship it' },
+    ]);
+    expect(sink.onMessage).not.toHaveBeenCalled();
+  });
+
+  it('item/completed todoList with empty items does not call onTodoUpdate', () => {
+    const sink = createSink();
+    const state = createState();
+    handleNotification(
+      'item/completed',
+      {
+        threadId: 't1',
+        turnId: 'turn_1',
+        item: { id: 'todo_2', type: 'todoList', items: [] },
+      },
+      sink,
+      state,
+    );
+    expect(sink.onTodoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('item/completed todoList all completed maps all to completed status', () => {
+    const sink = createSink();
+    const state = createState();
+    handleNotification(
+      'item/completed',
+      {
+        threadId: 't1',
+        turnId: 'turn_1',
+        item: {
+          id: 'todo_3',
+          type: 'todoList',
+          items: [{ text: 'Done task', completed: true }],
+        },
+      },
+      sink,
+      state,
+    );
+    expect(sink.onTodoUpdate).toHaveBeenCalledWith([
+      { content: 'Done task', status: 'completed', activeForm: 'Done task' },
+    ]);
+  });
 });

--- a/packages/core/src/__tests__/todos-normalize.test.ts
+++ b/packages/core/src/__tests__/todos-normalize.test.ts
@@ -1,0 +1,170 @@
+// packages/core/src/__tests__/todos-normalize.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeTodos } from '../todos/normalize.js';
+
+describe('normalizeTodos — todoV1', () => {
+  it('returns valid TodoItems as-is', () => {
+    const input = [
+      { content: 'Write tests', status: 'pending', activeForm: 'Write tests' },
+      { content: 'Fix bug', status: 'in_progress', activeForm: 'Fixing the bug' },
+      { content: 'Ship it', status: 'completed', activeForm: 'Ship it' },
+    ];
+    expect(normalizeTodos('todoV1', input)).toEqual(input);
+  });
+
+  it('filters out items missing content or status', () => {
+    const input = [
+      { content: 'Valid', status: 'pending', activeForm: 'Valid' },
+      { status: 'pending' }, // missing content
+      { content: 'Also valid', status: 'completed', activeForm: '' },
+    ];
+    const result = normalizeTodos('todoV1', input);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.content).toBe('Valid');
+    expect(result[1]!.content).toBe('Also valid');
+  });
+
+  it('returns empty array for non-array payload', () => {
+    expect(normalizeTodos('todoV1', null)).toEqual([]);
+    expect(normalizeTodos('todoV1', 'string')).toEqual([]);
+    expect(normalizeTodos('todoV1', {})).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(normalizeTodos('todoV1', [])).toEqual([]);
+  });
+});
+
+describe('normalizeTodos — taskV2', () => {
+  it('maps TaskCreate events to pending todos', () => {
+    const events = [
+      {
+        toolName: 'TaskCreate' as const,
+        args: { subject: 'Write tests', activeForm: 'Writing tests' },
+        result: 'Task #1 created',
+      },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ content: 'Write tests', status: 'pending', activeForm: 'Writing tests' });
+  });
+
+  it('TaskUpdate changes status of existing task', () => {
+    const events = [
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task A' }, result: 'Task #1 created' },
+      { toolName: 'TaskUpdate' as const, args: { taskId: '1', status: 'in_progress' } },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.status).toBe('in_progress');
+  });
+
+  it('TaskUpdate marks task as completed', () => {
+    const events = [
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task A' }, result: 'Task #1 created' },
+      { toolName: 'TaskUpdate' as const, args: { taskId: '1', status: 'completed' } },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result[0]!.status).toBe('completed');
+  });
+
+  it('TaskStop removes task from list', () => {
+    const events = [
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task A' }, result: 'Task #1 created' },
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task B' }, result: 'Task #2 created' },
+      { toolName: 'TaskStop' as const, args: { taskId: '1' } },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content).toBe('Task B');
+  });
+
+  it('handles multiple TaskCreate events', () => {
+    const events = [
+      { toolName: 'TaskCreate' as const, args: { subject: 'Alpha' }, result: 'Task #1 created' },
+      { toolName: 'TaskCreate' as const, args: { subject: 'Beta' }, result: 'Task #2 created' },
+      { toolName: 'TaskCreate' as const, args: { subject: 'Gamma' }, result: 'Task #3 created' },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.content)).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+
+  it('returns empty array for empty event list', () => {
+    expect(normalizeTodos('taskV2', [])).toEqual([]);
+  });
+
+  it('returns empty array for non-array payload', () => {
+    expect(normalizeTodos('taskV2', null)).toEqual([]);
+  });
+
+  it('mid-task update preserves other tasks', () => {
+    const events = [
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task 1' }, result: 'Task #1 created' },
+      { toolName: 'TaskCreate' as const, args: { subject: 'Task 2' }, result: 'Task #2 created' },
+      { toolName: 'TaskUpdate' as const, args: { taskId: '1', status: 'in_progress' } },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.status).toBe('in_progress');
+    expect(result[1]!.status).toBe('pending');
+  });
+
+  it('TaskUpdate for unknown taskId creates a new entry', () => {
+    const events = [
+      { toolName: 'TaskUpdate' as const, args: { taskId: '99', status: 'in_progress', subject: 'Mystery Task' } },
+    ];
+    const result = normalizeTodos('taskV2', events);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.content).toBe('Mystery Task');
+    expect(result[0]!.status).toBe('in_progress');
+  });
+});
+
+describe('normalizeTodos — codexTodoList', () => {
+  it('maps items correctly to pending/completed', () => {
+    const items = [
+      { text: 'Write tests', completed: false },
+      { text: 'Fix bug', completed: true },
+    ];
+    const result = normalizeTodos('codexTodoList', items);
+    expect(result).toEqual([
+      { content: 'Write tests', status: 'pending', activeForm: 'Write tests' },
+      { content: 'Fix bug', status: 'completed', activeForm: 'Fix bug' },
+    ]);
+  });
+
+  it('returns empty array for empty items', () => {
+    expect(normalizeTodos('codexTodoList', [])).toEqual([]);
+  });
+
+  it('returns empty array for non-array payload', () => {
+    expect(normalizeTodos('codexTodoList', null)).toEqual([]);
+    expect(normalizeTodos('codexTodoList', {})).toEqual([]);
+  });
+
+  it('filters out items without text field', () => {
+    const items = [
+      { text: 'Valid', completed: false },
+      { completed: true }, // missing text
+      { text: 'Also valid', completed: false },
+    ];
+    const result = normalizeTodos('codexTodoList', items);
+    expect(result).toHaveLength(2);
+  });
+
+  it('all completed maps to all completed status', () => {
+    const items = [
+      { text: 'Done 1', completed: true },
+      { text: 'Done 2', completed: true },
+    ];
+    const result = normalizeTodos('codexTodoList', items);
+    expect(result.every((t) => t.status === 'completed')).toBe(true);
+  });
+
+  it('activeForm matches content', () => {
+    const items = [{ text: 'My task', completed: false }];
+    const result = normalizeTodos('codexTodoList', items);
+    expect(result[0]!.activeForm).toBe('My task');
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -12,6 +12,7 @@ import type {
 import type { ClaudeSession } from './session.js';
 import { buildToolResultBlocks } from './history.js';
 import { createChildLogger } from '../../../logger.js';
+import { normalizeTodos } from '../../../todos/normalize.js';
 
 const log = createChildLogger('claude:events');
 
@@ -214,6 +215,10 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
           if (valid.length > 0) sink.onTodoUpdate(valid);
         }
       }
+      const taskV2Name = block.name as string;
+      if (taskV2Name === 'TaskCreate' || taskV2Name === 'TaskUpdate' || taskV2Name === 'TaskStop') {
+        handleTaskV2Event(session, taskV2Name as 'TaskCreate' | 'TaskUpdate' | 'TaskStop', block.input, sink);
+      }
       const name = block.name as string;
       if (name === 'Bash' || name === 'BashTool') {
         const input = block.input as { command?: string } | undefined;
@@ -243,6 +248,21 @@ function handleAssistantEvent(session: ClaudeSession, event: Record<string, unkn
     model: message.model,
     usage: message.usage,
   });
+}
+
+/**
+ * Handle a V2 task event (TaskCreate/TaskUpdate/TaskStop), accumulating state
+ * on the session and emitting onTodoUpdate with the current snapshot.
+ */
+function handleTaskV2Event(
+  session: ClaudeSession,
+  toolName: 'TaskCreate' | 'TaskUpdate' | 'TaskStop',
+  input: Record<string, unknown>,
+  sink: SessionSink,
+): void {
+  session.state.taskV2Events.push({ toolName, args: input });
+  const todos = normalizeTodos('taskV2', session.state.taskV2Events);
+  if (todos.length > 0) sink.onTodoUpdate(todos);
 }
 
 /**
@@ -588,6 +608,18 @@ function handleEvent(session: ClaudeSession, event: Record<string, unknown>, sin
     case 'control_response':
       return handleControlResponseEvent(session, event, sink);
     case 'result':
+      // Subagent result events carry `parent_tool_use_id` and represent an
+      // inner Task/Agent sub-turn completing, NOT the top-level chat turn.
+      // Forwarding them to onResult() would flip processState to 'idle' while
+      // the parent session is still running. Drop them here; their completion
+      // is already surfaced via the tool_result block in the parent's user event.
+      if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+        log.debug(
+          { sessionId: session.id, parentToolUseId: event.parent_tool_use_id },
+          'claude: skipping subagent result event (parent_tool_use_id present)',
+        );
+        return;
+      }
       return handleResultEvent(session, event, sink);
   }
 }

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -71,6 +71,8 @@ export interface ClaudeSessionState {
   // Cached skill-name → resolved SKILL.md path, populated lazily on SkillTool
   // detection to avoid re-probing the filesystem for the same skill.
   skillPathCache: Map<string, string>;
+  /** Accumulated V2 task events (TaskCreate/TaskUpdate/TaskStop) for progressive todo updates. */
+  taskV2Events: import('../../../todos/normalize.js').TaskV2Event[];
 }
 
 /**
@@ -115,6 +117,7 @@ export class ClaudeSession implements AdapterSession {
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       skillPathCache: new Map(),
+      taskV2Events: [],
     };
   }
 

--- a/packages/core/src/plugins/builtin/codex/event-mapper.ts
+++ b/packages/core/src/plugins/builtin/codex/event-mapper.ts
@@ -9,6 +9,7 @@ import type {
   ThreadStartedParams,
   TokenUsageUpdatedParams,
   PatchChangeKind,
+  TodoListItem,
 } from './types.js';
 import { parseUnifiedDiff } from '../../../messages/parse-unified-diff.js';
 import { createChildLogger } from '../../../logger.js';
@@ -211,9 +212,23 @@ function handleItemCompleted(params: ItemCompletedParams, sink: SessionSink, sta
       return;
     }
 
+    case 'todoList': {
+      const todos = normalizeTodoListItems(item);
+      if (todos.length > 0) sink.onTodoUpdate(todos);
+      return;
+    }
+
     default:
       log.debug({ type: (item as { type: string }).type }, 'codex: unhandled item type');
   }
+}
+
+function normalizeTodoListItems(item: TodoListItem): import('@qlan-ro/mainframe-types').TodoItem[] {
+  return item.items.map((t) => ({
+    content: t.text,
+    status: t.completed ? ('completed' as const) : ('pending' as const),
+    activeForm: t.text,
+  }));
 }
 
 function handleTurnCompleted(params: TurnCompletedParams, sink: SessionSink, state: CodexSessionState): void {

--- a/packages/core/src/plugins/builtin/codex/types.ts
+++ b/packages/core/src/plugins/builtin/codex/types.ts
@@ -151,6 +151,7 @@ export type ThreadItem =
   | McpToolCallItem
   | WebSearchItem
   | ImageGenerationItem
+  | TodoListItem
   | UserMessageItem;
 
 export interface AgentMessageItem {

--- a/packages/core/src/todos/normalize.ts
+++ b/packages/core/src/todos/normalize.ts
@@ -1,0 +1,117 @@
+// packages/core/src/todos/normalize.ts
+import type { TodoItem } from '@qlan-ro/mainframe-types';
+
+/** The three sources that can produce a TodoItem list. */
+export type TodoSource = 'todoV1' | 'taskV2' | 'codexTodoList';
+
+/**
+ * A single V2 task event (TaskCreate, TaskUpdate, TaskStop) used as input
+ * to the taskV2 normalizer. Shape mirrors TaskProgressItem from tool-grouping.
+ */
+export interface TaskV2Event {
+  toolName: 'TaskCreate' | 'TaskUpdate' | 'TaskStop' | 'TaskList';
+  args: Record<string, unknown>;
+  result?: unknown;
+}
+
+/** Internal mutable task state used while accumulating V2 events. */
+interface TaskState {
+  id: string;
+  subject: string;
+  status: string;
+  activeForm: string;
+}
+
+/**
+ * Normalize raw payload from a given source into a canonical TodoItem[].
+ *
+ * - 'todoV1': payload is the TodoWrite.todos array (already TodoItem-shaped).
+ * - 'taskV2': payload is an ordered array of TaskV2Event from TaskCreate / TaskUpdate / TaskStop.
+ *   Accumulates progressive state into a snapshot of current tasks.
+ * - 'codexTodoList': payload is Codex TodoListItem.items ({ text, completed }[]).
+ */
+export function normalizeTodos(source: TodoSource, payload: unknown): TodoItem[] {
+  switch (source) {
+    case 'todoV1':
+      return normalizeTodoV1(payload);
+    case 'taskV2':
+      return normalizeTaskV2(payload);
+    case 'codexTodoList':
+      return normalizeCodexTodoList(payload);
+  }
+}
+
+function normalizeTodoV1(payload: unknown): TodoItem[] {
+  if (!Array.isArray(payload)) return [];
+  return payload.filter(
+    (t): t is TodoItem =>
+      typeof t === 'object' &&
+      t !== null &&
+      typeof (t as Record<string, unknown>).content === 'string' &&
+      typeof (t as Record<string, unknown>).status === 'string',
+  );
+}
+
+function normalizeTaskV2(payload: unknown): TodoItem[] {
+  if (!Array.isArray(payload)) return [];
+  const events = payload as TaskV2Event[];
+
+  const list: TaskState[] = [];
+  const map = new Map<string, TaskState>();
+
+  for (const event of events) {
+    if (event.toolName === 'TaskCreate') {
+      const resultStr = typeof event.result === 'string' ? event.result : '';
+      const match = resultStr.match(/Task #(\d+)/);
+      const id = match ? match[1]! : String(map.size + 1);
+      const subject = (event.args.subject as string) || `Task #${id}`;
+      const activeForm = (event.args.activeForm as string) || subject;
+      const task: TaskState = { id, subject, status: 'pending', activeForm };
+      map.set(id, task);
+      list.push(task);
+    } else if (event.toolName === 'TaskUpdate') {
+      const taskId = (event.args.taskId as string) || '';
+      const newStatus = (event.args.status as string) || '';
+      const existing = map.get(taskId);
+      if (existing) {
+        if (newStatus) existing.status = newStatus;
+        if (event.args.subject) existing.subject = event.args.subject as string;
+        if (event.args.activeForm) existing.activeForm = event.args.activeForm as string;
+      } else if (taskId) {
+        const subject = (event.args.subject as string) || `Task #${taskId}`;
+        const task: TaskState = { id: taskId, subject, status: newStatus || 'pending', activeForm: subject };
+        map.set(taskId, task);
+        list.push(task);
+      }
+    } else if (event.toolName === 'TaskStop') {
+      const taskId = (event.args.taskId as string) || '';
+      const existing = map.get(taskId);
+      if (existing) existing.status = 'deleted';
+    }
+  }
+
+  return list
+    .filter((t) => t.status !== 'deleted')
+    .map((t) => ({
+      content: t.subject,
+      status: taskStatusToTodoStatus(t.status),
+      activeForm: t.activeForm,
+    }));
+}
+
+function taskStatusToTodoStatus(status: string): TodoItem['status'] {
+  if (status === 'completed') return 'completed';
+  if (status === 'in_progress') return 'in_progress';
+  return 'pending';
+}
+
+function normalizeCodexTodoList(payload: unknown): TodoItem[] {
+  if (!Array.isArray(payload)) return [];
+  return (payload as Array<{ text: string; completed: boolean }>)
+    .filter((t) => typeof t.text === 'string')
+    .map((t) => ({
+      content: t.text,
+      status: t.completed ? ('completed' as const) : ('pending' as const),
+      activeForm: t.text,
+    }));
+}

--- a/packages/desktop/src/renderer/components/SearchPalette.tsx
+++ b/packages/desktop/src/renderer/components/SearchPalette.tsx
@@ -48,11 +48,10 @@ export function SearchPalette(): React.ReactElement | null {
     }
   }, [isOpen]);
 
-  // Global ⌘F / Ctrl+F and ⌘O / Ctrl+O
+  // Global ⌘O / Ctrl+O. ⌘F is reserved for the chat-local Find bar.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const key = e.key.toLowerCase();
-      if ((e.metaKey || e.ctrlKey) && (key === 'f' || key === 'o')) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'o') {
         e.preventDefault();
         if (isOpen) {
           close();

--- a/packages/desktop/src/renderer/components/TitleBar.tsx
+++ b/packages/desktop/src/renderer/components/TitleBar.tsx
@@ -86,7 +86,7 @@ export function TitleBar(): React.ReactElement {
           className="w-[480px] max-w-[90%] flex items-center gap-2 px-3 py-[5px] rounded-mf-card border border-mf-border text-mf-text-secondary text-mf-body app-no-drag cursor-pointer hover:border-mf-text-secondary transition-colors pointer-events-auto"
         >
           <Search size={14} />
-          <span>Search ⌘F</span>
+          <span>Search ⌘O</span>
         </div>
       </div>
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/FindBar.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/FindBar.tsx
@@ -40,6 +40,40 @@ function searchMessages(query: string, chatId: string | null): import('../../../
   return matches;
 }
 
+/**
+ * Convert flat character offsets within an element's textContent into a Range
+ * spanning the underlying text nodes (which may be split across nested HTML
+ * from rendered markdown).
+ */
+function rangeFromOffsets(root: Element, start: number, end: number): Range | null {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let pos = 0;
+  let startNode: Text | null = null;
+  let startOffset = 0;
+  let endNode: Text | null = null;
+  let endOffset = 0;
+  let node = walker.nextNode() as Text | null;
+  while (node) {
+    const len = node.data.length;
+    if (!startNode && pos + len > start) {
+      startNode = node;
+      startOffset = start - pos;
+    }
+    if (startNode && pos + len >= end) {
+      endNode = node;
+      endOffset = end - pos;
+      break;
+    }
+    pos += len;
+    node = walker.nextNode() as Text | null;
+  }
+  if (!startNode || !endNode) return null;
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  return range;
+}
+
 export function FindBar(): React.ReactElement | null {
   const { isOpen, query, matches, activeIndex, close, setQuery, setMatches, next, prev } = useFindInChatStore();
   const activeChatId = useChatsStore((s) => s.activeChatId);
@@ -66,17 +100,56 @@ export function FindBar(): React.ReactElement | null {
     };
   }, [query, isOpen, activeChatId, setMatches]);
 
-  // Scroll active match into view
+  // Paint highlights via CSS Custom Highlight API and scroll active match into view
   useEffect(() => {
-    if (!isOpen || matches.length === 0) return;
-    const match = matches[activeIndex];
-    if (!match) return;
+    if (typeof CSS === 'undefined' || !('highlights' in CSS)) return;
+    const matchReg = CSS.highlights;
+
+    if (!isOpen || matches.length === 0) {
+      matchReg.delete('mf-find-match');
+      matchReg.delete('mf-find-active');
+      return;
+    }
+
     const threadEl = document.querySelector('[data-mf-chat-thread]');
     if (!threadEl) return;
-    const msgEl = threadEl.querySelector(`[data-message-id="${match.messageId}"]`);
-    if (msgEl) {
-      msgEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+    const allRanges: Range[] = [];
+    let activeRange: Range | null = null;
+
+    const partCache = new Map<string, NodeListOf<Element>>();
+    matches.forEach((m, i) => {
+      let textEls = partCache.get(m.messageId);
+      if (!textEls) {
+        const msgEl = threadEl.querySelector(`[data-message-id="${m.messageId}"]`);
+        if (!msgEl) return;
+        textEls = msgEl.querySelectorAll('[data-text-part]');
+        partCache.set(m.messageId, textEls);
+      }
+      const partEl = textEls[m.partIndex];
+      if (!partEl) return;
+      const range = rangeFromOffsets(partEl, m.charStart, m.charEnd);
+      if (!range) return;
+      if (i === activeIndex) activeRange = range;
+      else allRanges.push(range);
+    });
+
+    matchReg.set('mf-find-match', new Highlight(...allRanges));
+    matchReg.set('mf-find-active', activeRange ? new Highlight(activeRange) : new Highlight());
+
+    if (activeRange) {
+      const rect = (activeRange as Range).getBoundingClientRect();
+      const viewport = threadEl.parentElement;
+      if (viewport && (rect.top < 0 || rect.bottom > viewport.clientHeight)) {
+        const scroller = viewport.scrollTop + rect.top - viewport.clientHeight / 2;
+        viewport.scrollTo({ top: scroller, behavior: 'smooth' });
+      }
     }
+
+    return () => {
+      matchReg.delete('mf-find-match');
+      matchReg.delete('mf-find-active');
+    };
   }, [activeIndex, matches, isOpen]);
 
   const handleKeyDown = useCallback(

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/FindBar.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/FindBar.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import { X, ChevronUp, ChevronDown } from 'lucide-react';
+import { useFindInChatStore } from '../../../store/find-in-chat';
+import { useChatsStore } from '../../../store/chats';
+
+/**
+ * Search the visible chat messages for text query matches.
+ * Returns an ordered list of { messageId, partIndex, charStart, charEnd }.
+ *
+ * v1 scope: user message text and assistant text parts only.
+ */
+function searchMessages(query: string, chatId: string | null): import('../../../store/find-in-chat').FindMatch[] {
+  if (!query || !chatId) return [];
+
+  const lower = query.toLowerCase();
+  const matches: import('../../../store/find-in-chat').FindMatch[] = [];
+
+  // Walk through all rendered text nodes inside [data-mf-chat-thread]
+  const threadEl = document.querySelector('[data-mf-chat-thread]');
+  if (!threadEl) return [];
+
+  // Find all text-bearing elements with a message id
+  const messageEls = threadEl.querySelectorAll('[data-message-id]');
+  messageEls.forEach((msgEl) => {
+    const messageId = msgEl.getAttribute('data-message-id') ?? '';
+    const textEls = msgEl.querySelectorAll('[data-text-part]');
+    textEls.forEach((textEl, partIndex) => {
+      const text = textEl.textContent ?? '';
+      const textLower = text.toLowerCase();
+      let idx = 0;
+      while (idx < textLower.length) {
+        const found = textLower.indexOf(lower, idx);
+        if (found === -1) break;
+        matches.push({ messageId, partIndex, charStart: found, charEnd: found + query.length });
+        idx = found + 1;
+      }
+    });
+  });
+
+  return matches;
+}
+
+export function FindBar(): React.ReactElement | null {
+  const { isOpen, query, matches, activeIndex, close, setQuery, setMatches, next, prev } = useFindInChatStore();
+  const activeChatId = useChatsStore((s) => s.activeChatId);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Focus input when bar opens
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Debounced search on query change
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!isOpen) return;
+    debounceRef.current = setTimeout(() => {
+      const found = searchMessages(query, activeChatId);
+      setMatches(found);
+    }, 80);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, isOpen, activeChatId, setMatches]);
+
+  // Scroll active match into view
+  useEffect(() => {
+    if (!isOpen || matches.length === 0) return;
+    const match = matches[activeIndex];
+    if (!match) return;
+    const threadEl = document.querySelector('[data-mf-chat-thread]');
+    if (!threadEl) return;
+    const msgEl = threadEl.querySelector(`[data-message-id="${match.messageId}"]`);
+    if (msgEl) {
+      msgEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [activeIndex, matches, isOpen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          prev();
+        } else {
+          next();
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        next();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        prev();
+      }
+    },
+    [next, prev, close],
+  );
+
+  if (!isOpen) return null;
+
+  const count = matches.length;
+  const current = count > 0 ? activeIndex + 1 : 0;
+
+  return (
+    <div
+      data-testid="find-bar"
+      className="flex items-center gap-2 px-3 py-1.5 bg-mf-sidebar border-b border-mf-border text-mf-small"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in chat…"
+        className="flex-1 bg-mf-input-bg border border-mf-border rounded px-2 py-1 text-mf-text-primary placeholder:text-mf-text-secondary/50 focus:outline-none focus:border-mf-accent text-mf-body"
+        aria-label="Find in chat"
+      />
+      <span className="text-mf-text-secondary min-w-[3rem] text-center shrink-0">
+        {query ? `${current}/${count}` : ''}
+      </span>
+      <button
+        onClick={prev}
+        disabled={count === 0}
+        className="p-1 rounded hover:bg-mf-hover text-mf-text-secondary disabled:opacity-30"
+        aria-label="Previous match"
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        onClick={next}
+        disabled={count === 0}
+        className="p-1 rounded hover:bg-mf-hover text-mf-text-secondary disabled:opacity-30"
+        aria-label="Next match"
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button
+        onClick={close}
+        className="p-1 rounded hover:bg-mf-hover text-mf-text-secondary"
+        aria-label="Close find bar"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useCallback } from 'react';
 import { ThreadPrimitive, useThread } from '@assistant-ui/react';
 import { Loader2 } from 'lucide-react';
 import { useMainframeRuntime } from './MainframeRuntimeProvider';
@@ -7,6 +7,8 @@ import { ImageLightbox } from '../ImageLightbox';
 import { UserMessage, AssistantMessage, SystemMessage } from './messages';
 import { ComposerCard } from './composer';
 import { QuoteOnSelectionButton } from './QuoteOnSelectionButton';
+import { FindBar } from './FindBar';
+import { useFindInChatStore } from '../../../store';
 
 const PermissionCard = React.lazy(() => import('../PermissionCard').then((m) => ({ default: m.PermissionCard })));
 const AskUserQuestionCard = React.lazy(() =>
@@ -77,40 +79,66 @@ export function MainframeThread() {
   const { lightbox, closeLightbox, navigateLightbox } = useMainframeRuntime();
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const isLoading = useChatsStore((s) => (activeChatId ? s.loadingChats.has(activeChatId) : false));
+  const openFindBar = useFindInChatStore((s) => s.open);
+  const closeFindBar = useFindInChatStore((s) => s.close);
+  const findBarOpen = useFindInChatStore((s) => s.isOpen);
+
+  // Intercept Cmd/Ctrl+F while the chat thread is focused — open find bar
+  // instead of the global search palette.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (findBarOpen) {
+          closeFindBar();
+        } else {
+          openFindBar();
+        }
+      }
+    },
+    [findBarOpen, openFindBar, closeFindBar],
+  );
 
   return (
-    <ThreadPrimitive.Root className="h-full flex flex-col">
-      <ThreadPrimitive.Viewport autoScroll className="flex-1 overflow-y-auto scrollbar-on-hover">
-        {isLoading ? (
-          <LoadingState />
-        ) : (
-          <>
-            <EmptyState />
-            <div data-mf-chat-thread className="px-6 py-6 space-y-5">
-              <ThreadPrimitive.Messages
-                components={{
-                  UserMessage,
-                  AssistantMessage,
-                  SystemMessage,
-                }}
-              />
-              <GeneratingIndicator />
-            </div>
-          </>
+    // Outer wrapper captures Cmd/Ctrl+F and routes it to the chat-local
+    // find bar, preventing the global search palette from opening when the
+    // user is focused on the chat thread.
+    <div className="h-full flex flex-col" onKeyDown={handleKeyDown}>
+      <FindBar />
+      <ThreadPrimitive.Root className="flex-1 flex flex-col min-h-0">
+        <ThreadPrimitive.Viewport autoScroll className="flex-1 overflow-y-auto scrollbar-on-hover">
+          {isLoading ? (
+            <LoadingState />
+          ) : (
+            <>
+              <EmptyState />
+              <div data-mf-chat-thread className="px-6 py-6 space-y-5">
+                <ThreadPrimitive.Messages
+                  components={{
+                    UserMessage,
+                    AssistantMessage,
+                    SystemMessage,
+                  }}
+                />
+                <GeneratingIndicator />
+              </div>
+            </>
+          )}
+        </ThreadPrimitive.Viewport>
+        <QuoteOnSelectionButton />
+        <div className="shrink-0 px-6 pb-5 pt-2">
+          <BottomCard />
+        </div>
+        {lightbox && (
+          <ImageLightbox
+            images={lightbox.images}
+            index={lightbox.index}
+            onClose={closeLightbox}
+            onNavigate={navigateLightbox}
+          />
         )}
-      </ThreadPrimitive.Viewport>
-      <QuoteOnSelectionButton />
-      <div className="shrink-0 px-6 pb-5 pt-2">
-        <BottomCard />
-      </div>
-      {lightbox && (
-        <ImageLightbox
-          images={lightbox.images}
-          index={lightbox.index}
-          onClose={closeLightbox}
-          onNavigate={navigateLightbox}
-        />
-      )}
-    </ThreadPrimitive.Root>
+      </ThreadPrimitive.Root>
+    </div>
   );
 }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/UserMessage.tsx
@@ -83,7 +83,7 @@ export function UserMessage() {
             <span className="text-mf-body font-semibold text-mf-accent">Plan to implement</span>
           </div>
           <div className="px-4 py-3">
-            <div className="aui-md text-mf-chat text-mf-text-primary">
+            <div data-text-part className="aui-md text-mf-chat text-mf-text-primary">
               <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={urlTransform} components={markdownComponents}>
                 {planBody}
               </Markdown>
@@ -110,7 +110,7 @@ export function UserMessage() {
           data-testid={parsed.isCommand ? 'user-command-bubble' : 'user-skill-bubble'}
           className="max-w-[75%] bg-mf-hover rounded-[12px_12px_4px_12px] px-4 py-2.5"
         >
-          <div className="aui-md text-mf-chat text-mf-text-primary">
+          <div data-text-part className="aui-md text-mf-chat text-mf-text-primary">
             <Icon size={14} className="text-mf-accent inline-block align-[-2px] mr-0.5" />
             <span className="font-mono text-mf-chat text-mf-accent mr-1.5">/{parsed.commandName}</span>
             {parsed.userText}
@@ -129,7 +129,7 @@ export function UserMessage() {
       {queuedBadge}
       {hasTextContent && (
         <div className="max-w-[75%] bg-mf-hover rounded-[12px_12px_4px_12px] px-4 py-2.5">
-          <div className="aui-md text-mf-chat text-mf-text-primary">
+          <div data-text-part className="aui-md text-mf-chat text-mf-text-primary">
             <Markdown remarkPlugins={REMARK_PLUGINS} urlTransform={urlTransform} components={userComponents}>
               {cleanText}
             </Markdown>

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
@@ -19,8 +19,12 @@ export const MainframeText: TextMessagePartComponent = (props) => {
 
   if (!text || text.trim() === '') return null;
 
-  // Props required by TextMessagePartComponent contract; MarkdownText reads text via context internally
-  return <MarkdownText {...props} />;
+  // data-text-part marks this subtree as searchable by the chat-local FindBar.
+  return (
+    <div data-text-part>
+      <MarkdownText {...props} />
+    </div>
+  );
 };
 
 function ErrorPartFromMessage() {

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -486,3 +486,12 @@ textarea:focus-visible,
   line-height: 1;
   font-family: var(--font-mono);
 }
+
+/* Find-in-Chat highlights (CSS Custom Highlight API) */
+::highlight(mf-find-match) {
+  background-color: rgba(250, 204, 21, 0.35);
+}
+::highlight(mf-find-active) {
+  background-color: rgba(249, 115, 22, 0.75);
+  color: #ffffff;
+}

--- a/packages/desktop/src/renderer/store/find-in-chat.ts
+++ b/packages/desktop/src/renderer/store/find-in-chat.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+
+export interface FindMatch {
+  messageId: string;
+  partIndex: number;
+  charStart: number;
+  charEnd: number;
+}
+
+interface FindInChatState {
+  isOpen: boolean;
+  query: string;
+  /** All matches in message order. */
+  matches: FindMatch[];
+  /** Index into matches[] of the currently focused match. */
+  activeIndex: number;
+
+  open: () => void;
+  close: () => void;
+  setQuery: (q: string) => void;
+  setMatches: (matches: FindMatch[]) => void;
+  setActiveIndex: (index: number) => void;
+  next: () => void;
+  prev: () => void;
+}
+
+export const useFindInChatStore = create<FindInChatState>((set, get) => ({
+  isOpen: false,
+  query: '',
+  matches: [],
+  activeIndex: 0,
+
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false, query: '', matches: [], activeIndex: 0 }),
+  setQuery: (query) => set({ query, activeIndex: 0 }),
+  setMatches: (matches) => set({ matches, activeIndex: 0 }),
+  setActiveIndex: (activeIndex) => set({ activeIndex }),
+
+  next: () => {
+    const { matches, activeIndex } = get();
+    if (matches.length === 0) return;
+    set({ activeIndex: (activeIndex + 1) % matches.length });
+  },
+
+  prev: () => {
+    const { matches, activeIndex } = get();
+    if (matches.length === 0) return;
+    set({ activeIndex: (activeIndex - 1 + matches.length) % matches.length });
+  },
+}));

--- a/packages/desktop/src/renderer/store/index.ts
+++ b/packages/desktop/src/renderer/store/index.ts
@@ -12,3 +12,5 @@ export type { Capture } from './sandbox';
 export { useTerminalStore } from './terminal';
 export type { TerminalTab } from './terminal';
 export { useLayoutStore } from './layout';
+export { useFindInChatStore } from './find-in-chat';
+export type { FindMatch } from './find-in-chat';


### PR DESCRIPTION
## Summary

The Find-in-Chat bar shipped in #142 had three blocking issues that made it non-functional for end users. This PR fixes all of them.

- **No matches were ever found.** `FindBar.searchMessages` walked `[data-text-part]` elements to compute matches, but no component ever emitted that attribute, so every query returned `0/0` regardless of input. Added `data-text-part` to the rendered text wrappers in `MainframeText` (assistant text parts) and `UserMessage` (the three markdown bubble variants).
- **Cmd+F was stolen by the global Search palette.** `SearchPalette` registered both `Cmd+O` and `Cmd+F` on `window`, so the chat-local `onKeyDown` never saw the event. The palette now binds `Cmd+O` only; the titlebar hint reads `Search ⌘O` to match. Cmd+F is reserved for the chat-local find bar, as #142 intended.
- **Matches were not visualized.** Even with matches found, only the counter and a `scrollIntoView` ran — nothing was painted on screen. Now uses the CSS Custom Highlight API with two registries (`mf-find-match` pale yellow, `mf-find-active` orange) plus a `rangeFromOffsets` helper that maps flat character offsets across markdown's nested text nodes. Replaced the per-message `scrollIntoView` with a center-the-active-range scroll that only fires when the active match is actually off-screen.

## Test plan

- [x] Cmd+F opens the find bar while the chat thread is focused
- [x] `'Markdown'` in a one-message chat → counter `1/1`, single yellow highlight
- [x] `'files'` in the same chat → `1/2`, two yellow highlights, Next advances to `2/2` (active goes orange), Prev wraps `1 → 6 → 5 …`
- [x] `'ReadMoreBubble'` in a long user message → `1/6`, all six highlighted yellow, active orange; Next advances active highlight; off-screen active match scrolls into view
- [x] Esc closes the bar; close (×) and Cmd+F again also close it
- [x] Sticky-bottom autoscroll is preserved (clientHeight shrinks by FindBar height, scrollTop stays pinned to bottom)
- [x] Cmd+O still opens the global Search palette
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)