### PR TITLE
fix(desktop): three HIGH priority UI bugs (#149, #150, #151)

### DIFF
--- a/.changeset/desktop-ui-fixes.md
+++ b/.changeset/desktop-ui-fixes.md
@@ -1,0 +1,8 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Fix three HIGH priority desktop UI bugs:
+- #149: Remove overflow-hidden clipping that prevented worktree dialog and "/" popover from displaying
+- #150: Reorder SystemMessage rendering logic to prioritize compaction pills and suppress unwanted artifacts
+- #151: Preserve Monaco editor scroll position when external file modifications trigger value updates

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -517,6 +517,77 @@ describe('subagent events (parent_tool_use_id != null)', () => {
   });
 });
 
+describe('handleStdout — compaction summary suppression (#150)', () => {
+  // The CLI synthesizes a `user` event when resuming a session post-compaction
+  // to seed the new context. It carries `isCompactSummary: true` and
+  // `isVisibleInTranscriptOnly: true`. Mainframe already renders a CompactionPill
+  // for the compaction event itself; surfacing the synthesized summary as a
+  // CLI feedback pill produces a giant text bubble (issue #150).
+
+  it('skips a string-content user event flagged isCompactSummary', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      isCompactSummary: true,
+      isVisibleInTranscriptOnly: true,
+      message: {
+        role: 'user',
+        content:
+          'This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\nSummary: ...',
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces a user event flagged only isVisibleInTranscriptOnly (skill-invocation, errors, etc.)', () => {
+    // `isVisibleInTranscriptOnly` is set on a wider class of entries — including
+    // skill invocations and CLI errors that we DO want to surface. The compaction
+    // filter is keyed on `isCompactSummary` alone, so this should still render.
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      isVisibleInTranscriptOnly: true,
+      message: { role: 'user', content: 'Unknown skill: /unknown' },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown skill: /unknown');
+  });
+
+  it('skips when content begins with the canonical compaction-summary preamble (flag missing)', () => {
+    // Defensive fallback: tolerate CLI versions / SDK shims that drop the flag.
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content:
+          'This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\nSummary: ...',
+      },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces normal CLI feedback strings (regression guard)', () => {
+    const session = createSession();
+    const sink = createSink();
+    const event = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: 'Unknown command: /typo' },
+    });
+    handleStdout(session, Buffer.from(event + '\n'), sink);
+
+    expect(sink.onCliMessage).toHaveBeenCalledWith('Unknown command: /typo');
+  });
+});
+
 describe('handleStderr', () => {
   it('emits error for non-informational messages', () => {
     const session = createSession();

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -356,7 +356,23 @@ function handleSubagentUserEvent(
   if (collected.length > 0) sink.onSubagentChild(parentToolUseId, collected);
 }
 
+// Canonical preamble the CLI prepends to the synthesized post-compaction
+// "continuation" user message. Used as a defensive fallback when the
+// `isCompactSummary` / `isVisibleInTranscriptOnly` flags are missing —
+// e.g. older CLI versions or third-party SDK shims that drop them.
+const COMPACT_SUMMARY_PREAMBLE = 'This session is being continued from a previous conversation that ran out of context';
+
 function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
+  // Drop the post-compaction continuation user message — the CLI emits it to
+  // seed the new context with the prior conversation summary, but Mainframe
+  // already shows a CompactionPill, so the raw text becomes a giant pill
+  // containing the whole summary (#150). Filter strictly on `isCompactSummary`;
+  // `isVisibleInTranscriptOnly` is broader and may apply to entries we want
+  // to render, so we don't use it here. The string-content branch below also
+  // matches against the canonical preamble as a defensive fallback for CLI
+  // versions / SDK shims that drop the flag.
+  if (event.isCompactSummary === true) return;
+
   // Detect queued message processed by CLI (isReplay from SDK mode)
   const isReplay = event.isReplay === true || event.is_replay === true;
   const uuid = (event.uuid as string) || undefined;
@@ -412,7 +428,11 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
     // original text already exists as a transient from chat-manager.sendMessage.
     if (!isReplay && !isMeta) {
       const trimmed = message.content.trim();
-      if (trimmed) sink.onCliMessage(trimmed);
+      // Defensive: catch post-compaction continuation messages whose flags
+      // were stripped by the CLI/SDK (see COMPACT_SUMMARY_PREAMBLE).
+      if (trimmed && !trimmed.startsWith(COMPACT_SUMMARY_PREAMBLE)) {
+        sink.onCliMessage(trimmed);
+      }
     }
     return;
   }
@@ -489,7 +509,8 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
             trimmed,
           );
         const isInterruptMarker = /^\[Request interrupted by user[^\]]*\]\s*$/.test(trimmed);
-        if (!isLocalCommandWrapper && !isInterruptMarker) {
+        const isCompactPreamble = trimmed.startsWith(COMPACT_SUMMARY_PREAMBLE);
+        if (!isLocalCommandWrapper && !isInterruptMarker && !isCompactPreamble) {
           sink.onCliMessage(trimmed);
         }
       }

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -278,7 +278,7 @@ export function ComposerCard() {
   return (
     <ComposerPrimitive.Root
       data-tutorial="step-3"
-      className="relative border border-mf-border rounded-mf-card bg-transparent overflow-hidden"
+      className="relative border border-mf-border rounded-mf-card bg-transparent"
     >
       <ContextPickerMenu forceOpen={pickerOpen} onClose={() => setPickerOpen(false)} />
       <div className="flex items-center gap-1 px-2 pt-2">

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -3,7 +3,7 @@ import { ArrowUp, Square, Paperclip, Shield, X, AlertTriangle, CopySlash, Folder
 import { createLogger } from '../../../../lib/logger';
 
 const log = createLogger('renderer:composer');
-import { ComposerPrimitive, useThreadRuntime, useComposerRuntime, type ComposerRuntime } from '@assistant-ui/react';
+import { ComposerPrimitive, useThread, useComposerRuntime, type ComposerRuntime } from '@assistant-ui/react';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
 import { useChatsStore } from '../../../../store/chats';
 import { useSkillsStore } from '../../../../store/skills';
@@ -55,7 +55,7 @@ function useComposerEmpty(composerRuntime: ComposerRuntime) {
 }
 
 function StopButton() {
-  const thread = useThreadRuntime();
+  const thread = useThread();
   if (!thread.isRunning) return null;
   return (
     <ComposerPrimitive.Cancel
@@ -119,23 +119,7 @@ export function ComposerCard() {
   const adapters = useAdaptersStore((s) => s.adapters);
   const messages = useChatsStore((s) => s.messages.get(chatId));
   const hasMessages = (messages?.length ?? 0) > 0;
-  const composerRuntime =
-    useSyncExternalStore(
-      (cb) => {
-        try {
-          return useComposerRuntime().subscribe(cb);
-        } catch {
-          return () => {};
-        }
-      },
-      () => {
-        try {
-          return useComposerRuntime();
-        } catch {
-          return null as any;
-        }
-      },
-    ) ?? useComposerRuntime();
+  const composerRuntime = useComposerRuntime();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [worktreePopoverOpen, setWorktreePopoverOpen] = useState(false);
   const [isGitProject, setIsGitProject] = useState(false);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { ArrowUp, Square, Paperclip, Shield, X, AlertTriangle, CopySlash, FolderGit, GitBranch } from 'lucide-react';
 import { createLogger } from '../../../../lib/logger';
 
 const log = createLogger('renderer:composer');
-import { ComposerPrimitive, useThread, useComposerRuntime, type ComposerRuntime } from '@assistant-ui/react';
+import { ComposerPrimitive, useThreadRuntime, useComposerRuntime, type ComposerRuntime } from '@assistant-ui/react';
 import { useMainframeRuntime } from '../MainframeRuntimeProvider';
 import { useChatsStore } from '../../../../store/chats';
 import { useSkillsStore } from '../../../../store/skills';
@@ -55,7 +55,7 @@ function useComposerEmpty(composerRuntime: ComposerRuntime) {
 }
 
 function StopButton() {
-  const thread = useThread();
+  const thread = useThreadRuntime();
   if (!thread.isRunning) return null;
   return (
     <ComposerPrimitive.Cancel
@@ -119,7 +119,23 @@ export function ComposerCard() {
   const adapters = useAdaptersStore((s) => s.adapters);
   const messages = useChatsStore((s) => s.messages.get(chatId));
   const hasMessages = (messages?.length ?? 0) > 0;
-  const composerRuntime = useComposerRuntime();
+  const composerRuntime =
+    useSyncExternalStore(
+      (cb) => {
+        try {
+          return useComposerRuntime().subscribe(cb);
+        } catch {
+          return () => {};
+        }
+      },
+      () => {
+        try {
+          return useComposerRuntime();
+        } catch {
+          return null as any;
+        }
+      },
+    ) ?? useComposerRuntime();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [worktreePopoverOpen, setWorktreePopoverOpen] = useState(false);
   const [isGitProject, setIsGitProject] = useState(false);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Zap } from 'lucide-react';
-import { MessagePrimitive, useMessage } from '@assistant-ui/react';
+import { MessagePrimitive, useMessageRuntime } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
 import { CompactionPill } from '../parts/tools/CompactionPill';
@@ -12,7 +12,7 @@ function isCliError(text: string): boolean {
 }
 
 export function SystemMessage() {
-  const message = useMessage();
+  const message = useMessageRuntime();
   const [original] = getExternalStoreMessages<DisplayMessage>(message);
 
   // Compaction takes priority — if any block is compaction, show only the compaction pill

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Zap } from 'lucide-react';
-import { MessagePrimitive, useMessageRuntime } from '@assistant-ui/react';
+import { MessagePrimitive, useMessage } from '@assistant-ui/react';
 import { getExternalStoreMessages } from '@assistant-ui/react';
 import { SkillLoadedCard } from '../parts/tools/SkillLoadedCard';
 import { CompactionPill } from '../parts/tools/CompactionPill';
@@ -12,7 +12,7 @@ function isCliError(text: string): boolean {
 }
 
 export function SystemMessage() {
-  const message = useMessageRuntime();
+  const message = useMessage();
   const [original] = getExternalStoreMessages<DisplayMessage>(message);
 
   // Compaction takes priority — if any block is compaction, show only the compaction pill

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/messages/SystemMessage.tsx
@@ -15,6 +15,15 @@ export function SystemMessage() {
   const message = useMessage();
   const [original] = getExternalStoreMessages<DisplayMessage>(message);
 
+  // Compaction takes priority — if any block is compaction, show only the compaction pill
+  if (original?.content?.some((c) => c.type === 'compaction')) {
+    return (
+      <MessagePrimitive.Root>
+        <CompactionPill />
+      </MessagePrimitive.Root>
+    );
+  }
+
   const skillBlock = original?.content?.find(
     (c): c is DisplayContent & { type: 'skill_loaded' } => c.type === 'skill_loaded',
   );
@@ -22,14 +31,6 @@ export function SystemMessage() {
     return (
       <MessagePrimitive.Root>
         <SkillLoadedCard skillName={skillBlock.skillName} path={skillBlock.path} content={skillBlock.content} />
-      </MessagePrimitive.Root>
-    );
-  }
-
-  if (original?.content?.some((c) => c.type === 'compaction')) {
-    return (
-      <MessagePrimitive.Root>
-        <CompactionPill />
       </MessagePrimitive.Root>
     );
   }

--- a/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
@@ -96,7 +96,13 @@ export function MonacoEditor({
     const model = editor.getModel();
     if (!model) return;
     if (model.getValue() !== value) {
+      // Save scroll position before updating content
+      const savedViewState = editor.saveViewState();
       model.setValue(value);
+      // Restore scroll position after content update
+      if (savedViewState) {
+        editor.restoreViewState(savedViewState);
+      }
     }
   }, [value]);
 

--- a/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
+++ b/packages/desktop/src/renderer/components/editor/MonacoEditor.tsx
@@ -8,6 +8,7 @@ import { useInlineComments } from './useInlineComments';
 import './setup';
 import { registerDefinitionProvider } from './navigation';
 import { copyReference } from './copy-reference';
+import { applyValueUpdate } from './apply-value-update';
 import { useProjectsStore } from '../../store';
 import { useActiveProjectId } from '../../hooks/useActiveProjectId.js';
 import { useTabsStore } from '../../store/tabs';
@@ -95,15 +96,7 @@ export function MonacoEditor({
     if (!editor) return;
     const model = editor.getModel();
     if (!model) return;
-    if (model.getValue() !== value) {
-      // Save scroll position before updating content
-      const savedViewState = editor.saveViewState();
-      model.setValue(value);
-      // Restore scroll position after content update
-      if (savedViewState) {
-        editor.restoreViewState(savedViewState);
-      }
-    }
+    applyValueUpdate(editor, model, value);
   }, [value]);
 
   useEffect(() => {

--- a/packages/desktop/src/renderer/components/editor/apply-value-update.test.ts
+++ b/packages/desktop/src/renderer/components/editor/apply-value-update.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyValueUpdate } from './apply-value-update';
+
+function makeStubEditor(initialValue: string) {
+  let modelValue = initialValue;
+  const savedState = { scrollTop: 1234, cursor: { line: 42, col: 1 } };
+  const setValue = vi.fn((v: string) => {
+    modelValue = v;
+  });
+  const saveViewState = vi.fn(() => savedState);
+  const restoreViewState = vi.fn();
+  return {
+    editor: { saveViewState, restoreViewState } as unknown as Parameters<typeof applyValueUpdate>[0],
+    model: {
+      getValue: () => modelValue,
+      setValue,
+    } as unknown as Parameters<typeof applyValueUpdate>[1],
+    saveViewState,
+    restoreViewState,
+    setValue,
+    savedState,
+  };
+}
+
+describe('applyValueUpdate', () => {
+  it('saves view state, sets the new value, then restores view state', () => {
+    const stub = makeStubEditor('original');
+    applyValueUpdate(stub.editor, stub.model, 'changed');
+
+    expect(stub.saveViewState).toHaveBeenCalledOnce();
+    expect(stub.setValue).toHaveBeenCalledWith('changed');
+    expect(stub.restoreViewState).toHaveBeenCalledWith(stub.savedState);
+  });
+
+  it('preserves call order: save → setValue → restore', () => {
+    const stub = makeStubEditor('a');
+    const order: string[] = [];
+    stub.saveViewState.mockImplementation(() => {
+      order.push('save');
+      return stub.savedState;
+    });
+    stub.setValue.mockImplementation(() => {
+      order.push('setValue');
+    });
+    stub.restoreViewState.mockImplementation(() => {
+      order.push('restore');
+    });
+
+    applyValueUpdate(stub.editor, stub.model, 'b');
+    expect(order).toEqual(['save', 'setValue', 'restore']);
+  });
+
+  it('is a no-op when nextValue equals current value (no setValue, no view state churn)', () => {
+    const stub = makeStubEditor('same');
+    applyValueUpdate(stub.editor, stub.model, 'same');
+
+    expect(stub.setValue).not.toHaveBeenCalled();
+    expect(stub.saveViewState).not.toHaveBeenCalled();
+    expect(stub.restoreViewState).not.toHaveBeenCalled();
+  });
+
+  it('skips restore when saveViewState returns null (fresh editor with no usable state)', () => {
+    const stub = makeStubEditor('a');
+    (stub.saveViewState as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+
+    applyValueUpdate(stub.editor, stub.model, 'b');
+    expect(stub.setValue).toHaveBeenCalledWith('b');
+    expect(stub.restoreViewState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/renderer/components/editor/apply-value-update.ts
+++ b/packages/desktop/src/renderer/components/editor/apply-value-update.ts
@@ -1,0 +1,23 @@
+import type * as monacoType from 'monaco-editor';
+
+/**
+ * Apply a new value to a Monaco editor's text model while preserving the
+ * editor's view state (scroll position, cursor, folding, selection).
+ *
+ * `model.setValue` resets the model and clears any view state attached to it,
+ * which is the source of "external file change scrolls editor to the top"
+ * (issue #151). Saving the view state before the swap and restoring it after
+ * keeps the user's place. No-ops when the value is unchanged.
+ */
+export function applyValueUpdate(
+  editor: monacoType.editor.IStandaloneCodeEditor,
+  model: monacoType.editor.ITextModel,
+  nextValue: string,
+): void {
+  if (model.getValue() === nextValue) return;
+  const saved = editor.saveViewState();
+  model.setValue(nextValue);
+  if (saved) {
+    editor.restoreViewState(saved);
+  }
+}


### PR DESCRIPTION
## Summary

Three desktop UI bugs.

### #149 — Composer clipped popovers (worktree dialog, `/` menu)
`WorktreePopover` and `ContextPickerMenu` are positioned `absolute bottom-full` inside `ComposerPrimitive.Root`. The root carried `overflow-hidden`, which clipped them. Removed `overflow-hidden`. **Tradeoff:** without the clip, non-rounded children can visually bleed past the rounded card border. Tracked as follow-up todo #152 to portal the popovers (so the fix is robust against future composer styling).

### #150 — Giant pill containing the entire compaction summary
**Root cause:** When the CLI resumes a session after compaction, it emits a `user` event whose `message.content` is a single string carrying the entire prior-conversation summary. The entry is flagged `isCompactSummary: true`. `handleUserEvent` only filtered on `isReplay`/`isMeta`, so the summary fell through to `sink.onCliMessage`, which created a system message with the full text — and `SystemMessage` wraps any text into one centered pill, producing the giant bubble visible in the bug report.

**Fix:** filter strictly on `isCompactSummary === true` at the top of `handleUserEvent`, plus a defensive preamble-prefix match (`"This session is being continued from a previous conversation that ran out of context"`) to catch CLI versions / SDK shims that drop the flag. Deliberately **not** filtering on `isVisibleInTranscriptOnly` — that flag is broader and carries skill-invocation pills, "Unknown skill:" errors, and other entries we still want to render.

### #151 — Editor scrolls to top when an external write changes the file
`model.setValue(value)` in `MonacoEditor`'s `value` effect resets the model and clears its view state (scroll, cursor, folding). Wrap with `editor.saveViewState()` / `editor.restoreViewState(saved)` so the user's scroll position survives the swap. Extracted into a tiny pure helper `applyValueUpdate` and unit-tested.

## Test plan

- [x] `claude-events.test.ts` — 4 new cases under "compaction summary suppression": flag-set, isVisibleInTranscriptOnly-only (regression guard), flag-missing-but-preamble-matches, normal CLI feedback still surfaces.
- [x] `apply-value-update.test.ts` — 4 cases: save/setValue/restore order, no-op when value unchanged, skip-restore when saveViewState returns null, full integration sequence.
- [x] All 1254 core tests pass.
- [ ] Manual: open a session with compaction history → verify only the pill renders, no giant text bubble.
- [ ] Manual: open WorktreePopover and `/` menu → verify they render unclipped.
- [ ] Manual: edit a file externally with editor open at a deep scroll position → verify scroll is preserved.

## Follow-ups

- #152 — Portal composer popovers to drop the overflow-hidden tradeoff entirely.
- (Open question) `history.ts:532` filters JSONL entries on both `isCompactSummary` and `isVisibleInTranscriptOnly`. If the latter also carries skill-invocation entries, replay drops them silently. Worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)