### PR TITLE
fix(desktop): scope terminals per chat, preserve output, drop auto-create

### DIFF
--- a/.changeset/terminal-session-scoped.md
+++ b/.changeset/terminal-session-scoped.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(desktop): scope terminal tabs per session, preserve output across switches, and stop auto-creating tabs
+
+Terminal panel now scopes tabs by active chat (session) instead of project — switching chats no longer leaks terminals between sessions. Output is preserved across project/session switches and panel minimize via a module-level xterm cache. The `+` icon now sits next to the tabs (not the far right), the close `×` is always visible, and an empty state prompts users to click `+` to start a session. No terminal is auto-created on mount — users open one explicitly.

--- a/packages/desktop/src/renderer/components/terminal/TerminalInstance.tsx
+++ b/packages/desktop/src/renderer/components/terminal/TerminalInstance.tsx
@@ -8,83 +8,120 @@ interface TerminalInstanceProps {
   visible: boolean;
 }
 
+interface CachedTerminal {
+  wrapper: HTMLDivElement;
+  term: Terminal;
+  fitAddon: FitAddon;
+  dispose: () => void;
+}
+
+// Module-level cache: xterm instances survive component unmount so output is
+// preserved across project switches and panel minimize. Entries are removed
+// only by disposeCachedTerminal() when the user closes a tab.
+const cache = new Map<string, CachedTerminal>();
+
+function getOrCreate(terminalId: string): CachedTerminal {
+  const existing = cache.get(terminalId);
+  if (existing) return existing;
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'absolute inset-0';
+
+  const term = new Terminal({
+    cursorBlink: true,
+    fontSize: 13,
+    fontFamily: "'JetBrains Mono', monospace",
+    theme: {
+      background: getComputedStyle(document.documentElement).getPropertyValue('--mf-input-bg').trim() || '#1e1e2e',
+      foreground: getComputedStyle(document.documentElement).getPropertyValue('--mf-text-primary').trim() || '#cdd6f4',
+      cursor: getComputedStyle(document.documentElement).getPropertyValue('--mf-accent').trim() || '#fab387',
+      selectionBackground: '#585b7066',
+    },
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(wrapper);
+
+  const onDataDisposable = term.onData((data) => {
+    window.mainframe.terminal.write(terminalId, data);
+  });
+
+  const handleData = (id: string, data: string): void => {
+    if (id === terminalId) term.write(data);
+  };
+  const removeDataListener = window.mainframe.terminal.onData(handleData);
+
+  const onResizeDisposable = term.onResize(({ cols, rows }) => {
+    window.mainframe.terminal.resize(terminalId, cols, rows);
+  });
+
+  const dispose = (): void => {
+    onDataDisposable.dispose();
+    onResizeDisposable.dispose();
+    removeDataListener();
+    term.dispose();
+    wrapper.remove();
+  };
+
+  const entry: CachedTerminal = { wrapper, term, fitAddon, dispose };
+  cache.set(terminalId, entry);
+  return entry;
+}
+
+/**
+ * Permanently destroy a cached terminal. Call when the user closes a tab —
+ * not on component unmount. After this returns, the terminalId can be
+ * reused (a new wrapper/Terminal will be created on next getOrCreate).
+ */
+export function disposeCachedTerminal(terminalId: string): void {
+  const entry = cache.get(terminalId);
+  if (!entry) return;
+  entry.dispose();
+  cache.delete(terminalId);
+}
+
 export function TerminalInstance({ terminalId, visible }: TerminalInstanceProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container) return;
 
-    const term = new Terminal({
-      cursorBlink: true,
-      fontSize: 13,
-      fontFamily: "'JetBrains Mono', monospace",
-      theme: {
-        background: getComputedStyle(document.documentElement).getPropertyValue('--mf-input-bg').trim() || '#1e1e2e',
-        foreground:
-          getComputedStyle(document.documentElement).getPropertyValue('--mf-text-primary').trim() || '#cdd6f4',
-        cursor: getComputedStyle(document.documentElement).getPropertyValue('--mf-accent').trim() || '#fab387',
-        selectionBackground: '#585b7066',
-      },
-    });
+    const entry = getOrCreate(terminalId);
+    fitAddonRef.current = entry.fitAddon;
+    container.appendChild(entry.wrapper);
 
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(containerRef.current);
-    fitAddon.fit();
-
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
-
-    // Wire keystrokes → PTY
-    const onDataDisposable = term.onData((data) => {
-      window.mainframe.terminal.write(terminalId, data);
-    });
-
-    // Wire PTY output → xterm
-    const handleData = (id: string, data: string): void => {
-      if (id === terminalId) {
-        term.write(data);
-      }
-    };
-    const removeDataListener = window.mainframe.terminal.onData(handleData);
-
-    // Handle resize
-    const onResizeDisposable = term.onResize(({ cols, rows }) => {
-      window.mainframe.terminal.resize(terminalId, cols, rows);
-    });
-
-    // ResizeObserver for auto-fit — debounced with trailing delay to prevent
-    // rapid-fire PTY resize calls during drag. Each fit() resizes xterm AND
-    // sends cols/rows to the PTY via IPC; flooding the PTY at 60Hz causes
-    // cols mismatch when the shell emits output between resize calls.
+    // Debounced auto-fit. Each fit() resizes xterm AND sends cols/rows to the
+    // PTY via IPC; flooding at 60Hz causes cols mismatch when the shell emits
+    // output between resize calls.
     let resizeTimer: ReturnType<typeof setTimeout> | undefined;
     const RESIZE_DEBOUNCE_MS = 150;
     const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry || !fitAddonRef.current) return;
-      const { width, height } = entry.contentRect;
-      if (width === 0 || height === 0) return; // container hidden or collapsed
+      const e = entries[0];
+      if (!e) return;
+      const { width, height } = e.contentRect;
+      if (width === 0 || height === 0) return;
       clearTimeout(resizeTimer);
       resizeTimer = setTimeout(() => {
         try {
-          fitAddonRef.current?.fit();
+          entry.fitAddon.fit();
         } catch {
           /* container transitioning — fit will be retried on next resize */
         }
       }, RESIZE_DEBOUNCE_MS);
     });
