### PR TITLE
feat(core): persist detected PRs to DB so sidebar shows them on app load

### DIFF
--- a/.changeset/persist-detected-prs.md
+++ b/.changeset/persist-detected-prs.md
@@ -1,6 +1,6 @@
 ---
 "@qlan-ro/mainframe-types": patch
-"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-core": patch
 "@qlan-ro/mainframe-desktop": patch
 ---
 

--- a/.changeset/persist-detected-prs.md
+++ b/.changeset/persist-detected-prs.md
@@ -1,0 +1,7 @@
+---
+"@qlan-ro/mainframe-types": patch
+"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Persist detected PRs to the database. Previously they lived only in the renderer's in-memory `detectedPrs` Map, which was rebuilt by replaying events from the daemon's per-`loadChat` history scan — so PR badges only appeared on sessions the user had opened during the current daemon lifetime. PRs are now stored on the chat row (new `detected_prs` column) by both the live `onPrDetected` sink and the history-replay scan, with URL-based dedup and `mentioned → created` source upgrades. The renderer seeds its Map from `chat.detectedPrs` on chat list load, so badges show on the sidebar immediately on app start.

--- a/packages/core/src/__tests__/db/chats.test.ts
+++ b/packages/core/src/__tests__/db/chats.test.ts
@@ -626,4 +626,70 @@ describe('ChatsRepository', () => {
       expect(chats.findByExternalSessionId('session-ggg', p2.id)).not.toBeNull();
     });
   });
+
+  describe('detected PRs', () => {
+    it('getDetectedPrs returns empty array for a new chat', () => {
+      const chat = chats.create(projectId, 'claude');
+      expect(chats.getDetectedPrs(chat.id)).toEqual([]);
+    });
+
+    it('addDetectedPrs persists a PR and is retrievable', () => {
+      const chat = chats.create(projectId, 'claude');
+      const pr = {
+        number: 123,
+        owner: 'owner',
+        repo: 'repo',
+        url: 'https://github.com/owner/repo/pull/123',
+        source: 'mentioned' as const,
+      };
+
+      const added = chats.addDetectedPrs(chat.id, [pr]);
+      expect(added).toEqual([pr]);
+      expect(chats.getDetectedPrs(chat.id)).toEqual([pr]);
+    });
+
+    it('addDetectedPrs deduplicates by URL across calls', () => {
+      const chat = chats.create(projectId, 'claude');
+      const pr = {
+        number: 1,
+        owner: 'o',
+        repo: 'r',
+        url: 'https://github.com/o/r/pull/1',
+        source: 'mentioned' as const,
+      };
+
+      chats.addDetectedPrs(chat.id, [pr]);
+      const second = chats.addDetectedPrs(chat.id, [pr]);
+      expect(second).toEqual([]);
+      expect(chats.getDetectedPrs(chat.id)).toHaveLength(1);
+    });
+
+    it('addDetectedPrs upgrades source from mentioned → created on second sighting', () => {
+      const chat = chats.create(projectId, 'claude');
+      const url = 'https://github.com/o/r/pull/9';
+
+      chats.addDetectedPrs(chat.id, [{ number: 9, owner: 'o', repo: 'r', url, source: 'mentioned' }]);
+      chats.addDetectedPrs(chat.id, [{ number: 9, owner: 'o', repo: 'r', url, source: 'created' }]);
+
+      const result = chats.getDetectedPrs(chat.id);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.source).toBe('created');
+    });
+
+    it('Chat returned by get() includes detectedPrs from DB', () => {
+      const chat = chats.create(projectId, 'claude');
+      chats.addDetectedPrs(chat.id, [
+        {
+          number: 7,
+          owner: 'o',
+          repo: 'r',
+          url: 'https://github.com/o/r/pull/7',
+          source: 'mentioned',
+        },
+      ]);
+
+      const reloaded = chats.get(chat.id);
+      expect(reloaded?.detectedPrs).toEqual([expect.objectContaining({ number: 7, source: 'mentioned' })]);
+    });
+  });
 });

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -402,7 +402,13 @@ function buildSessionSink(
     },
 
     onPrDetected(pr: import('@qlan-ro/mainframe-types').DetectedPr) {
-      emitEvent({ type: 'chat.prDetected', chatId, pr });
+      // Persist before emitting so reconnecting renderers / sidebar entries
+      // that never trigger a loadChat see the PR via the DB-backed Chat row.
+      // Suppress the WS event when addDetectedPrs reports no change — avoids
+      // re-emitting on every duplicate sighting from the live stream.
+      const persisted = db.chats.addDetectedPrs(chatId, [pr]);
+      if (persisted.length === 0) return;
+      emitEvent({ type: 'chat.prDetected', chatId, pr: persisted[0]! });
     },
 
     onCliMessage(text: string) {

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -360,6 +360,8 @@ export class ChatLifecycleManager {
         // Scan history for PR URLs with command-level correlation.
         // Walk messages in order: assistant tool_use blocks identify PR-create
         // commands; subsequent tool_result blocks with PR URLs are classified.
+        const scanned: { url: string; owner: string; repo: string; number: number; source: 'created' | 'mentioned' }[] =
+          [];
         const seenPrs = new Set<string>();
         const pendingCreates = new Set<string>();
         for (const msg of cached) {
@@ -388,7 +390,19 @@ export class ChatLifecycleManager {
             const toolUseId = (block as Record<string, unknown>).toolUseId as string | undefined;
             const source = toolUseId && pendingCreates.has(toolUseId) ? ('created' as const) : ('mentioned' as const);
             if (source === 'created') pendingCreates.delete(toolUseId!);
-            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr: { ...pr, source } });
+            scanned.push({ ...pr, source });
+          }
+        }
+
+        // Persist to DB so subsequent renderer connects (or sidebar views that
+        // never trigger a loadChat for this session) can surface PRs without
+        // re-running history replay. Emit `chat.prDetected` only for entries
+        // that are actually new or had their source upgraded — addDetectedPrs
+        // returns the diff. The renderer's `detectedPrs` Map merges idempotently.
+        if (scanned.length > 0) {
+          const persisted = this.deps.db.chats.addDetectedPrs(chatId, scanned);
+          for (const pr of persisted) {
+            this.deps.emitEvent({ type: 'chat.prDetected', chatId, pr });
           }
         }
       }

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -1,15 +1,19 @@
 import type Database from 'better-sqlite3';
