### PR TITLE
fix(core): queued messages + thinking indicator state corruption (#147)

### DIFF
--- a/.changeset/queued-messages-thinking-fix.md
+++ b/.changeset/queued-messages-thinking-fix.md
@@ -1,0 +1,8 @@
+---
+"@qlan-ro/mainframe-core": patch
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Fix #147: Queued messages don't dismiss and thinking indicator disappears while assistant is working
+
+Add comprehensive debug logging and test coverage for message queuing and thinking state management. Identify race conditions and edge cases where queued messages fail to dismiss or the thinking indicator flips false prematurely while the assistant is still streaming responses. Tests cover queued message lifecycle and proper thinking indicator state transitions across subagent execution.

--- a/packages/core/src/__tests__/queued-message-lifecycle.test.ts
+++ b/packages/core/src/__tests__/queued-message-lifecycle.test.ts
@@ -20,6 +20,7 @@ function makeSink(
   callbacks?: {
     onQueuedProcessed?: (chatId: string, uuid: string) => void;
     onQueuedCleared?: (chatId: string) => void;
+    getQueuedCount?: (chatId: string) => number;
   },
 ) {
   const db: any = {
@@ -38,6 +39,7 @@ function makeSink(
     () => undefined,
     callbacks?.onQueuedProcessed,
     callbacks?.onQueuedCleared,
+    callbacks?.getQueuedCount,
   );
   const sink: SessionSink = handler.buildSink(chatId, vi.fn().mockResolvedValue(undefined));
   return { sink, messages, handler, db };
@@ -154,7 +156,10 @@ describe('Queued message cleanup — onResult must NOT prematurely clear', () =>
 
   it('does not strip metadata.queued from messages still waiting in the CLI queue', () => {
     const emit = emitEvent as unknown as (e: DaemonEvent) => void;
-    const { sink, messages } = makeSink(activeChats, chatId, emit);
+    // Real-world scenario: ChatManager has 2 entries in queuedRefs corresponding
+    // to the cached messages below. Pass that count via getQueuedCount so the
+    // sink knows the queue is non-empty and stays in 'working' / no sweep.
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedCount: () => 2 });
     // Two queued messages, neither yet dequeued by the CLI
     messages.append(
       chatId,
@@ -177,6 +182,26 @@ describe('Queued message cleanup — onResult must NOT prematurely clear', () =>
     // And no bulk clear event leaks out.
     const clearEvents = emitEvent.mock.calls.filter((call) => call[0].type === 'message.queued.cleared');
     expect(clearEvents).toHaveLength(0);
+  });
+
+  it('sweeps stranded metadata.queued flags when result fires with empty queuedRefs', () => {
+    const emit = emitEvent as unknown as (e: DaemonEvent) => void;
+    // queuedRefs is empty (getQueuedCount=0). The cached message's metadata.queued
+    // flag is therefore stranded — happens when the CLI's isReplay ack arrived in
+    // a uuid shape we didn't dispatch on. onResult must clean it up.
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedCount: () => 0 });
+    messages.append(
+      chatId,
+      messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'orphan' }], {
+        queued: true,
+        uuid: 'uuid-orphan',
+      }),
+    );
+
+    sink.onResult({ total_cost_usd: 0, usage: { input_tokens: 0, output_tokens: 0 } });
+
+    const stranded = messages.get(chatId)!.find((m) => m.metadata?.queued === true);
+    expect(stranded).toBeUndefined();
   });
 });
 

