### PR TITLE
fix(desktop): stop hijacking active chat on remote-created sessions

### DIFF
--- a/.changeset/smooth-icons-tease.md
+++ b/.changeset/smooth-icons-tease.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Stop the desktop from auto-switching its active chat when another client (e.g. mobile) creates a new session. The daemon now stamps `chat.created` events with an `originClientId` derived from the originating WebSocket connection, and the desktop only opens/selects the new chat when the event originated locally. Each client receives its own id via a new `connection.ready` event sent on WS open.

--- a/packages/core/src/__tests__/ws-inbound-flow.test.ts
+++ b/packages/core/src/__tests__/ws-inbound-flow.test.ts
@@ -127,6 +127,18 @@ function connectWs(port: number): Promise<WebSocket> {
   });
 }
 
+/** Connect and start collecting messages immediately so events fired between
+ *  upgrade and the test's first await aren't lost. */
+function connectWsCollecting(port: number): Promise<{ socket: WebSocket; events: DaemonEvent[] }> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+    const events: DaemonEvent[] = [];
+    socket.on('message', (d) => events.push(JSON.parse(d.toString()) as DaemonEvent));
+    socket.on('open', () => resolve({ socket, events }));
+    socket.on('error', reject);
+  });
+}
+
 function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -210,6 +222,40 @@ describe('WS inbound flows', () => {
 
     const chatUpdated = events.find((e) => e.type === 'chat.updated' && (e as any).chat?.planMode === true);
     expect(chatUpdated).toBeDefined();
+  }, 10_000);
+
+  it('chat.created carries originClientId of the creating connection only', async () => {
+    const adapter = new MockAdapter();
+    const { httpServer } = createStack(adapter);
+    server = httpServer;
+    const port = await startServer(server);
+
+    const { socket: a, events: eventsA } = await connectWsCollecting(port);
+    const { socket: b, events: eventsB } = await connectWsCollecting(port);
+    await sleep(50);
+
+    const readyA = eventsA.find((e) => e.type === 'connection.ready');
+    const readyB = eventsB.find((e) => e.type === 'connection.ready');
+    expect(readyA?.type).toBe('connection.ready');
+    expect(readyB?.type).toBe('connection.ready');
+    const idA = (readyA as { type: 'connection.ready'; clientId: string }).clientId;
+    const idB = (readyB as { type: 'connection.ready'; clientId: string }).clientId;
+    expect(idA).toBeTypeOf('string');
+    expect(idB).toBeTypeOf('string');
+    expect(idA).not.toBe(idB);
+
+    a.send(JSON.stringify({ type: 'chat.create', projectId: 'proj-1', adapterId: 'claude' }));
+    await sleep(100);
+
+    const createdOnA = eventsA.find((e) => e.type === 'chat.created');
+    const createdOnB = eventsB.find((e) => e.type === 'chat.created');
+    expect(createdOnA).toBeDefined();
+    expect(createdOnB).toBeDefined();
+    expect((createdOnA as { originClientId?: string }).originClientId).toBe(idA);
+    expect((createdOnB as { originClientId?: string }).originClientId).toBe(idA);
+
+    a.close();
+    b.close();
   }, 10_000);
 
   it('invalid WS message sends back error type', async () => {

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -1,5 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import { realpath, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Server } from 'node:http';
 import type { ChatManager } from '../chat/index.js';
 import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
@@ -20,10 +22,15 @@ export function isWsAuthRequired(ip: string, secret: string | null): boolean {
 
 interface ClientConnection {
   ws: WebSocket;
+  /** Stable per-connection id; sent to the client and stamped on origin-sensitive broadcasts. */
+  id: string;
   subscriptions: Set<string>;
   /** Absolute file paths this client has subscribed to. */
   fileSubscriptions: Set<string>;
 }
+
+/** Identifies which client triggered the inbound message currently being handled. */
+const originContext = new AsyncLocalStorage<{ clientId: string }>();
 
 export class WebSocketManager {
   private wss: WebSocketServer;
@@ -82,8 +89,16 @@ export class WebSocketManager {
 
   private setupEventHandlers(): void {
     this.wss.on('connection', (ws) => {
-      const client: ClientConnection = { ws, subscriptions: new Set(), fileSubscriptions: new Set() };
+      const client: ClientConnection = {
+        ws,
+        id: randomUUID(),
+        subscriptions: new Set(),
+        fileSubscriptions: new Set(),
+      };
       this.clients.set(ws, client);
+
+      const ready: DaemonEvent = { type: 'connection.ready', clientId: client.id };
+      ws.send(JSON.stringify(ready));
 
       ws.on('message', async (data) => {
         try {
@@ -94,7 +109,9 @@ export class WebSocketManager {
             this.sendError(ws, `Invalid message: ${parsed.error.issues.map((i) => i.message).join(', ')}`);
             return;
           }
-          await this.handleClientEvent(client, parsed.data as ClientEvent);
+          await originContext.run({ clientId: client.id }, () =>
+            this.handleClientEvent(client, parsed.data as ClientEvent),
+          );
         } catch (err) {
           log.error({ err }, 'ws message handler error');
           const message = err instanceof SyntaxError ? 'Invalid JSON' : 'Internal error';
@@ -288,7 +305,16 @@ export class WebSocketManager {
       if ('projectId' in event) extra.projectId = event.projectId;
       log.debug(extra, 'broadcast %s to %d client(s)', event.type, this.clients.size);
     }
-    const payload = JSON.stringify(event);
+
+    // Stamp origin only on events whose client side-effects (selection, navigation)
+    // should fire on the originating client alone. Pure state-sync events broadcast
+    // unchanged so every client converges on the same store state.
+    const origin = originContext.getStore();
+    const stamped: DaemonEvent =
+      origin && event.type === 'chat.created' && event.originClientId === undefined
+        ? { ...event, originClientId: origin.clientId }
+        : event;
+    const payload = JSON.stringify(stamped);
 
     for (const client of this.clients.values()) {
       if (!chatId || client.subscriptions.has(chatId)) {

--- a/packages/desktop/src/renderer/lib/client.ts
+++ b/packages/desktop/src/renderer/lib/client.ts
@@ -16,7 +16,13 @@ export class DaemonClient {
   private intentionalClose = false;
   private pendingMessages: ClientEvent[] = [];
   private connectionListeners = new Set<() => void>();
+  private clientId: string | null = null;
   readonly visitedChats = new Set<string>();
+
+  /** Stable id assigned by the daemon when this WS connection was accepted. */
+  getClientId(): string | null {
+    return this.clientId;
+  }
 
   get connected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
@@ -55,6 +61,10 @@ export class DaemonClient {
     socket.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data) as DaemonEvent;
+        if (data.type === 'connection.ready') {
+          this.clientId = data.clientId;
+          return;
+        }
         this.eventHandlers.forEach((handler) => handler(data));
       } catch (error) {
         log.error('failed to parse event', { err: String(error) });

--- a/packages/desktop/src/renderer/lib/ws-event-router.test.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DaemonEvent, Chat } from '@qlan-ro/mainframe-types';
+
+const setActiveChat = vi.fn();
+const addChat = vi.fn();
+const openChatTab = vi.fn();
+const updateTabLabel = vi.fn();
+const getClientId = vi.fn<() => string | undefined>();
+
+vi.mock('../store/chats', () => ({
+  useChatsStore: {
+    getState: () => ({
+      addChat,
+      setActiveChat,
+      chats: [],
+      pendingPermissions: new Map(),
+      removePendingPermission: vi.fn(),
+      addPendingPermission: vi.fn(),
+      removeChat: vi.fn(),
+      removeProcess: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      setMessages: vi.fn(),
+      updateChat: vi.fn(),
+      setProcess: vi.fn(),
+      updateProcessStatus: vi.fn(),
+      setCompacting: vi.fn(),
+      setContextUsage: vi.fn(),
+      setTodos: vi.fn(),
+      addDetectedPr: vi.fn(),
+      addQueuedMessage: vi.fn(),
+      removeQueuedMessage: vi.fn(),
+      clearQueuedMessages: vi.fn(),
+      setQueuedMessages: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../store/tabs', () => ({
+  useTabsStore: {
+    getState: () => ({
+      openChatTab,
+      updateTabLabel,
+    }),
+  },
+}));
+
+vi.mock('../store/projects', () => ({
+  useProjectsStore: { getState: () => ({ setError: vi.fn() }) },
+}));
+
+vi.mock('../store/plugins', () => ({
+  usePluginLayoutStore: {
+    getState: () => ({
+      registerContribution: vi.fn(),
+      unregisterContribution: vi.fn(),
+      registerAction: vi.fn(),
+      unregisterAction: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../store/sandbox', () => ({
+  useSandboxStore: { getState: () => ({ appendLog: vi.fn(), setProcessStatus: vi.fn() }) },
+}));
+
+vi.mock('../store/adapters', () => ({
+  useAdaptersStore: { getState: () => ({ updateAdapterModels: vi.fn() }) },
+}));
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('./launch-scope.js', () => ({
+  buildLaunchScope: vi.fn(() => 'scope'),
+}));
+
+vi.mock('./notify', () => ({ notify: vi.fn() }));
+
+vi.mock('./client', () => ({
+  daemonClient: { getClientId: () => getClientId() },
+}));
+
+import { routeEvent } from './ws-event-router';
+
+const baseChat: Chat = {
+  id: 'chat-A',
+  adapterId: 'claude',
+  projectId: 'p-1',
+  status: 'active',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  totalCost: 0,
+  totalTokensInput: 0,
+  totalTokensOutput: 0,
+  lastContextTokensInput: 0,
+};
+
+beforeEach(() => {
+  setActiveChat.mockClear();
+  addChat.mockClear();
+  openChatTab.mockClear();
+  getClientId.mockReset();
+});
+
+describe('routeEvent — chat.created auto-select gate', () => {
+  it('auto-selects when originClientId matches our own clientId', () => {
+    getClientId.mockReturnValue('client-self');
+    const event: DaemonEvent = { type: 'chat.created', chat: baseChat, originClientId: 'client-self' };
+    routeEvent(event);
+    expect(addChat).toHaveBeenCalledWith(baseChat);
+    expect(setActiveChat).toHaveBeenCalledWith(baseChat.id);
+    expect(openChatTab).toHaveBeenCalledWith(baseChat.id, baseChat.title);
+  });
+
+  it('does NOT auto-select when originClientId belongs to another client', () => {
+    getClientId.mockReturnValue('client-self');
+    const event: DaemonEvent = { type: 'chat.created', chat: baseChat, originClientId: 'client-other' };
+    routeEvent(event);
+    expect(addChat).toHaveBeenCalledWith(baseChat);
+    expect(setActiveChat).not.toHaveBeenCalled();
+    expect(openChatTab).not.toHaveBeenCalled();
+  });
+
+  it('auto-selects when originClientId is undefined (legacy / plugin HTTP path)', () => {
+    // Plugin-driven HTTP routes (e.g. POST /todos/:id/start-session) emit
+    // chat.created outside the WS AsyncLocalStorage scope, so origin is
+    // undefined. We treat that as "this client" so the user clicking
+    // "Start session" still gets navigation.
+    getClientId.mockReturnValue('client-self');
+    const event: DaemonEvent = { type: 'chat.created', chat: baseChat };
+    routeEvent(event);
+    expect(setActiveChat).toHaveBeenCalledWith(baseChat.id);
+    expect(openChatTab).toHaveBeenCalledWith(baseChat.id, baseChat.title);
+  });
+
+  it('does NOT auto-select for imports even when origin matches', () => {
+    getClientId.mockReturnValue('client-self');
+    const event: DaemonEvent = {
+      type: 'chat.created',
+      chat: baseChat,
+      source: 'import',
+      originClientId: 'client-self',
+    };
+    routeEvent(event);
+    expect(setActiveChat).not.toHaveBeenCalled();
+    expect(openChatTab).not.toHaveBeenCalled();
+  });
+
+  it('does NOT auto-select for imports even when origin is undefined', () => {
+    getClientId.mockReturnValue('client-self');
+    const event: DaemonEvent = { type: 'chat.created', chat: baseChat, source: 'import' };
+    routeEvent(event);
+    expect(setActiveChat).not.toHaveBeenCalled();
+    expect(openChatTab).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -8,6 +8,7 @@ import { useAdaptersStore } from '../store/adapters';
 import { createLogger } from './logger';
 import { buildLaunchScope } from './launch-scope.js';
 import { notify } from './notify';
+import { daemonClient } from './client';
 
 const log = createLogger('renderer:ws');
 
@@ -16,13 +17,26 @@ export function routeEvent(event: DaemonEvent): void {
   const tabs = useTabsStore.getState();
 
   switch (event.type) {
-    case 'chat.created':
-      log.info('event:chat.created', { chatId: event.chat.id, title: event.chat.title, source: event.source });
+    case 'chat.created': {
+      log.info('event:chat.created', {
+        chatId: event.chat.id,
+        title: event.chat.title,
+        source: event.source,
+        originClientId: event.originClientId,
+      });
       chats.addChat(event.chat);
-      if (event.source !== 'import') {
+      // Auto-select + open tab only when this client originated the creation.
+      // Imported chats and chats created by other clients (mobile, secondary
+      // desktops) update the list without hijacking the active selection.
+      const isLocalOrigin = event.originClientId === daemonClient.getClientId();
+      if (event.source !== 'import' && isLocalOrigin) {
         chats.setActiveChat(event.chat.id);
         tabs.openChatTab(event.chat.id, event.chat.title);
       }
+      break;
+    }
+    case 'connection.ready':
+      // Handled in DaemonClient before dispatch — no-op here for exhaustiveness.
       break;
     case 'chat.updated': {
       log.debug('event:chat.updated', { chatId: event.chat.id });

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -25,11 +25,19 @@ export function routeEvent(event: DaemonEvent): void {
         originClientId: event.originClientId,
       });
       chats.addChat(event.chat);
-      // Auto-select + open tab only when this client originated the creation.
-      // Imported chats and chats created by other clients (mobile, secondary
-      // desktops) update the list without hijacking the active selection.
-      const isLocalOrigin = event.originClientId === daemonClient.getClientId();
-      if (event.source !== 'import' && isLocalOrigin) {
+      // Auto-select + open tab when this client either (a) originated the
+      // creation over WS (originClientId matches our id), or (b) the event
+      // carries no origin attribution at all — that path covers plugin HTTP
+      // routes (e.g. POST /todos/:id/start-session) that emit chat.created
+      // outside the WS AsyncLocalStorage context. Skipping those would leave
+      // the user clicking "Start session" with no visible navigation.
+      // Other-client originated creates (mobile, secondary desktops) still
+      // get filtered by the strict mismatch case below — and imports always
+      // skip the auto-select via the source check.
+      const ownClientId = daemonClient.getClientId();
+      const hasOrigin = event.originClientId !== undefined;
+      const isOwnOrigin = hasOrigin ? event.originClientId === ownClientId : true;
+      if (event.source !== 'import' && isOwnOrigin) {
         chats.setActiveChat(event.chat.id);
         tabs.openChatTab(event.chat.id, event.chat.title);
       }

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -4,7 +4,8 @@ import type { UIZone } from './plugin.js';
 import type { LaunchProcessStatus } from './launch.js';
 
 export type DaemonEvent =
-  | { type: 'chat.created'; chat: Chat; source?: 'import' }
+  | { type: 'connection.ready'; clientId: string }
+  | { type: 'chat.created'; chat: Chat; source?: 'import'; originClientId?: string }
   | { type: 'chat.updated'; chat: Chat; reason?: 'completed' | 'error' | 'interrupted' }
   | { type: 'chat.ended'; chatId: string }
   | { type: 'process.started'; chatId: string; process: AdapterProcess }


### PR DESCRIPTION
## Summary
- Creating a chat on mobile (or any non-active client) was making the desktop auto-switch its active chat to the new one. Root cause: `chat.created` is broadcast to every WS client, and the desktop router unconditionally called `setActiveChat` + `openChatTab` on receipt.
- Fix: the daemon now stamps `chat.created` with `originClientId` taken from the originating WS connection (threaded via `AsyncLocalStorage`), and clients learn their own id from a new `connection.ready` event on WS open. The desktop only auto-selects when `event.originClientId === daemonClient.getClientId()`. State-sync for every other event is untouched.
- Mechanism is generic: future origin-sensitive side effects (e.g. transient error toasts) can opt-in by stamping in `broadcastEvent` and gating in the router.

## Out of scope (filed mentally, not in this PR)
- Notification fan-out (`chat.notification`, `permission.requested.notify`, `plugin.notification`) is a separate axis — per-device preferences, not origin attribution.
- Mobile event-router doesn't handle `connection.ready`; its `default: break` swallows it. No change required there.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test` — full suite (1251 tests) passes, including the new `chat.created carries originClientId` test that connects two clients, has A create a chat, and verifies both A and B see `originClientId === A.clientId`.
- [x] `pnpm -r build` clean.
- [ ] Manual: open desktop + mobile, tap "new session" on mobile → desktop list updates, active selection stays put. Tap "new chat" on desktop → desktop selects it as before.
- [ ] Manual: import flow still skips auto-select (unchanged `source: 'import'` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)