-import type { Chat, SessionMention, SkillFileEntry, TodoItem } from '@qlan-ro/mainframe-types';
+import type { Chat, DetectedPr, SessionMention, SkillFileEntry, TodoItem } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
 
 /** Raw shape returned by SQLite before boolean/JSON coercion. */
-type RawChatRow = Omit<Chat, 'pinned' | 'planMode' | 'mentions' | 'modifiedFiles' | 'todos' | 'effort'> & {
+type RawChatRow = Omit<
+  Chat,
+  'pinned' | 'planMode' | 'mentions' | 'modifiedFiles' | 'todos' | 'effort' | 'detectedPrs'
+> & {
   mentions: string;
   modifiedFiles: string;
   todos: string;
   pinned: number;
   planMode: number;
   effort: string | null;
+  detectedPrs: string;
 };
 
 function parseEffort(value: string | null | undefined): Chat['effort'] {
@@ -41,7 +45,7 @@ export class ChatsRepository {
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
         process_state as processState, todos, pinned, effort,
-        plan_mode as planMode
+        plan_mode as planMode, detected_prs as detectedPrs
       FROM chats
       WHERE project_id = ?
       ORDER BY pinned DESC, updated_at DESC
@@ -58,6 +62,7 @@ export class ChatsRepository {
       pinned: Boolean(row.pinned),
       effort: parseEffort(row.effort),
       planMode: Boolean(row.planMode),
+      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
   }
 
@@ -73,7 +78,7 @@ export class ChatsRepository {
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
         process_state as processState, todos, pinned, effort,
-        plan_mode as planMode
+        plan_mode as planMode, detected_prs as detectedPrs
       FROM chats
       ORDER BY pinned DESC, updated_at DESC, rowid DESC
     `);
@@ -89,6 +94,7 @@ export class ChatsRepository {
       pinned: Boolean(row.pinned),
       effort: parseEffort(row.effort),
       planMode: Boolean(row.planMode),
+      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
   }
 
@@ -104,7 +110,7 @@ export class ChatsRepository {
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
         process_state as processState, todos, pinned, effort,
-        plan_mode as planMode
+        plan_mode as planMode, detected_prs as detectedPrs
       FROM chats WHERE id = ?
     `);
     const row = stmt.get(id) as RawChatRow | null;
@@ -120,6 +126,7 @@ export class ChatsRepository {
       pinned: Boolean(row.pinned),
       effort: parseEffort(row.effort),
       planMode: Boolean(row.planMode),
+      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
   }
 
@@ -242,6 +249,45 @@ export class ChatsRepository {
     return true;
   }
 
+  getDetectedPrs(chatId: string): DetectedPr[] {
+    const stmt = this.db.prepare('SELECT detected_prs FROM chats WHERE id = ?');
+    const row = stmt.get(chatId) as { detected_prs: string } | undefined;
+    return parseJsonColumn(row?.detected_prs, []);
+  }
+
+  /**
+   * Persist newly-detected PRs, deduplicating by URL. Returns the rows that
+   * were actually written (i.e. either new, or had their `source` upgraded
+   * from `mentioned` → `created`). Existing 'created' entries are never
+   * downgraded to 'mentioned'.
+   */
+  addDetectedPrs(chatId: string, prs: DetectedPr[]): DetectedPr[] {
+    const existing = this.getDetectedPrs(chatId);
+    const byUrl = new Map(existing.map((p) => [p.url, p] as const));
+    const written: DetectedPr[] = [];
+    let mutated = false;
+
+    for (const pr of prs) {
+      const prev = byUrl.get(pr.url);
+      if (!prev) {
+        byUrl.set(pr.url, pr);
+        written.push(pr);
+        mutated = true;
+      } else if (prev.source !== 'created' && pr.source === 'created') {
+        byUrl.set(pr.url, { ...prev, source: 'created' });
+        written.push({ ...prev, source: 'created' });
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      this.db
+        .prepare('UPDATE chats SET detected_prs = ? WHERE id = ?')
+        .run(JSON.stringify([...byUrl.values()]), chatId);
+    }
+    return written;
+  }
+
   getTodos(chatId: string): TodoItem[] | null {
     const stmt = this.db.prepare('SELECT todos FROM chats WHERE id = ?');
     const row = stmt.get(chatId) as { todos: string | null } | undefined;
@@ -274,7 +320,7 @@ export class ChatsRepository {
         mentions, modified_files as modifiedFiles,
         worktree_path as worktreePath, branch_name as branchName,
         process_state as processState, todos, pinned, effort,
-        plan_mode as planMode
+        plan_mode as planMode, detected_prs as detectedPrs
       FROM chats WHERE claude_session_id = ? AND project_id = ?
     `);
     const row = stmt.get(sessionId, projectId) as RawChatRow | null;
@@ -290,6 +336,7 @@ export class ChatsRepository {
       pinned: Boolean(row.pinned),
       effort: parseEffort(row.effort),
       planMode: Boolean(row.planMode),
+      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
   }
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -94,6 +94,9 @@ export function initializeSchema(db: Database.Database): void {
   if (!cols.some((c) => c.name === 'effort')) {
     db.exec('ALTER TABLE chats ADD COLUMN effort TEXT');
   }
+  if (!cols.some((c) => c.name === 'detected_prs')) {
+    db.exec("ALTER TABLE chats ADD COLUMN detected_prs TEXT DEFAULT '[]'");
+  }
   if (!cols.some((c) => c.name === 'plan_mode')) {
     db.exec('ALTER TABLE chats ADD COLUMN plan_mode INTEGER NOT NULL DEFAULT 0');
     db.exec("UPDATE chats SET plan_mode = 1, permission_mode = 'default' WHERE permission_mode = 'plan'");

--- a/packages/desktop/src/renderer/store/chats.test.ts
+++ b/packages/desktop/src/renderer/store/chats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useChatsStore } from './chats';
-import type { Chat } from '@qlan-ro/mainframe-types';
+import { useChatsStore, mergeDetectedPrs } from './chats';
+import type { Chat, DetectedPr } from '@qlan-ro/mainframe-types';
 
 function makeChat(id: string, updatedAt: string, pinned = false, projectId = 'proj-1'): Chat {
   return {
@@ -175,5 +175,98 @@ describe('filterProjectId reconciliation on setActiveChat', () => {
     useChatsStore.getState().setFilterProjectId('proj-A');
     useChatsStore.getState().setActiveChat('chat-missing');
     expect(useChatsStore.getState().filterProjectId).toBe('proj-A');
+  });
+});
+
+const pr = (number: number, source: 'created' | 'mentioned' = 'mentioned', owner = 'o', repo = 'r'): DetectedPr => ({
+  number,
+  owner,
+  repo,
+  url: `https://github.com/${owner}/${repo}/pull/${number}`,
+  source,
+});
+
+describe('mergeDetectedPrs', () => {
+  it('returns DB entries when in-memory is empty', () => {
+    const result = mergeDetectedPrs([], [pr(1), pr(2)]);
+    expect(result.map((p) => p.number).sort()).toEqual([1, 2]);
+  });
+
+  it('returns in-memory entries when DB is empty (live event raced ahead of DB write)', () => {
+    const result = mergeDetectedPrs([pr(5)], []);
+    expect(result.map((p) => p.number)).toEqual([5]);
+  });
+
+  it('dedups by URL across both sources', () => {
+    const result = mergeDetectedPrs([pr(1)], [pr(1), pr(2)]);
+    expect(result.map((p) => p.number).sort()).toEqual([1, 2]);
+  });
+
+  it('upgrades source from mentioned → created when DB has the upgrade', () => {
+    // Renderer disconnected with PR#7 'mentioned'. While offline, daemon saw
+    // the gh pr create succeed and persisted PR#7 as 'created'. On reconnect,
+    // setChats merges — DB version wins.
+    const result = mergeDetectedPrs([pr(7, 'mentioned')], [pr(7, 'created')]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('created');
+  });
+
+  it('does NOT downgrade source from created → mentioned', () => {
+    // Inverse: renderer saw the live 'created' event but DB only has
+    // 'mentioned' (race window between live emit and DB commit). Keep 'created'.
+    const result = mergeDetectedPrs([pr(7, 'created')], [pr(7, 'mentioned')]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('created');
+  });
+
+  it('preserves in-memory entries the DB does not yet know about', () => {
+    const result = mergeDetectedPrs([pr(99)], [pr(1)]);
+    expect(result.map((p) => p.number).sort()).toEqual([1, 99]);
+  });
+});
+
+describe('setChats — detectedPrs reconciliation across reconnect', () => {
+  beforeEach(() => {
+    useChatsStore.setState({ chats: [], detectedPrs: new Map() });
+  });
+
+  function makeChatWithPrs(id: string, prs: DetectedPr[]): Chat {
+    return {
+      id,
+      adapterId: 'claude',
+      projectId: 'p1',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      totalCost: 0,
+      totalTokensInput: 0,
+      totalTokensOutput: 0,
+      lastContextTokensInput: 0,
+      detectedPrs: prs,
+    };
+  }
+
+  it('seeds the Map from DB on first setChats', () => {
+    useChatsStore.getState().setChats([makeChatWithPrs('c1', [pr(1)])]);
+    expect(
+      useChatsStore
+        .getState()
+        .detectedPrs.get('c1')
+        ?.map((p) => p.number),
+    ).toEqual([1]);
+  });
+
+  it('merges DB into existing Map on reconnect — picks up DB-only PRs added while offline', () => {
+    useChatsStore.setState({ detectedPrs: new Map([['c1', [pr(1)]]]) });
+    // Daemon, while we were offline, persisted PR#2 too.
+    useChatsStore.getState().setChats([makeChatWithPrs('c1', [pr(1), pr(2)])]);
+    const result = useChatsStore.getState().detectedPrs.get('c1');
+    expect(result?.map((p) => p.number).sort()).toEqual([1, 2]);
+  });
+
+  it('upgrades source on reconnect when DB has source upgrade', () => {
+    useChatsStore.setState({ detectedPrs: new Map([['c1', [pr(7, 'mentioned')]]]) });
+    useChatsStore.getState().setChats([makeChatWithPrs('c1', [pr(7, 'created')])]);
+    expect(useChatsStore.getState().detectedPrs.get('c1')?.[0]?.source).toBe('created');
   });
 });

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -90,6 +90,22 @@ function sortChats(chats: Chat[]): Chat[] {
   });
 }
 
+/**
+ * Merge two PR lists deduped by URL. 'created' source always wins over
+ * 'mentioned' (matches the DB's addDetectedPrs upgrade rule). Order is
+ * preserved from the merged-into list, with new entries appended.
+ */
+export function mergeDetectedPrs(into: DetectedPr[], add: DetectedPr[]): DetectedPr[] {
+  const byUrl = new Map<string, DetectedPr>();
+  for (const pr of into) byUrl.set(pr.url, pr);
+  for (const pr of add) {
+    const prev = byUrl.get(pr.url);
+    if (!prev) byUrl.set(pr.url, pr);
+    else if (prev.source !== 'created' && pr.source === 'created') byUrl.set(pr.url, { ...prev, source: 'created' });
+  }
+  return [...byUrl.values()];
+}
+
 export const useChatsStore = create<ChatsState>((set) => ({
   chats: [],
   activeChatId: null,
@@ -120,15 +136,19 @@ export const useChatsStore = create<ChatsState>((set) => ({
     }),
   setChats: (chats) =>
     set((state) => {
-      // Seed `detectedPrs` from the DB-backed Chat rows so PR badges render
-      // immediately on app load without requiring each session to be opened
-      // (which is what triggers the daemon's history-replay PR scan). Live
-      // `chat.prDetected` events still merge into this Map idempotently.
+      // Reconcile `detectedPrs` with the DB-backed Chat rows so PR badges
+      // render immediately on app load AND so reconnects pick up DB writes
+      // that happened while the renderer was offline (live `chat.prDetected`
+      // events would have been missed). DB is authoritative; merge in any
+      // in-memory entries the DB doesn't yet know about (covers the brief
+      // window between an live event arriving over WS and the DB write
+      // completing). Source-rank: 'created' beats 'mentioned'.
       const next = new Map(state.detectedPrs);
       for (const chat of chats) {
-        if (chat.detectedPrs && chat.detectedPrs.length > 0 && !next.has(chat.id)) {
-          next.set(chat.id, chat.detectedPrs);
-        }
+        const dbPrs = chat.detectedPrs ?? [];
+        const memPrs = next.get(chat.id) ?? [];
+        if (dbPrs.length === 0 && memPrs.length === 0) continue;
+        next.set(chat.id, mergeDetectedPrs(memPrs, dbPrs));
       }
       return { chats: sortChats([...chats]), detectedPrs: next };
     }),

--- a/packages/desktop/src/renderer/store/chats.ts
+++ b/packages/desktop/src/renderer/store/chats.ts
@@ -118,7 +118,20 @@ export const useChatsStore = create<ChatsState>((set) => ({
       next.delete(chatId);
       return { unreadChatIds: next };
     }),
-  setChats: (chats) => set({ chats: sortChats([...chats]) }),
+  setChats: (chats) =>
+    set((state) => {
+      // Seed `detectedPrs` from the DB-backed Chat rows so PR badges render
+      // immediately on app load without requiring each session to be opened
+      // (which is what triggers the daemon's history-replay PR scan). Live
+      // `chat.prDetected` events still merge into this Map idempotently.
+      const next = new Map(state.detectedPrs);
+      for (const chat of chats) {
+        if (chat.detectedPrs && chat.detectedPrs.length > 0 && !next.has(chat.id)) {
+          next.set(chat.id, chat.detectedPrs);
+        }
+      }
+      return { chats: sortChats([...chats]), detectedPrs: next };
+    }),
   setFilterProjectId: (id) => {
     if (id) {
       localStorage.setItem('mf:filterProjectId', id);

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -1,4 +1,5 @@
 import type { SessionMention } from './context.js';
+import type { DetectedPr } from './adapter.js';
 
 export interface TodoItem {
   content: string;
@@ -37,6 +38,8 @@ export interface Chat {
   pinned?: boolean;
   /** Reasoning effort for Claude adapter (gated on model.supportsEffort). Applied as --effort on CLI spawn. */
   effort?: ChatEffort;
+  /** PRs detected in the session's tool_results (created via `gh pr create` or merely mentioned). */
+  detectedPrs?: DetectedPr[];
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary

PR badges in the sidebar were only populated by replaying `chat.prDetected` events from the daemon's per-`loadChat` history-replay scan. So sessions the user hadn't opened during the current daemon lifetime never got their badges — the scan never ran for them. The renderer's `detectedPrs` Map was reset on every reconnect.

This persists detected PRs to the chat row (new `detected_prs` JSON column) on both code paths:

- **History replay** (`lifecycle-manager`): collect PRs into a list, dedup via the new `ChatsRepository.addDetectedPrs`, emit only the diff.
- **Live stream** (`event-handler.onPrDetected`): persist first, suppress the WS event when nothing changed, so duplicate sightings don't re-emit.

`addDetectedPrs` dedups by URL and upgrades `mentioned → created` on re-sighting (never downgrades). The renderer's `setChats` now seeds `detectedPrs` from `chat.detectedPrs`, so sidebar badges render immediately on chat list load without requiring a session to be opened.

## Changes

- `packages/types`: `Chat.detectedPrs?: DetectedPr[]`
- `packages/core`:
  - DB migration for `detected_prs` column
  - `ChatsRepository.getDetectedPrs` / `addDetectedPrs` (URL dedup, source upgrade)
  - `Chat.get` / `list` / `listAll` now include `detectedPrs`
  - Persist in lifecycle-manager history scan and event-handler live sink
- `packages/desktop`: `setChats` seeds `detectedPrs` Map from chat rows

## Test plan

- [x] 5 new DB tests (dedup, source upgrade, Chat-row inclusion) — green
- [x] All 86 chats tests pass
- [x] Full core suite green except an unrelated flaky ripgrep search test (passes in isolation)
- [ ] Verify sidebar shows PR badge on a session created in a previous daemon lifetime (without opening it)
- [ ] Verify duplicate PR mentions in live stream don't re-emit `chat.prDetected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)