### PR TITLE
fix(desktop): TerminalPanel infinite render loop crashing v0.17.0

### DIFF
--- a/.changeset/terminal-panel-render-loop.md
+++ b/.changeset/terminal-panel-render-loop.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix TerminalPanel infinite render loop on app startup. The `getTerminals` selector returned a fresh `[]` for any project without a stored entry, causing `useSyncExternalStore` to detect a new snapshot every render and crash the renderer with React error #185 (Maximum update depth exceeded). Returns a stable empty-array reference instead. Also adds the missing `getHomedir` field to the renderer's `MainframeAPI` type so the preload contract typechecks end-to-end.

--- a/packages/desktop/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/packages/desktop/src/renderer/components/terminal/TerminalPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
-import { useTerminalStore } from '../../store/terminal';
+import { useTerminalStore, type TerminalTab } from '../../store/terminal';
 import { useProjectsStore } from '../../store';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useChatsStore } from '../../store/chats';
@@ -10,10 +10,13 @@ import { useZoneHeaderTabs, useZoneHeaderActions } from '../zone/ZoneHeaderSlot.
 import type { InternalTab } from '../zone/ZoneHeaderSlot.js';
 import { resolveCwd } from './terminal-cwd.js';
 
+// Stable reference for the no-project case — see store/terminal.ts.
+const EMPTY_TERMINALS: TerminalTab[] = [];
+
 export function TerminalPanel(): React.ReactElement {
   const activeProjectId = useActiveProjectId();
 
-  const terminals = useTerminalStore((s) => (activeProjectId ? s.getTerminals(activeProjectId) : []));
+  const terminals = useTerminalStore((s) => (activeProjectId ? s.getTerminals(activeProjectId) : EMPTY_TERMINALS));
   const activeTerminalId = useTerminalStore((s) => (activeProjectId ? s.getActiveTerminalId(activeProjectId) : null));
   const addTerminal = useTerminalStore((s) => s.addTerminal);
   const removeTerminal = useTerminalStore((s) => s.removeTerminal);

--- a/packages/desktop/src/renderer/store/__tests__/terminal.test.ts
+++ b/packages/desktop/src/renderer/store/__tests__/terminal.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTerminalStore } from '../terminal';
+
+describe('useTerminalStore', () => {
+  beforeEach(() => {
+    useTerminalStore.setState({
+      terminalsByProject: new Map(),
+      activeTerminalByProject: new Map(),
+    });
+  });
+
+  describe('getTerminals', () => {
+    it('returns the same empty array reference on repeated calls for an unknown project', () => {
+      // Regression: returning a fresh `[]` from the selector caused
+      // useSyncExternalStore to detect a new snapshot every render, triggering
+      // React error #185 (Maximum update depth exceeded) in TerminalPanel.
+      const { getTerminals } = useTerminalStore.getState();
+      const a = getTerminals('proj-1');
+      const b = getTerminals('proj-1');
+      const c = getTerminals('proj-2');
+      expect(a).toBe(b);
+      expect(a).toBe(c);
+    });
+
+    it('returns the stored array when the project has terminals', () => {
+      const { addTerminal, getTerminals } = useTerminalStore.getState();
+      addTerminal('proj-1', { id: 't1', name: 'zsh' });
+      const list = getTerminals('proj-1');
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual({ id: 't1', name: 'zsh' });
+    });
+  });
+
+  describe('addTerminal', () => {
+    it('caps tabs per project at 3, dropping the oldest', () => {
+      const { addTerminal, getTerminals } = useTerminalStore.getState();
+      addTerminal('p', { id: '1', name: 'a' });
+      addTerminal('p', { id: '2', name: 'b' });
+      addTerminal('p', { id: '3', name: 'c' });
+      addTerminal('p', { id: '4', name: 'd' });
+      expect(getTerminals('p').map((t) => t.id)).toEqual(['2', '3', '4']);
+    });
+
+    it('sets the new tab as active', () => {
+      const { addTerminal, getActiveTerminalId } = useTerminalStore.getState();
+      addTerminal('p', { id: 't1', name: 'zsh' });
+      expect(getActiveTerminalId('p')).toBe('t1');
+    });
+  });
+
+  describe('removeTerminal', () => {
+    it('promotes the last remaining tab when active is removed', () => {
+      const { addTerminal, removeTerminal, getActiveTerminalId } = useTerminalStore.getState();
+      addTerminal('p', { id: '1', name: 'a' });
+      addTerminal('p', { id: '2', name: 'b' });
+      removeTerminal('p', '2');
+      expect(getActiveTerminalId('p')).toBe('1');
+    });
+
+    it('sets active to null when the last tab is removed', () => {
+      const { addTerminal, removeTerminal, getActiveTerminalId } = useTerminalStore.getState();
+      addTerminal('p', { id: '1', name: 'a' });
+      removeTerminal('p', '1');
+      expect(getActiveTerminalId('p')).toBeNull();
+    });
+  });
+});