-    observer.observe(containerRef.current);
+    observer.observe(container);
 
     return () => {
       clearTimeout(resizeTimer);
       observer.disconnect();
-      onDataDisposable.dispose();
-      onResizeDisposable.dispose();
-      removeDataListener();
-      term.dispose();
-      termRef.current = null;
+      // Detach wrapper from this container — keep the cached Terminal alive
+      // so output is preserved across project switches and panel minimize.
+      if (entry.wrapper.parentNode === container) {
+        container.removeChild(entry.wrapper);
+      }
       fitAddonRef.current = null;
     };
   }, [terminalId]);

--- a/packages/desktop/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/packages/desktop/src/renderer/components/terminal/TerminalPanel.tsx
@@ -5,25 +5,33 @@ import { useTerminalStore, type TerminalTab } from '../../store/terminal';
 import { useProjectsStore } from '../../store';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useChatsStore } from '../../store/chats';
-import { TerminalInstance } from './TerminalInstance';
+import { TerminalInstance, disposeCachedTerminal } from './TerminalInstance';
 import { useZoneHeaderTabs, useZoneHeaderActions } from '../zone/ZoneHeaderSlot.js';
 import type { InternalTab } from '../zone/ZoneHeaderSlot.js';
 import { resolveCwd } from './terminal-cwd.js';
 