--- a/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
+++ b/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
@@ -193,7 +193,9 @@ describe('queued messages and thinking indicator', () => {
     await sleep(50);
 
     // Simulate tool result
-    adapter.currentSession!.simulateToolResult([{ type: 'tool_result', toolUseId: 'tool-1', content: 'hello' }]);
+    adapter.currentSession!.simulateToolResult([
+      { type: 'tool_result', toolUseId: 'tool-1', content: 'hello', isError: false },
+    ]);
     await sleep(50);
 
     // Verify tool_result message was added

--- a/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
+++ b/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { WebSocket } from 'ws';
+import { WebSocketManager } from '../server/websocket.js';
+import { createHttpServer } from '../server/http.js';
+import { ChatManager } from '../chat/index.js';
+import { AdapterRegistry } from '../adapters/index.js';
+import { MockBaseAdapter } from './helpers/mock-adapter.js';
+import { MockBaseSession } from './helpers/mock-session.js';
+import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
+
+class MockSession extends MockBaseSession {
+  constructor(private adapter: MockAdapter) {
+    super('proc-1', adapter.id, '/tmp');
+  }
+
+  override async sendMessage(msg: string): Promise<void> {
+    this.adapter.sendMessageSpy(msg);
+  }
+  override async respondToPermission(r: ControlResponse): Promise<void> {
+    this.adapter.respondToPermissionSpy(r);
+  }
+  override async interrupt(): Promise<void> {
+    this.adapter.interruptSpy();
+  }
+  override async kill(): Promise<void> {
+    await super.kill();
+    this.adapter.killSpy();
+  }
+}
+
+class MockAdapter extends MockBaseAdapter {
+  override id = 'claude';
+  override name = 'Mock';
+  respondToPermissionSpy = vi.fn();
+  sendMessageSpy = vi.fn();
+  killSpy = vi.fn();
+  interruptSpy = vi.fn();
+  currentSession: MockSession | null = null;
+
+  override createSession(_options: SessionOptions): AdapterSession {
+    this.currentSession = new MockSession(this);
+    return this.currentSession;
+  }
+}
+
+function makeChat(permissionMode: string) {
+  return {
+    id: 'test-chat',
+    adapterId: 'claude',
+    projectId: 'proj-1',
+    status: 'active',
+    claudeSessionId: 'session-1',
+    processState: 'working',
+    permissionMode,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+  };
+}
+
+function createMockDb(permissionMode = 'default') {
+  const chat = makeChat(permissionMode);
+  return {
+    chats: {
+      get: vi.fn().mockReturnValue(chat),
+      create: vi.fn().mockReturnValue(chat),
+      list: vi.fn().mockReturnValue([chat]),
+      update: vi.fn(),
+      addPlanFile: vi.fn().mockReturnValue(false),
+      addSkillFile: vi.fn().mockReturnValue(false),
+      addMention: vi.fn().mockReturnValue(false),
+      getMentions: vi.fn().mockReturnValue([]),
+      getPlanFiles: vi.fn().mockReturnValue([]),
+      getSkillFiles: vi.fn().mockReturnValue([]),
+    },
+    projects: {
+      get: vi.fn().mockReturnValue({ id: 'proj-1', name: 'Test', path: '/tmp/test' }),
+      list: vi.fn().mockReturnValue([]),
+      getByPath: vi.fn().mockReturnValue(null),
+      create: vi.fn(),
+      remove: vi.fn(),
+      updateLastOpened: vi.fn(),
+    },
+    settings: {
+      get: vi.fn().mockReturnValue(null),
+      getByCategory: vi.fn().mockReturnValue({}),
+    },
+  };
+}
+
+function createStack(adapter: MockAdapter, permissionMode = 'default') {
+  const db = createMockDb(permissionMode);
+  const registry = new AdapterRegistry();
+  (registry as any).adapters = new Map();
+  registry.register(adapter);
+  const wsRef: { current: WebSocketManager | null } = { current: null };
+  const chats = new ChatManager(db as any, registry, undefined, (event) => wsRef.current?.broadcastEvent(event));
+  const { app } = createHttpServer(db as any, chats, registry);
+  const httpServer = createServer(app);
+  wsRef.current = new WebSocketManager(httpServer, chats);
+  return { httpServer, chats, db };
+}
+
+function startServer(server: Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve((server.address() as { port: number }).port);
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.closeAllConnections();
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function connectWs(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.on('open', () => resolve(ws));
+    ws.on('error', reject);
+  });
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('queued messages and thinking indicator', () => {
+  let server: Server | null = null;
+  let ws: WebSocket | null = null;
+
+  afterEach(async () => {
+    ws?.close();
+    if (server?.listening) await stopServer(server);
+  });
+
+  async function setup(adapter: MockAdapter) {
+    const { httpServer } = createStack(adapter, 'default');
+    server = httpServer;
+    const port = await startServer(server);
+    ws = await connectWs(port);
+    ws.send(JSON.stringify({ type: 'chat.resume', chatId: 'test-chat' }));
+    await sleep(100);
+    const events: DaemonEvent[] = [];
+    ws.on('message', (data) => events.push(JSON.parse(data.toString()) as DaemonEvent));
+    return events;
+  }
+
+  it('assistant message event followed by result does not impact queued message state', async () => {
+    const adapter = new MockAdapter();
+    const events = await setup(adapter);
+
+    // Simulate assistant streaming a message
+    adapter.currentSession!.simulateMessage([{ type: 'text', text: 'Processing user request...' }]);
+    await sleep(50);
+
+    // Verify message.added event
+    const messageEvent = events.find((e) => e.type === 'message.added');
+    expect(messageEvent).toBeDefined();
+
+    // Complete the session - this should transition to idle
+    adapter.currentSession!.simulateResult({
+      subtype: 'completed',
+      is_error: false,
+    });
+    await sleep(50);
+
+    // Verify chat.updated with processState = idle was emitted
+    const idleEvent = events.find((e) => e.type === 'chat.updated' && (e as any).chat.processState === 'idle');
+    expect(idleEvent).toBeDefined();
+    expect((idleEvent as any).reason).toBe('completed');
+  }, 10_000);
+
+  it('tool result followed by result transitions to idle correctly', async () => {
+    const adapter = new MockAdapter();
+    const events = await setup(adapter);
+
+    // Simulate assistant sending a tool_use
+    adapter.currentSession!.simulateMessage([
+      {
+        type: 'tool_use',
+        id: 'tool-1',
+        name: 'Bash',
+        input: { command: 'echo hello' },
+      },
+    ]);
+    await sleep(50);
+
+    // Simulate tool result
+    adapter.currentSession!.simulateToolResult([{ type: 'tool_result', toolUseId: 'tool-1', content: 'hello' }]);
+    await sleep(50);
+
+    // Verify tool_result message was added
+    const toolResultEvent = events.find((e) => e.type === 'message.added' && (e as any).message.type === 'tool_result');
+    expect(toolResultEvent).toBeDefined();
+
+    // Complete the session
+    adapter.currentSession!.simulateResult({
+      subtype: 'completed',
+      is_error: false,
+    });
+    await sleep(50);
+
+    // Verify transition to idle happened correctly
+    const idleEvent = events.find((e) => e.type === 'chat.updated' && (e as any).chat.processState === 'idle');
+    expect(idleEvent).toBeDefined();
+  }, 10_000);
+
+  it('result event for parent session transitions to idle (subagent results already filtered)', async () => {
+    const adapter = new MockAdapter();
+    const events = await setup(adapter);
+
+    // Simulate assistant message with a tool that might spawn a subagent
+    adapter.currentSession!.simulateMessage([
+      {
+        type: 'tool_use',
+        id: 'task-1',
+        name: 'Task',
+        input: { description: 'Do something' },
+      },
+    ]);
+    await sleep(50);
+
+    // Verify assistant message was added
+    const assistantEvent = events.find((e) => e.type === 'message.added' && (e as any).message.type === 'assistant');
+    expect(assistantEvent).toBeDefined();
+
+    // The subagent result event should be filtered in events.ts (lines 611-622),
+    // so we only see the parent session's result event
+    adapter.currentSession!.simulateResult({
+      subtype: 'completed',
+      is_error: false,
+    });
+    await sleep(50);
+
+    // Parent session should transition to idle
+    const idleEvent = events.find((e) => e.type === 'chat.updated' && (e as any).chat.processState === 'idle');
+    expect(idleEvent).toBeDefined();
+    expect((idleEvent as any).reason).toBe('completed');
+  }, 10_000);
+});

--- a/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
+++ b/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
@@ -10,6 +10,11 @@ import { MockBaseSession } from './helpers/mock-session.js';
 import type { ControlResponse, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 class MockSession extends MockBaseSession {
+  // Tests that exercise the queued-message path simulate the Claude protocol,
+  // which echoes per-message replay acks (isReplay). Mark the mock adapter as
+  // ack-supporting so chat-manager enrolls messages in queuedRefs.
+  readonly supportsReplayAck = true;
+
   constructor(private adapter: MockAdapter) {
     super('proc-1', adapter.id, '/tmp');
   }
@@ -212,6 +217,57 @@ describe('queued messages and thinking indicator', () => {
     // Verify transition to idle happened correctly
     const idleEvent = events.find((e) => e.type === 'chat.updated' && (e as any).chat.processState === 'idle');
     expect(idleEvent).toBeDefined();
+  }, 10_000);
+
+  it('non-acking adapters (no supportsReplayAck) still transition to idle on result', async () => {
+    // Adapters without per-message replay ack — Codex turn/start, Claude SDK
+    // streamFollowUp — must NOT get stuck in processState=working when a
+    // second message is sent while busy. chat-manager skips queuedRefs for
+    // them entirely, so the new getQueuedCount gate sees 0 and onResult
+    // flips to idle as expected.
+    class NonAckingMockSession extends MockBaseSession {
+      constructor(private adapter: MockAdapter) {
+        super('proc-1', adapter.id, '/tmp');
+      }
+      override async sendMessage(msg: string): Promise<void> {
+        this.adapter.sendMessageSpy(msg);
+      }
+      override async respondToPermission(r: ControlResponse): Promise<void> {
+        this.adapter.respondToPermissionSpy(r);
+      }
+      override async interrupt(): Promise<void> {
+        this.adapter.interruptSpy();
+      }
+      override async kill(): Promise<void> {
+        await super.kill();
+        this.adapter.killSpy();
+      }
+    }
+    class NonAckingMockAdapter extends MockAdapter {
+      override createSession(_options: SessionOptions): AdapterSession {
+        this.currentSession = new NonAckingMockSession(this) as unknown as MockSession;
+        return this.currentSession;
+      }
+    }
+    const adapter = new NonAckingMockAdapter();
+    const events = await setup(adapter);
+    const chatManager = events.chats;
+
+    // Send a second message while processState='working'. Without the
+    // adapter-capability check, this would enroll a queuedRef that never
+    // drains (the adapter never calls onQueuedProcessed). With the check,
+    // no ref is enrolled.
+    await chatManager.sendMessage('test-chat', 'second message');
+    await sleep(50);
+    events.length = 0;
+
+    adapter.currentSession!.simulateResult({ subtype: 'completed', is_error: false });
+    await sleep(50);
+
+    const idle = events.find(
+      (e) => e.type === 'chat.updated' && (e as { chat: { processState?: string } }).chat.processState === 'idle',
+    );
+    expect(idle).toBeDefined();
   }, 10_000);
 
   it('keeps processState=working when result fires while a queued message is still pending', async () => {

--- a/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
+++ b/packages/core/src/__tests__/queued-messages-and-thinking.test.ts
@@ -141,15 +141,15 @@ describe('queued messages and thinking indicator', () => {
   });
 
   async function setup(adapter: MockAdapter) {
-    const { httpServer } = createStack(adapter, 'default');
-    server = httpServer;
+    const stack = createStack(adapter, 'default');
+    server = stack.httpServer;
     const port = await startServer(server);
     ws = await connectWs(port);
     ws.send(JSON.stringify({ type: 'chat.resume', chatId: 'test-chat' }));
     await sleep(100);
     const events: DaemonEvent[] = [];
     ws.on('message', (data) => events.push(JSON.parse(data.toString()) as DaemonEvent));
-    return events;
+    return Object.assign(events, { chats: stack.chats });
   }
 
   it('assistant message event followed by result does not impact queued message state', async () => {
@@ -212,6 +212,63 @@ describe('queued messages and thinking indicator', () => {
     // Verify transition to idle happened correctly
     const idleEvent = events.find((e) => e.type === 'chat.updated' && (e as any).chat.processState === 'idle');
     expect(idleEvent).toBeDefined();
+  }, 10_000);
+
+  it('keeps processState=working when result fires while a queued message is still pending', async () => {
+    const adapter = new MockAdapter();
+    const events = await setup(adapter);
+    const chatManager = events.chats;
+
+    // The mock chat row reports processState='working', so this sendMessage
+    // takes the queued path: it stores a queuedRef and tags metadata.queued.
+    await chatManager.sendMessage('test-chat', 'second message');
+    await sleep(50);
+
+    events.length = 0;
+
+    // Result for the first turn. Queue still has the second message pending —
+    // onResult must NOT flip processState to idle.
+    adapter.currentSession!.simulateResult({ subtype: 'completed', is_error: false });
+    await sleep(50);
+
+    const droppedToIdle = events.some(
+      (e) => e.type === 'chat.updated' && (e as { chat: { processState?: string } }).chat.processState === 'idle',
+    );
+    expect(droppedToIdle).toBe(false);
+  }, 10_000);
+
+  it('sweeps stranded message.metadata.queued flags when result fires with empty queue', async () => {
+    const adapter = new MockAdapter();
+    const events = await setup(adapter);
+    const chatManager = events.chats;
+
+    // Inject a stranded queued flag — simulates the CLI ack arriving in a
+    // shape (event.uuid missing) we didn't dispatch, so the metadata was
+    // never cleared by onQueuedProcessed.
+    const cache = (
+      chatManager as unknown as {
+        messages: {
+          append(chatId: string, msg: { metadata?: Record<string, unknown> }): void;
+          get(id: string): Array<{ metadata?: Record<string, unknown> }> | undefined;
+        };
+      }
+    ).messages;
+    cache.append('test-chat', {
+      id: 'orphan-msg',
+      chatId: 'test-chat',
+      type: 'user',
+      content: [{ type: 'text', text: 'orphan' }],
+      timestamp: new Date().toISOString(),
+      metadata: { queued: true, uuid: 'orphan-uuid-1' },
+    } as never);
+    const msgs = cache.get('test-chat')!;
+
+    events.length = 0;
+    adapter.currentSession!.simulateResult({ subtype: 'completed', is_error: false });
+    await sleep(50);
+
+    const stranded = msgs.find((m) => m.metadata?.queued === true);
+    expect(stranded).toBeUndefined();
   }, 10_000);
 
   it('result event for parent session transitions to idle (subagent results already filtered)', async () => {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -265,7 +265,14 @@ export class ChatManager {
     const outgoingContent =
       textPrefix.length > 0 ? (content ? `${textPrefix.join('\n')}\n\n${content}` : textPrefix.join('\n')) : content;
 
-    const isQueued = postStart.chat.processState === 'working';
+    // Only treat the message as queued for adapters whose protocol echoes a
+    // per-message replay ack (Claude CLI stream-json). Adapters that consume
+    // sendMessage synchronously (Codex turn/start, Claude SDK streamFollowUp)
+    // never call `sink.onQueuedProcessed`, so leaving them on the queued path
+    // would strand `queuedRefs` and pin `processState='working'` forever via
+    // the new `getQueuedCount` gate in onResult.
+    const adapterAcksReplay = postStart.session.supportsReplayAck === true;
+    const isQueued = adapterAcksReplay && postStart.chat.processState === 'working';
     const transientMetadata: Record<string, unknown> = {};
     if (isQueued) transientMetadata.queued = true;
     if (attachmentPreviews.length > 0) transientMetadata.attachments = attachmentPreviews;

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -65,6 +65,7 @@ export class ChatManager {
       },
       (chatId, uuid) => this.handleQueuedProcessed(chatId, uuid),
       (chatId) => this.clearAllQueuedForChat(chatId),
+      (chatId) => this.getQueuedForChat(chatId).length,
     );
     this.planMode = new PlanModeHandler({
       permissions: this.permissions,

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -245,6 +245,11 @@ function buildSessionSink(
       const active = getActiveChat(chatId);
       if (!active) return;
 
+      log.debug(
+        { chatId, sessionId: active.session?.id, subtype: data.subtype, is_error: data.is_error },
+        'onResult: processing session result',
+      );
+
       const cost = data.total_cost_usd ?? 0;
       const tokensInput = data.usage?.input_tokens ?? 0;
       const tokensOutput = data.usage?.output_tokens ?? 0;
@@ -278,6 +283,7 @@ function buildSessionSink(
 
       const isError = data.subtype === 'error_during_execution' && data.is_error !== false;
       const reason = wasInterrupted ? 'interrupted' : isError ? 'error' : 'completed';
+      log.debug({ chatId, reason, wasInterrupted, isError }, 'onResult: emitting chat.updated with processState=idle');
       emitEvent({ type: 'chat.updated', chat: active.chat, reason });
 
       const notifyConfig = readNotificationConfig(db);
@@ -317,12 +323,16 @@ function buildSessionSink(
     },
 
     onQueuedProcessed(uuid: string) {
+      log.debug({ chatId, uuid }, 'onQueuedProcessed: removing queued flag from message');
       const msgs = messages.get(chatId);
       const msg = msgs?.find((m) => m.metadata?.uuid === uuid);
       if (msg?.metadata) {
         delete (msg.metadata as Record<string, unknown>).queued;
         delete (msg.metadata as Record<string, unknown>).uuid;
+        log.debug({ chatId, uuid, messageId: msg.id }, 'onQueuedProcessed: queued flag removed, emitting display');
         emitDisplay();
+      } else {
+        log.warn({ chatId, uuid }, 'onQueuedProcessed: message not found in cache or already processed');
       }
       emitEvent({ type: 'message.queued.processed', chatId, uuid });
       onQueuedProcessedCb(chatId, uuid);

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -53,6 +53,7 @@ export class EventHandler {
     private getToolCategories: (chatId: string) => ToolCategories | undefined = () => undefined,
     private onQueuedProcessed: (chatId: string, uuid: string) => void = () => {},
     private onQueuedCleared: (chatId: string) => void = () => {},
+    private getQueuedCount: (chatId: string) => number = () => 0,
   ) {}
 
   setPushService(service: PushService): void {
@@ -83,6 +84,7 @@ export class EventHandler {
       this.getToolCategories,
       this.onQueuedProcessed,
       this.onQueuedCleared,
+      this.getQueuedCount,
       this.pushService,
     );
   }
@@ -112,6 +114,7 @@ function buildSessionSink(
   getToolCategories: (chatId: string) => ToolCategories | undefined,
   onQueuedProcessedCb: (chatId: string, uuid: string) => void,
   onQueuedClearedCb: (chatId: string) => void,
+  getQueuedCount: (chatId: string) => number,
   pushService?: PushService,
 ): SessionSink {
   function emitDisplay(): void {
@@ -261,20 +264,50 @@ function buildSessionSink(
       // the AI finishes a turn, not only when the user sends a message.
       const now = new Date().toISOString();
 
+      // Result events fire per-turn. If the user queued more messages while the
+      // CLI was busy, the CLI will keep processing them — we must NOT flip to
+      // idle here, or the thinking indicator drops while the assistant is
+      // still streaming the next queued turn. The final result (when the queue
+      // drains) will set idle.
+      const queueRemaining = getQueuedCount(chatId);
+      const nextProcessState: 'idle' | 'working' = queueRemaining > 0 ? 'working' : 'idle';
+
       db.chats.update(chatId, {
         totalCost: newCost,
         totalTokensInput: newInput,
         totalTokensOutput: newOutput,
         lastContextTokensInput: tokensInput,
-        processState: 'idle',
+        processState: nextProcessState,
         updatedAt: now,
       });
       active.chat.totalCost = newCost;
       active.chat.totalTokensInput = newInput;
       active.chat.totalTokensOutput = newOutput;
       active.chat.lastContextTokensInput = tokensInput;
-      active.chat.processState = 'idle';
+      active.chat.processState = nextProcessState;
       active.chat.updatedAt = now;
+
+      // Belt-and-suspenders: when the queue is genuinely empty, sweep any
+      // message still flagged metadata.queued. These are stranded acks —
+      // happens when the CLI's isReplay event arrived in a uuid shape we
+      // didn't dispatch on, so the per-message flag was never cleared.
+      if (queueRemaining === 0) {
+        const cached = messages.get(chatId);
+        let swept = false;
+        if (cached) {
+          for (const m of cached) {
+            if (m.metadata?.queued) {
+              delete (m.metadata as Record<string, unknown>).queued;
+              delete (m.metadata as Record<string, unknown>).uuid;
+              swept = true;
+            }
+          }
+        }
+        if (swept) {
+          log.warn({ chatId }, 'onResult: swept stranded metadata.queued flags');
+          emitDisplay();
+        }
+      }
       // Check interrupted flag before clearing permissions (clear() wipes both).
       const wasInterrupted = permissions.clearInterrupted(chatId);
       // CLI process ended — clear stale permissions so displayStatus reflects

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -372,11 +372,24 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   // versions / SDK shims that drop the flag.
   if (event.isCompactSummary === true) return;
 
-  // Detect queued message processed by CLI (isReplay from SDK mode)
+  // Detect queued message processed by CLI (isReplay from SDK mode).
+  // The uuid identifying the original user message can land in any of three
+  // places depending on CLI version and event shape:
+  //   - event.uuid              (stream-json entry-level)
+  //   - event.message.uuid      (some SDK builds)
+  //   - event.message.id        (when treated as a regular Anthropic message id)
+  // Reading only event.uuid leaves a stranded queued flag in the cache when
+  // the CLI uses one of the other shapes — see issue #147.
   const isReplay = event.isReplay === true || event.is_replay === true;
-  const uuid = (event.uuid as string) || undefined;
+  const messageObj = event.message as { uuid?: string; id?: string } | undefined;
+  const uuid = (event.uuid as string) || messageObj?.uuid || messageObj?.id || undefined;
   if (isReplay && uuid) {
     sink.onQueuedProcessed(uuid);
+  } else if (isReplay) {
+    log.warn(
+      { sessionId: session.id, eventKeys: Object.keys(event) },
+      'isReplay user event without recognizable uuid — queued flag may strand',
+    );
   }
 
   // Live stream handles ONLY tool_result blocks from user events.

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -590,6 +590,11 @@ function handleResultEvent(session: ClaudeSession, event: Record<string, unknown
   session.state.lastAssistantUsage = undefined;
   session.clearInterruptTimer();
 
+  log.debug(
+    { sessionId: session.id, sessionChatId: session.state.chatId, subtype: event.subtype },
+    'handling result event for parent session',
+  );
+
   sink.onResult({
     total_cost_usd: (event.total_cost_usd as number) || 0,
     usage: usage

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -7,7 +7,6 @@ import type {
   DetectedPr,
   MessageContent,
   SessionSink,
-  SkillFileEntry,
 } from '@qlan-ro/mainframe-types';
 import type { ClaudeSession } from './session.js';
 import { buildToolResultBlocks } from './history.js';
@@ -146,7 +145,7 @@ const INFORMATIONAL_PATTERNS = [
   /^Cloning into/,
 ];
 
-export function handleStderr(session: ClaudeSession, chunk: Buffer, sink: SessionSink): void {
+export function handleStderr(_session: ClaudeSession, chunk: Buffer, sink: SessionSink): void {
   const message = chunk.toString().trim();
   if (!message) return;
   if (INFORMATIONAL_PATTERNS.some((p) => p.test(message))) return;
@@ -518,7 +517,7 @@ function handleUserEvent(session: ClaudeSession, event: Record<string, unknown>,
   }
 }
 
-function handleControlRequestEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
+function handleControlRequestEvent(_session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
   const request = event.request as Record<string, unknown>;
   if (request?.subtype === 'can_use_tool') {
     const permRequest: ControlRequest = {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -89,6 +89,7 @@ export class ClaudeSession implements AdapterSession {
   readonly id: string;
   readonly adapterId = 'claude';
   readonly projectPath: string;
+  readonly supportsReplayAck = true;
 
   /** Mutable internal state — readable by claude-events.ts and tests. */
   readonly state: ClaudeSessionState;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -147,6 +147,17 @@ export interface AdapterSession {
   readonly adapterId: string;
   readonly projectPath: string;
   readonly isSpawned: boolean;
+  /**
+   * True when the adapter's protocol echoes a per-message replay ack that
+   * Mainframe can use to drive `sink.onQueuedProcessed(uuid)` — e.g. the
+   * Claude CLI's `isReplay` user event over stream-json. Adapters whose
+   * `sendMessage` consumes the message synchronously (Codex `turn/start`,
+   * Claude SDK `streamFollowUp`) leave this `false` (or undefined). The
+   * chat-manager only enrolls a message in `queuedRefs` when this is true,
+   * so chats on non-acknowledging adapters never get stuck in
+   * `processState='working'` waiting for an ack that will never arrive.
+   */
+  readonly supportsReplayAck?: boolean;
 
   spawn(options?: SessionSpawnOptions, sink?: SessionSink): Promise<AdapterProcess>;
   kill(): Promise<void>;


### PR DESCRIPTION
## Summary

Resolves #147. Fixes two real bugs in the queued-message + thinking-indicator state machine.

### Bug 1 — Thinking indicator dropped while assistant was still rendering

`onResult` unconditionally set `processState='idle'` on every result event. With `isRunning = processState==='working' && !pendingPermission`, the result for the **first** message in a queued sequence flipped the chat to idle while the CLI was still about to process the queued ones. The indicator went dark mid-turn.

**Fix:** pass a `getQueuedCount(chatId)` accessor (backed by `ChatManager.queuedRefs`) into the session sink. `onResult` now stays in `'working'` when the queue is non-empty; only the final result that drains the queue flips to `'idle'`.

### Bug 2 — Queued banner sometimes stranded forever

`handleUserEvent` read uuid only from `event.uuid`, but the CLI's `isReplay` user event lands the uuid on `event.message.uuid` or `event.message.id` depending on version / SDK shape. When neither matched, `onQueuedProcessed` never dispatched and `metadata.queued` survived in the cache — cleaned up only on process exit, useless if the CLI keeps running.

**Fix:**
- Read uuid from `event.uuid ?? event.message.uuid ?? event.message.id`; warn if `isReplay` arrives without any recognizable uuid (telemetry for new shapes).
- Belt-and-suspenders: when `onResult` fires with empty `queuedRefs`, sweep any cached message still flagged `metadata.queued`. Those are stranded acks; clearing them stops the composer banner / SessionRow from showing the queued state forever.

## Test plan

- [x] `queued-messages-and-thinking.test.ts` — 2 new end-to-end tests:
  - `processState=working` is preserved when result fires with a queued message still pending
  - `onResult` sweeps stranded `metadata.queued` flags when `queuedRefs` is empty
- [x] `queued-message-lifecycle.test.ts` — existing test updated to pass `getQueuedCount=2`; new test exercises the empty-queue sweep
- [x] Full core suite green (one unrelated ripgrep search test is flaky, passes in isolation)
- [ ] Manual: type 2-3 messages back-to-back into a busy chat, verify thinking indicator stays on across all turns
- [ ] Manual: verify composer banner clears as each queued message is dequeued

🤖 Generated with [Claude Code](https://claude.com/claude-code)