--- a/packages/desktop/src/renderer/store/terminal.ts
+++ b/packages/desktop/src/renderer/store/terminal.ts
@@ -8,6 +8,11 @@ export interface TerminalTab {
 /** Maximum number of terminal tabs retained per project when it is not active. */
 const MAX_TERMINALS_PER_PROJECT = 3;
 
+// Stable empty array — returning a fresh `[]` from `getTerminals` would make
+// `useSyncExternalStore` see a new snapshot on every render, infinite-looping
+// `TerminalPanel` with React error #185.
+const EMPTY_TERMINALS: readonly TerminalTab[] = Object.freeze([]);
+
 interface TerminalState {
   /** Per-project terminal lists. Keyed by projectId. */
   terminalsByProject: Map<string, TerminalTab[]>;
@@ -26,7 +31,7 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   terminalsByProject: new Map(),
   activeTerminalByProject: new Map(),
 
-  getTerminals: (projectId) => get().terminalsByProject.get(projectId) ?? [],
+  getTerminals: (projectId) => get().terminalsByProject.get(projectId) ?? (EMPTY_TERMINALS as TerminalTab[]),
 
   getActiveTerminalId: (projectId) => get().activeTerminalByProject.get(projectId) ?? null,
 

--- a/packages/desktop/src/renderer/types/global.d.ts
+++ b/packages/desktop/src/renderer/types/global.d.ts
@@ -30,6 +30,7 @@ export interface MainframeAPI {
     electron: string;
   };
   getAppInfo: () => Promise<{ version: string; author: string }>;
+  getHomedir: () => Promise<string>;
   readFile: (filePath: string) => Promise<string | null>;
   showItemInFolder: (fullPath: string) => Promise<void>;
   openExternal: (url: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- v0.17.0 renderer crashes immediately on startup with React error #185 (Maximum update depth exceeded) for users whose persisted layout restores the terminal zone open with an active project.
- Root cause: introduced in #279. `useTerminalStore.getTerminals(projectId)` returned a fresh `[]` for any project without a stored entry. `useSyncExternalStore` then saw a new snapshot every render → re-render → new `[]` → infinite loop. The auto-create effect never ran because rendering crashed first.
- Fix: stable `EMPTY_TERMINALS` reference returned from both the store selector and the no-project branch in `TerminalPanel`. Also adds the missing `getHomedir` field to the renderer's `MainframeAPI` type (also missed in #279) so the preload contract typechecks end-to-end.

## Test plan

- [x] New regression test in `store/__tests__/terminal.test.ts` asserts `getTerminals(unknownProject)` returns the same array reference on repeated calls (and across different unknown projects).
- [x] Test reproduces the bug pre-fix (fails with `expected [] to be []`) and passes post-fix.
- [x] Full desktop suite green (580/580).
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` succeeds.
- [ ] Manual: launch packaged app with persisted terminal-zone-open layout → window renders, no React #185 in `~/.mainframe/logs/desktop-app.*.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)