-// Stable reference for the no-project case — see store/terminal.ts.
+// Stable reference for the no-scope case — see store/terminal.ts.
 const EMPTY_TERMINALS: TerminalTab[] = [];
 
 export function TerminalPanel(): React.ReactElement {
   const activeProjectId = useActiveProjectId();
+  const activeChatId = useChatsStore((s) => s.activeChatId);
 
-  const terminals = useTerminalStore((s) => (activeProjectId ? s.getTerminals(activeProjectId) : EMPTY_TERMINALS));
-  const activeTerminalId = useTerminalStore((s) => (activeProjectId ? s.getActiveTerminalId(activeProjectId) : null));
+  // Terminals follow the active chat (so each session's terminals stay tied
+  // to its worktree). When no chat is selected, fall back to the project so
+  // we still have a valid scope.
+  const scopeId = activeChatId ?? activeProjectId ?? null;
+
+  const terminals = useTerminalStore((s) => (scopeId ? s.getTerminals(scopeId) : EMPTY_TERMINALS));
+  const activeTerminalId = useTerminalStore((s) => (scopeId ? s.getActiveTerminalId(scopeId) : null));
   const addTerminal = useTerminalStore((s) => s.addTerminal);
   const removeTerminal = useTerminalStore((s) => s.removeTerminal);
   const setActiveTerminal = useTerminalStore((s) => s.setActiveTerminal);
 
   const shellNameRef = useRef('zsh');
-  const counterRef = useRef(0);
+  // Per-scope tab counter so numbering restarts at 1 in each session/project
+  // and survives across scope switches.
+  const counterByScopeRef = useRef<Map<string, number>>(new Map());
 
   // Resolved homedir — fetched once via IPC on mount.
   const [homedir, setHomedir] = useState<string | null>(null);
@@ -44,7 +52,8 @@ export function TerminalPanel(): React.ReactElement {
       console.warn('[terminal] getCwd: no activeProjectId, deferring to homedir');
       return homedir;
     }
-    const chat = useChatsStore.getState().chats.find((c) => c.id === useChatsStore.getState().activeChatId);
+    const chatsState = useChatsStore.getState();
+    const chat = chatsState.chats.find((c) => c.id === chatsState.activeChatId);
     const project = useProjectsStore.getState().projects.find((p) => p.id === activeProjectId);
     const cwd = resolveCwd({
       worktreePath: chat?.worktreePath,
@@ -66,52 +75,40 @@ export function TerminalPanel(): React.ReactElement {
   const createTerminal = useCallback(async () => {
     const cwd = getCwd();
     if (!cwd) {
-      // homedir not yet loaded — silently bail; auto-create will retry
+      // homedir not yet loaded — silently bail; user can retry by clicking +
       return;
     }
-    if (!activeProjectId) {
-      console.warn('[terminal] createTerminal called without activeProjectId — using homedir');
+    if (!scopeId) {
+      console.warn('[terminal] createTerminal called without a scope — using homedir');
     }
     try {
       const rect = containerRef.current?.getBoundingClientRect();
       const initCols = rect ? Math.max(2, Math.floor(rect.width / 7.8)) : undefined;
       const initRows = rect ? Math.max(1, Math.floor(rect.height / 17)) : undefined;
       const { id } = await window.mainframe.terminal.create({ cwd, cols: initCols, rows: initRows });
-      counterRef.current += 1;
-      const name = counterRef.current === 1 ? shellNameRef.current : `${shellNameRef.current} (${counterRef.current})`;
-      const projectId = activeProjectId ?? '__no_project__';
-      addTerminal(projectId, { id, name });
+      const scope = scopeId ?? '__no_scope__';
+      const next = (counterByScopeRef.current.get(scope) ?? 0) + 1;
+      counterByScopeRef.current.set(scope, next);
+      const name = next === 1 ? shellNameRef.current : `${shellNameRef.current} (${next})`;
+      addTerminal(scope, { id, name });
     } catch (err) {
       console.warn('[terminal] failed to create terminal', err);
     }
-  }, [getCwd, addTerminal, activeProjectId]);
+  }, [getCwd, addTerminal, scopeId]);
 
   const closeTerminal = useCallback(
     (id: string) => {
       window.mainframe.terminal.kill(id).catch((err) => {
         console.warn('[terminal] failed to kill terminal', id, err);
       });
-      if (activeProjectId) {
-        removeTerminal(activeProjectId, id);
+      // Tear down the cached xterm instance — output is no longer needed.
+      disposeCachedTerminal(id);
+      if (scopeId) {
+        removeTerminal(scopeId, id);
       }
     },
-    [removeTerminal, activeProjectId],
+    [removeTerminal, scopeId],
   );
-
-  // Auto-create first terminal when both homedir is ready and we have a project
-  const didAutoCreate = useRef(false);
-  useEffect(() => {
-    if (terminals.length === 0 && !didAutoCreate.current && homedir !== null) {
-      didAutoCreate.current = true;
-      void createTerminal();
-    }
-  }, [terminals.length, createTerminal, homedir]);
-
-  // Reset auto-create flag when project changes so the first terminal for a
-  // new project is created automatically.
-  useEffect(() => {
-    didAutoCreate.current = false;
-  }, [activeProjectId]);
 
   // Handle terminal exit events
   useEffect(() => {
@@ -144,9 +141,9 @@ export function TerminalPanel(): React.ReactElement {
 
   const handleTabChange = useCallback(
     (tabId: string) => {
-      if (activeProjectId) setActiveTerminal(activeProjectId, tabId);
+      if (scopeId) setActiveTerminal(scopeId, tabId);
     },
-    [setActiveTerminal, activeProjectId],
+    [setActiveTerminal, scopeId],
   );
 
   useZoneHeaderTabs(internalTabs, activeTerminalId, handleTabChange);
@@ -172,11 +169,15 @@ export function TerminalPanel(): React.ReactElement {
 
   return (
     <div className="h-full flex flex-col" data-testid="terminal-panel">
-      {/* Terminal instances — all mounted, only active one visible */}
+      {/* Terminal instances — all mounted, only active one visible. */}
       <div ref={containerRef} className="flex-1 min-h-0 relative">
-        {terminals.map((t) => (
-          <TerminalInstance key={t.id} terminalId={t.id} visible={t.id === activeTerminalId} />
-        ))}
+        {terminals.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-mf-text-secondary select-none">
+            Click the + icon to start a new terminal session
+          </div>
+        ) : (
+          terminals.map((t) => <TerminalInstance key={t.id} terminalId={t.id} visible={t.id === activeTerminalId} />)
+        )}
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/components/zone/ZoneHeader.tsx
+++ b/packages/desktop/src/renderer/components/zone/ZoneHeader.tsx
@@ -26,7 +26,10 @@ export function ZoneHeader({ zoneId }: ZoneHeaderProps): React.ReactElement | nu
       {/* Panel name */}
       <span className="text-sm font-semibold text-mf-text-primary select-none shrink-0">{tw.label}</span>
 
-      {/* Internal tabs registered by the panel */}
+      {/* Internal tabs registered by the panel. Inline (`buttons`) tabs render
+          panel actions immediately after the tab list so the new-tab `+` sits
+          next to the tabs instead of at the far right. Dropdown / no-tabs
+          panels keep actions at the right via the trailing render below. */}
       {internalTabs.length > 0 &&
         (tabStyle === 'dropdown' ? (
           <TabDropdown tabs={internalTabs} activeTabId={activeTabId} onTabChange={onTabChange} />
@@ -53,7 +56,7 @@ export function ZoneHeader({ zoneId }: ZoneHeaderProps): React.ReactElement | nu
                         e.stopPropagation();
                         tab.onClose?.();
                       }}
-                      className="opacity-0 group-hover:opacity-100 hover:text-mf-destructive transition-opacity"
+                      className="hover:text-mf-destructive transition-colors"
                     >
                       <X size={10} />
                     </span>
@@ -61,14 +64,18 @@ export function ZoneHeader({ zoneId }: ZoneHeaderProps): React.ReactElement | nu
                 </button>
               );
             })}
+            {actions && <div className="flex items-center gap-0.5 shrink-0 ml-1">{actions}</div>}
           </div>
         ))}
 
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Panel-registered actions */}
-      {actions && <div className="flex items-center gap-0.5 shrink-0">{actions}</div>}
+      {/* Panel-registered actions — only rendered here when actions weren't
+          already rendered inline next to the tabs above. */}
+      {actions && (internalTabs.length === 0 || tabStyle === 'dropdown') && (
+        <div className="flex items-center gap-0.5 shrink-0">{actions}</div>
+      )}
 
       {/* Minimize */}
       <div className="flex items-center gap-0.5 shrink-0">

--- a/packages/desktop/src/renderer/store/__tests__/terminal.test.ts
+++ b/packages/desktop/src/renderer/store/__tests__/terminal.test.ts
@@ -4,64 +4,83 @@ import { useTerminalStore } from '../terminal';
 describe('useTerminalStore', () => {
   beforeEach(() => {
     useTerminalStore.setState({
-      terminalsByProject: new Map(),
-      activeTerminalByProject: new Map(),
+      terminalsByScope: new Map(),
+      activeTerminalByScope: new Map(),
     });
   });
 
   describe('getTerminals', () => {
-    it('returns the same empty array reference on repeated calls for an unknown project', () => {
+    it('returns the same empty array reference on repeated calls for an unknown scope', () => {
       // Regression: returning a fresh `[]` from the selector caused
       // useSyncExternalStore to detect a new snapshot every render, triggering
       // React error #185 (Maximum update depth exceeded) in TerminalPanel.
       const { getTerminals } = useTerminalStore.getState();
-      const a = getTerminals('proj-1');
-      const b = getTerminals('proj-1');
-      const c = getTerminals('proj-2');
+      const a = getTerminals('scope-1');
+      const b = getTerminals('scope-1');
+      const c = getTerminals('scope-2');
       expect(a).toBe(b);
       expect(a).toBe(c);
     });
 
-    it('returns the stored array when the project has terminals', () => {
+    it('returns the stored array when the scope has terminals', () => {
       const { addTerminal, getTerminals } = useTerminalStore.getState();
-      addTerminal('proj-1', { id: 't1', name: 'zsh' });
-      const list = getTerminals('proj-1');
+      addTerminal('scope-1', { id: 't1', name: 'zsh' });
+      const list = getTerminals('scope-1');
       expect(list).toHaveLength(1);
       expect(list[0]).toEqual({ id: 't1', name: 'zsh' });
+    });
+
+    it('isolates terminals across scopes (chat A vs chat B in same project)', () => {
+      const { addTerminal, getTerminals } = useTerminalStore.getState();
+      addTerminal('chat-a', { id: 't1', name: 'zsh' });
+      addTerminal('chat-b', { id: 't2', name: 'zsh' });
+      expect(getTerminals('chat-a').map((t) => t.id)).toEqual(['t1']);
+      expect(getTerminals('chat-b').map((t) => t.id)).toEqual(['t2']);
     });
   });
 
   describe('addTerminal', () => {
-    it('caps tabs per project at 3, dropping the oldest', () => {
+    it('caps tabs per scope at 3, dropping the oldest', () => {
       const { addTerminal, getTerminals } = useTerminalStore.getState();
-      addTerminal('p', { id: '1', name: 'a' });
-      addTerminal('p', { id: '2', name: 'b' });
-      addTerminal('p', { id: '3', name: 'c' });
-      addTerminal('p', { id: '4', name: 'd' });
-      expect(getTerminals('p').map((t) => t.id)).toEqual(['2', '3', '4']);
+      addTerminal('s', { id: '1', name: 'a' });
+      addTerminal('s', { id: '2', name: 'b' });
+      addTerminal('s', { id: '3', name: 'c' });
+      addTerminal('s', { id: '4', name: 'd' });
+      expect(getTerminals('s').map((t) => t.id)).toEqual(['2', '3', '4']);
     });
 
     it('sets the new tab as active', () => {
       const { addTerminal, getActiveTerminalId } = useTerminalStore.getState();
-      addTerminal('p', { id: 't1', name: 'zsh' });
-      expect(getActiveTerminalId('p')).toBe('t1');
+      addTerminal('s', { id: 't1', name: 'zsh' });
+      expect(getActiveTerminalId('s')).toBe('t1');
     });
   });
 
   describe('removeTerminal', () => {
     it('promotes the last remaining tab when active is removed', () => {
       const { addTerminal, removeTerminal, getActiveTerminalId } = useTerminalStore.getState();
-      addTerminal('p', { id: '1', name: 'a' });
-      addTerminal('p', { id: '2', name: 'b' });
-      removeTerminal('p', '2');
-      expect(getActiveTerminalId('p')).toBe('1');
+      addTerminal('s', { id: '1', name: 'a' });
+      addTerminal('s', { id: '2', name: 'b' });
+      removeTerminal('s', '2');
+      expect(getActiveTerminalId('s')).toBe('1');
     });
 
     it('sets active to null when the last tab is removed', () => {
       const { addTerminal, removeTerminal, getActiveTerminalId } = useTerminalStore.getState();
-      addTerminal('p', { id: '1', name: 'a' });
-      removeTerminal('p', '1');
-      expect(getActiveTerminalId('p')).toBeNull();
+      addTerminal('s', { id: '1', name: 'a' });
+      removeTerminal('s', '1');
+      expect(getActiveTerminalId('s')).toBeNull();
+    });
+  });
+
+  describe('clearScope', () => {
+    it('removes all terminals and active state for a scope', () => {
+      const { addTerminal, clearScope, getTerminals, getActiveTerminalId } = useTerminalStore.getState();
+      addTerminal('s', { id: '1', name: 'a' });
+      addTerminal('s', { id: '2', name: 'b' });
+      clearScope('s');
+      expect(getTerminals('s')).toHaveLength(0);
+      expect(getActiveTerminalId('s')).toBeNull();
     });
   });
 });

--- a/packages/desktop/src/renderer/store/terminal.ts
+++ b/packages/desktop/src/renderer/store/terminal.ts
@@ -5,8 +5,8 @@ export interface TerminalTab {
   name: string;
 }
 
-/** Maximum number of terminal tabs retained per project when it is not active. */
-const MAX_TERMINALS_PER_PROJECT = 3;
+/** Maximum number of terminal tabs retained per scope when it is not active. */
+const MAX_TERMINALS_PER_SCOPE = 3;
 
 // Stable empty array — returning a fresh `[]` from `getTerminals` would make
 // `useSyncExternalStore` see a new snapshot on every render, infinite-looping
@@ -14,66 +14,70 @@ const MAX_TERMINALS_PER_PROJECT = 3;
 const EMPTY_TERMINALS: readonly TerminalTab[] = Object.freeze([]);
 
 interface TerminalState {
-  /** Per-project terminal lists. Keyed by projectId. */
-  terminalsByProject: Map<string, TerminalTab[]>;
-  /** Per-project active terminal id. Keyed by projectId. */
-  activeTerminalByProject: Map<string, string | null>;
+  /**
+   * Per-scope terminal lists. The "scope" is the active chat id when there is
+   * one (so each session's terminals follow its worktree), falling back to
+   * the project id when no chat is active.
+   */
+  terminalsByScope: Map<string, TerminalTab[]>;
+  /** Per-scope active terminal id. */
+  activeTerminalByScope: Map<string, string | null>;
 
-  getTerminals: (projectId: string) => TerminalTab[];
-  getActiveTerminalId: (projectId: string) => string | null;
-  addTerminal: (projectId: string, tab: TerminalTab) => void;
-  removeTerminal: (projectId: string, id: string) => void;
-  setActiveTerminal: (projectId: string, id: string | null) => void;
-  clearProject: (projectId: string) => void;
+  getTerminals: (scopeId: string) => TerminalTab[];
+  getActiveTerminalId: (scopeId: string) => string | null;
+  addTerminal: (scopeId: string, tab: TerminalTab) => void;
+  removeTerminal: (scopeId: string, id: string) => void;
+  setActiveTerminal: (scopeId: string, id: string | null) => void;
+  clearScope: (scopeId: string) => void;
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
-  terminalsByProject: new Map(),
-  activeTerminalByProject: new Map(),
+  terminalsByScope: new Map(),
+  activeTerminalByScope: new Map(),
 
-  getTerminals: (projectId) => get().terminalsByProject.get(projectId) ?? (EMPTY_TERMINALS as TerminalTab[]),
+  getTerminals: (scopeId) => get().terminalsByScope.get(scopeId) ?? (EMPTY_TERMINALS as TerminalTab[]),
 
-  getActiveTerminalId: (projectId) => get().activeTerminalByProject.get(projectId) ?? null,
+  getActiveTerminalId: (scopeId) => get().activeTerminalByScope.get(scopeId) ?? null,
 
-  addTerminal: (projectId, tab) =>
+  addTerminal: (scopeId, tab) =>
     set((state) => {
-      const existing = state.terminalsByProject.get(projectId) ?? [];
-      // Cap the list so idle projects don't accumulate unlimited tabs
-      const capped = existing.length >= MAX_TERMINALS_PER_PROJECT ? existing.slice(1) : existing;
-      const terminals = new Map(state.terminalsByProject);
-      terminals.set(projectId, [...capped, tab]);
-      const active = new Map(state.activeTerminalByProject);
-      active.set(projectId, tab.id);
-      return { terminalsByProject: terminals, activeTerminalByProject: active };
+      const existing = state.terminalsByScope.get(scopeId) ?? [];
+      // Cap the list so idle scopes don't accumulate unlimited tabs
+      const capped = existing.length >= MAX_TERMINALS_PER_SCOPE ? existing.slice(1) : existing;
+      const terminals = new Map(state.terminalsByScope);
+      terminals.set(scopeId, [...capped, tab]);
+      const active = new Map(state.activeTerminalByScope);
+      active.set(scopeId, tab.id);
+      return { terminalsByScope: terminals, activeTerminalByScope: active };
     }),
 
-  removeTerminal: (projectId, id) =>
+  removeTerminal: (scopeId, id) =>
     set((state) => {
-      const existing = state.terminalsByProject.get(projectId) ?? [];
+      const existing = state.terminalsByScope.get(scopeId) ?? [];
       const next = existing.filter((t) => t.id !== id);
-      const terminals = new Map(state.terminalsByProject);
-      terminals.set(projectId, next);
+      const terminals = new Map(state.terminalsByScope);
+      terminals.set(scopeId, next);
 
-      const active = new Map(state.activeTerminalByProject);
-      if (state.activeTerminalByProject.get(projectId) === id) {
-        active.set(projectId, next[next.length - 1]?.id ?? null);
+      const active = new Map(state.activeTerminalByScope);
+      if (state.activeTerminalByScope.get(scopeId) === id) {
+        active.set(scopeId, next[next.length - 1]?.id ?? null);
       }
-      return { terminalsByProject: terminals, activeTerminalByProject: active };
+      return { terminalsByScope: terminals, activeTerminalByScope: active };
     }),
 
-  setActiveTerminal: (projectId, id) =>
+  setActiveTerminal: (scopeId, id) =>
     set((state) => {
-      const active = new Map(state.activeTerminalByProject);
-      active.set(projectId, id);
-      return { activeTerminalByProject: active };
+      const active = new Map(state.activeTerminalByScope);
+      active.set(scopeId, id);
+      return { activeTerminalByScope: active };
     }),
 
-  clearProject: (projectId) =>
+  clearScope: (scopeId) =>
     set((state) => {
-      const terminals = new Map(state.terminalsByProject);
-      terminals.delete(projectId);
-      const active = new Map(state.activeTerminalByProject);
-      active.delete(projectId);
-      return { terminalsByProject: terminals, activeTerminalByProject: active };
+      const terminals = new Map(state.terminalsByScope);
+      terminals.delete(scopeId);
+      const active = new Map(state.activeTerminalByScope);
+      active.delete(scopeId);
+      return { terminalsByScope: terminals, activeTerminalByScope: active };
     }),
 }));


### PR DESCRIPTION
## Summary
- **Per-chat scoping (the leak fix).** Terminals were keyed by project, so two chats inside the same project shared tab state — switching chats left the previous chat's terminal mounted ("leaks between sessions"). Tabs are now keyed by active chat id, falling back to project id when no chat is active.
- **Output survives switches.** A module-level xterm cache (`disposeCachedTerminal`) keeps the Terminal alive across project/session/panel-minimize unmounts. Tabs are torn down only on explicit close.
- **Per-scope tab numbering.** Counter resets to 1 in each session/project instead of being global.
- **No auto-create.** No terminal opens on mount — users click `+` to start one.
- **UI polish.** `+` sits inline next to the tabs (falls back to right-side actions when no tabs / dropdown style). Close `×` always visible. Empty state: _"Click the + icon to start a new terminal session"_.

Builds on the per-project + cwd fix from #279 and the render-loop fix from #284.

## Test plan
- [x] Open chat A → click `+` → type something. Switch to chat B (same project) → no tab from A is visible. Click `+` → opens fresh tab at chat B's cwd.
- [x] Switch back to chat A → original tab is still there with its output preserved.
- [x] Switch to a different project → terminals don't leak across projects either.
- [x] Minimize the terminal panel and reopen → output preserved.
- [x] Close the panel without opening a terminal → no PTY spawned (nothing to leak).
- [x] Close `×` is visible without hovering the tab.
- [x] `+` sits next to the last tab; when no tabs are open it sits in the right-side actions area.
- [x] Empty state copy is shown when there are no tabs.
- [x] 582 desktop tests pass; new tests cover scope isolation and `clearScope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)