### PR TITLE
Session row tagging

### DIFF
--- a/.changeset/session-row-tagging.md
+++ b/.changeset/session-row-tagging.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-desktop': minor
+---
+
+Add session row tagging.
+
+Sessions can now be tagged with user-defined tags via right-click → Tags or by clicking the tag row on hover. The sessions panel header gains a tag filter row with synthetic `has-pr` and `has-worktree` chips alongside user tags; multiple selected chips combine with strict AND. The session row layout moves the worktree pill and PR badge into the title row and replaces the project · branch · time metadata line with a dedicated tag row.

--- a/docs/superpowers/plans/2026-05-05-session-row-tagging.md
+++ b/docs/superpowers/plans/2026-05-05-session-row-tagging.md
@@ -1,0 +1,2243 @@
+# Session Row Tagging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user-defined tags on session rows plus synthetic `has-pr` / `has-worktree` filter chips, while moving worktree pill and PR badge into the title row.
+
+**Architecture:** New `tags` (registry) and `chat_tags` (associations) SQLite tables in core. Synthetic chips are computed at query time from existing `chats.worktree_path` / PR fields, not stored. HTTP API only — no WS events. Frontend gets a Zustand `tags` store, `FilterBar` above the chats list, `TagPopover` triggered by right-click and tag-row click, and a refactored `FlatSessionRow`.
+
+**Tech Stack:** TypeScript (NodeNext), better-sqlite3, Express + Zod, React + Zustand, Tailwind, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-session-row-tagging-design.md`
+
+---
+
+## File Map
+
+**New:**
+- `packages/types/src/tags.ts` — `Tag`, `TagColor`, `TAG_PALETTE`, `RESERVED_TAG_PREFIX`, `Synthetic` constants
+- `packages/core/src/lib/validate-tag-name.ts` + test — name validation single source of truth
+- `packages/core/src/lib/tag-color.ts` + test — stable hash → palette index
+- `packages/core/src/db/tags.ts` + test — `TagsRepository` (registry CRUD)
+- `packages/core/src/db/chat-tags.ts` + test — `ChatTagsRepository` (associations + filter queries)
+- `packages/core/src/server/routes/tags.ts` + test — tag registry + chat-tags HTTP routes
+- `packages/desktop/src/renderer/lib/api/tags-api.ts` — client for tag endpoints
+- `packages/desktop/src/renderer/store/tags.ts` + test — Zustand store
+- `packages/desktop/src/renderer/components/tags/TagPill.tsx`
+- `packages/desktop/src/renderer/components/tags/TagPopover.tsx`
+- `packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx`
+
+**Modified:**
+- `packages/types/src/chat.ts` — add `tags?: string[]`
+- `packages/types/src/index.ts` — export `./tags.js`
+- `packages/core/src/db/schema.ts` — add `tags` and `chat_tags` table DDL
+- `packages/core/src/db/index.ts` — wire `TagsRepository` + `ChatTagsRepository`
+- `packages/core/src/db/chats.ts` — populate `tags` on `list()` / `get()`, add filtered list
+- `packages/core/src/server/routes/index.ts` — export `tagRoutes`
+- `packages/core/src/server/index.ts` — mount `tagRoutes`
+- `packages/desktop/src/renderer/lib/api/index.ts` — re-export tag api
+- `packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx` — move worktree + PR to title row, add tag row
+- `packages/desktop/src/renderer/components/panels/ChatsPanel.tsx` — mount `SessionFilterBar`, use filter state
+
+---
+
+## Task 1: Shared types
+
+**Files:**
+- Create: `packages/types/src/tags.ts`
+- Modify: `packages/types/src/index.ts`
+- Modify: `packages/types/src/chat.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/types/src/__tests__/tags.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { TAG_PALETTE, RESERVED_TAG_PREFIX, SYNTHETIC_TAGS } from '../tags.js';
+
+describe('tag constants', () => {
+  it('TAG_PALETTE is non-empty and immutable', () => {
+    expect(TAG_PALETTE.length).toBeGreaterThan(0);
+    expect(Object.isFrozen(TAG_PALETTE)).toBe(true);
+  });
+  it('RESERVED_TAG_PREFIX is "has-"', () => {
+    expect(RESERVED_TAG_PREFIX).toBe('has-');
+  });
+  it('SYNTHETIC_TAGS contains has-pr and has-worktree only', () => {
+    expect([...SYNTHETIC_TAGS].sort()).toEqual(['has-pr', 'has-worktree']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types test -- tags.test.ts`
+Expected: FAIL — Cannot find module `../tags.js`.
+
+- [ ] **Step 3: Create `packages/types/src/tags.ts`**
+
+```ts
+export const TAG_PALETTE = Object.freeze([
+  'blue', 'red', 'purple', 'violet', 'amber',
+  'teal', 'cyan', 'green', 'pink', 'orange',
+] as const);
+export type TagColor = (typeof TAG_PALETTE)[number];
+
+export const SYNTHETIC_TAG_COLOR: TagColor | 'gray' = 'gray';
+export const RESERVED_TAG_PREFIX = 'has-';
+
+export const SYNTHETIC_TAGS = Object.freeze(['has-pr', 'has-worktree'] as const);
+export type SyntheticTag = (typeof SYNTHETIC_TAGS)[number];
+
+export interface Tag {
+  name: string;
+  color: TagColor;
+  createdAt: string;
+}
+```
+
+Note: `SYNTHETIC_TAG_COLOR` is typed wider than `TagColor` because `'gray'` is intentionally outside the user palette — it signals "system chip" in the filter bar.
+
+- [ ] **Step 4: Add `tags?: string[]` to `Chat` interface**
+
+In `packages/types/src/chat.ts` after line 39 (`effort?: ChatEffort;`), add:
+
+```ts
+  /** User-source tags applied to this chat. Synthetic chips (has-pr, has-worktree) are NOT included. */
+  tags?: string[];
+```
+
+- [ ] **Step 5: Re-export from index**
+
+In `packages/types/src/index.ts`, add the line:
+
+```ts
+export * from './tags.js';
+```
+
+- [ ] **Step 6: Re-run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-types test -- tags.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/types/src/tags.ts packages/types/src/__tests__/tags.test.ts packages/types/src/index.ts packages/types/src/chat.ts
+git commit -m "feat(types): tag palette, reserved prefix, synthetic tag constants"
+```
+
+---
+
+## Task 2: Validation helper
+
+**Files:**
+- Create: `packages/core/src/lib/validate-tag-name.ts`
+- Test: `packages/core/src/lib/__tests__/validate-tag-name.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { validateTagName } from '../validate-tag-name.js';
+
+describe('validateTagName', () => {
+  it.each([
+    ['feature', { ok: true, normalized: 'feature' }],
+    ['  Feature  ', { ok: true, normalized: 'feature' }],
+    ['ui-bug', { ok: true, normalized: 'ui-bug' }],
+    ['perf-2', { ok: true, normalized: 'perf-2' }],
+  ])('accepts %s', (input, expected) => {
+    expect(validateTagName(input)).toEqual(expected);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['a', 'too short'],
+    ['a'.repeat(25), 'too long'],
+    ['has-pr', 'reserved prefix'],
+    ['has-anything', 'reserved prefix'],
+    ['feature!', 'invalid characters'],
+    ['white space', 'invalid characters'],
+  ])('rejects %s', (input, _label) => {
+    const result = validateTagName(input);
+    expect(result.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- validate-tag-name.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement validator**
+
+Create `packages/core/src/lib/validate-tag-name.ts`:
+
+```ts
+import { RESERVED_TAG_PREFIX } from '@qlan-ro/mainframe-types';
+
+const PATTERN = /^[a-z0-9-]+$/;
+const MIN_LEN = 2;
+const MAX_LEN = 24;
+
+export type ValidateResult =
+  | { ok: true; normalized: string }
+  | { ok: false; error: string };
+
+export function validateTagName(input: string): ValidateResult {
+  const normalized = input.trim().toLowerCase();
+  if (normalized.length < MIN_LEN) return { ok: false, error: 'Tag name too short (min 2 chars).' };
+  if (normalized.length > MAX_LEN) return { ok: false, error: 'Tag name too long (max 24 chars).' };
+  if (normalized.startsWith(RESERVED_TAG_PREFIX)) {
+    return { ok: false, error: `Names starting with "${RESERVED_TAG_PREFIX}" are reserved.` };
+  }
+  if (!PATTERN.test(normalized)) {
+    return { ok: false, error: 'Tag name must use lowercase letters, numbers, or hyphens only.' };
+  }
+  return { ok: true, normalized };
+}
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- validate-tag-name.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/lib/validate-tag-name.ts packages/core/src/lib/__tests__/validate-tag-name.test.ts
+git commit -m "feat(core): tag name validation helper"
+```
+
+---
+
+## Task 3: Color hashing helper
+
+**Files:**
+- Create: `packages/core/src/lib/tag-color.ts`
+- Test: `packages/core/src/lib/__tests__/tag-color.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { TAG_PALETTE } from '@qlan-ro/mainframe-types';
+import { hashTagColor } from '../tag-color.js';
+
+describe('hashTagColor', () => {
+  it('returns a palette color', () => {
+    const c = hashTagColor('feature');
+    expect(TAG_PALETTE).toContain(c);
+  });
+  it('is deterministic for the same name', () => {
+    expect(hashTagColor('bug')).toBe(hashTagColor('bug'));
+  });
+  it('distributes across different names', () => {
+    const colors = new Set(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map(hashTagColor));
+    expect(colors.size).toBeGreaterThan(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- tag-color.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement hash**
+
+Create `packages/core/src/lib/tag-color.ts`:
+
+```ts
+import { TAG_PALETTE, type TagColor } from '@qlan-ro/mainframe-types';
+
+/** Stable djb2 hash → palette index. Same name always maps to same color. */
+export function hashTagColor(name: string): TagColor {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) {
+    h = ((h << 5) + h + name.charCodeAt(i)) | 0;
+  }
+  const idx = Math.abs(h) % TAG_PALETTE.length;
+  return TAG_PALETTE[idx]!;
+}
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- tag-color.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/lib/tag-color.ts packages/core/src/lib/__tests__/tag-color.test.ts
+git commit -m "feat(core): stable tag color hash"
+```
+
+---
+
+## Task 4: DB schema migration
+
+**Files:**
+- Modify: `packages/core/src/db/schema.ts`
+- Test: `packages/core/src/db/__tests__/schema.test.ts` (extend or create)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) `packages/core/src/db/__tests__/schema.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+
+describe('schema — tags', () => {
+  it('creates tags and chat_tags tables', () => {
+    const db = new Database(':memory:');
+    initializeSchema(db);
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('tags');
+    expect(names).toContain('chat_tags');
+  });
+  it('chat_tags cascades on chat deletion', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)',
+    ).run('p1', 'p', '/tmp/p', now, now);
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    db.prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)').run('feature', 'blue', now);
+    db.prepare(
+      "INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)",
+    ).run('c1', 'feature', now);
+    db.prepare('DELETE FROM chats WHERE id = ?').run('c1');
+    const remaining = db.prepare('SELECT COUNT(*) AS n FROM chat_tags').get() as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — tables not created)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- schema.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add DDL to `packages/core/src/db/schema.ts`**
+
+Inside the existing `db.exec(\`...\`)` block in `initializeSchema`, append before the closing backtick:
+
+```sql
+    CREATE TABLE IF NOT EXISTS tags (
+      name       TEXT PRIMARY KEY,
+      color      TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS chat_tags (
+      chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      tag        TEXT NOT NULL REFERENCES tags(name) ON UPDATE CASCADE,
+      source     TEXT NOT NULL DEFAULT 'user',
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (chat_id, tag, source)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_chat_tags_chat ON chat_tags(chat_id);
+    CREATE INDEX IF NOT EXISTS idx_chat_tags_tag  ON chat_tags(tag);
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- schema.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/schema.ts packages/core/src/db/__tests__/schema.test.ts
+git commit -m "feat(core): tags + chat_tags schema with cascade"
+```
+
+---
+
+## Task 5: TagsRepository
+
+**Files:**
+- Create: `packages/core/src/db/tags.ts`
+- Test: `packages/core/src/db/__tests__/tags.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+import { TagsRepository } from '../tags.js';
+
+function setup() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  return new TagsRepository(db);
+}
+
+describe('TagsRepository', () => {
+  it('list returns empty initially', () => {
+    expect(setup().list()).toEqual([]);
+  });
+
+  it('upsert creates a tag with auto-color when missing', () => {
+    const repo = setup();
+    const tag = repo.upsert('feature');
+    expect(tag.name).toBe('feature');
+    expect(tag.color).toBeTruthy();
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('upsert is idempotent', () => {
+    const repo = setup();
+    const a = repo.upsert('feature');
+    const b = repo.upsert('feature');
+    expect(b.color).toBe(a.color);
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('rejects reserved prefix', () => {
+    expect(() => setup().upsert('has-pr')).toThrow(/reserved/i);
+  });
+
+  it('rename moves the row and cascades chat_tags', () => {
+    const repo = setup();
+    repo.upsert('feat');
+    repo.rename('feat', 'feature');
+    const names = repo.list().map((t) => t.name);
+    expect(names).toContain('feature');
+    expect(names).not.toContain('feat');
+  });
+
+  it('rename to existing name merges (drops the source row)', () => {
+    const repo = setup();
+    repo.upsert('feat');
+    repo.upsert('feature');
+    repo.rename('feat', 'feature');
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('recolor updates color only', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    repo.setColor('feature', 'red');
+    expect(repo.list()[0]!.color).toBe('red');
+  });
+
+  it('remove deletes the row', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    repo.remove('feature');
+    expect(repo.list()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- db/__tests__/tags.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement repository**
+
+Create `packages/core/src/db/tags.ts`:
+
+```ts
+import type Database from 'better-sqlite3';
+import type { Tag, TagColor } from '@qlan-ro/mainframe-types';
+import { validateTagName } from '../lib/validate-tag-name.js';
+import { hashTagColor } from '../lib/tag-color.js';
+
+export class TagsRepository {
+  constructor(private db: Database.Database) {}
+
+  list(): Tag[] {
+    const rows = this.db
+      .prepare('SELECT name, color, created_at as createdAt FROM tags ORDER BY name')
+      .all() as Tag[];
+    return rows;
+  }
+
+  get(name: string): Tag | null {
+    const row = this.db
+      .prepare('SELECT name, color, created_at as createdAt FROM tags WHERE name = ?')
+      .get(name) as Tag | undefined;
+    return row ?? null;
+  }
+
+  /** Idempotent upsert. Returns the existing row if present, else creates with auto color. */
+  upsert(rawName: string, color?: TagColor): Tag {
+    const v = validateTagName(rawName);
+    if (!v.ok) throw new Error(v.error);
+    const existing = this.get(v.normalized);
+    if (existing) return existing;
+    const finalColor: TagColor = color ?? hashTagColor(v.normalized);
+    const now = new Date().toISOString();
+    this.db
+      .prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)')
+      .run(v.normalized, finalColor, now);
+    return { name: v.normalized, color: finalColor, createdAt: now };
+  }
+
+  setColor(name: string, color: TagColor): void {
+    this.db.prepare('UPDATE tags SET color = ? WHERE name = ?').run(color, name);
+  }
+
+  /** Atomic rename. If `to` already exists, merges associations and drops `from`. */
+  rename(fromRaw: string, toRaw: string): void {
+    const from = fromRaw.trim().toLowerCase();
+    const v = validateTagName(toRaw);
+    if (!v.ok) throw new Error(v.error);
+    const to = v.normalized;
+    if (from === to) return;
+    const tx = this.db.transaction(() => {
+      const target = this.get(to);
+      if (target) {
+        // Merge: redirect chat_tags then delete `from` registry row.
+        this.db
+          .prepare(
+            "INSERT OR IGNORE INTO chat_tags (chat_id, tag, source, created_at) " +
+              "SELECT chat_id, ?, source, created_at FROM chat_tags WHERE tag = ?",
+          )
+          .run(to, from);
+        this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(from);
+        this.db.prepare('DELETE FROM tags WHERE name = ?').run(from);
+      } else {
+        // Plain rename — ON UPDATE CASCADE moves chat_tags rows.
+        this.db.prepare('UPDATE tags SET name = ? WHERE name = ?').run(to, from);
+      }
+    });
+    tx();
+  }
+
+  remove(name: string): void {
+    const tx = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(name);
+      this.db.prepare('DELETE FROM tags WHERE name = ?').run(name);
+    });
+    tx();
+  }
+}
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- db/__tests__/tags.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/tags.ts packages/core/src/db/__tests__/tags.test.ts
+git commit -m "feat(core): TagsRepository with idempotent upsert + merge-on-rename"
+```
+
+---
+
+## Task 6: ChatTagsRepository
+
+**Files:**
+- Create: `packages/core/src/db/chat-tags.ts`
+- Test: `packages/core/src/db/__tests__/chat-tags.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+import { TagsRepository } from '../tags.js';
+import { ChatTagsRepository } from '../chat-tags.js';
+
+function setup() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const now = new Date().toISOString();
+  db.prepare(
+    'INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)',
+  ).run('p1', 'p', '/tmp/p', now, now);
+  for (const id of ['c1', 'c2', 'c3']) {
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(id, 'claude', 'p1', 'active', now, now);
+  }
+  return { tags: new TagsRepository(db), chatTags: new ChatTagsRepository(db) };
+}
+
+describe('ChatTagsRepository', () => {
+  it('listForChat returns empty initially', () => {
+    expect(setup().chatTags.listForChat('c1')).toEqual([]);
+  });
+
+  it('setForChat replaces user tags atomically', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature', 'ui'], tags);
+    expect(chatTags.listForChat('c1').sort()).toEqual(['feature', 'ui']);
+    chatTags.setForChat('c1', ['bug'], tags);
+    expect(chatTags.listForChat('c1')).toEqual(['bug']);
+  });
+
+  it('setForChat auto-creates missing tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['mobile'], tags);
+    expect(tags.get('mobile')).not.toBeNull();
+  });
+
+  it('listInUse returns distinct tags currently associated', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature'], tags);
+    chatTags.setForChat('c2', ['feature', 'bug'], tags);
+    expect(chatTags.listInUse().sort()).toEqual(['bug', 'feature']);
+  });
+
+  it('listInUse with projectId filters', () => {
+    const db = setup();
+    db.chatTags.setForChat('c1', ['feature'], db.tags);
+    expect(db.chatTags.listInUse('p1').sort()).toEqual(['feature']);
+    expect(db.chatTags.listInUse('p-other')).toEqual([]);
+  });
+
+  it('filterChatIds AND-intersects user tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature', 'ui'], tags);
+    chatTags.setForChat('c2', ['feature'], tags);
+    chatTags.setForChat('c3', ['bug'], tags);
+    expect(chatTags.filterChatIds(['feature', 'ui'])!.sort()).toEqual(['c1']);
+    expect(chatTags.filterChatIds(['feature'])!.sort()).toEqual(['c1', 'c2']);
+    expect(chatTags.filterChatIds([])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- chat-tags.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement repository**
+
+Create `packages/core/src/db/chat-tags.ts`:
+
+```ts
+import type Database from 'better-sqlite3';
+import type { TagsRepository } from './tags.js';
+
+export class ChatTagsRepository {
+  constructor(private db: Database.Database) {}
+
+  listForChat(chatId: string): string[] {
+    const rows = this.db
+      .prepare("SELECT tag FROM chat_tags WHERE chat_id = ? AND source = 'user' ORDER BY tag")
+      .all(chatId) as { tag: string }[];
+    return rows.map((r) => r.tag);
+  }
+
+  /** Map of chatId -> user tags. Used to populate Chat.tags on list queries. */
+  bulkForChats(chatIds: string[]): Map<string, string[]> {
+    const out = new Map<string, string[]>();
+    if (chatIds.length === 0) return out;
+    const placeholders = chatIds.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT chat_id as chatId, tag FROM chat_tags
+         WHERE source = 'user' AND chat_id IN (${placeholders})
+         ORDER BY chat_id, tag`,
+      )
+      .all(...chatIds) as { chatId: string; tag: string }[];
+    for (const r of rows) {
+      const list = out.get(r.chatId);
+      if (list) list.push(r.tag);
+      else out.set(r.chatId, [r.tag]);
+    }
+    return out;
+  }
+
+  /** Replace the user tag set for a chat atomically. Auto-creates any missing tags. */
+  setForChat(chatId: string, tags: string[], registry: TagsRepository): void {
+    const tx = this.db.transaction(() => {
+      this.db.prepare("DELETE FROM chat_tags WHERE chat_id = ? AND source = 'user'").run(chatId);
+      const insert = this.db.prepare(
+        "INSERT OR IGNORE INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)",
+      );
+      const now = new Date().toISOString();
+      for (const raw of tags) {
+        const tag = registry.upsert(raw); // throws on invalid input
+        insert.run(chatId, tag.name, now);
+      }
+    });
+    tx();
+  }
+
+  /**
+   * Distinct user tags currently in use, optionally restricted to a project.
+   * Drives the filter bar's tag chip list.
+   */
+  listInUse(projectId?: string): string[] {
+    if (projectId) {
+      const rows = this.db
+        .prepare(
+          `SELECT DISTINCT ct.tag FROM chat_tags ct
+           JOIN chats c ON c.id = ct.chat_id
+           WHERE ct.source = 'user' AND c.project_id = ? AND c.status != 'archived'
+           ORDER BY ct.tag`,
+        )
+        .all(projectId) as { tag: string }[];
+      return rows.map((r) => r.tag);
+    }
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT ct.tag FROM chat_tags ct
+         JOIN chats c ON c.id = ct.chat_id
+         WHERE ct.source = 'user' AND c.status != 'archived'
+         ORDER BY ct.tag`,
+      )
+      .all() as { tag: string }[];
+    return rows.map((r) => r.tag);
+  }
+
+  /**
+   * Returns chat ids that have ALL of the supplied tags.
+   * Returns null when `tags` is empty (caller treats null as "no tag filter").
+   */
+  filterChatIds(tags: string[]): string[] | null {
+    if (tags.length === 0) return null;
+    const placeholders = tags.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT chat_id FROM chat_tags
+         WHERE source = 'user' AND tag IN (${placeholders})
+         GROUP BY chat_id
+         HAVING COUNT(DISTINCT tag) = ?`,
+      )
+      .all(...tags, tags.length) as { chat_id: string }[];
+    return rows.map((r) => r.chat_id);
+  }
+}
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- chat-tags.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/db/chat-tags.ts packages/core/src/db/__tests__/chat-tags.test.ts
+git commit -m "feat(core): ChatTagsRepository with AND-intersect filter"
+```
+
+---
+
+## Task 7: Wire repos into DatabaseManager + populate Chat.tags
+
+**Files:**
+- Modify: `packages/core/src/db/index.ts`
+- Modify: `packages/core/src/db/chats.ts`
+- Test: `packages/core/src/db/__tests__/chats.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/src/db/__tests__/chats.test.ts`:
+
+```ts
+describe('chats list — populates tags', () => {
+  it('Chat.tags reflects user-source associations', () => {
+    // Use the same helper the existing tests use; this is a sketch:
+    const dbm = makeManager(); // existing helper or new() of DatabaseManager-like
+    dbm.projects.create('/tmp/p');
+    const project = dbm.projects.list()[0]!;
+    const chat = dbm.chats.createChat({ adapterId: 'claude', projectId: project.id });
+    dbm.chatTags.setForChat(chat.id, ['feature', 'ui'], dbm.tags);
+    const fresh = dbm.chats.list(project.id)[0]!;
+    expect(fresh.tags?.sort()).toEqual(['feature', 'ui']);
+  });
+});
+```
+
+(Use the actual test helper present in the file. If `makeManager` doesn't exist, use the same construction pattern the existing chats test uses.)
+
+- [ ] **Step 2: Run test (should fail — `dbm.tags` / `dbm.chatTags` undefined)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- db/__tests__/chats.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Wire repos in `packages/core/src/db/index.ts`**
+
+```ts
+import Database from 'better-sqlite3';
+import { join } from 'node:path';
+import { getDataDir } from '../config.js';
+import { initializeSchema } from './schema.js';
+import { ProjectsRepository } from './projects.js';
+import { ChatsRepository } from './chats.js';
+import { SettingsRepository } from './settings.js';
+import { DevicesRepository } from './devices.js';
+import { TagsRepository } from './tags.js';
+import { ChatTagsRepository } from './chat-tags.js';
+
+export class DatabaseManager {
+  private db: Database.Database;
+  public projects: ProjectsRepository;
+  public chats: ChatsRepository;
+  public settings: SettingsRepository;
+  public devices: DevicesRepository;
+  public tags: TagsRepository;
+  public chatTags: ChatTagsRepository;
+
+  constructor() {
+    const dbPath = join(getDataDir(), 'mainframe.db');
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+
+    initializeSchema(this.db);
+
+    this.projects = new ProjectsRepository(this.db);
+    this.tags = new TagsRepository(this.db);
+    this.chatTags = new ChatTagsRepository(this.db);
+    this.chats = new ChatsRepository(this.db, this.chatTags);
+    this.settings = new SettingsRepository(this.db);
+    this.devices = new DevicesRepository(this.db);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+export { ProjectsRepository } from './projects.js';
+export { ChatsRepository } from './chats.js';
+export { SettingsRepository } from './settings.js';
+export { DevicesRepository } from './devices.js';
+export { TagsRepository } from './tags.js';
+export { ChatTagsRepository } from './chat-tags.js';
+```
+
+- [ ] **Step 4: Update `ChatsRepository` constructor to accept `chatTags` and populate `tags`**
+
+In `packages/core/src/db/chats.ts`:
+
+```ts
+export class ChatsRepository {
+  constructor(
+    private db: Database.Database,
+    private chatTags?: ChatTagsRepository,
+  ) {}
+```
+
+Add the import at the top:
+
+```ts
+import type { ChatTagsRepository } from './chat-tags.js';
+```
+
+In `list()` (and any sibling `listAll()`), after the existing `rows.map(...)` produces the Chat array, before returning, fold in tags:
+
+```ts
+const chats = rows.map((row) => ({ /* existing mapping */ }));
+if (this.chatTags && chats.length > 0) {
+  const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
+  for (const c of chats) {
+    c.tags = tagsByChat.get(c.id) ?? [];
+  }
+}
+return chats;
+```
+
+Apply the same pattern to `getChat`:
+
+```ts
+const chat = /* existing single-row fetch */;
+if (chat && this.chatTags) {
+  chat.tags = this.chatTags.listForChat(chat.id);
+}
+return chat;
+```
+
+The `chatTags` is optional in the constructor so existing tests that construct `new ChatsRepository(db)` directly still work; production goes through `DatabaseManager` which always passes it.
+
+- [ ] **Step 5: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- db/__tests__/chats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/db/index.ts packages/core/src/db/chats.ts packages/core/src/db/__tests__/chats.test.ts
+git commit -m "feat(core): wire tag repos into DatabaseManager + populate Chat.tags"
+```
+
+---
+
+## Task 8: Tag HTTP routes
+
+**Files:**
+- Create: `packages/core/src/server/routes/tags.ts`
+- Test: `packages/core/src/server/routes/__tests__/tags.test.ts`
+- Modify: `packages/core/src/server/routes/index.ts`
+- Modify: `packages/core/src/server/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../../../db/schema.js';
+import { TagsRepository } from '../../../db/tags.js';
+import { ChatTagsRepository } from '../../../db/chat-tags.js';
+import { tagRoutes } from '../tags.js';
+
+function makeApp() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const tags = new TagsRepository(db);
+  const chatTags = new ChatTagsRepository(db);
+  const ctx = { db: { tags, chatTags } } as any;
+  const app = express();
+  app.use(express.json());
+  app.use(tagRoutes(ctx));
+  return { app, db, tags, chatTags };
+}
+
+describe('tag routes', () => {
+  it('GET /api/tags returns []', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/tags');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('POST /api/tags creates a tag', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/tags').send({ name: 'feature' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('feature');
+  });
+
+  it('POST /api/tags rejects has- prefix with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/tags').send({ name: 'has-foo' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH /api/tags/:name renames', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feat');
+    const res = await request(app).patch('/api/tags/feat').send({ rename: 'feature' });
+    expect(res.status).toBe(200);
+    expect(tags.get('feature')).not.toBeNull();
+    expect(tags.get('feat')).toBeNull();
+  });
+
+  it('DELETE /api/tags/:name removes', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feature');
+    const res = await request(app).delete('/api/tags/feature');
+    expect(res.status).toBe(204);
+    expect(tags.get('feature')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — module missing)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- routes/__tests__/tags.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement routes**
+
+Create `packages/core/src/server/routes/tags.ts`:
+
+```ts
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import type { RouteContext } from './types.js';
+import { param } from './types.js';
+import { TAG_PALETTE } from '@qlan-ro/mainframe-types';
+import { createChildLogger } from '../../logger.js';
+
+const logger = createChildLogger('routes:tags');
+
+const ColorSchema = z.enum(TAG_PALETTE);
+const CreateBody = z.object({ name: z.string(), color: ColorSchema.optional() });
+const PatchBody = z.object({ rename: z.string().optional(), color: ColorSchema.optional() }).refine(
+  (v) => v.rename !== undefined || v.color !== undefined,
+  { message: 'rename or color required' },
+);
+const SetChatTagsBody = z.object({ tags: z.array(z.string()) });
+
+export function tagRoutes(ctx: RouteContext): Router {
+  const router = Router();
+
+  router.get('/api/tags', (_req: Request, res: Response) => {
+    res.json({ success: true, data: ctx.db.tags.list() });
+  });
+
+  router.post('/api/tags', (req: Request, res: Response) => {
+    const parsed = CreateBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    try {
+      const tag = ctx.db.tags.upsert(parsed.data.name, parsed.data.color);
+      res.status(201).json({ success: true, data: tag });
+    } catch (err) {
+      logger.warn({ err }, 'create tag failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  router.patch('/api/tags/:name', (req: Request, res: Response) => {
+    const parsed = PatchBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    const name = param(req, 'name');
+    if (!ctx.db.tags.get(name)) {
+      res.status(404).json({ success: false, error: 'Tag not found' });
+      return;
+    }
+    try {
+      if (parsed.data.rename) ctx.db.tags.rename(name, parsed.data.rename);
+      const final = parsed.data.rename ?? name;
+      if (parsed.data.color) ctx.db.tags.setColor(final, parsed.data.color);
+      const result = ctx.db.tags.get(final);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      logger.warn({ err, name }, 'update tag failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  router.delete('/api/tags/:name', (req: Request, res: Response) => {
+    const name = param(req, 'name');
+    if (!ctx.db.tags.get(name)) {
+      res.status(404).json({ success: false, error: 'Tag not found' });
+      return;
+    }
+    ctx.db.tags.remove(name);
+    res.status(204).end();
+  });
+
+  router.get('/api/chats/:id/tags', (req: Request, res: Response) => {
+    const tags = ctx.db.chatTags.listForChat(param(req, 'id'));
+    res.json({ success: true, data: tags });
+  });
+
+  router.put('/api/chats/:id/tags', (req: Request, res: Response) => {
+    const parsed = SetChatTagsBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    try {
+      ctx.db.chatTags.setForChat(param(req, 'id'), parsed.data.tags, ctx.db.tags);
+      res.json({ success: true, data: ctx.db.chatTags.listForChat(param(req, 'id')) });
+    } catch (err) {
+      logger.warn({ err }, 'set chat tags failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  return router;
+}
+```
+
+- [ ] **Step 4: Export and mount**
+
+In `packages/core/src/server/routes/index.ts`, add:
+
+```ts
+export { tagRoutes } from './tags.js';
+```
+
+In `packages/core/src/server/index.ts`, locate where the other route routers are mounted (search for `chatRoutes(ctx)` etc.) and add a sibling `app.use(tagRoutes(ctx));`. The exact insertion point follows the existing pattern in that file.
+
+- [ ] **Step 5: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- routes/__tests__/tags.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/server/routes/tags.ts packages/core/src/server/routes/__tests__/tags.test.ts packages/core/src/server/routes/index.ts packages/core/src/server/index.ts
+git commit -m "feat(core): tag CRUD + chat-tags HTTP routes"
+```
+
+---
+
+## Task 9: Filtered chat list endpoint
+
+**Files:**
+- Modify: `packages/core/src/db/chats.ts` — add `listFiltered`
+- Modify: `packages/core/src/server/routes/chats.ts` — extend `GET /api/chats`
+- Test: `packages/core/src/server/routes/__tests__/chats.test.ts` (extend or create)
+
+- [ ] **Step 1: Write the failing test**
+
+Test the route directly, asserting AND combination across `tags` + `synthetic`:
+
+```ts
+it('GET /api/chats?tags=feature&synthetic=has-pr returns AND filter', async () => {
+  // Setup: 3 chats, only one tagged feature AND has worktree+PR
+  // ... seed via repos
+  const res = await request(app).get('/api/chats?tags=feature&synthetic=has-pr');
+  expect(res.status).toBe(200);
+  expect(res.body.data.map((c: any) => c.id)).toEqual(['c-target']);
+});
+```
+
+(Adapt seeding to the existing test pattern in this file. If the file doesn't exist, create it following the pattern in `routes/__tests__/auth.test.ts` for app construction.)
+
+- [ ] **Step 2: Run test (should fail)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- routes/__tests__/chats.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `listFiltered` to ChatsRepository**
+
+In `packages/core/src/db/chats.ts`, add a new method:
+
+```ts
+interface ListFilters {
+  projectId?: string;
+  tagsAll?: string[];          // AND-intersect across these user tags
+  syntheticAll?: ('has-pr' | 'has-worktree')[];
+}
+
+listFiltered(filters: ListFilters): Chat[] {
+  const where: string[] = ["status != 'archived'"];
+  const params: unknown[] = [];
+
+  if (filters.projectId) {
+    where.push('project_id = ?');
+    params.push(filters.projectId);
+  }
+  if (filters.syntheticAll?.includes('has-worktree')) {
+    where.push('worktree_path IS NOT NULL');
+  }
+  if (filters.syntheticAll?.includes('has-pr')) {
+    // PR detection in mainframe lives on chat.created_pr_url-equivalent fields.
+    // If the column name differs, adjust here. Fallback: check via an exists join
+    // with whatever PR table is in use.
+    where.push('created_pr_url IS NOT NULL');
+  }
+
+  if (filters.tagsAll && filters.tagsAll.length > 0 && this.chatTags) {
+    const ids = this.chatTags.filterChatIds(filters.tagsAll);
+    if (!ids || ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(',');
+    where.push(`id IN (${placeholders})`);
+    params.push(...ids);
+  }
+
+  // Reuse the existing SELECT projection from list(); extract it into a constant
+  // CHAT_SELECT_FIELDS so both methods share it. (Refactor inline: pull the column
+  // list out of the existing list() query into a local const, reuse here.)
+  const sql = `
+    SELECT ${CHAT_SELECT_FIELDS}
+    FROM chats
+    WHERE ${where.join(' AND ')}
+    ORDER BY pinned DESC, updated_at DESC
+  `;
+  const rows = this.db.prepare(sql).all(...params) as RawChatRow[];
+  const chats = rows.map(/* same mapping as list() */);
+  if (this.chatTags && chats.length > 0) {
+    const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
+    for (const c of chats) c.tags = tagsByChat.get(c.id) ?? [];
+  }
+  return chats;
+}
+```
+
+Pull the existing column list from `list()` into a top-of-file `const CHAT_SELECT_FIELDS = '...'` and use it in both `list()` and `listFiltered()` — DRY rule.
+
+**Important**: confirm the actual PR column name on `chats`. If PR detection is via a separate table or via `created_pr_url` doesn't exist, replace the `has-pr` predicate with the right join. Search core for where the PR URL is read on a chat to confirm.
+
+- [ ] **Step 4: Extend `GET /api/chats`**
+
+In `packages/core/src/server/routes/chats.ts`, replace the existing `/api/chats` handler:
+
+```ts
+const ListQuery = z.object({
+  project: z.string().optional(),
+  tags: z.string().optional(),       // comma-separated user tags
+  synthetic: z.string().optional(),  // comma-separated, allowed: has-pr, has-worktree
+});
+
+router.get('/api/chats', (req: Request, res: Response) => {
+  const parsed = ListQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ success: false, error: parsed.error.message });
+    return;
+  }
+  const tagsAll = parsed.data.tags ? parsed.data.tags.split(',').filter(Boolean) : undefined;
+  const synthRaw = parsed.data.synthetic ? parsed.data.synthetic.split(',').filter(Boolean) : [];
+  const allowed = new Set(['has-pr', 'has-worktree']);
+  const syntheticAll = synthRaw.filter((s) => allowed.has(s)) as ('has-pr' | 'has-worktree')[];
+  const chats = ctx.chats.listFiltered({
+    projectId: parsed.data.project,
+    tagsAll,
+    syntheticAll: syntheticAll.length > 0 ? syntheticAll : undefined,
+  });
+  res.json({ success: true, data: chats });
+});
+```
+
+`ctx.chats.listFiltered` should be exposed by `ChatManager` (which currently wraps `db.chats.listAllChats()`); add a method there that simply delegates to `db.chats.listFiltered`. Verify the method name on `ChatManager` matches what the routes expect.
+
+- [ ] **Step 5: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-core test -- routes/__tests__/chats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/db/chats.ts packages/core/src/server/routes/chats.ts packages/core/src/server/routes/__tests__/chats.test.ts
+git commit -m "feat(core): listFiltered chats endpoint with tag + synthetic AND"
+```
+
+---
+
+## Task 10: Frontend API client
+
+**Files:**
+- Create: `packages/desktop/src/renderer/lib/api/tags-api.ts`
+- Modify: `packages/desktop/src/renderer/lib/api/index.ts`
+
+- [ ] **Step 1: Write the file**
+
+Create `packages/desktop/src/renderer/lib/api/tags-api.ts`:
+
+```ts
+import type { Tag, TagColor } from '@qlan-ro/mainframe-types';
+import { API_BASE } from './http';
+import { createLogger } from '../logger';
+
+const log = createLogger('renderer:api:tags');
+
+export async function listTags(): Promise<Tag[]> {
+  const res = await fetch(`${API_BASE}/api/tags`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+
+export async function createTag(name: string, color?: TagColor): Promise<Tag> {
+  log.info('createTag', { name, color });
+  const res = await fetch(`${API_BASE}/api/tags`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, color }),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()).data;
+}
+
+export async function updateTag(name: string, patch: { rename?: string; color?: TagColor }): Promise<Tag> {
+  log.info('updateTag', { name, patch });
+  const res = await fetch(`${API_BASE}/api/tags/${encodeURIComponent(name)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+
+export async function deleteTag(name: string): Promise<void> {
+  log.info('deleteTag', { name });
+  const res = await fetch(`${API_BASE}/api/tags/${encodeURIComponent(name)}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+export async function getChatTags(chatId: string): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/api/chats/${chatId}/tags`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+
+export async function setChatTags(chatId: string, tags: string[]): Promise<string[]> {
+  log.info('setChatTags', { chatId, tags });
+  const res = await fetch(`${API_BASE}/api/chats/${chatId}/tags`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tags }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+```
+
+- [ ] **Step 2: Re-export**
+
+In `packages/desktop/src/renderer/lib/api/index.ts`, add:
+
+```ts
+export * from './tags-api';
+```
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/lib/api/tags-api.ts packages/desktop/src/renderer/lib/api/index.ts
+git commit -m "feat(desktop): tag api client"
+```
+
+---
+
+## Task 11: Tags Zustand store
+
+**Files:**
+- Create: `packages/desktop/src/renderer/store/tags.ts`
+- Test: `packages/desktop/src/renderer/store/tags.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTagsStore } from './tags';
+
+vi.mock('../lib/api/tags-api', () => ({
+  listTags: vi.fn().mockResolvedValue([{ name: 'feature', color: 'blue', createdAt: 'x' }]),
+  setChatTags: vi.fn().mockResolvedValue(['feature']),
+  createTag: vi.fn(),
+  deleteTag: vi.fn(),
+  updateTag: vi.fn(),
+  getChatTags: vi.fn(),
+}));
+
+describe('tags store', () => {
+  beforeEach(() => {
+    useTagsStore.setState({
+      registry: [],
+      registryLoaded: false,
+      selectedTags: new Set(),
+      selectedSynthetic: new Set(),
+      selectedProject: null,
+    });
+  });
+
+  it('refreshRegistry hydrates the registry', async () => {
+    await useTagsStore.getState().refreshRegistry();
+    expect(useTagsStore.getState().registry.map((t) => t.name)).toEqual(['feature']);
+    expect(useTagsStore.getState().registryLoaded).toBe(true);
+  });
+
+  it('toggleTag adds and removes from selectedTags', () => {
+    useTagsStore.getState().toggleTag('feature');
+    expect(useTagsStore.getState().selectedTags.has('feature')).toBe(true);
+    useTagsStore.getState().toggleTag('feature');
+    expect(useTagsStore.getState().selectedTags.has('feature')).toBe(false);
+  });
+
+  it('clearFilters resets selection but not registry', async () => {
+    await useTagsStore.getState().refreshRegistry();
+    useTagsStore.getState().toggleTag('feature');
+    useTagsStore.getState().clearFilters();
+    expect(useTagsStore.getState().selectedTags.size).toBe(0);
+    expect(useTagsStore.getState().registry.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test (should fail — store not created)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- store/tags.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement store**
+
+Create `packages/desktop/src/renderer/store/tags.ts`:
+
+```ts
+import { create } from 'zustand';
+import type { Tag, SyntheticTag } from '@qlan-ro/mainframe-types';
+import { listTags, setChatTags as apiSetChatTags } from '../lib/api/tags-api';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('store:tags');
+
+interface TagsState {
+  registry: Tag[];
+  registryLoaded: boolean;
+
+  selectedProject: string | null; // null = "All"
+  selectedTags: Set<string>;
+  selectedSynthetic: Set<SyntheticTag>;
+
+  refreshRegistry: () => Promise<void>;
+  toggleTag: (name: string) => void;
+  toggleSynthetic: (name: SyntheticTag) => void;
+  setSelectedProject: (id: string | null) => void;
+  clearFilters: () => void;
+
+  applyToChat: (chatId: string, tags: string[]) => Promise<void>;
+}
+
+export const useTagsStore = create<TagsState>((set, get) => ({
+  registry: [],
+  registryLoaded: false,
+  selectedProject: null,
+  selectedTags: new Set(),
+  selectedSynthetic: new Set(),
+
+  async refreshRegistry() {
+    try {
+      const registry = await listTags();
+      set({ registry, registryLoaded: true });
+    } catch (err) {
+      log.warn('refreshRegistry failed', { err: String(err) });
+    }
+  },
+
+  toggleTag(name: string) {
+    const next = new Set(get().selectedTags);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    set({ selectedTags: next });
+  },
+
+  toggleSynthetic(name: SyntheticTag) {
+    const next = new Set(get().selectedSynthetic);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    set({ selectedSynthetic: next });
+  },
+
+  setSelectedProject(id: string | null) {
+    set({ selectedProject: id });
+  },
+
+  clearFilters() {
+    set({
+      selectedTags: new Set(),
+      selectedSynthetic: new Set(),
+      selectedProject: null,
+    });
+  },
+
+  async applyToChat(chatId: string, tags: string[]) {
+    try {
+      await apiSetChatTags(chatId, tags);
+      // Caller (chats store) updates the Chat row with the new tags array.
+      await get().refreshRegistry();
+    } catch (err) {
+      log.warn('applyToChat failed', { err: String(err) });
+      throw err;
+    }
+  },
+}));
+```
+
+- [ ] **Step 4: Run test (should pass)**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- store/tags.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/store/tags.ts packages/desktop/src/renderer/store/tags.test.ts
+git commit -m "feat(desktop): tags store"
+```
+
+---
+
+## Task 12: TagPill component
+
+**Files:**
+- Create: `packages/desktop/src/renderer/components/tags/TagPill.tsx`
+
+- [ ] **Step 1: Add palette → Tailwind class map**
+
+In `TagPill.tsx`:
+
+```tsx
+import React from 'react';
+import type { TagColor } from '@qlan-ro/mainframe-types';
+import { cn } from '../../lib/utils';
+
+const COLOR_BG: Record<TagColor, string> = {
+  blue: 'bg-mf-tag-blue text-white',
+  red: 'bg-mf-tag-red text-white',
+  purple: 'bg-mf-tag-purple text-white',
+  violet: 'bg-mf-tag-violet text-white',
+  amber: 'bg-mf-tag-amber text-black',
+  teal: 'bg-mf-tag-teal text-white',
+  cyan: 'bg-mf-tag-cyan text-black',
+  green: 'bg-mf-tag-green text-white',
+  pink: 'bg-mf-tag-pink text-white',
+  orange: 'bg-mf-tag-orange text-white',
+};
+
+const COLOR_DOT: Record<TagColor | 'gray', string> = {
+  blue: 'bg-mf-tag-blue',
+  red: 'bg-mf-tag-red',
+  purple: 'bg-mf-tag-purple',
+  violet: 'bg-mf-tag-violet',
+  amber: 'bg-mf-tag-amber',
+  teal: 'bg-mf-tag-teal',
+  cyan: 'bg-mf-tag-cyan',
+  green: 'bg-mf-tag-green',
+  pink: 'bg-mf-tag-pink',
+  orange: 'bg-mf-tag-orange',
+  gray: 'bg-mf-text-secondary',
+};
+
+interface Props {
+  label: string;
+  color: TagColor | 'gray';
+  variant: 'row' | 'filter';
+  active?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+}
+
+export function TagPill({ label, color, variant, active, onClick, onContextMenu }: Props): React.ReactElement {
+  if (variant === 'row') {
+    const cls = color === 'gray' ? 'bg-mf-text-secondary text-white' : COLOR_BG[color as TagColor];
+    return (
+      <span
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className={cn(
+          'inline-flex items-center px-2 py-0.5 rounded-full text-mf-status font-medium cursor-pointer',
+          cls,
+        )}
+      >
+        {label}
+      </span>
+    );
+  }
+  // filter
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-mf-status border transition-colors',
+        active
+          ? 'border-mf-accent bg-mf-hover text-mf-text-primary'
+          : 'border-mf-border-subtle text-mf-text-secondary hover:bg-mf-hover/50',
+      )}
+    >
+      <span className={cn('w-1.5 h-1.5 rounded-full', COLOR_DOT[color])} />
+      {label}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Add `mf-tag-*` Tailwind tokens if missing**
+
+Search for existing `mf-tag-*` tokens:
+
+```bash
+grep -r "mf-tag-" packages/desktop/src/
+```
+
+If none exist, add them to the Tailwind config / CSS variable definitions used by the design system. Pick palette hex values that align with existing `mf-accent` and friends. Mind the memory rule: never use `/opacity` modifiers with these — they are hex CSS variables and the modifier silently fails.
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/tags/TagPill.tsx packages/desktop/src/renderer/styles
+git commit -m "feat(desktop): TagPill component with row + filter variants"
+```
+
+---
+
+## Task 13: TagPopover component
+
+**Files:**
+- Create: `packages/desktop/src/renderer/components/tags/TagPopover.tsx`
+
+- [ ] **Step 1: Implement popover**
+
+```tsx
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Check } from 'lucide-react';
+import type { Tag } from '@qlan-ro/mainframe-types';
+import { useTagsStore } from '../../store/tags';
+import { useChatsStore } from '../../store';
+import { cn } from '../../lib/utils';
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('renderer:tag-popover');
+
+interface Props {
+  chatId: string;
+  anchorRect: DOMRect;
+  onClose: () => void;
+}
+
+export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactElement {
+  const registry = useTagsStore((s) => s.registry);
+  const refreshRegistry = useTagsStore((s) => s.refreshRegistry);
+  const applyToChat = useTagsStore((s) => s.applyToChat);
+
+  const chat = useChatsStore((s) => s.chats.find((c) => c.id === chatId));
+  const updateChat = useChatsStore((s) => s.updateChat);
+
+  const [query, setQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    void refreshRegistry();
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [refreshRegistry]);
+
+  const lower = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!lower) return registry;
+    return registry.filter((t) => t.name.includes(lower));
+  }, [registry, lower]);
+
+  const exactMatch = useMemo(() => registry.some((t) => t.name === lower), [registry, lower]);
+  const showCreate = lower.length > 0 && !exactMatch;
+
+  const applied = new Set(chat?.tags ?? []);
+
+  async function toggle(name: string) {
+    if (!chat) return;
+    setError(null);
+    const next = new Set(applied);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    const arr = [...next];
+    updateChat({ ...chat, tags: arr }); // optimistic
+    try {
+      await applyToChat(chat.id, arr);
+    } catch (err) {
+      updateChat({ ...chat, tags: chat.tags }); // rollback
+      setError(String((err as Error).message));
+    }
+  }
+
+  async function createAndApply() {
+    if (!chat || !lower) return;
+    setError(null);
+    const next = [...(chat.tags ?? []), lower];
+    updateChat({ ...chat, tags: next });
+    try {
+      await applyToChat(chat.id, next);
+      setQuery('');
+    } catch (err) {
+      updateChat({ ...chat, tags: chat.tags });
+      setError(String((err as Error).message));
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      style={{ position: 'fixed', left: anchorRect.left, top: anchorRect.bottom + 4 }}
+      className="z-50 w-64 rounded-mf-input border border-mf-border-subtle bg-mf-panel-bg shadow-lg p-2"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="text-mf-status text-mf-text-secondary uppercase tracking-wide px-2 py-1">Tag session</div>
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+          if (e.key === 'Enter' && showCreate) void createAndApply();
+        }}
+        placeholder="# Find or create..."
+        className="w-full bg-mf-bg text-mf-small px-2 py-1 rounded outline-none border border-mf-border-subtle"
+      />
+      {error && <div className="text-mf-status text-mf-destructive px-2 py-1">{error}</div>}
+      <div className="max-h-64 overflow-y-auto mt-1">
+        {filtered.map((t: Tag) => (
+          <button
+            key={t.name}
+            type="button"
+            onClick={() => void toggle(t.name)}
+            className={cn(
+              'w-full flex items-center justify-between gap-2 px-2 py-1 rounded hover:bg-mf-hover text-mf-small',
+            )}
+          >
+            <span className="flex items-center gap-2">
+              <span className={cn('w-1.5 h-1.5 rounded-full', `bg-mf-tag-${t.color}`)} />
+              {t.name}
+            </span>
+            {applied.has(t.name) && <Check size={12} className="text-mf-accent" />}
+          </button>
+        ))}
+      </div>
+      {showCreate && (
+        <button
+          type="button"
+          onClick={() => void createAndApply()}
+          className="w-full text-left px-2 py-1 rounded hover:bg-mf-hover text-mf-small text-mf-text-secondary mt-1 border-t border-mf-border-subtle"
+        >
+          + Create tag &quot;{lower}&quot;
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+The popover closes via parent click-outside handling — host site responsibility (FlatSessionRow / ChatsPanel uses `useEffect` + `mousedown` listener to call `onClose`).
+
+- [ ] **Step 2: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/tags/TagPopover.tsx
+git commit -m "feat(desktop): TagPopover with search + create"
+```
+
+---
+
+## Task 14: SessionFilterBar component
+
+**Files:**
+- Create: `packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx`
+
+- [ ] **Step 1: Implement**
+
+```tsx
+import React, { useEffect, useMemo } from 'react';
+import { useTagsStore } from '../../store/tags';
+import { useChatsStore, useProjectsStore } from '../../store';
+import { TagPill } from '../tags/TagPill';
+import type { TagColor, SyntheticTag } from '@qlan-ro/mainframe-types';
+
+export function SessionFilterBar(): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const chats = useChatsStore((s) => s.chats);
+
+  const registry = useTagsStore((s) => s.registry);
+  const registryLoaded = useTagsStore((s) => s.registryLoaded);
+  const refreshRegistry = useTagsStore((s) => s.refreshRegistry);
+
+  const selectedProject = useTagsStore((s) => s.selectedProject);
+  const selectedTags = useTagsStore((s) => s.selectedTags);
+  const selectedSynthetic = useTagsStore((s) => s.selectedSynthetic);
+  const setSelectedProject = useTagsStore((s) => s.setSelectedProject);
+  const toggleTag = useTagsStore((s) => s.toggleTag);
+  const toggleSynthetic = useTagsStore((s) => s.toggleSynthetic);
+
+  useEffect(() => {
+    if (!registryLoaded) void refreshRegistry();
+  }, [registryLoaded, refreshRegistry]);
+
+  // Tags currently in use across the active project scope.
+  const tagsInUse = useMemo(() => {
+    const visibleChats = selectedProject
+      ? chats.filter((c) => c.projectId === selectedProject)
+      : chats;
+    const set = new Set<string>();
+    for (const c of visibleChats) for (const t of c.tags ?? []) set.add(t);
+    return [...set].sort();
+  }, [chats, selectedProject]);
+
+  const hasAnyWorktree = useMemo(() => chats.some((c) => Boolean(c.worktreePath)), [chats]);
+  const hasAnyPr = useMemo(
+    () => chats.some((c) => Boolean((c as { createdPrUrl?: string }).createdPrUrl)),
+    [chats],
+  );
+
+  const colorByName = useMemo(() => {
+    const m = new Map<string, TagColor>();
+    for (const t of registry) m.set(t.name, t.color);
+    return m;
+  }, [registry]);
+
+  const showTagsRow = tagsInUse.length > 0 || hasAnyWorktree || hasAnyPr;
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 border-b border-mf-border-subtle">
+      <div className="flex items-center gap-1 overflow-x-auto">
+        <span className="text-mf-status text-mf-text-secondary uppercase mr-1">Project</span>
+        <button
+          type="button"
+          onClick={() => setSelectedProject(null)}
+          className={`px-2 py-0.5 rounded-full text-mf-status ${selectedProject === null ? 'bg-mf-accent text-white' : 'border border-mf-border-subtle text-mf-text-secondary'}`}
+        >
+          All
+        </button>
+        {projects.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => setSelectedProject(p.id)}
+            className={`px-2 py-0.5 rounded-full text-mf-status ${selectedProject === p.id ? 'bg-mf-accent text-white' : 'border border-mf-border-subtle text-mf-text-secondary'}`}
+          >
+            {p.name}
+          </button>
+        ))}
+      </div>
+      {showTagsRow && (
+        <div className="flex items-center gap-1 flex-wrap">
+          <span className="text-mf-status text-mf-text-secondary uppercase mr-1">Tags</span>
+          {tagsInUse.map((name) => (
+            <TagPill
+              key={name}
+              label={name}
+              color={colorByName.get(name) ?? 'gray'}
+              variant="filter"
+              active={selectedTags.has(name)}
+              onClick={() => toggleTag(name)}
+            />
+          ))}
+          {hasAnyPr && (
+            <TagPill
+              label="has-pr"
+              color="gray"
+              variant="filter"
+              active={selectedSynthetic.has('has-pr')}
+              onClick={() => toggleSynthetic('has-pr' as SyntheticTag)}
+            />
+          )}
+          {hasAnyWorktree && (
+            <TagPill
+              label="has-worktree"
+              color="gray"
+              variant="filter"
+              active={selectedSynthetic.has('has-worktree')}
+              onClick={() => toggleSynthetic('has-worktree' as SyntheticTag)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+The filter logic itself (applying selection to the visible list) is wired in `ChatsPanel` (Task 16) since this component is presentational.
+
+- [ ] **Step 2: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx
+git commit -m "feat(desktop): SessionFilterBar component"
+```
+
+---
+
+## Task 15: Refactor FlatSessionRow
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx`
+
+- [ ] **Step 1: Move worktree pill + PR badge into title row, add tag row**
+
+Replace the existing `<div>` returned in the component (currently with `data-testid="chat-list-item"`) with the structure below. Keep all existing handlers (`handleSelect`, `handleArchive`, `handleStartRename`, `handleCommitRename`, etc.) untouched.
+
+Add:
+
+```tsx
+import { Tag as TagIcon } from 'lucide-react';
+import { TagPill } from '../tags/TagPill';
+import { TagPopover } from '../tags/TagPopover';
+import { useTagsStore } from '../../store/tags';
+```
+
+Inside the component, add popover state:
+
+```tsx
+const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
+const tagButtonRef = useRef<HTMLButtonElement>(null);
+
+const openTagPopover = useCallback((e: React.MouseEvent) => {
+  e.stopPropagation();
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  setPopoverRect(rect);
+}, []);
+
+const closeTagPopover = useCallback(() => setPopoverRect(null), []);
+
+const registry = useTagsStore((s) => s.registry);
+const colorOf = useCallback(
+  (name: string) => registry.find((t) => t.name === name)?.color ?? 'gray',
+  [registry],
+);
+```
+
+Then the JSX (replacing the existing return body):
+
+```tsx
+return (
+  <div
+    data-testid="chat-list-item"
+    onContextMenu={(e) => onContextMenu?.(e, chat.claudeSessionId, chat.id)}
+    className={cn(
+      'group w-full rounded-mf-input transition-colors',
+      isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',
+    )}
+  >
+    <div className="flex items-center gap-2 px-3 py-1.5">
+      {/* status dot — unchanged */}
+      <div className="w-3 h-3 shrink-0 flex items-center justify-center">
+        {chat.worktreeMissing ? (
+          <div className="w-2 h-2 rounded-full bg-mf-destructive" />
+        ) : isWorking ? (
+          <Loader2 size={12} className="text-mf-accent animate-spin" />
+        ) : (
+          <div className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary opacity-40')} />
+        )}
+      </div>
+
+      <button type="button" onClick={handleSelect} className="flex-1 min-w-0 text-left flex items-center gap-2">
+        {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            onBlur={handleCommitRename}
+            onKeyDown={handleRenameKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            className="flex-1 bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
+          />
+        ) : (
+          <span
+            className={cn(
+              'truncate text-mf-small',
+              isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+              isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+            )}
+          >
+            {chat.title || 'Untitled session'}
+          </span>
+        )}
+
+        {/* worktree pill */}
+        {chat.worktreePath && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-mf-bg border border-mf-border-subtle font-mono text-mf-status text-mf-text-secondary max-w-[140px] truncate"
+                tabIndex={0}
+              >
+                <GitBranch size={10} className="shrink-0" />
+                {chat.worktreePath.split('/').pop()}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{chat.worktreePath}</TooltipContent>
+          </Tooltip>
+        )}
+
+        {/* PR badge */}
+        {createdPrUrl && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(createdPrUrl, '_blank');
+                }}
+                className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
+                aria-label="Open PR"
+              >
+                <GitPullRequest size={12} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Open PR</TooltipContent>
+          </Tooltip>
+        )}
+      </button>
+
+      {/* time — visible when row not hovered */}
+      <span className="shrink-0 text-mf-status text-mf-text-secondary tabular-nums group-hover:hidden">
+        {formatRelativeTime(chat.updatedAt)}
+      </span>
+
+      {/* hover actions */}
+      <div className={cn('shrink-0 items-center gap-0.5 hidden group-hover:flex', archiving && 'flex')}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              ref={tagButtonRef}
+              onClick={openTagPopover}
+              className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+              aria-label="Edit tags"
+            >
+              <TagIcon size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Tags</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleStartRename}
+              className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+              aria-label="Rename session"
+            >
+              <Pencil size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Rename</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleArchive}
+              disabled={archiving}
+              className={cn(
+                'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors',
+                archiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
+              )}
+              aria-label="Archive session"
+            >
+              {archiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Archive</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+
+    {/* tag row */}
+    {((chat.tags && chat.tags.length > 0) || true) && (
+      <div
+        className={cn(
+          'flex items-center gap-1 px-3 pb-1.5 flex-wrap',
+          (!chat.tags || chat.tags.length === 0) && 'hidden group-hover:flex',
+        )}
+        onClick={openTagPopover}
+      >
+        {(chat.tags ?? []).map((name) => (
+          <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
+        ))}
+        {(!chat.tags || chat.tags.length === 0) && (
+          <span className="text-mf-status text-mf-text-secondary opacity-60">+ tag</span>
+        )}
+      </div>
+    )}
+
+    {popoverRect && <TagPopover chatId={chat.id} anchorRect={popoverRect} onClose={closeTagPopover} />}
+  </div>
+);
+```
+
+The metadata line with `📁 project · 🌿 worktree · ⏰ time` is removed entirely.
+
+- [ ] **Step 2: Add click-outside handling for popover**
+
+```tsx
+useEffect(() => {
+  if (!popoverRect) return;
+  function onDocClick() { closeTagPopover(); }
+  document.addEventListener('mousedown', onDocClick);
+  return () => document.removeEventListener('mousedown', onDocClick);
+}, [popoverRect, closeTagPopover]);
+```
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 4: Manual sanity test**
+
+Per CLAUDE.md UI rule: start the dev server, click a session row's tag icon, verify popover opens; right-click → context menu still appears (archive/rename/etc still work). Verify worktree pill + PR badge sit on the title row, not below.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+git commit -m "feat(desktop): refactor FlatSessionRow — worktree+PR in title, tag row below"
+```
+
+---
+
+## Task 16: Wire SessionFilterBar into ChatsPanel + apply filters
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/panels/ChatsPanel.tsx`
+
+- [ ] **Step 1: Mount the filter bar and apply selections to the displayed list**
+
+In `ChatsPanel.tsx`, import and render `SessionFilterBar` near the top of the panel (above the list). Then, where the chats list is built (`buildGroups` / direct list), apply the active filters.
+
+```tsx
+import { SessionFilterBar } from './SessionFilterBar';
+import { useTagsStore } from '../../store/tags';
+```
+
+Inside the component, derive the filtered chats:
+
+```tsx
+const selectedProject = useTagsStore((s) => s.selectedProject);
+const selectedTags = useTagsStore((s) => s.selectedTags);
+const selectedSynthetic = useTagsStore((s) => s.selectedSynthetic);
+
+const visibleChats = useMemo(() => {
+  return chats.filter((c) => {
+    if (c.status === 'archived') return false;
+    if (selectedProject && c.projectId !== selectedProject) return false;
+    if (selectedSynthetic.has('has-worktree') && !c.worktreePath) return false;
+    if (selectedSynthetic.has('has-pr')) {
+      const pr = (c as { createdPrUrl?: string }).createdPrUrl;
+      if (!pr) return false;
+    }
+    if (selectedTags.size > 0) {
+      const tagSet = new Set(c.tags ?? []);
+      for (const t of selectedTags) if (!tagSet.has(t)) return false;
+    }
+    return true;
+  });
+}, [chats, selectedProject, selectedTags, selectedSynthetic]);
+```
+
+Where `chats` was previously fed into `buildGroups(...)` or the flat list, pass `visibleChats` instead.
+
+Render the bar above the list:
+
+```tsx
+<>
+  <SessionFilterBar />
+  {/* existing list rendering, but using visibleChats */}
+</>
+```
+
+If the list ends up empty due to filters, show:
+
+```tsx
+{visibleChats.length === 0 && (selectedProject || selectedTags.size > 0 || selectedSynthetic.size > 0) && (
+  <div className="px-3 py-4 text-mf-small text-mf-text-secondary">
+    No sessions match these filters.{' '}
+    <button
+      type="button"
+      onClick={() => useTagsStore.getState().clearFilters()}
+      className="underline hover:text-mf-text-primary"
+    >
+      Clear filters
+    </button>
+  </div>
+)}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: succeeds.
+
+- [ ] **Step 3: Manual sanity test**
+
+Start the dev server. Verify:
+- Project pills work (filter by project).
+- Selecting a tag chip narrows the list.
+- Selecting `has-pr` and `has-worktree` narrows further.
+- Multi-select is strict AND.
+- "No sessions match these filters" + Clear button appears when nothing matches.
+- Reload the app — filters reset (no persistence).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+git commit -m "feat(desktop): mount filter bar in ChatsPanel + AND-filter chats"
+```
+
+---
+
+## Task 17: Verification + changeset
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+pnpm test
+```
+Expected: all pass.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm build
+```
+Expected: succeeds in all packages.
+
+- [ ] **Step 3: Manual regression sweep**
+
+Per CLAUDE.md UI rule, exercise the dev app:
+- Right-click a session → `Tags...` opens popover; create + apply works.
+- Click the tag row of a tagged session → opens popover.
+- Hover an untagged row → `+ tag` ghost appears and is clickable.
+- Filter bar `Project` + `Tags` + synthetic chips combine as strict AND.
+- Renaming a tag in the popover (right-click on a registry row) cascades to all sessions immediately.
+- Renaming to an existing tag triggers the merge confirmation modal.
+- Deleting a tag triggers the delete confirmation modal.
+- Refresh the app — filter selection clears (no persistence). Tag registry persists.
+
+- [ ] **Step 4: Add changeset**
+
+```bash
+pnpm changeset
+```
+Pick `@qlan-ro/mainframe-types`, `@qlan-ro/mainframe-core`, `@qlan-ro/mainframe-desktop`, bump `minor` for each. Description: "Add session row tagging with synthetic has-pr / has-worktree filter chips."
+
+- [ ] **Step 5: Commit changeset**
+
+```bash
+git add .changeset/
+git commit -m "chore: changeset for session row tagging"
+```
+
+---
+
+## Self-Review Notes
+
+- The `has-pr` predicate in Task 9 references `created_pr_url` — that column may not exist on the `chats` table as named. **Implementation note for the executor:** before writing the SQL, search core for how `createdPrUrl` is populated on `Chat` (currently it's surfaced via `chats-store.detectedPrs` on the renderer side, derived from runtime detection rather than persisted). If the data isn't persisted on `chats`, either persist it (add a column + populate on PR detection) or implement `has-pr` filtering client-side only (filter on the renderer using `chatsStore.detectedPrs`, treating the API's `synthetic=has-pr` as a no-op). Pick persistence for correctness — the filter should match what the row UI shows.
+- Task 15's tag-row conditional (`((chat.tags && chat.tags.length > 0) || true)`) is intentionally always true because the empty-state hover ghost needs the row in the DOM. The CSS class `hidden group-hover:flex` handles visibility.
+- Tasks 13 and 15 reuse `Chat.tags` from the chat store. The chats store needs no changes because `updateChat` already merges arbitrary `Chat` fields — the `tags` field flows through automatically.
+- **Right-click on a registry row inside the popover → Rename / Recolor / Delete** is in the spec but not in Task 13's code. The executor should add it as a follow-on inside Task 13: a context-menu handler on each row that opens a small menu, with confirmation modals for rename (with merge prompt when the new name already exists) and delete. If this stretches Task 13 too far, split into Task 13a (popover core) + Task 13b (registry management).
+- **Right-click context menu item on the session row** ("Tags...") is in the spec but not added to the existing `ChatsPanel` context-menu builder. The executor should add it: in `ChatsPanel.tsx`'s `onContextMenu` handler that builds `ContextMenuItem[]`, prepend a `Tags...` action that triggers the same popover-open path as the hover icon (Task 15). This lets `onContextMenu` continue to delegate to the parent without `FlatSessionRow` owning the menu shape.

--- a/docs/superpowers/specs/2026-05-05-review-panel-design.md
+++ b/docs/superpowers/specs/2026-05-05-review-panel-design.md
@@ -1,0 +1,289 @@
+# Review Panel
+
+**Status:** Approved · **Date:** 2026-05-05
+
+## Summary
+
+The Review panel is a large modal interface for preparing pull requests within a chat session. It displays all changes since main (committed and uncommitted), enables file-level staging, supports inline code annotations, and facilitates commit + PR creation without leaving the chat context.
+
+## Motivation
+
+Today, users audit changes via in-app terminal or external git tools. This breaks the chat flow and lacks native integration with Mainframe's session model. The Review panel brings the critical pre-PR workflow into the chat, making code review, annotation, and PR creation native operations on the session.
+
+## Scope
+
+**In scope:**
+- Display `git diff main` for all files (added, modified, deleted)
+- File-level staging and unstaging
+- Monaco diff editor with inline comment widgets (session-persisted)
+- Commit message generation (with AI suggestion via `writing-clearly-and-concisely`)
+- `git commit` and PR creation via `gh pr create`
+- Support both worktree-isolated and main-project workflows
+- Two diff view modes: inline and side-by-side
+
+**Out of scope:**
+- Hunk-level staging (file-level only)
+- Merge conflict resolution (user handles manually)
+- Multi-PR workflows (one PR per Review session)
+- Stashing or branch switching
+- History rewriting (rebase, squash on demand)
+
+## Design
+
+### UI Structure
+
+The Review panel appears as a large, centered modal (85–90% of viewport) with visible frame and dimmed chat underneath, preserving the sense of modality rather than a page replace.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Chat thread (dimmed/blurred behind)                                 │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────┐    │
+│  │ Review Panel                                  [X] Close    │    │
+│  │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   │    │
+│  │                                                            │    │
+│  │  Files (left)       │  Diff View (right)                 │    │
+│  │  ─────────────────  │  [≣ Inline] [⇄ Split]             │    │
+│  │                     │  ─────────────────────────        │    │
+│  │  📄 src/index.ts    │                                   │    │
+│  │  ☑️ (staged)        │ INLINE MODE:                      │    │
+│  │  📄 README.md       │ @@ -10,5 +10,7 @@                │    │
+│  │  ☐ (unstaged)      │ function foo() {                  │    │
+│  │  ➕ new file.ts     │ -  return 1;                      │    │
+│  │  ☐ (unstaged)      │ +  return 2; // updated          │    │
+│  │                     │ }                                 │    │
+│  │                     │ [inline comment widget]           │    │
+│  │                     │                                   │    │
+│  ├─────────────────────┴───────────────────────────────────┤    │
+│  │ [Stage All] [Unstage All]  │  Commit Message Input      │    │
+│  │                            │  [AI Suggest] [Commit]     │    │
+│  │                            │  [Open PR]                 │    │
+│  └────────────────────────────────────────────────────────┘    │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Left Pane: File Tree
+
+- Hierarchical list of files from `git diff main --name-status`
+- File badges: `📄` (modified), `➕` (added), `🗑` (deleted), `🔄` (renamed)
+- Two sections: "Staged" (checked files) and "Unstaged" (unchecked files)
+- Checkboxes for file-level staging toggles
+- Click file to load its diff in the right pane
+
+#### Right Pane: Diff View
+
+- Monaco diff editor (read-only) showing `git diff main -- <file>`
+- Two modes (toggle in toolbar):
+  - **Inline:** Changes shown with context lines, compact layout (default)
+  - **Side-by-side:** Main branch (left) vs. worktree (right), wider viewport
+- Supports Monaco inline comment widgets for session-persisted annotations
+- Mode preference saved to localStorage
+
+#### Bottom Action Bar
+
+- **[Stage All] / [Unstage All]** buttons to toggle all files at once
+- **Commit Message Input** field (auto-filled with AI suggestion)
+- **[AI Suggest]** button to regenerate message from changed files
+- **[Commit]** button to stage and create commit
+- **[Open PR]** button to push and create PR via `gh pr create`
+
+#### Warning Banner
+
+If no worktree and reviewing main project directory:
+```
+⚠️  Changes are not isolated to this chat. Review includes all uncommitted work in the project.
+```
+
+### Workflow
+
+```
+User opens Review panel
+       ↓
+Load git diff main, populate file tree
+       ↓
+User selects file → load diff in editor
+       ↓
+User stages/unstages files (checkboxes)
+       ↓
+User adds inline comments (Monaco widgets) → stored in session
+       ↓
+User enters commit message (or clicks [AI Suggest])
+       ↓
+[Commit] → git add <staged-files> && git commit -m "..."
+       ↓
+[Open PR] → git push && gh pr create --base main --head <branch>
+       ↓
+Modal closes, PR URL shown in chat
+```
+
+**Inline Comments:**
+- Comments are stored in `chat.reviewComments` (session-level)
+- Format: `{ fileId, line, content, authorId, timestamp }`
+- Persisted when session ends or modal explicitly saved
+- Survives modal close/reopen (not lost if user edits content and reopens)
+
+### Worktree Support
+
+**Scenario A: Chat with worktree (preferred)**
+- Review shows `git diff main` within isolated worktree branch
+- Changes scoped to this chat only
+- PR created on worktree branch (reuses existing branch if PR exists)
+- No warning banner
+
+**Scenario B: Chat without worktree (main project)**
+- Review shows `git diff main` in project root directory
+- Show warning banner (changes not isolated to this chat)
+- User can still stage, commit, and create PR
+- Useful for simpler workflows where isolation isn't required
+
+### Staging & Commits
+
+- **File-level only:** No hunk-level staging (simpler implementation, covers 90% of use cases)
+- **Preserve existing commits:** If worktree already has commits, they stay; new commits added on top
+- **Single new commit:** Unstaged changes get one new commit on top of any existing worktree commits
+- **Commit message:** Pre-filled via AI suggestion from `writing-clearly-and-concisely` patterns
+
+### PR Creation
+
+- **Branch reuse:** Push to existing worktree branch (idempotent)
+- **Idempotent PR:** If PR already exists for this branch, update the existing PR (via `gh pr create` re-run or detection logic)
+- **PR source tracking:** Detected as `source: 'created'` in existing PR detection system
+
+### Diff View Modes
+
+**Inline Mode (default):**
+- Changes shown with context lines
+- Compact vertical layout
+- Good for sequential reading
+
+**Side-by-Side Mode:**
+- Main branch (left) vs. worktree (right)
+- Wider viewport, easier to scan visual differences
+- Better for large changes
+- Toggle via `[≣ Inline] [⇄ Split]` buttons
+
+Both modes support Monaco features: syntax highlighting, line numbers, minimap, inline comments.
+
+**Mode persistence:** User preference saved to localStorage per session/user.
+
+## Integration
+
+### API Endpoints
+
+New or extended endpoints in `packages/core/src/server/routes/git.ts`:
+
+```typescript
+POST /api/git/diff
+  body: { chatId, files?: string[] }
+  returns: { diffs: Record<string, { main: string; worktree: string }> }
+
+POST /api/git/status
+  body: { chatId }
+  returns: { staged: string[]; unstaged: string[]; untracked: string[] }
+
+POST /api/git/stage
+  body: { chatId, files: string[] }
+  returns: { success: boolean; error?: string }
+
+POST /api/git/commit
+  body: { chatId, message: string, files: string[] }
+  returns: { hash: string; error?: string }
+
+POST /api/git/push
+  body: { chatId }
+  returns: { success: boolean; error?: string }
+```
+
+All endpoints operate on `chat.worktreePath` (if set) or `project.path` (if no worktree). Path resolution via existing `resolveAndValidatePath()` helper.
+
+### Existing Systems
+
+| System | Integration |
+|--------|-------------|
+| **Worktree system** | Uses `chat.worktreePath` or `project.path` |
+| **DiffViewer** | Reuses Monaco diff editor + comment widget infrastructure |
+| **Chat session** | Stores review comments in `chat.reviewComments` |
+| **PR detection** | Existing `detectPr` hook fires on `gh pr create` success |
+| **Desktop UI** | New modal component, triggered via button or keyboard shortcut |
+
+### Component Structure
+
+```
+packages/desktop/src/renderer/components/
+├── modals/
+│   └── ReviewPanel.tsx
+│       ├── ReviewPanelHeader.tsx
+│       ├── FileTree.tsx
+│       ├── DiffView.tsx (reuses Monaco editor)
+│       └── ActionBar.tsx
+└── ... (existing)
+```
+
+**State management:** Zustand store or component state (TBD based on complexity).
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| No worktree, project dirty | Allow Review to proceed; show warning banner |
+| `git diff` fails (repo error) | Toast error; show retry button |
+| Diff too large (>50k lines) | Show warning; offer file filtering |
+| File deleted in worktree | Show in tree with 🗑 badge; diff shows full deletion |
+| Commit fails (conflicts detected) | Modal error dialog; user resolves manually |
+| Push fails (auth, network, branch deleted) | Error dialog; suggest manual `git push` |
+| PR creation fails (`gh pr create` error) | Error dialog; suggest manual `gh pr create` |
+| Comment widget error | Graceful fallback; diff still readable |
+| Modal closed with changes | Confirm dialog: "Discard changes?" |
+
+## Data Model
+
+### Review Modal State
+
+```typescript
+type ReviewPanelState = {
+  isOpen: boolean;
+  selectedFile: string | null;
+  stagedFiles: Set<string>;
+  diffMode: 'inline' | 'split';
+  commitMessage: string;
+  loading: boolean;
+  error: string | null;
+};
+```
+
+### Chat Session Extension
+
+```typescript
+chat.reviewComments?: {
+  [fileId: string]: Array<{
+    line: number;
+    content: string;
+    authorId: string;
+    timestamp: number;
+  }>;
+};
+```
+
+### Persistence
+
+- **Diff mode preference:** Browser localStorage
+- **Review comments:** Attached to chat session, persisted to DB on session end
+- **Staged files:** Live only in modal memory, lost on close (not persisted)
+
+## Testing Strategy
+
+- Unit tests for git command wrappers (diff, status, stage, commit, push)
+- Component tests for FileTree, DiffView, ActionBar (props, interactions)
+- Integration tests: full flow (open → stage → commit → PR create)
+- E2E tests: Review panel in actual Electron app with real git repo
+- Error cases: network failures, repo corruption, auth errors
+
+## Open Questions
+
+None. Design is complete and approved.
+
+## Related Issues
+
+- #35 Review Panel (this feature)
+- Existing: Worktree support, DiffViewer, PR detection system

--- a/docs/superpowers/specs/2026-05-05-session-row-tagging-design.md
+++ b/docs/superpowers/specs/2026-05-05-session-row-tagging-design.md
@@ -1,0 +1,229 @@
+# Session Row Tagging — Design
+
+**Status:** Draft
+**Date:** 2026-05-05
+**Issue:** #64
+
+## Problem
+
+Sessions accumulate quickly. Renaming each one to encode state (`bug:`, `wip-`, etc.) is a manual workaround for a missing primitive: lightweight categorization. Identity (worktree, PR) and category (tags) are also currently mixed in the same metadata line, which makes both harder to scan.
+
+This feature adds user-defined tags on session rows, plus a small set of system-managed synthetic chips (`has-pr`, `has-worktree`) for stateful filtering. Identity (worktree, PR) stays in the title row as before.
+
+## Goals
+
+- User can apply, create, rename, recolor, and delete tags on sessions.
+- Filter the sessions list by project + tags (strict AND).
+- Identity badges (worktree pill, PR badge) move to the title row to keep the tag namespace clean.
+- Storage and queries scale to thousands of sessions and tags without rewrites.
+
+## Non-Goals
+
+- Linking sessions to todos (separate feature; `has-todo` deferred).
+- `Cmd+K` `tag:` query token (deferred).
+- Multi-device tag sync (project-wide concern, not solved here).
+- Tag analytics (usage counts in delete/merge dialogs).
+- Filter state persistence across launches (resets every launch).
+
+## Layout
+
+### Session row
+
+```
+● [pin] Title text                [feat-tool-cards 🌿] [PR ↗]   1d
+        [feature]  [bug]  [ui]
+```
+
+- **Title row (identity):** status dot, optional pin, title, then on the right — worktree pill (mono, max-width 140px, tooltip = full path), PR badge (clickable, opens PR), relative time.
+- **Tag row (categorization):** filled colored pills, label only (no leading dot). Renders only when the chat has user tags or the row is hovered. On hover, an empty row shows a faint `+ tag` ghost as a click target.
+- **Hover actions:** the time slot is replaced by `Tag / Rename / Archive` icon buttons. No reflow (slot width reserved).
+- The previous `📁 project · 🌿 worktree · ⏰ time` metadata line is removed.
+
+### Filter bar (sessions panel header)
+
+```
+PROJECT:  [All]  [mainframe]  [DBricks_Optimizer]  [Anastasia] ...
+TAGS:     [• feature] [• bug] [• ui] [• refactor] [• has-pr] [• has-worktree]
+```
+
+- **Project row:** existing pills, single-select. `All` is default.
+- **Tags row:** outlined pills with leading colored dot. User tags and synthetic chips flow together (no divider). Synthetic chips use a neutral gray dot.
+- **Filter logic:** strict AND across every selected chip in every row. Project AND tag1 AND tag2 AND has-pr AND has-worktree.
+- **Empty state:** if there are no user tags and no synthetic matches, the `TAGS:` row hides.
+- **Persistence:** filter state resets on every launch.
+
+### Tag editor popover
+
+Triggered by:
+- Right-click on a session row → context menu has `Tags...`.
+- Click on the tag row of a session, or the `+ tag` ghost on empty hover.
+
+```
+TAG SESSION
+[# Find or create...        ]
+─────────────────────────────
+✓ • feature
+✓ • ui
+  • bug
+  • refactor
+─────────────────────────────
++ Create tag "mobile"     ← when query has no exact match
+```
+
+- Toggling a row applies/removes the tag immediately (optimistic).
+- `+ Create tag "<query>"` appears when the query is non-empty and no exact match exists. Validates `[a-z0-9-]+`, max 24 chars, rejects `has-*` prefix with inline error.
+- Synthetic chips do NOT appear here — they are system-managed.
+- Right-click a tag inside the popover → `Rename` / `Change color` / `Delete from all sessions`. Right-clicking a chip in the filter bar opens the same menu.
+
+## Tag Format & Colors
+
+- **Name format:** lowercase, `^[a-z0-9-]+$`, max 24 characters.
+- **Reserved prefix:** `has-` is system-only. Creating any tag starting with `has-` returns an inline error.
+- **Color:** assigned automatically on create from the seed palette via stable hash on the name. User can recolor via the right-click menu. Colors are stored in the `tags` registry, not on associations.
+
+```ts
+// packages/types/src/tags.ts
+export const TAG_PALETTE = [
+  'blue', 'red', 'purple', 'violet', 'amber',
+  'teal', 'cyan', 'green', 'pink', 'orange',
+] as const;
+export type TagColor = typeof TAG_PALETTE[number];
+export const RESERVED_TAG_PREFIX = 'has-';
+```
+
+Concrete hex values map from existing `mf-*` Tailwind tokens; if missing, add `mf-tag-{color}` tokens to the design system.
+
+## Data Model
+
+New tables in `packages/core/src/db/schema.ts`:
+
+```sql
+CREATE TABLE tags (
+  name       TEXT PRIMARY KEY,        -- normalized lowercase
+  color      TEXT NOT NULL,           -- TagColor key
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE chat_tags (
+  chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+  tag        TEXT NOT NULL REFERENCES tags(name) ON UPDATE CASCADE,
+  source     TEXT NOT NULL DEFAULT 'user', -- 'user' (only value in v1)
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (chat_id, tag, source)
+);
+CREATE INDEX idx_chat_tags_chat ON chat_tags(chat_id);
+CREATE INDEX idx_chat_tags_tag  ON chat_tags(tag);
+```
+
+### Synthetic tags
+
+Synthetic tags (`has-pr`, `has-worktree`) are NOT stored. They are computed at query time from existing chat row fields:
+
+- `has-pr` ← chat has a created PR URL or detected PR.
+- `has-worktree` ← `chats.worktree_path IS NOT NULL`.
+
+This avoids stale-data problems and event plumbing. Filter queries use `WHERE` clauses on the chat row directly.
+
+### Cascade
+
+`ON DELETE CASCADE` on `chat_tags.chat_id` removes associations on chat deletion (per Code Rules — cascade deletes for parent entities).
+
+`ON UPDATE CASCADE` on `chat_tags.tag` lets rename be a single `UPDATE tags SET name = ?` statement.
+
+### Migrations
+
+Additive. No data migration needed. Initial registry is empty; tags appear as users create them.
+
+## API
+
+All routes are HTTP, Zod-validated. No WebSocket events — tag mutations are user-triggered from a single client.
+
+### Tag registry
+
+- `GET    /tags` → `{ tags: Array<{ name: string, color: TagColor }> }`
+- `POST   /tags` → body `{ name: string, color?: TagColor }` → 201 with created tag. 400 on invalid format or reserved prefix.
+- `PATCH  /tags/:name` → body `{ rename?: string, color?: TagColor }` → 200. Rename atomically updates `tags.name` and cascades to `chat_tags`. If the new name already exists, performs a merge (associations deduped via `INSERT OR IGNORE`).
+- `DELETE /tags/:name` → 204. Removes tag and all associations via cascade.
+
+### Chat associations
+
+- `GET /chats/:id/tags` → `string[]` (user tags only).
+- `PUT /chats/:id/tags` → body `{ tags: string[] }` → replaces user-source associations atomically. Auto-creates any tag that doesn't exist yet (palette-hashed color).
+
+### Chat list filtering
+
+Extend the existing list endpoint:
+
+- `GET /chats?project=<id>&tags=feature,bug&synthetic=has-pr,has-worktree`
+- AND across all parameters.
+- Synthetic resolved server-side from `chats.worktree_path` and PR fields.
+
+## Frontend
+
+### Files touched
+
+- `packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx`
+  - Drop the metadata line; render worktree pill + PR badge + time on the right of the title row.
+  - Add tag row below the title row, conditional on `chat.tags.length > 0 || hovered`.
+  - Add `Tag` icon to the hover action group (alongside Rename / Archive).
+
+- `packages/desktop/src/renderer/components/panels/ChatsPanel.tsx`
+  - Add filter bar component above the list. Wire filter state to chat list query.
+
+### New files
+
+- `packages/desktop/src/renderer/components/tags/TagPopover.tsx` — search, list, toggle, create. Triggered by right-click and tag-row-click.
+- `packages/desktop/src/renderer/components/tags/TagPill.tsx` — two variants: `row` (filled, no dot) and `filter` (outlined, leading dot).
+- `packages/desktop/src/renderer/components/tags/FilterBar.tsx` — project pills + tag chips.
+- `packages/desktop/src/renderer/store/tags.ts` — Zustand store: registry cache, filter state (project + selected tags), session→tags map. Optimistic updates with rollback on API failure.
+- `packages/types/src/tags.ts` — `Tag`, `TagColor`, `TAG_PALETTE`, `RESERVED_TAG_PREFIX`.
+- `packages/core/src/lib/validateTagName.ts` — single source of truth for name validation.
+
+### Extensions
+
+- `packages/types/src/chat.ts` — add `Chat.tags?: string[]` (user tags), populated by daemon on list/get.
+- `packages/desktop/src/renderer/lib/api.ts` — add `listTags / createTag / updateTag / deleteTag / getChatTags / setChatTags`.
+
+### Color resolution
+
+`getTagColor(name, registry)` returns the registry color, or hashes the name to a palette entry as a fallback (handles eventual-consistency before registry loads).
+
+## Edge Cases
+
+- **Empty list with active filters** → empty-state message with a `Clear filters` button.
+- **Tag with zero matches in current filter** → chip stays in the bar; deselecting unstucks. It does NOT disappear mid-interaction.
+- **Filter bar tag list scope** → tags currently used by any chat in the active project (or all projects if `All`). Unused tags are hidden from the bar but still appear in the popover.
+- **Renaming to an existing name** → confirmation modal: "Merge `feat` into `feature`?" — no usage count query.
+- **Deleting a tag** → confirmation modal: "Delete tag `feature`? This removes it from all sessions." — no usage count.
+- **Synthetic chip with zero matches** → still rendered (consistent set). Selecting shows the empty state. Avoids flicker on PR open/close.
+- **Archived sessions** → excluded from the filter bar's tag-aggregation query. Tags stay attached on the row.
+- **Concurrent tag creation** → server uses `INSERT OR IGNORE`; whichever insert wins owns the color.
+
+## Testing
+
+Per Code Rules: new public methods need tests; coverage thresholds enforced.
+
+### Core DB (`packages/core/src/db/__tests__/`)
+
+- `tags.test.ts` — CRUD, normalization, reserved prefix rejection, format validation, rename cascade, merge-on-rename, color preserved on update.
+- `chats.test.ts` (extend) — `getChatTags`, `setChatTags`, cascade delete on chat removal, idempotency of `setChatTags`.
+
+### Core routes (`packages/core/src/server/__tests__/`)
+
+- `tags.routes.test.ts` — Zod validation on each endpoint, 400s for malformed input, 404s for unknown tags.
+- `chats.routes.test.ts` (extend) — list filtering with `project + tags + synthetic` (AND), synthetic computed correctly from chat row fields.
+
+### Validation helper
+
+- `validateTagName.test.ts` — table-driven cases including the reserved `has-*` prefix.
+
+### Renderer
+
+- `TagPopover` — open/close, create flow, toggle apply, validation error display.
+- `tags` store — subscription correctness, optimistic update and rollback on API failure.
+
+No E2E in v1 — covered by component + store tests.
+
+## Open Items
+
+None at design time. Implementation plan to follow.

--- a/packages/core/src/__tests__/routes/chats.test.ts
+++ b/packages/core/src/__tests__/routes/chats.test.ts
@@ -15,6 +15,7 @@ function createMockContext(): RouteContext {
       getChat: vi.fn(),
       listChats: vi.fn(),
       listAllChats: vi.fn(),
+      listFiltered: vi.fn(),
       archiveChat: vi.fn(),
       unarchiveChat: vi.fn(),
       getMessages: vi.fn(),
@@ -54,7 +55,7 @@ describe('chatRoutes', () => {
         { id: 'c1', projectId: 'p1', title: 'Chat 1', status: 'active' },
         { id: 'c2', projectId: 'p2', title: 'Chat 2', status: 'active' },
       ];
-      (ctx.chats.listAllChats as any).mockReturnValue(mockChats);
+      (ctx.chats.listFiltered as any).mockReturnValue(mockChats);
 
       const router = chatRoutes(ctx);
       const handler = extractHandler(router, 'get', '/api/chats');
@@ -62,7 +63,7 @@ describe('chatRoutes', () => {
 
       handler({ params: {}, query: {} }, res, vi.fn());
 
-      expect(ctx.chats.listAllChats).toHaveBeenCalled();
+      expect(ctx.chats.listFiltered).toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith({ success: true, data: mockChats });
     });
   });

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -12,6 +12,7 @@ import type {
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
+import type { ChatListFilters } from '../db/chats.js';
 import { existsSync } from 'node:fs';
 import { nanoid } from 'nanoid';
 import { createChildLogger } from '../logger.js';
@@ -454,6 +455,11 @@ export class ChatManager {
 
   listAllChats(): Chat[] {
     const chats = this.db.chats.listAll();
+    return chats.map((chat) => this.enrichChat(chat));
+  }
+
+  listFiltered(filters: ChatListFilters): Chat[] {
+    const chats = this.db.chats.listFiltered(filters);
     return chats.map((chat) => this.enrichChat(chat));
   }
 

--- a/packages/core/src/db/__tests__/chat-tags.test.ts
+++ b/packages/core/src/db/__tests__/chat-tags.test.ts
@@ -66,4 +66,58 @@ describe('ChatTagsRepository', () => {
     expect(chatTags.filterChatIds(['feature'])!.sort()).toEqual(['c1', 'c2']);
     expect(chatTags.filterChatIds([])).toBeNull();
   });
+
+  it('bulkForChats returns a map of chatId -> tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature', 'ui'], tags);
+    chatTags.setForChat('c2', ['bug'], tags);
+    const map = chatTags.bulkForChats(['c1', 'c2', 'c3']);
+    expect(map.get('c1')?.sort()).toEqual(['feature', 'ui']);
+    expect(map.get('c2')).toEqual(['bug']);
+    expect(map.has('c3')).toBe(false); // c3 has no tags
+  });
+
+  it('bulkForChats with empty input returns empty Map', () => {
+    const { chatTags } = setup();
+    expect(chatTags.bulkForChats([]).size).toBe(0);
+  });
+
+  it('cascades on chat deletion', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    const tags = new TagsRepository(db);
+    const chatTags = new ChatTagsRepository(db);
+    chatTags.setForChat('c1', ['feature'], tags);
+    expect(chatTags.listForChat('c1')).toEqual(['feature']);
+    db.prepare('DELETE FROM chats WHERE id = ?').run('c1');
+    expect(chatTags.listForChat('c1')).toEqual([]);
+  });
+
+  it('setForChat rolls back when an invalid tag name throws', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['existing'], tags);
+    // 'has-foo' triggers the reserved-prefix throw inside registry.upsert
+    expect(() => chatTags.setForChat('c1', ['ok-tag', 'has-foo'], tags)).toThrow(/reserved/i);
+    // Original associations preserved by transaction rollback.
+    expect(chatTags.listForChat('c1')).toEqual(['existing']);
+  });
+
+  it('filterChatIds dedupes duplicate input tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature'], tags);
+    // Duplicate input must not break HAVING COUNT
+    expect(chatTags.filterChatIds(['feature', 'feature'])!.sort()).toEqual(['c1']);
+  });
 });

--- a/packages/core/src/db/__tests__/chat-tags.test.ts
+++ b/packages/core/src/db/__tests__/chat-tags.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+import { TagsRepository } from '../tags.js';
+import { ChatTagsRepository } from '../chat-tags.js';
+
+function setup() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const now = new Date().toISOString();
+  db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+    'p1',
+    'p',
+    '/tmp/p',
+    now,
+    now,
+  );
+  for (const id of ['c1', 'c2', 'c3']) {
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(id, 'claude', 'p1', 'active', now, now);
+  }
+  return { tags: new TagsRepository(db), chatTags: new ChatTagsRepository(db) };
+}
+
+describe('ChatTagsRepository', () => {
+  it('listForChat returns empty initially', () => {
+    expect(setup().chatTags.listForChat('c1')).toEqual([]);
+  });
+
+  it('setForChat replaces user tags atomically', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature', 'ui'], tags);
+    expect(chatTags.listForChat('c1').sort()).toEqual(['feature', 'ui']);
+    chatTags.setForChat('c1', ['bug'], tags);
+    expect(chatTags.listForChat('c1')).toEqual(['bug']);
+  });
+
+  it('setForChat auto-creates missing tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['mobile'], tags);
+    expect(tags.get('mobile')).not.toBeNull();
+  });
+
+  it('listInUse returns distinct tags currently associated', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature'], tags);
+    chatTags.setForChat('c2', ['feature', 'bug'], tags);
+    expect(chatTags.listInUse().sort()).toEqual(['bug', 'feature']);
+  });
+
+  it('listInUse with projectId filters', () => {
+    const db = setup();
+    db.chatTags.setForChat('c1', ['feature'], db.tags);
+    expect(db.chatTags.listInUse('p1').sort()).toEqual(['feature']);
+    expect(db.chatTags.listInUse('p-other')).toEqual([]);
+  });
+
+  it('filterChatIds AND-intersects user tags', () => {
+    const { tags, chatTags } = setup();
+    chatTags.setForChat('c1', ['feature', 'ui'], tags);
+    chatTags.setForChat('c2', ['feature'], tags);
+    chatTags.setForChat('c3', ['bug'], tags);
+    expect(chatTags.filterChatIds(['feature', 'ui'])!.sort()).toEqual(['c1']);
+    expect(chatTags.filterChatIds(['feature'])!.sort()).toEqual(['c1', 'c2']);
+    expect(chatTags.filterChatIds([])).toBeNull();
+  });
+});

--- a/packages/core/src/db/__tests__/chats-tags.test.ts
+++ b/packages/core/src/db/__tests__/chats-tags.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+import { ChatsRepository } from '../chats.js';
+import { ProjectsRepository } from '../projects.js';
+import { TagsRepository } from '../tags.js';
+import { ChatTagsRepository } from '../chat-tags.js';
+
+function setup() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const projects = new ProjectsRepository(db);
+  const tags = new TagsRepository(db);
+  const chatTags = new ChatTagsRepository(db);
+  const chats = new ChatsRepository(db, chatTags);
+  return { db, projects, tags, chatTags, chats };
+}
+
+describe('ChatsRepository — Chat.tags population', () => {
+  it('list() populates Chat.tags from chat_tags', () => {
+    const { projects, tags, chatTags, chats } = setup();
+    const p = projects.create('/tmp/p');
+    const chat = chats.create(p.id, 'claude');
+    chatTags.setForChat(chat.id, ['feature', 'ui'], tags);
+    const result = chats.list(p.id);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.tags?.sort()).toEqual(['feature', 'ui']);
+  });
+
+  it('list() returns empty tags array for chats with no tags', () => {
+    const { projects, chats } = setup();
+    const p = projects.create('/tmp/p');
+    chats.create(p.id, 'claude');
+    const result = chats.list(p.id);
+    expect(result[0]!.tags).toEqual([]);
+  });
+
+  it('list() does not run extra queries when chatTags is omitted (back-compat)', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const projects = new ProjectsRepository(db);
+    const chatsNoTags = new ChatsRepository(db);
+    const p = projects.create('/tmp/p');
+    chatsNoTags.create(p.id, 'claude');
+    const result = chatsNoTags.list(p.id);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.tags).toBeUndefined();
+  });
+
+  it('get() populates Chat.tags for a single chat', () => {
+    const { projects, tags, chatTags, chats } = setup();
+    const p = projects.create('/tmp/p');
+    const chat = chats.create(p.id, 'claude');
+    chatTags.setForChat(chat.id, ['backend'], tags);
+    const result = chats.get(chat.id);
+    expect(result).not.toBeNull();
+    expect(result!.tags).toEqual(['backend']);
+  });
+
+  it('get() returns empty tags array for a chat with no tags', () => {
+    const { projects, chats } = setup();
+    const p = projects.create('/tmp/p');
+    const chat = chats.create(p.id, 'claude');
+    const result = chats.get(chat.id);
+    expect(result!.tags).toEqual([]);
+  });
+});

--- a/packages/core/src/db/__tests__/chats-tags.test.ts
+++ b/packages/core/src/db/__tests__/chats-tags.test.ts
@@ -67,3 +67,13 @@ describe('ChatsRepository — Chat.tags population', () => {
     expect(result!.tags).toEqual([]);
   });
 });
+
+describe('ChatsRepository — listFiltered invariant', () => {
+  it('listFiltered throws when tagsAll given but chatTags is absent', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const chats = new ChatsRepository(db); // no chatTags
+    expect(() => chats.listFiltered({ tagsAll: ['feature'] })).toThrow(/ChatTagsRepository/);
+  });
+});

--- a/packages/core/src/db/__tests__/schema.test.ts
+++ b/packages/core/src/db/__tests__/schema.test.ts
@@ -37,4 +37,57 @@ describe('schema — tags', () => {
     const remaining = db.prepare('SELECT COUNT(*) AS n FROM chat_tags').get() as { n: number };
     expect(remaining.n).toBe(0);
   });
+
+  it('chat_tags follows tag renames via ON UPDATE CASCADE', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    db.prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)').run('feat', 'blue', now);
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c1',
+      'feat',
+      now,
+    );
+
+    db.prepare('UPDATE tags SET name = ? WHERE name = ?').run('feature', 'feat');
+
+    const row = db.prepare('SELECT tag FROM chat_tags WHERE chat_id = ?').get('c1') as { tag: string };
+    expect(row.tag).toBe('feature');
+  });
+
+  it('rejects deleting a tag that is still applied (RESTRICT default)', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    db.prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)').run('feature', 'blue', now);
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c1',
+      'feature',
+      now,
+    );
+
+    expect(() => db.prepare('DELETE FROM tags WHERE name = ?').run('feature')).toThrow(/FOREIGN KEY/i);
+  });
 });

--- a/packages/core/src/db/__tests__/schema.test.ts
+++ b/packages/core/src/db/__tests__/schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+
+describe('schema — tags', () => {
+  it('creates tags and chat_tags tables', () => {
+    const db = new Database(':memory:');
+    initializeSchema(db);
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('tags');
+    expect(names).toContain('chat_tags');
+  });
+
+  it('chat_tags cascades on chat deletion', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    db.prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)').run('feature', 'blue', now);
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c1',
+      'feature',
+      now,
+    );
+    db.prepare('DELETE FROM chats WHERE id = ?').run('c1');
+    const remaining = db.prepare('SELECT COUNT(*) AS n FROM chat_tags').get() as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+});

--- a/packages/core/src/db/__tests__/tags.test.ts
+++ b/packages/core/src/db/__tests__/tags.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../schema.js';
+import { TagsRepository } from '../tags.js';
+
+function setup() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  return new TagsRepository(db);
+}
+
+describe('TagsRepository', () => {
+  it('list returns empty initially', () => {
+    expect(setup().list()).toEqual([]);
+  });
+
+  it('upsert creates a tag with auto-color when missing', () => {
+    const repo = setup();
+    const tag = repo.upsert('feature');
+    expect(tag.name).toBe('feature');
+    expect(tag.color).toBeTruthy();
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('upsert is idempotent', () => {
+    const repo = setup();
+    const a = repo.upsert('feature');
+    const b = repo.upsert('feature');
+    expect(b.color).toBe(a.color);
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('rejects reserved prefix', () => {
+    expect(() => setup().upsert('has-pr')).toThrow(/reserved/i);
+  });
+
+  it('rename moves the row and cascades chat_tags', () => {
+    const repo = setup();
+    repo.upsert('feat');
+    repo.rename('feat', 'feature');
+    const names = repo.list().map((t) => t.name);
+    expect(names).toContain('feature');
+    expect(names).not.toContain('feat');
+  });
+
+  it('rename to existing name merges (drops the source row)', () => {
+    const repo = setup();
+    repo.upsert('feat');
+    repo.upsert('feature');
+    repo.rename('feat', 'feature');
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('recolor updates color only', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    repo.setColor('feature', 'red');
+    expect(repo.list()[0]!.color).toBe('red');
+  });
+
+  it('remove deletes the row', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    repo.remove('feature');
+    expect(repo.list()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/db/__tests__/tags.test.ts
+++ b/packages/core/src/db/__tests__/tags.test.ts
@@ -65,4 +65,105 @@ describe('TagsRepository', () => {
     repo.remove('feature');
     expect(repo.list()).toHaveLength(0);
   });
+
+  it('upsert normalizes whitespace and case', () => {
+    const repo = setup();
+    const a = repo.upsert('  Feature  ');
+    expect(a.name).toBe('feature');
+  });
+
+  it('rename to self is a no-op (no throw, no list change)', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    expect(() => repo.rename('feature', 'feature')).not.toThrow();
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('upsert ignores color arg when tag already exists (color preserved)', () => {
+    const repo = setup();
+    const first = repo.upsert('feature'); // gets auto color
+    const second = repo.upsert('feature', 'red');
+    expect(second.color).toBe(first.color);
+  });
+
+  it('plain rename cascades chat_tags via ON UPDATE CASCADE', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    const repo = new TagsRepository(db);
+    repo.upsert('feat');
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c1',
+      'feat',
+      now,
+    );
+    repo.rename('feat', 'feature');
+    const row = db.prepare('SELECT tag FROM chat_tags WHERE chat_id = ?').get('c1') as { tag: string };
+    expect(row.tag).toBe('feature');
+  });
+
+  it('merge rename moves chat_tags rows under the target tag', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    initializeSchema(db);
+    const now = new Date().toISOString();
+    db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+      'p1',
+      'p',
+      '/tmp/p',
+      now,
+      now,
+    );
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c1', 'claude', 'p1', 'active', now, now);
+    db.prepare(
+      'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('c2', 'claude', 'p1', 'active', now, now);
+    const repo = new TagsRepository(db);
+    repo.upsert('feat');
+    repo.upsert('feature');
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c1',
+      'feat',
+      now,
+    );
+    db.prepare("INSERT INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)").run(
+      'c2',
+      'feature',
+      now,
+    );
+    repo.rename('feat', 'feature');
+    const tags = db.prepare('SELECT tag FROM chat_tags ORDER BY chat_id').all() as { tag: string }[];
+    expect(tags.map((r) => r.tag)).toEqual(['feature', 'feature']);
+  });
+
+  it('get returns null for missing tag', () => {
+    expect(setup().get('nonexistent')).toBeNull();
+  });
+
+  it('rename rejects reserved-prefix target', () => {
+    const repo = setup();
+    repo.upsert('feature');
+    expect(() => repo.rename('feature', 'has-pr')).toThrow(/reserved/i);
+  });
+
+  it('setColor throws when tag missing', () => {
+    expect(() => setup().setColor('nope', 'red')).toThrow(/not found/i);
+  });
+
+  it('remove throws when tag missing', () => {
+    expect(() => setup().remove('nope')).toThrow(/not found/i);
+  });
 });

--- a/packages/core/src/db/chat-tags.ts
+++ b/packages/core/src/db/chat-tags.ts
@@ -1,0 +1,94 @@
+import type Database from 'better-sqlite3';
+import type { TagsRepository } from './tags.js';
+
+export class ChatTagsRepository {
+  constructor(private db: Database.Database) {}
+
+  listForChat(chatId: string): string[] {
+    const rows = this.db
+      .prepare("SELECT tag FROM chat_tags WHERE chat_id = ? AND source = 'user' ORDER BY tag")
+      .all(chatId) as { tag: string }[];
+    return rows.map((r) => r.tag);
+  }
+
+  /** Map of chatId -> user tags. Used to populate Chat.tags on list queries. */
+  bulkForChats(chatIds: string[]): Map<string, string[]> {
+    const out = new Map<string, string[]>();
+    if (chatIds.length === 0) return out;
+    const placeholders = chatIds.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT chat_id as chatId, tag FROM chat_tags
+         WHERE source = 'user' AND chat_id IN (${placeholders})
+         ORDER BY chat_id, tag`,
+      )
+      .all(...chatIds) as { chatId: string; tag: string }[];
+    for (const r of rows) {
+      const list = out.get(r.chatId);
+      if (list) list.push(r.tag);
+      else out.set(r.chatId, [r.tag]);
+    }
+    return out;
+  }
+
+  /** Replace the user tag set for a chat atomically. Auto-creates any missing tags. */
+  setForChat(chatId: string, tags: string[], registry: TagsRepository): void {
+    const tx = this.db.transaction(() => {
+      this.db.prepare("DELETE FROM chat_tags WHERE chat_id = ? AND source = 'user'").run(chatId);
+      const insert = this.db.prepare(
+        "INSERT OR IGNORE INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)",
+      );
+      const now = new Date().toISOString();
+      for (const raw of tags) {
+        const tag = registry.upsert(raw); // throws on invalid input
+        insert.run(chatId, tag.name, now);
+      }
+    });
+    tx();
+  }
+
+  /**
+   * Distinct user tags currently in use, optionally restricted to a project.
+   * Drives the filter bar's tag chip list.
+   */
+  listInUse(projectId?: string): string[] {
+    if (projectId) {
+      const rows = this.db
+        .prepare(
+          `SELECT DISTINCT ct.tag FROM chat_tags ct
+           JOIN chats c ON c.id = ct.chat_id
+           WHERE ct.source = 'user' AND c.project_id = ? AND c.status != 'archived'
+           ORDER BY ct.tag`,
+        )
+        .all(projectId) as { tag: string }[];
+      return rows.map((r) => r.tag);
+    }
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT ct.tag FROM chat_tags ct
+         JOIN chats c ON c.id = ct.chat_id
+         WHERE ct.source = 'user' AND c.status != 'archived'
+         ORDER BY ct.tag`,
+      )
+      .all() as { tag: string }[];
+    return rows.map((r) => r.tag);
+  }
+
+  /**
+   * Returns chat ids that have ALL of the supplied tags.
+   * Returns null when `tags` is empty (caller treats null as "no tag filter").
+   */
+  filterChatIds(tags: string[]): string[] | null {
+    if (tags.length === 0) return null;
+    const placeholders = tags.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT chat_id FROM chat_tags
+         WHERE source = 'user' AND tag IN (${placeholders})
+         GROUP BY chat_id
+         HAVING COUNT(DISTINCT tag) = ?`,
+      )
+      .all(...tags, tags.length) as { chat_id: string }[];
+    return rows.map((r) => r.chat_id);
+  }
+}

--- a/packages/core/src/db/chat-tags.ts
+++ b/packages/core/src/db/chat-tags.ts
@@ -33,13 +33,14 @@ export class ChatTagsRepository {
 
   /** Replace the user tag set for a chat atomically. Auto-creates any missing tags. */
   setForChat(chatId: string, tags: string[], registry: TagsRepository): void {
+    const unique = [...new Set(tags)];
     const tx = this.db.transaction(() => {
       this.db.prepare("DELETE FROM chat_tags WHERE chat_id = ? AND source = 'user'").run(chatId);
       const insert = this.db.prepare(
         "INSERT OR IGNORE INTO chat_tags (chat_id, tag, source, created_at) VALUES (?, ?, 'user', ?)",
       );
       const now = new Date().toISOString();
-      for (const raw of tags) {
+      for (const raw of unique) {
         const tag = registry.upsert(raw); // throws on invalid input
         insert.run(chatId, tag.name, now);
       }
@@ -79,8 +80,9 @@ export class ChatTagsRepository {
    * Returns null when `tags` is empty (caller treats null as "no tag filter").
    */
   filterChatIds(tags: string[]): string[] | null {
-    if (tags.length === 0) return null;
-    const placeholders = tags.map(() => '?').join(',');
+    const unique = [...new Set(tags)];
+    if (unique.length === 0) return null;
+    const placeholders = unique.map(() => '?').join(',');
     const rows = this.db
       .prepare(
         `SELECT chat_id FROM chat_tags
@@ -88,7 +90,7 @@ export class ChatTagsRepository {
          GROUP BY chat_id
          HAVING COUNT(DISTINCT tag) = ?`,
       )
-      .all(...tags, tags.length) as { chat_id: string }[];
+      .all(...unique, unique.length) as { chat_id: string }[];
     return rows.map((r) => r.chat_id);
   }
 }

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -68,12 +68,7 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
-    if (this.chatTags && chats.length > 0) {
-      const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
-      for (const c of chats) {
-        c.tags = tagsByChat.get(c.id) ?? [];
-      }
-    }
+    this.populateBulkTags(chats);
     return chats;
   }
 
@@ -107,12 +102,7 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
-    if (this.chatTags && chats.length > 0) {
-      const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
-      for (const c of chats) {
-        c.tags = tagsByChat.get(c.id) ?? [];
-      }
-    }
+    this.populateBulkTags(chats);
     return chats;
   }
 
@@ -146,9 +136,7 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
-    if (this.chatTags) {
-      chat.tags = this.chatTags.listForChat(chat.id);
-    }
+    this.populateTags(chat);
     return chat;
   }
 
@@ -360,9 +348,20 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
-    if (this.chatTags) {
-      chat.tags = this.chatTags.listForChat(chat.id);
-    }
+    this.populateTags(chat);
     return chat;
+  }
+
+  private populateBulkTags(chats: Chat[]): void {
+    if (!this.chatTags || chats.length === 0) return;
+    const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
+    for (const c of chats) {
+      c.tags = tagsByChat.get(c.id) ?? [];
+    }
+  }
+
+  private populateTags(chat: Chat): void {
+    if (!this.chatTags) return;
+    chat.tags = this.chatTags.listForChat(chat.id);
   }
 }

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -17,6 +17,25 @@ type RawChatRow = Omit<
   detectedPrs: string;
 };
 
+const CHAT_SELECT_FIELDS = `
+  id, adapter_id as adapterId, project_id as projectId,
+  title, claude_session_id as claudeSessionId, model,
+  permission_mode as permissionMode, status,
+  created_at as createdAt, updated_at as updatedAt,
+  total_cost as totalCost, total_tokens_input as totalTokensInput,
+  total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
+  mentions, modified_files as modifiedFiles,
+  worktree_path as worktreePath, branch_name as branchName,
+  process_state as processState, todos, pinned, effort,
+  plan_mode as planMode, detected_prs as detectedPrs
+`.trim();
+
+export interface ChatListFilters {
+  projectId?: string;
+  tagsAll?: string[];
+  hasWorktree?: boolean;
+}
+
 function parseEffort(value: string | null | undefined): Chat['effort'] {
   if (value === 'low' || value === 'medium' || value === 'high') return value;
   return undefined;
@@ -38,104 +57,56 @@ export class ChatsRepository {
   ) {}
 
   list(projectId: string): Chat[] {
-    const stmt = this.db.prepare(`
-      SELECT
-        id, adapter_id as adapterId, project_id as projectId,
-        title, claude_session_id as claudeSessionId, model,
-        permission_mode as permissionMode, status,
-        created_at as createdAt, updated_at as updatedAt,
-        total_cost as totalCost, total_tokens_input as totalTokensInput,
-        total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
-        mentions, modified_files as modifiedFiles,
-        worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned, effort,
-        plan_mode as planMode, detected_prs as detectedPrs
-      FROM chats
-      WHERE project_id = ?
-      ORDER BY pinned DESC, updated_at DESC
-    `);
-    const rows = stmt.all(projectId) as RawChatRow[];
-    const chats = rows.map((row) => ({
-      ...row,
-      mentions: parseJsonColumn(row.mentions, []),
-      modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
-      worktreePath: row.worktreePath || undefined,
-      branchName: row.branchName || undefined,
-      processState: (row.processState as Chat['processState']) || null,
-      todos: parseJsonColumn(row.todos, undefined) ?? undefined,
-      pinned: Boolean(row.pinned),
-      effort: parseEffort(row.effort),
-      planMode: Boolean(row.planMode),
-      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
-    }));
+    const rows = this.db
+      .prepare(`SELECT ${CHAT_SELECT_FIELDS} FROM chats WHERE project_id = ? ORDER BY pinned DESC, updated_at DESC`)
+      .all(projectId) as RawChatRow[];
+    const chats = this.mapRows(rows);
     this.populateBulkTags(chats);
     return chats;
   }
 
   listAll(): Chat[] {
-    const stmt = this.db.prepare(`
-      SELECT
-        id, adapter_id as adapterId, project_id as projectId,
-        title, claude_session_id as claudeSessionId, model,
-        permission_mode as permissionMode, status,
-        created_at as createdAt, updated_at as updatedAt,
-        total_cost as totalCost, total_tokens_input as totalTokensInput,
-        total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
-        mentions, modified_files as modifiedFiles,
-        worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned, effort,
-        plan_mode as planMode, detected_prs as detectedPrs
-      FROM chats
-      ORDER BY pinned DESC, updated_at DESC, rowid DESC
-    `);
-    const rows = stmt.all() as RawChatRow[];
-    const chats = rows.map((row) => ({
-      ...row,
-      mentions: parseJsonColumn(row.mentions, []),
-      modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
-      worktreePath: row.worktreePath || undefined,
-      branchName: row.branchName || undefined,
-      processState: (row.processState as Chat['processState']) || null,
-      todos: parseJsonColumn(row.todos, undefined) ?? undefined,
-      pinned: Boolean(row.pinned),
-      effort: parseEffort(row.effort),
-      planMode: Boolean(row.planMode),
-      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
-    }));
+    const rows = this.db
+      .prepare(`SELECT ${CHAT_SELECT_FIELDS} FROM chats ORDER BY pinned DESC, updated_at DESC, rowid DESC`)
+      .all() as RawChatRow[];
+    const chats = this.mapRows(rows);
+    this.populateBulkTags(chats);
+    return chats;
+  }
+
+  listFiltered(filters: ChatListFilters): Chat[] {
+    const where: string[] = ["status != 'archived'"];
+    const params: unknown[] = [];
+
+    if (filters.projectId) {
+      where.push('project_id = ?');
+      params.push(filters.projectId);
+    }
+    if (filters.hasWorktree) {
+      where.push('worktree_path IS NOT NULL');
+    }
+    if (filters.tagsAll && filters.tagsAll.length > 0) {
+      if (!this.chatTags) {
+        throw new Error('listFiltered with tagsAll requires ChatTagsRepository');
+      }
+      const ids = this.chatTags.filterChatIds(filters.tagsAll);
+      if (!ids || ids.length === 0) return [];
+      const placeholders = ids.map(() => '?').join(',');
+      where.push(`id IN (${placeholders})`);
+      params.push(...ids);
+    }
+
+    const sql = `SELECT ${CHAT_SELECT_FIELDS} FROM chats WHERE ${where.join(' AND ')} ORDER BY pinned DESC, updated_at DESC`;
+    const rows = this.db.prepare(sql).all(...params) as RawChatRow[];
+    const chats = this.mapRows(rows);
     this.populateBulkTags(chats);
     return chats;
   }
 
   get(id: string): Chat | null {
-    const stmt = this.db.prepare(`
-      SELECT
-        id, adapter_id as adapterId, project_id as projectId,
-        title, claude_session_id as claudeSessionId, model,
-        permission_mode as permissionMode, status,
-        created_at as createdAt, updated_at as updatedAt,
-        total_cost as totalCost, total_tokens_input as totalTokensInput,
-        total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
-        mentions, modified_files as modifiedFiles,
-        worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned, effort,
-        plan_mode as planMode, detected_prs as detectedPrs
-      FROM chats WHERE id = ?
-    `);
-    const row = stmt.get(id) as RawChatRow | null;
+    const row = this.db.prepare(`SELECT ${CHAT_SELECT_FIELDS} FROM chats WHERE id = ?`).get(id) as RawChatRow | null;
     if (!row) return null;
-    const chat: Chat = {
-      ...row,
-      mentions: parseJsonColumn(row.mentions, []),
-      modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
-      worktreePath: row.worktreePath || undefined,
-      branchName: row.branchName || undefined,
-      processState: (row.processState as Chat['processState']) || null,
-      todos: parseJsonColumn(row.todos, undefined) ?? undefined,
-      pinned: Boolean(row.pinned),
-      effort: parseEffort(row.effort),
-      planMode: Boolean(row.planMode),
-      detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
-    };
+    const chat = this.mapRow(row);
     this.populateTags(chat);
     return chat;
   }
@@ -319,23 +290,17 @@ export class ChatsRepository {
   }
 
   findByExternalSessionId(sessionId: string, projectId: string): Chat | null {
-    const stmt = this.db.prepare(`
-      SELECT
-        id, adapter_id as adapterId, project_id as projectId,
-        title, claude_session_id as claudeSessionId, model,
-        permission_mode as permissionMode, status,
-        created_at as createdAt, updated_at as updatedAt,
-        total_cost as totalCost, total_tokens_input as totalTokensInput,
-        total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
-        mentions, modified_files as modifiedFiles,
-        worktree_path as worktreePath, branch_name as branchName,
-        process_state as processState, todos, pinned, effort,
-        plan_mode as planMode, detected_prs as detectedPrs
-      FROM chats WHERE claude_session_id = ? AND project_id = ?
-    `);
-    const row = stmt.get(sessionId, projectId) as RawChatRow | null;
+    const row = this.db
+      .prepare(`SELECT ${CHAT_SELECT_FIELDS} FROM chats WHERE claude_session_id = ? AND project_id = ?`)
+      .get(sessionId, projectId) as RawChatRow | null;
     if (!row) return null;
-    const chat: Chat = {
+    const chat = this.mapRow(row);
+    this.populateTags(chat);
+    return chat;
+  }
+
+  private mapRow(row: RawChatRow): Chat {
+    return {
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
@@ -348,8 +313,10 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
-    this.populateTags(chat);
-    return chat;
+  }
+
+  private mapRows(rows: RawChatRow[]): Chat[] {
+    return rows.map((row) => this.mapRow(row));
   }
 
   private populateBulkTags(chats: Chat[]): void {

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import type { Chat, DetectedPr, SessionMention, SkillFileEntry, TodoItem } from '@qlan-ro/mainframe-types';
 import { nanoid } from 'nanoid';
+import type { ChatTagsRepository } from './chat-tags.js';
 
 /** Raw shape returned by SQLite before boolean/JSON coercion. */
 type RawChatRow = Omit<
@@ -31,7 +32,10 @@ function parseJsonColumn<T>(value: string | null | undefined, fallback: T): T {
 }
 
 export class ChatsRepository {
-  constructor(private db: Database.Database) {}
+  constructor(
+    private db: Database.Database,
+    private chatTags?: ChatTagsRepository,
+  ) {}
 
   list(projectId: string): Chat[] {
     const stmt = this.db.prepare(`
@@ -51,7 +55,7 @@ export class ChatsRepository {
       ORDER BY pinned DESC, updated_at DESC
     `);
     const rows = stmt.all(projectId) as RawChatRow[];
-    return rows.map((row) => ({
+    const chats = rows.map((row) => ({
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
@@ -64,6 +68,13 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
+    if (this.chatTags && chats.length > 0) {
+      const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
+      for (const c of chats) {
+        c.tags = tagsByChat.get(c.id) ?? [];
+      }
+    }
+    return chats;
   }
 
   listAll(): Chat[] {
@@ -83,7 +94,7 @@ export class ChatsRepository {
       ORDER BY pinned DESC, updated_at DESC, rowid DESC
     `);
     const rows = stmt.all() as RawChatRow[];
-    return rows.map((row) => ({
+    const chats = rows.map((row) => ({
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
@@ -96,6 +107,13 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     }));
+    if (this.chatTags && chats.length > 0) {
+      const tagsByChat = this.chatTags.bulkForChats(chats.map((c) => c.id));
+      for (const c of chats) {
+        c.tags = tagsByChat.get(c.id) ?? [];
+      }
+    }
+    return chats;
   }
 
   get(id: string): Chat | null {
@@ -115,7 +133,7 @@ export class ChatsRepository {
     `);
     const row = stmt.get(id) as RawChatRow | null;
     if (!row) return null;
-    return {
+    const chat: Chat = {
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
@@ -128,6 +146,10 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
+    if (this.chatTags) {
+      chat.tags = this.chatTags.listForChat(chat.id);
+    }
+    return chat;
   }
 
   create(projectId: string, adapterId: string, model?: string, permissionMode?: string): Chat {
@@ -325,7 +347,7 @@ export class ChatsRepository {
     `);
     const row = stmt.get(sessionId, projectId) as RawChatRow | null;
     if (!row) return null;
-    return {
+    const chat: Chat = {
       ...row,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
@@ -338,5 +360,9 @@ export class ChatsRepository {
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
     };
+    if (this.chatTags) {
+      chat.tags = this.chatTags.listForChat(chat.id);
+    }
+    return chat;
   }
 }

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -6,6 +6,8 @@ import { ProjectsRepository } from './projects.js';
 import { ChatsRepository } from './chats.js';
 import { SettingsRepository } from './settings.js';
 import { DevicesRepository } from './devices.js';
+import { TagsRepository } from './tags.js';
+import { ChatTagsRepository } from './chat-tags.js';
 
 export class DatabaseManager {
   private db: Database.Database;
@@ -13,6 +15,8 @@ export class DatabaseManager {
   public chats: ChatsRepository;
   public settings: SettingsRepository;
   public devices: DevicesRepository;
+  public tags: TagsRepository;
+  public chatTags: ChatTagsRepository;
 
   constructor() {
     const dbPath = join(getDataDir(), 'mainframe.db');
@@ -23,7 +27,10 @@ export class DatabaseManager {
     initializeSchema(this.db);
 
     this.projects = new ProjectsRepository(this.db);
-    this.chats = new ChatsRepository(this.db);
+    this.tags = new TagsRepository(this.db);
+    this.chatTags = new ChatTagsRepository(this.db);
+    // Pass chatTags into ChatsRepository so list/get can populate Chat.tags
+    this.chats = new ChatsRepository(this.db, this.chatTags);
     this.settings = new SettingsRepository(this.db);
     this.devices = new DevicesRepository(this.db);
   }
@@ -37,3 +44,5 @@ export { ProjectsRepository } from './projects.js';
 export { ChatsRepository } from './chats.js';
 export { SettingsRepository } from './settings.js';
 export { DevicesRepository } from './devices.js';
+export { TagsRepository } from './tags.js';
+export { ChatTagsRepository } from './chat-tags.js';

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -61,7 +61,7 @@ export function initializeSchema(db: Database.Database): void {
     CREATE TABLE IF NOT EXISTS chat_tags (
       chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
       tag        TEXT NOT NULL REFERENCES tags(name) ON UPDATE CASCADE,
-      source     TEXT NOT NULL DEFAULT 'user',
+      source     TEXT NOT NULL DEFAULT 'user' CHECK (source IN ('user')),
       created_at TEXT NOT NULL,
       PRIMARY KEY (chat_id, tag, source)
     );

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -51,6 +51,23 @@ export function initializeSchema(db: Database.Database): void {
       created_at  TEXT NOT NULL,
       last_seen   TEXT
     );
+
+    CREATE TABLE IF NOT EXISTS tags (
+      name       TEXT PRIMARY KEY,
+      color      TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS chat_tags (
+      chat_id    TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+      tag        TEXT NOT NULL REFERENCES tags(name) ON UPDATE CASCADE,
+      source     TEXT NOT NULL DEFAULT 'user',
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (chat_id, tag, source)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_chat_tags_chat ON chat_tags(chat_id);
+    CREATE INDEX IF NOT EXISTS idx_chat_tags_tag  ON chat_tags(tag);
   `);
 
   // Migrations

--- a/packages/core/src/db/tags.ts
+++ b/packages/core/src/db/tags.ts
@@ -1,0 +1,71 @@
+import type Database from 'better-sqlite3';
+import type { Tag, TagColor } from '@qlan-ro/mainframe-types';
+import { validateTagName } from '../lib/validate-tag-name.js';
+import { hashTagColor } from '../lib/tag-color.js';
+
+export class TagsRepository {
+  constructor(private db: Database.Database) {}
+
+  list(): Tag[] {
+    const rows = this.db.prepare('SELECT name, color, created_at as createdAt FROM tags ORDER BY name').all() as Tag[];
+    return rows;
+  }
+
+  get(name: string): Tag | null {
+    const row = this.db.prepare('SELECT name, color, created_at as createdAt FROM tags WHERE name = ?').get(name) as
+      | Tag
+      | undefined;
+    return row ?? null;
+  }
+
+  /** Idempotent upsert. Returns the existing row if present, else creates with auto color. */
+  upsert(rawName: string, color?: TagColor): Tag {
+    const v = validateTagName(rawName);
+    if (!v.ok) throw new Error(v.error);
+    const existing = this.get(v.normalized);
+    if (existing) return existing;
+    const finalColor: TagColor = color ?? hashTagColor(v.normalized);
+    const now = new Date().toISOString();
+    this.db.prepare('INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)').run(v.normalized, finalColor, now);
+    return { name: v.normalized, color: finalColor, createdAt: now };
+  }
+
+  setColor(name: string, color: TagColor): void {
+    this.db.prepare('UPDATE tags SET color = ? WHERE name = ?').run(color, name);
+  }
+
+  /** Atomic rename. If `to` already exists, merges associations and drops `from`. */
+  rename(fromRaw: string, toRaw: string): void {
+    const from = fromRaw.trim().toLowerCase();
+    const v = validateTagName(toRaw);
+    if (!v.ok) throw new Error(v.error);
+    const to = v.normalized;
+    if (from === to) return;
+    const tx = this.db.transaction(() => {
+      const target = this.get(to);
+      if (target) {
+        // Merge: redirect chat_tags then delete `from` registry row.
+        this.db
+          .prepare(
+            'INSERT OR IGNORE INTO chat_tags (chat_id, tag, source, created_at) ' +
+              'SELECT chat_id, ?, source, created_at FROM chat_tags WHERE tag = ?',
+          )
+          .run(to, from);
+        this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(from);
+        this.db.prepare('DELETE FROM tags WHERE name = ?').run(from);
+      } else {
+        // Plain rename — ON UPDATE CASCADE moves chat_tags rows.
+        this.db.prepare('UPDATE tags SET name = ? WHERE name = ?').run(to, from);
+      }
+    });
+    tx();
+  }
+
+  remove(name: string): void {
+    const tx = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(name);
+      this.db.prepare('DELETE FROM tags WHERE name = ?').run(name);
+    });
+    tx();
+  }
+}

--- a/packages/core/src/db/tags.ts
+++ b/packages/core/src/db/tags.ts
@@ -6,15 +6,20 @@ import { hashTagColor } from '../lib/tag-color.js';
 export class TagsRepository {
   constructor(private db: Database.Database) {}
 
+  private normalize(name: string): string {
+    return name.trim().toLowerCase();
+  }
+
   list(): Tag[] {
     const rows = this.db.prepare('SELECT name, color, created_at as createdAt FROM tags ORDER BY name').all() as Tag[];
     return rows;
   }
 
   get(name: string): Tag | null {
-    const row = this.db.prepare('SELECT name, color, created_at as createdAt FROM tags WHERE name = ?').get(name) as
-      | Tag
-      | undefined;
+    const normalized = this.normalize(name);
+    const row = this.db
+      .prepare('SELECT name, color, created_at as createdAt FROM tags WHERE name = ?')
+      .get(normalized) as Tag | undefined;
     return row ?? null;
   }
 
@@ -31,12 +36,14 @@ export class TagsRepository {
   }
 
   setColor(name: string, color: TagColor): void {
-    this.db.prepare('UPDATE tags SET color = ? WHERE name = ?').run(color, name);
+    const normalized = this.normalize(name);
+    const info = this.db.prepare('UPDATE tags SET color = ? WHERE name = ?').run(color, normalized);
+    if (info.changes === 0) throw new Error(`Tag not found: ${normalized}`);
   }
 
   /** Atomic rename. If `to` already exists, merges associations and drops `from`. */
   rename(fromRaw: string, toRaw: string): void {
-    const from = fromRaw.trim().toLowerCase();
+    const from = this.normalize(fromRaw);
     const v = validateTagName(toRaw);
     if (!v.ok) throw new Error(v.error);
     const to = v.normalized;
@@ -62,9 +69,11 @@ export class TagsRepository {
   }
 
   remove(name: string): void {
+    const normalized = this.normalize(name);
     const tx = this.db.transaction(() => {
-      this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(name);
-      this.db.prepare('DELETE FROM tags WHERE name = ?').run(name);
+      this.db.prepare('DELETE FROM chat_tags WHERE tag = ?').run(normalized);
+      const info = this.db.prepare('DELETE FROM tags WHERE name = ?').run(normalized);
+      if (info.changes === 0) throw new Error(`Tag not found: ${normalized}`);
     });
     tx();
   }

--- a/packages/core/src/lib/__tests__/tag-color.test.ts
+++ b/packages/core/src/lib/__tests__/tag-color.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { TAG_PALETTE } from '@qlan-ro/mainframe-types';
+import { hashTagColor } from '../tag-color.js';
+
+describe('hashTagColor', () => {
+  it('returns a palette color', () => {
+    const c = hashTagColor('feature');
+    expect(TAG_PALETTE).toContain(c);
+  });
+  it('is deterministic for the same name', () => {
+    expect(hashTagColor('bug')).toBe(hashTagColor('bug'));
+  });
+  it('distributes across different names', () => {
+    const colors = new Set(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map(hashTagColor));
+    expect(colors.size).toBeGreaterThan(1);
+  });
+});

--- a/packages/core/src/lib/__tests__/validate-tag-name.test.ts
+++ b/packages/core/src/lib/__tests__/validate-tag-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { validateTagName } from '../validate-tag-name.js';
+
+describe('validateTagName', () => {
+  it.each([
+    ['feature', { ok: true, normalized: 'feature' }],
+    ['  Feature  ', { ok: true, normalized: 'feature' }],
+    ['ui-bug', { ok: true, normalized: 'ui-bug' }],
+    ['perf-2', { ok: true, normalized: 'perf-2' }],
+  ])('accepts %s', (input, expected) => {
+    expect(validateTagName(input)).toEqual(expected);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['a', 'too short'],
+    ['a'.repeat(25), 'too long'],
+    ['has-pr', 'reserved prefix'],
+    ['has-anything', 'reserved prefix'],
+    ['feature!', 'invalid characters'],
+    ['white space', 'invalid characters'],
+  ])('rejects %s', (input, _label) => {
+    const result = validateTagName(input);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/core/src/lib/tag-color.ts
+++ b/packages/core/src/lib/tag-color.ts
@@ -1,0 +1,11 @@
+import { TAG_PALETTE, type TagColor } from '@qlan-ro/mainframe-types';
+
+/** Stable djb2 hash → palette index. Same name always maps to same color. */
+export function hashTagColor(name: string): TagColor {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) {
+    h = ((h << 5) + h + name.charCodeAt(i)) | 0;
+  }
+  const idx = Math.abs(h) % TAG_PALETTE.length;
+  return TAG_PALETTE[idx]!;
+}

--- a/packages/core/src/lib/validate-tag-name.ts
+++ b/packages/core/src/lib/validate-tag-name.ts
@@ -1,0 +1,20 @@
+import { RESERVED_TAG_PREFIX } from '@qlan-ro/mainframe-types';
+
+const PATTERN = /^[a-z0-9-]+$/;
+const MIN_LEN = 2;
+const MAX_LEN = 24;
+
+export type ValidateResult = { ok: true; normalized: string } | { ok: false; error: string };
+
+export function validateTagName(input: string): ValidateResult {
+  const normalized = input.trim().toLowerCase();
+  if (normalized.length < MIN_LEN) return { ok: false, error: 'Tag name too short (min 2 chars).' };
+  if (normalized.length > MAX_LEN) return { ok: false, error: 'Tag name too long (max 24 chars).' };
+  if (normalized.startsWith(RESERVED_TAG_PREFIX)) {
+    return { ok: false, error: `Names starting with "${RESERVED_TAG_PREFIX}" are reserved.` };
+  }
+  if (!PATTERN.test(normalized)) {
+    return { ok: false, error: 'Tag name must use lowercase letters, numbers, or hyphens only.' };
+  }
+  return { ok: true, normalized };
+}

--- a/packages/core/src/server/http.ts
+++ b/packages/core/src/server/http.ts
@@ -23,6 +23,7 @@ import {
   contentSearchRoutes,
   lspRoutes,
   worktreeRoutes,
+  tagRoutes,
 } from './routes/index.js';
 import { authRoutes } from './routes/auth.js';
 import { tunnelRoutes } from './routes/tunnel.js';
@@ -114,6 +115,7 @@ export function createHttpServer(
   app.use(launchRoutes(ctx));
   app.use(externalSessionRoutes(ctx));
   app.use(worktreeRoutes(ctx));
+  app.use(tagRoutes(ctx));
 
   // Plugin routes — the PluginManager owns a parent router with listing + per-plugin sub-routers
   if (pluginManager) {

--- a/packages/core/src/server/routes/__tests__/chats-filter.test.ts
+++ b/packages/core/src/server/routes/__tests__/chats-filter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../../../db/schema.js';
+import { TagsRepository } from '../../../db/tags.js';
+import { ChatTagsRepository } from '../../../db/chat-tags.js';
+import { ChatsRepository } from '../../../db/chats.js';
+import { chatRoutes } from '../chats.js';
+import type { RouteContext } from '../types.js';
+
+function makeApp() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const tags = new TagsRepository(db);
+  const chatTags = new ChatTagsRepository(db);
+  const chats = new ChatsRepository(db, chatTags);
+
+  const now = new Date().toISOString();
+  db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+    'p1',
+    'p',
+    '/tmp/p',
+    now,
+    now,
+  );
+  db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+    'p2',
+    'q',
+    '/tmp/q',
+    now,
+    now,
+  );
+
+  // c1: tagged feature, has worktree
+  // c2: tagged feature, no worktree
+  // c3: tagged bug, has worktree
+  // c4: untagged, has worktree (project p2)
+  // c5: archived (must never appear)
+  const seed = (id: string, projectId: string, worktree: string | null, status = 'active'): void => {
+    db.prepare(
+      `INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at, worktree_path)
+       VALUES (?, 'claude', ?, ?, ?, ?, ?)`,
+    ).run(id, projectId, status, now, now, worktree);
+  };
+  seed('c1', 'p1', '/wt/c1');
+  seed('c2', 'p1', null);
+  seed('c3', 'p1', '/wt/c3');
+  seed('c4', 'p2', '/wt/c4');
+  seed('c5', 'p1', '/wt/c5', 'archived');
+  chatTags.setForChat('c1', ['feature'], tags);
+  chatTags.setForChat('c2', ['feature'], tags);
+  chatTags.setForChat('c3', ['bug'], tags);
+
+  const ctx = { chats: { listFiltered: chats.listFiltered.bind(chats) } } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use(chatRoutes(ctx));
+  return { app, db };
+}
+
+describe('GET /api/chats — filtered list', () => {
+  it('no filters returns all non-archived chats', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats');
+    expect(res.status).toBe(200);
+    const ids = res.body.data.map((c: { id: string }) => c.id).sort();
+    expect(ids).toEqual(['c1', 'c2', 'c3', 'c4']);
+  });
+
+  it('filters by project', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?project=p2');
+    expect(res.body.data.map((c: { id: string }) => c.id)).toEqual(['c4']);
+  });
+
+  it('filters by tags (single tag)', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?tags=feature');
+    const ids = res.body.data.map((c: { id: string }) => c.id).sort();
+    expect(ids).toEqual(['c1', 'c2']);
+  });
+
+  it('filters by synthetic has-worktree', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?synthetic=has-worktree');
+    const ids = res.body.data.map((c: { id: string }) => c.id).sort();
+    expect(ids).toEqual(['c1', 'c3', 'c4']);
+  });
+
+  it('AND-combines tags + synthetic + project', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?project=p1&tags=feature&synthetic=has-worktree');
+    expect(res.body.data.map((c: { id: string }) => c.id)).toEqual(['c1']);
+  });
+
+  it('ignores has-pr in synthetic (handled client-side)', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?synthetic=has-pr');
+    expect(res.body.data).toHaveLength(4);
+  });
+
+  it('Chat.tags is populated on filtered results', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?tags=feature');
+    const c1 = res.body.data.find((c: { id: string }) => c.id === 'c1');
+    expect(c1.tags).toEqual(['feature']);
+  });
+});

--- a/packages/core/src/server/routes/__tests__/chats-filter.test.ts
+++ b/packages/core/src/server/routes/__tests__/chats-filter.test.ts
@@ -107,4 +107,10 @@ describe('GET /api/chats — filtered list', () => {
     const c1 = res.body.data.find((c: { id: string }) => c.id === 'c1');
     expect(c1.tags).toEqual(['feature']);
   });
+
+  it('rejects malformed tag values with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats?tags=feature,BAD!');
+    expect(res.status).toBe(400);
+  });
 });

--- a/packages/core/src/server/routes/__tests__/tags.test.ts
+++ b/packages/core/src/server/routes/__tests__/tags.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import { initializeSchema } from '../../../db/schema.js';
+import { TagsRepository } from '../../../db/tags.js';
+import { ChatTagsRepository } from '../../../db/chat-tags.js';
+import { tagRoutes } from '../tags.js';
+import type { RouteContext } from '../types.js';
+
+function makeApp() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initializeSchema(db);
+  const tags = new TagsRepository(db);
+  const chatTags = new ChatTagsRepository(db);
+  // Minimal RouteContext stub — only fields tagRoutes uses are .db.tags / .db.chatTags
+  const ctx = { db: { tags, chatTags } } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use(tagRoutes(ctx));
+  // Seed a chat for the chat-scoped routes
+  const now = new Date().toISOString();
+  db.prepare('INSERT INTO projects (id, name, path, created_at, last_opened_at) VALUES (?, ?, ?, ?, ?)').run(
+    'p1',
+    'p',
+    '/tmp/p',
+    now,
+    now,
+  );
+  db.prepare(
+    'INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run('c1', 'claude', 'p1', 'active', now, now);
+  return { app, db, tags, chatTags };
+}
+
+describe('tag routes', () => {
+  it('GET /api/tags returns []', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/tags');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('POST /api/tags creates a tag', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/tags').send({ name: 'feature' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('feature');
+    expect(res.body.data.color).toBeTruthy();
+  });
+
+  it('POST /api/tags rejects has- prefix with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/tags').send({ name: 'has-foo' });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/tags rejects invalid color enum', async () => {
+    const { app } = makeApp();
+    const res = await request(app).post('/api/tags').send({ name: 'feature', color: 'not-a-color' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH /api/tags/:name renames', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feat');
+    const res = await request(app).patch('/api/tags/feat').send({ rename: 'feature' });
+    expect(res.status).toBe(200);
+    expect(tags.get('feature')).not.toBeNull();
+    expect(tags.get('feat')).toBeNull();
+  });
+
+  it('PATCH /api/tags/:name on missing tag returns 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).patch('/api/tags/nope').send({ color: 'red' });
+    expect(res.status).toBe(404);
+  });
+
+  it('PATCH /api/tags/:name with empty body returns 400', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feature');
+    const res = await request(app).patch('/api/tags/feature').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('DELETE /api/tags/:name removes', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feature');
+    const res = await request(app).delete('/api/tags/feature');
+    expect(res.status).toBe(204);
+    expect(tags.get('feature')).toBeNull();
+  });
+
+  it('DELETE /api/tags/:name on missing returns 404', async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete('/api/tags/nope');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/chats/:id/tags returns []', async () => {
+    const { app } = makeApp();
+    const res = await request(app).get('/api/chats/c1/tags');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('PUT /api/chats/:id/tags applies tags', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put('/api/chats/c1/tags')
+      .send({ tags: ['feature', 'ui'] });
+    expect(res.status).toBe(200);
+    expect(res.body.data.sort()).toEqual(['feature', 'ui']);
+  });
+
+  it('PUT /api/chats/:id/tags rejects reserved-prefix tag with 400', async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put('/api/chats/c1/tags')
+      .send({ tags: ['has-pr'] });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/core/src/server/routes/__tests__/tags.test.ts
+++ b/packages/core/src/server/routes/__tests__/tags.test.ts
@@ -114,6 +114,25 @@ describe('tag routes', () => {
     expect(res.body.data.sort()).toEqual(['feature', 'ui']);
   });
 
+  it('PATCH /api/tags/:name updates color only', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feature');
+    const res = await request(app).patch('/api/tags/feature').send({ color: 'red' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.color).toBe('red');
+    expect(tags.get('feature')?.color).toBe('red');
+  });
+
+  it('PATCH /api/tags/:name applies rename and color in one call', async () => {
+    const { app, tags } = makeApp();
+    tags.upsert('feat');
+    const res = await request(app).patch('/api/tags/feat').send({ rename: 'feature', color: 'red' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('feature');
+    expect(res.body.data.color).toBe('red');
+    expect(tags.get('feat')).toBeNull();
+  });
+
   it('PUT /api/chats/:id/tags rejects reserved-prefix tag with 400', async () => {
     const { app } = makeApp();
     const res = await request(app)

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -12,8 +12,37 @@ const logger = createChildLogger('routes:chats');
 export function chatRoutes(ctx: RouteContext): Router {
   const router = Router();
 
-  router.get('/api/chats', (_req: Request, res: Response) => {
-    const chats = ctx.chats.listAllChats();
+  const ListQuery = z.object({
+    project: z.string().optional(),
+    tags: z.string().optional(),
+    synthetic: z.string().optional(),
+  });
+
+  router.get('/api/chats', (req: Request, res: Response) => {
+    const parsed = ListQuery.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    const tagsAll = parsed.data.tags
+      ? parsed.data.tags
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
+    const synth = parsed.data.synthetic
+      ? new Set(
+          parsed.data.synthetic
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean),
+        )
+      : new Set<string>();
+    const chats = ctx.chats.listFiltered({
+      projectId: parsed.data.project,
+      tagsAll,
+      hasWorktree: synth.has('has-worktree'),
+    });
     res.json({ success: true, data: chats });
   });
 

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -12,9 +12,23 @@ const logger = createChildLogger('routes:chats');
 export function chatRoutes(ctx: RouteContext): Router {
   const router = Router();
 
+  const TAG_NAME_PATTERN = /^[a-z0-9-]+$/;
+
   const ListQuery = z.object({
     project: z.string().optional(),
-    tags: z.string().optional(),
+    tags: z
+      .string()
+      .optional()
+      .refine(
+        (v) =>
+          v === undefined ||
+          v
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .every((t) => TAG_NAME_PATTERN.test(t)),
+        { message: 'Tag values must match [a-z0-9-]+' },
+      ),
     synthetic: z.string().optional(),
   });
 

--- a/packages/core/src/server/routes/index.ts
+++ b/packages/core/src/server/routes/index.ts
@@ -16,5 +16,6 @@ export { contentSearchRoutes } from './search.js';
 export { lspRoutes } from './lsp-routes.js';
 export { worktreeRoutes } from './worktree.js';
 export { deviceRoutes } from './device.js';
+export { tagRoutes } from './tags.js';
 export { asyncHandler } from './async-handler.js';
 export type { RouteContext } from './types.js';

--- a/packages/core/src/server/routes/tags.ts
+++ b/packages/core/src/server/routes/tags.ts
@@ -1,0 +1,96 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import type { RouteContext } from './types.js';
+import { param } from './types.js';
+import { TAG_PALETTE } from '@qlan-ro/mainframe-types';
+import { createChildLogger } from '../../logger.js';
+
+const logger = createChildLogger('routes:tags');
+
+const ColorSchema = z.enum(TAG_PALETTE);
+const CreateBody = z.object({ name: z.string(), color: ColorSchema.optional() });
+const PatchBody = z
+  .object({ rename: z.string().optional(), color: ColorSchema.optional() })
+  .refine((v) => v.rename !== undefined || v.color !== undefined, {
+    message: 'rename or color required',
+  });
+const SetChatTagsBody = z.object({ tags: z.array(z.string()) });
+
+export function tagRoutes(ctx: RouteContext): Router {
+  const router = Router();
+
+  router.get('/api/tags', (_req: Request, res: Response) => {
+    res.json({ success: true, data: ctx.db.tags.list() });
+  });
+
+  router.post('/api/tags', (req: Request, res: Response) => {
+    const parsed = CreateBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    try {
+      const tag = ctx.db.tags.upsert(parsed.data.name, parsed.data.color);
+      res.status(201).json({ success: true, data: tag });
+    } catch (err) {
+      logger.warn({ err }, 'create tag failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  router.patch('/api/tags/:name', (req: Request, res: Response) => {
+    const parsed = PatchBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    const name = param(req, 'name');
+    if (!ctx.db.tags.get(name)) {
+      res.status(404).json({ success: false, error: 'Tag not found' });
+      return;
+    }
+    try {
+      if (parsed.data.rename) ctx.db.tags.rename(name, parsed.data.rename);
+      const final = parsed.data.rename ?? name;
+      if (parsed.data.color) ctx.db.tags.setColor(final, parsed.data.color);
+      const result = ctx.db.tags.get(final);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      logger.warn({ err, name }, 'update tag failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  router.delete('/api/tags/:name', (req: Request, res: Response) => {
+    const name = param(req, 'name');
+    if (!ctx.db.tags.get(name)) {
+      res.status(404).json({ success: false, error: 'Tag not found' });
+      return;
+    }
+    ctx.db.tags.remove(name);
+    res.status(204).end();
+  });
+
+  router.get('/api/chats/:id/tags', (req: Request, res: Response) => {
+    const tags = ctx.db.chatTags.listForChat(param(req, 'id'));
+    res.json({ success: true, data: tags });
+  });
+
+  router.put('/api/chats/:id/tags', (req: Request, res: Response) => {
+    const parsed = SetChatTagsBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: parsed.error.message });
+      return;
+    }
+    const chatId = param(req, 'id');
+    try {
+      ctx.db.chatTags.setForChat(chatId, parsed.data.tags, ctx.db.tags);
+      res.json({ success: true, data: ctx.db.chatTags.listForChat(chatId) });
+    } catch (err) {
+      logger.warn({ err, chatId }, 'set chat tags failed');
+      res.status(400).json({ success: false, error: String((err as Error).message) });
+    }
+  });
+
+  return router;
+}

--- a/packages/core/src/server/routes/tags.ts
+++ b/packages/core/src/server/routes/tags.ts
@@ -50,9 +50,9 @@ export function tagRoutes(ctx: RouteContext): Router {
       return;
     }
     try {
-      if (parsed.data.rename) ctx.db.tags.rename(name, parsed.data.rename);
+      if (parsed.data.rename !== undefined) ctx.db.tags.rename(name, parsed.data.rename);
       const final = parsed.data.rename ?? name;
-      if (parsed.data.color) ctx.db.tags.setColor(final, parsed.data.color);
+      if (parsed.data.color !== undefined) ctx.db.tags.setColor(final, parsed.data.color);
       const result = ctx.db.tags.get(final);
       res.json({ success: true, data: result });
     } catch (err) {

--- a/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
+++ b/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
@@ -10,6 +10,9 @@ vi.mock('../../renderer/store/index.js', () => ({
       activeChatId: null,
       setActiveChat: vi.fn(),
       removeChat: vi.fn(),
+      addChat: vi.fn(),
+      updateChat: vi.fn(),
+      chats: [],
       unreadChatIds: new Set(),
       detectedPrs: new Map(),
     }),
@@ -19,6 +22,9 @@ vi.mock('../../renderer/store/tabs.js', () => ({
 }));
 vi.mock('../../renderer/store/adapters.js', () => ({
   useAdaptersStore: (selector: (s: unknown) => unknown) => selector({ adapters: [] }),
+}));
+vi.mock('../../renderer/store/tags.js', () => ({
+  useTagsStore: (selector: (s: unknown) => unknown) => selector({ registry: [] }),
 }));
 vi.mock('../../renderer/lib/client.js', () => ({
   daemonClient: { createChat: vi.fn(), resumeChat: vi.fn() },

--- a/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
+++ b/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
@@ -3,12 +3,22 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import React from 'react';
 
+const mocks = vi.hoisted(() => ({
+  setActiveChat: vi.fn(),
+  openChatTab: vi.fn(),
+  closeTab: vi.fn(),
+  updateTabLabel: vi.fn(),
+  resumeChat: vi.fn(),
+}));
+
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
 // Mock stores and client before component import
 vi.mock('../../renderer/store/index.js', () => ({
   useChatsStore: (selector: (s: unknown) => unknown) =>
     selector({
       activeChatId: null,
-      setActiveChat: vi.fn(),
+      setActiveChat: mocks.setActiveChat,
       removeChat: vi.fn(),
       addChat: vi.fn(),
       updateChat: vi.fn(),
@@ -18,16 +28,23 @@ vi.mock('../../renderer/store/index.js', () => ({
     }),
 }));
 vi.mock('../../renderer/store/tabs.js', () => ({
-  useTabsStore: { getState: () => ({ openChatTab: vi.fn(), closeTab: vi.fn(), updateTabLabel: vi.fn() }) },
+  useTabsStore: {
+    getState: () => ({
+      openChatTab: mocks.openChatTab,
+      closeTab: mocks.closeTab,
+      updateTabLabel: mocks.updateTabLabel,
+    }),
+  },
 }));
 vi.mock('../../renderer/store/adapters.js', () => ({
   useAdaptersStore: (selector: (s: unknown) => unknown) => selector({ adapters: [] }),
 }));
 vi.mock('../../renderer/store/tags.js', () => ({
-  useTagsStore: (selector: (s: unknown) => unknown) => selector({ registry: [] }),
+  useTagsStore: (selector: (s: unknown) => unknown) =>
+    selector({ registry: [], refreshRegistry: vi.fn(), applyToChat: vi.fn() }),
 }));
 vi.mock('../../renderer/lib/client.js', () => ({
-  daemonClient: { createChat: vi.fn(), resumeChat: vi.fn() },
+  daemonClient: { createChat: vi.fn(), resumeChat: mocks.resumeChat },
 }));
 vi.mock('../../renderer/lib/adapters.js', () => ({
   getDefaultModelForAdapter: vi.fn(() => 'claude-sonnet-4-6'),
@@ -79,6 +96,17 @@ function renderGroup(collapsed = false) {
 describe('ProjectGroup header layout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resizeObserverCallbacks = [];
+    vi.restoreAllMocks();
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallbacks.push(callback);
+      }
+
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    } as typeof ResizeObserver;
   });
 
   it('renders the project name in the header', () => {
@@ -123,5 +151,164 @@ describe('ProjectGroup header layout', () => {
     const cluster = btn.parentElement;
     expect(cluster?.className).toMatch(/\bhidden\b/);
     expect(cluster?.className).toMatch(/group-hover:flex/);
+  });
+
+  it('shows the adapter label on the session row metadata line when there are no tags', () => {
+    renderGroup();
+    expect(screen.getByText('Claude CLI')).toBeInTheDocument();
+    expect(screen.queryByText('+ tag')).not.toBeInTheDocument();
+  });
+
+  it('shows the adapter label before tags on the session row metadata line', () => {
+    render(
+      <TooltipProvider>
+        <ProjectGroup
+          project={mockProject}
+          chats={[{ ...mockChat, tags: ['frontend'] }]}
+          collapsed={false}
+          onToggleCollapse={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText('Claude CLI')).toBeInTheDocument();
+    expect(screen.getByText('frontend')).toBeInTheDocument();
+    expect(screen.getByText('·')).toBeInTheDocument();
+  });
+
+  it('pushes the worktree pill to the right while allowing the title to use available space', () => {
+    render(
+      <TooltipProvider>
+        <ProjectGroup
+          project={mockProject}
+          chats={[{ ...mockChat, title: 'A very long session title', worktreePath: '/repo/.worktrees/feat-tags' }]}
+          collapsed={false}
+          onToggleCollapse={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const title = screen.getByText('A very long session title');
+    const worktree = screen.getByText('feat-tags');
+    const pill = worktree.parentElement;
+
+    expect(title.parentElement).toBe(pill?.closest('button'));
+    expect(title.className).toContain('flex-1');
+    expect(title.className).not.toContain('max-w-[50%]');
+    expect(pill?.className).toContain('ml-auto');
+    expect(pill?.className).toContain('rounded-full');
+    expect(pill?.className).toContain('px-2.5');
+    expect(pill?.className).toContain('bg-mf-hover');
+    expect(pill?.className).toContain('text-mf-text-secondary');
+    expect(title.parentElement?.parentElement?.className).toContain('grid-cols-[12px_minmax(0,1fr)]');
+  });
+
+  it('hides the worktree pill when the available title width drops below the threshold', async () => {
+    // The row container is narrow enough that, after subtracting the status dot,
+    // gaps, and the pill's natural width, the title would have <56px (the hysteresis
+    // hide threshold). Specifically: 200 - 28 - 120 = 52 < 56.
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement): number {
+      return this.dataset.testid === 'session-title-row' ? 200 : 0;
+    });
+    vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement): number {
+      return this.dataset.testid === 'worktree-pill' ? 120 : 0;
+    });
+
+    render(
+      <TooltipProvider>
+        <ProjectGroup
+          project={mockProject}
+          chats={[{ ...mockChat, worktreePath: '/repo/.worktrees/feat-tags' }]}
+          collapsed={false}
+          onToggleCollapse={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    for (const callback of resizeObserverCallbacks) {
+      callback([], {} as ResizeObserver);
+    }
+
+    const pill = screen.getByTestId('worktree-pill');
+    expect(pill.className).toContain('opacity-0');
+    expect(pill).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('keeps the right-side time and hover actions in a centered area outside content rows', () => {
+    renderGroup();
+
+    const time = screen.getByText('Jan 1, 2024');
+    const slot = time.parentElement;
+    const metadataRow = screen.getByTestId('session-row-metadata');
+    const actionsArea = screen.getByTestId('session-row-actions');
+
+    expect(slot?.className).toContain('w-[104px]');
+    expect(slot?.className).toContain('h-6');
+    expect(slot?.className).toContain('shrink-0');
+    expect(slot?.className).toContain('justify-end');
+    expect(time.className).toContain('whitespace-nowrap');
+    expect(actionsArea.className).toContain('self-center');
+    expect(actionsArea).toContainElement(slot);
+    expect(metadataRow).not.toContainElement(slot);
+  });
+
+  it('truncates worktree text inside the pill instead of clipping the whole pill', () => {
+    render(
+      <TooltipProvider>
+        <ProjectGroup
+          project={mockProject}
+          chats={[
+            {
+              ...mockChat,
+              worktreePath: '/repo/.worktrees/test-worktree-youcantakeitfromhere-super-long',
+            },
+          ]}
+          collapsed={false}
+          onToggleCollapse={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    const worktree = screen.getByText('test-worktree-youcantakeitfromhere-super-long');
+    expect(worktree.className).toContain('min-w-0');
+    expect(worktree.className).toContain('truncate');
+    expect(worktree.parentElement?.className).not.toContain('truncate');
+  });
+
+  it('shows the full session title in a tooltip when hovering the truncated title', async () => {
+    const longTitle = 'A very long session title that should be visible in full on hover';
+    render(
+      <TooltipProvider>
+        <ProjectGroup
+          project={mockProject}
+          chats={[{ ...mockChat, title: longTitle, worktreePath: '/repo/.worktrees/feat-tags' }]}
+          collapsed={false}
+          onToggleCollapse={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+
+    await userEvent.hover(screen.getByText(longTitle));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(longTitle);
+  });
+
+  it('does not open the tag popover when clicking session metadata', async () => {
+    renderGroup();
+
+    await userEvent.click(screen.getByText('Claude CLI'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('selects the session when clicking row background or metadata', async () => {
+    renderGroup();
+
+    await userEvent.click(screen.getByText('Claude CLI'));
+
+    expect(mocks.setActiveChat).toHaveBeenCalledWith('chat-1');
+    expect(mocks.openChatTab).toHaveBeenCalledWith('chat-1', 'Session 1');
+    expect(mocks.resumeChat).toHaveBeenCalledWith('chat-1');
   });
 });

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -18,8 +18,10 @@ import { getDefaultModelForAdapter } from '../../lib/adapters';
 import { pinChat } from '../../lib/api';
 import { ProjectGroup } from './ProjectGroup';
 import { FlatSessionRow } from './FlatSessionRow';
+import { SessionFilterBar } from './SessionFilterBar';
 import { ImportSessionsPopover } from './ImportSessionsPopover';
 import { ArchivedSessionsPopover } from './ArchivedSessionsPopover';
+import { useTagsStore } from '../../store/tags';
 import { useZoneHeaderActions } from '../zone/ZoneHeaderSlot.js';
 import type { Chat, Project } from '@qlan-ro/mainframe-types';
 
@@ -191,9 +193,29 @@ export function ChatsPanel(): React.ReactElement {
   const projects = useProjectsStore((s) => s.projects);
   const addProject = useProjectsStore((s) => s.addProject);
   const allChats = useChatsStore((s) => s.chats);
-  const chats = useMemo(() => allChats.filter((c) => c.status !== 'archived'), [allChats]);
+  const detectedPrs = useChatsStore((s) => s.detectedPrs);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const pendingPermissions = useChatsStore((s) => s.pendingPermissions);
+
+  const selectedTags = useTagsStore((s) => s.selectedTags);
+  const selectedSynthetic = useTagsStore((s) => s.selectedSynthetic);
+  const clearTagFilters = useTagsStore((s) => s.clearFilters);
+
+  const chats = useMemo(() => {
+    return allChats.filter((c) => {
+      if (c.status === 'archived') return false;
+      if (selectedSynthetic.has('has-worktree') && !c.worktreePath) return false;
+      if (selectedSynthetic.has('has-pr')) {
+        const prs = detectedPrs.get(c.id);
+        if (!prs || prs.length === 0) return false;
+      }
+      if (selectedTags.size > 0) {
+        const tagSet = new Set(c.tags ?? []);
+        for (const t of selectedTags) if (!tagSet.has(t)) return false;
+      }
+      return true;
+    });
+  }, [allChats, selectedTags, selectedSynthetic, detectedPrs]);
 
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -543,10 +565,19 @@ export function ChatsPanel(): React.ReactElement {
         </div>
       )}
 
+      <SessionFilterBar />
+
       {/* Session list */}
       <div className="flex-1 overflow-y-auto px-[10px]">
         {projects.length === 0 ? (
           <div className="py-4 text-center text-mf-text-secondary text-mf-label">No projects yet.</div>
+        ) : chats.length === 0 && (selectedTags.size > 0 || selectedSynthetic.size > 0) ? (
+          <div className="py-4 text-center text-sm text-mf-text-secondary">
+            No sessions match these filters.{' '}
+            <button type="button" onClick={clearTagFilters} className="underline hover:text-mf-text-primary">
+              Clear filters
+            </button>
+          </div>
         ) : viewMode === 'grouped' ? (
           <div className="space-y-1">
             {filteredGroups.map((g) => (

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -348,6 +348,16 @@ export function ChatsPanel(): React.ReactElement {
     renameCallbacks.current.delete(chatId);
   }, []);
 
+  const openTagPopoverCallbacks = useRef<Map<string, (rect: DOMRect) => void>>(new Map());
+
+  const registerOpenTagPopover = useCallback((chatId: string, trigger: (rect: DOMRect) => void) => {
+    openTagPopoverCallbacks.current.set(chatId, trigger);
+  }, []);
+
+  const unregisterOpenTagPopover = useCallback((chatId: string) => {
+    openTagPopoverCallbacks.current.delete(chatId);
+  }, []);
+
   const updateChat = useChatsStore((s) => s.updateChat);
 
   const handleContextMenu = useCallback(
@@ -360,6 +370,13 @@ export function ChatsPanel(): React.ReactElement {
         items: [
           ...(chat
             ? [
+                {
+                  label: 'Tags...',
+                  onClick: () => {
+                    const rect = new DOMRect(e.clientX, e.clientY - 4, 0, 0);
+                    openTagPopoverCallbacks.current.get(chat.id)?.(rect);
+                  },
+                },
                 {
                   label: 'Rename',
                   onClick: () => {
@@ -591,6 +608,8 @@ export function ChatsPanel(): React.ReactElement {
                 onContextMenu={handleContextMenu}
                 registerRenameCallback={registerRenameCallback}
                 unregisterRenameCallback={unregisterRenameCallback}
+                registerOpenTagPopover={registerOpenTagPopover}
+                unregisterOpenTagPopover={unregisterOpenTagPopover}
               />
             ))}
           </div>
@@ -607,6 +626,8 @@ export function ChatsPanel(): React.ReactElement {
                   onContextMenu={handleContextMenu}
                   registerRenameCallback={registerRenameCallback}
                   unregisterRenameCallback={unregisterRenameCallback}
+                  registerOpenTagPopover={registerOpenTagPopover}
+                  unregisterOpenTagPopover={unregisterOpenTagPopover}
                 />
               ))
             )}

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -1,14 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Archive, FolderOpen, GitBranch, GitPullRequest, Clock, Loader2, Pencil, Pin } from 'lucide-react';
+import { Archive, GitBranch, GitPullRequest, Loader2, Pencil, Pin, Tag as TagIcon } from 'lucide-react';
 import type { Chat } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
+import { useTagsStore } from '../../store/tags';
 import { daemonClient } from '../../lib/client';
 import { archiveChat, renameChat } from '../../lib/api';
 import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { createLogger } from '../../lib/logger';
+import { TagPill } from '../tags/TagPill';
+import { TagPopover } from '../tags/TagPopover';
 
 const log = createLogger('renderer:flat-session-row');
 
@@ -39,7 +42,7 @@ interface FlatSessionRowProps {
 
 export const FlatSessionRow = React.memo(function FlatSessionRow({
   chat,
-  projectName,
+  projectName: _projectName,
   onContextMenu,
   registerRenameCallback,
   unregisterRenameCallback,
@@ -150,136 +153,184 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const isActive = activeChatId === chat.id;
   const isWorking = chat.displayStatus === 'working' || chat.displayStatus === 'waiting';
 
+  // Tag popover state
+  const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
+  const tagButtonRef = useRef<HTMLButtonElement>(null);
+  const tagRowRef = useRef<HTMLDivElement>(null);
+
+  const openTagPopover = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setPopoverRect(rect);
+  }, []);
+
+  const closeTagPopover = useCallback(() => setPopoverRect(null), []);
+
+  const registry = useTagsStore((s) => s.registry);
+  const colorOf = useCallback((name: string) => registry.find((t) => t.name === name)?.color ?? 'gray', [registry]);
+
   return (
     <div
       data-testid="chat-list-item"
       onContextMenu={(e) => onContextMenu?.(e, chat.claudeSessionId, chat.id)}
-      className={cn(
-        'group w-full rounded-mf-input transition-colors flex items-center gap-2',
-        isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',
-      )}
+      className={cn('group w-full rounded-mf-input transition-colors', isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover')}
     >
-      <button type="button" onClick={handleSelect} className="flex-1 min-w-0 px-3 py-1.5 text-left">
-        <div className="flex items-center gap-2">
-          <div className="w-3 h-3 shrink-0 flex items-center justify-center">
-            {chat.worktreeMissing ? (
-              <div className="w-2 h-2 rounded-full bg-mf-destructive" />
-            ) : isWorking ? (
-              <Loader2 size={12} className="text-mf-accent animate-spin" />
-            ) : (
-              <div
-                className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary opacity-40')}
-              />
-            )}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1">
-              {editing ? (
-                <input
-                  ref={inputRef}
-                  value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
-                  onBlur={handleCommitRename}
-                  onKeyDown={handleRenameKeyDown}
-                  onClick={(e) => e.stopPropagation()}
-                  className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
-                />
-              ) : (
-                <div className="flex items-center gap-1 min-w-0">
-                  {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
-                  {createdPrUrl && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          role="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            window.open(createdPrUrl, '_blank');
-                          }}
-                          className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
-                          aria-label="Open PR"
-                        >
-                          <GitPullRequest size={12} />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>Open PR</TooltipContent>
-                    </Tooltip>
-                  )}
-                  <div
-                    className={cn(
-                      'text-mf-small truncate',
-                      isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                      isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                    )}
-                  >
-                    {chat.title || 'Untitled session'}
-                  </div>
-                </div>
-              )}
-            </div>
-            <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">
-              {projectName && (
-                <>
-                  <FolderOpen size={10} className="shrink-0" />
-                  <span className="truncate">{projectName}</span>
-                  <span className="shrink-0">{'·'}</span>
-                </>
-              )}
-              {chat.worktreePath && (
-                <>
-                  <GitBranch size={10} className="shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="truncate max-w-[100px]" tabIndex={0}>
-                        {chat.worktreePath.split('/').pop()}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{chat.worktreePath}</TooltipContent>
-                  </Tooltip>
-                  <span className="shrink-0">{'·'}</span>
-                </>
-              )}
-              <Clock size={10} className="shrink-0" />
-              <span className="shrink-0">{formatRelativeTime(chat.updatedAt)}</span>
-            </div>
-          </div>
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        {/* status dot */}
+        <div className="w-3 h-3 shrink-0 flex items-center justify-center">
+          {chat.worktreeMissing ? (
+            <div className="w-2 h-2 rounded-full bg-mf-destructive" />
+          ) : isWorking ? (
+            <Loader2 size={12} className="text-mf-accent animate-spin" />
+          ) : (
+            <div
+              className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary')}
+              style={!isUnread ? { opacity: 0.4 } : undefined}
+            />
+          )}
         </div>
-      </button>
-      {chat.displayStatus === 'waiting' && (
-        <span className="shrink-0 mr-2 px-2 py-1 rounded-full text-xs font-medium border border-mf-warning text-mf-warning">
-          Waiting
-        </span>
-      )}
-      <div className={cn('shrink-0 mr-1 flex items-center gap-0.5', archiving ? 'flex' : 'hidden group-hover:flex')}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleStartRename}
-              className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
-              aria-label="Rename session"
-            >
-              <Pencil size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Rename session</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleArchive}
-              disabled={archiving}
+
+        {/* title + select target */}
+        <button
+          type="button"
+          onClick={handleSelect}
+          className="flex-1 min-w-0 text-left flex items-center gap-1.5 min-h-[20px]"
+        >
+          {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              onBlur={handleCommitRename}
+              onKeyDown={handleRenameKeyDown}
+              onClick={(e) => e.stopPropagation()}
+              className="flex-1 bg-mf-panel-bg text-sm text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
+            />
+          ) : (
+            <span
               className={cn(
-                'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors shrink-0',
-                archiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
+                'truncate text-sm',
+                isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
               )}
-              aria-label="Archive session"
             >
-              {archiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Archive session</TooltipContent>
-        </Tooltip>
+              {chat.title || 'Untitled session'}
+            </span>
+          )}
+        </button>
+
+        {/* worktree pill */}
+        {chat.worktreePath && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-mf-input-bg border border-mf-border font-mono text-xs text-mf-text-secondary max-w-[140px] truncate"
+                tabIndex={0}
+              >
+                <GitBranch size={10} className="shrink-0" />
+                {chat.worktreePath.split('/').pop()}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{chat.worktreePath}</TooltipContent>
+          </Tooltip>
+        )}
+
+        {/* PR badge */}
+        {createdPrUrl && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                role="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(createdPrUrl, '_blank');
+                }}
+                className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
+                aria-label="Open PR"
+              >
+                <GitPullRequest size={12} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Open PR</TooltipContent>
+          </Tooltip>
+        )}
+
+        {/* time — visible when not hovered */}
+        <span className="shrink-0 text-xs text-mf-text-secondary tabular-nums group-hover:hidden">
+          {formatRelativeTime(chat.updatedAt)}
+        </span>
+
+        {/* hover actions (Tag / Rename / Archive) */}
+        <div className={cn('shrink-0 items-center gap-0.5 hidden group-hover:flex', archiving && 'flex')}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                ref={tagButtonRef}
+                onClick={openTagPopover}
+                className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+                aria-label="Edit tags"
+              >
+                <TagIcon size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Tags</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleStartRename}
+                className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+                aria-label="Rename session"
+              >
+                <Pencil size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Rename</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleArchive}
+                disabled={archiving}
+                className={cn(
+                  'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors',
+                  archiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
+                )}
+                aria-label="Archive session"
+              >
+                {archiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Archive</TooltipContent>
+          </Tooltip>
+        </div>
+
+        {chat.displayStatus === 'waiting' && (
+          <span className="shrink-0 px-2 py-1 rounded-full text-xs font-medium border border-mf-warning text-mf-warning">
+            Waiting
+          </span>
+        )}
       </div>
+
+      {/* tag row — visible if has tags, OR on hover (with ghost when empty) */}
+      <div
+        ref={tagRowRef}
+        onClick={openTagPopover}
+        className={cn(
+          'items-center gap-1 px-3 pb-1.5 flex-wrap',
+          chat.tags && chat.tags.length > 0 ? 'flex' : 'hidden group-hover:flex',
+        )}
+      >
+        {(chat.tags ?? []).map((name) => (
+          <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
+        ))}
+        {(!chat.tags || chat.tags.length === 0) && (
+          <span className="text-xs text-mf-text-secondary opacity-60">+ tag</span>
+        )}
+      </div>
+
+      {popoverRect && <TagPopover chatId={chat.id} anchorRect={popoverRect} onClose={closeTagPopover} />}
     </div>
   );
 });

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -38,6 +38,8 @@ interface FlatSessionRowProps {
   onContextMenu?: (e: React.MouseEvent, sessionId: string | undefined, chatId?: string) => void;
   registerRenameCallback?: (chatId: string, trigger: () => void) => void;
   unregisterRenameCallback?: (chatId: string) => void;
+  registerOpenTagPopover?: (chatId: string, trigger: (rect: DOMRect) => void) => void;
+  unregisterOpenTagPopover?: (chatId: string) => void;
 }
 
 export const FlatSessionRow = React.memo(function FlatSessionRow({
@@ -46,6 +48,8 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   onContextMenu,
   registerRenameCallback,
   unregisterRenameCallback,
+  registerOpenTagPopover,
+  unregisterOpenTagPopover,
 }: FlatSessionRowProps): React.ReactElement {
   const activeChatId = useChatsStore((s) => s.activeChatId);
   const chats = useChatsStore((s) => s.chats);
@@ -123,6 +127,11 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
     registerRenameCallback?.(chat.id, handleStartRename);
     return () => unregisterRenameCallback?.(chat.id);
   }, [chat.id, handleStartRename, registerRenameCallback, unregisterRenameCallback]);
+
+  useEffect(() => {
+    registerOpenTagPopover?.(chat.id, (rect) => setPopoverRect(rect));
+    return () => unregisterOpenTagPopover?.(chat.id);
+  }, [chat.id, registerOpenTagPopover, unregisterOpenTagPopover]);
 
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Archive, GitBranch, GitPullRequest, Loader2, Pencil, Pin, Tag as TagIcon } from 'lucide-react';
+import { Archive, FolderGit, GitPullRequest, Loader2, Pencil, Pin, Tag as TagIcon } from 'lucide-react';
 import type { Chat } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../store';
 import { useTabsStore } from '../../store/tabs';
 import { useTagsStore } from '../../store/tags';
+import { useAdaptersStore } from '../../store/adapters';
 import { daemonClient } from '../../lib/client';
 import { archiveChat, renameChat } from '../../lib/api';
+import { getAdapterLabel } from '../../lib/adapters';
 import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
 import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
@@ -61,6 +63,16 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
     useTabsStore.getState().openChatTab(chat.id, chat.title);
     daemonClient.resumeChat(chat.id);
   }, [chat.id, chat.title, setActiveChat]);
+
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) return;
+      if (target.closest('button, input, a, [role="button"]')) return;
+      handleSelect();
+    },
+    [handleSelect],
+  );
 
   const [archiving, setArchiving] = useState(false);
 
@@ -165,7 +177,6 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   // Tag popover state
   const [popoverRect, setPopoverRect] = useState<DOMRect | null>(null);
   const tagButtonRef = useRef<HTMLButtonElement>(null);
-  const tagRowRef = useRef<HTMLDivElement>(null);
 
   const openTagPopover = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -176,167 +187,239 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const closeTagPopover = useCallback(() => setPopoverRect(null), []);
 
   const registry = useTagsStore((s) => s.registry);
+  const adapters = useAdaptersStore((s) => s.adapters);
   const colorOf = useCallback((name: string) => registry.find((t) => t.name === name)?.color ?? 'gray', [registry]);
+  const tagNames = chat.tags ?? [];
+  const hasTags = tagNames.length > 0;
+  const adapterLabel = getAdapterLabel(chat.adapterId, adapters);
+  const worktreeName = chat.worktreePath?.split('/').pop();
+  const worktreePillRef = useRef<HTMLSpanElement>(null);
+  const titleRowRef = useRef<HTMLDivElement>(null);
+  const [hideWorktreePill, setHideWorktreePill] = useState(false);
+
+  useEffect(() => {
+    if (!worktreeName || editing) {
+      setHideWorktreePill(false);
+      return;
+    }
+
+    // Only observe the row container — its width is independent of pill visibility,
+    // which avoids the show/hide feedback loop. The pill's own width is content-driven
+    // (depends on `worktreeName` length, capped at 140px) and stable per render.
+    const STATUS_DOT_AND_GAPS = 28; // 12px dot + ~16px of grid gap + flex gaps
+    const MIN_TITLE_WIDTH = 80; // titles below this are uncomfortable to read
+    const HYSTERESIS_BUFFER = 24; // larger than typical sub-pixel resize jitter
+
+    const update = (): void => {
+      const container = titleRowRef.current;
+      const pill = worktreePillRef.current;
+      if (!container || !pill) return;
+      const containerWidth = container.clientWidth;
+      // scrollWidth gives the pill's natural rendered width even when hidden via opacity.
+      const pillWidth = pill.scrollWidth;
+      if (containerWidth === 0 || pillWidth === 0) return;
+      const availableForTitle = containerWidth - STATUS_DOT_AND_GAPS - pillWidth;
+      setHideWorktreePill((wasHidden) => {
+        const showThreshold = MIN_TITLE_WIDTH;
+        const hideThreshold = MIN_TITLE_WIDTH - HYSTERESIS_BUFFER;
+        return wasHidden ? availableForTitle < showThreshold : availableForTitle < hideThreshold;
+      });
+    };
+
+    update();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', update);
+      return () => window.removeEventListener('resize', update);
+    }
+
+    const observer = new ResizeObserver(update);
+    if (titleRowRef.current) observer.observe(titleRowRef.current);
+    return () => observer.disconnect();
+  }, [editing, worktreeName]);
 
   return (
     <div
       data-testid="chat-list-item"
+      onClick={handleRowClick}
       onContextMenu={(e) => onContextMenu?.(e, chat.claudeSessionId, chat.id)}
-      className={cn('group w-full rounded-mf-input transition-colors', isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover')}
+      className={cn(
+        'group w-full rounded-mf-input transition-colors cursor-pointer',
+        isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover',
+      )}
     >
-      <div className="flex items-center gap-2 px-3 py-1.5">
-        {/* status dot */}
-        <div className="w-3 h-3 shrink-0 flex items-center justify-center">
-          {chat.worktreeMissing ? (
-            <div className="w-2 h-2 rounded-full bg-mf-destructive" />
-          ) : isWorking ? (
-            <Loader2 size={12} className="text-mf-accent animate-spin" />
-          ) : (
-            <div
-              className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary')}
-              style={!isUnread ? { opacity: 0.4 } : undefined}
-            />
-          )}
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5">
+        <div className="min-w-0">
+          <div
+            ref={titleRowRef}
+            data-testid="session-title-row"
+            className="grid grid-cols-[12px_minmax(0,1fr)] items-center gap-2"
+          >
+            {/* status dot */}
+            <div className="w-3 h-3 shrink-0 flex items-center justify-center">
+              {chat.worktreeMissing ? (
+                <div className="w-2 h-2 rounded-full bg-mf-destructive" />
+              ) : isWorking ? (
+                <Loader2 size={12} className="text-mf-accent animate-spin" />
+              ) : (
+                <div
+                  className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary')}
+                  style={!isUnread ? { opacity: 0.4 } : undefined}
+                />
+              )}
+            </div>
+
+            {/* title + select target */}
+            <button
+              type="button"
+              onClick={handleSelect}
+              className="relative flex-1 min-w-0 text-left flex items-center gap-1.5 min-h-[20px]"
+            >
+              {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
+              {editing ? (
+                <input
+                  ref={inputRef}
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  onBlur={handleCommitRename}
+                  onKeyDown={handleRenameKeyDown}
+                  onClick={(e) => e.stopPropagation()}
+                  className="flex-1 bg-mf-panel-bg text-sm text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
+                />
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      data-testid="session-title-text"
+                      className={cn(
+                        'min-w-0 flex-1 truncate text-sm',
+                        isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
+                        isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
+                      )}
+                    >
+                      {chat.title || 'Untitled session'}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-[320px] whitespace-pre-wrap break-words">
+                    {chat.title || 'Untitled session'}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {chat.worktreePath && worktreeName && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      ref={worktreePillRef}
+                      data-testid="worktree-pill"
+                      aria-hidden={hideWorktreePill}
+                      className={cn(
+                        'ml-auto shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-mf-hover border border-mf-border text-xs text-mf-text-secondary max-w-[140px] min-w-0',
+                        hideWorktreePill && 'absolute right-0 opacity-0 pointer-events-none',
+                      )}
+                    >
+                      <FolderGit size={10} className="shrink-0 opacity-70" />
+                      <span className="min-w-0 truncate">{worktreeName}</span>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{chat.worktreePath}</TooltipContent>
+                </Tooltip>
+              )}
+            </button>
+          </div>
+
+          {/* metadata row */}
+          <div data-testid="session-row-metadata" className="grid grid-cols-[12px_minmax(0,1fr)] items-center gap-2">
+            <div className="w-3" />
+            <div className="min-w-0 flex items-center gap-1 flex-wrap">
+              <span className="text-xs text-mf-text-secondary opacity-80">{adapterLabel}</span>
+              {hasTags && <span className="text-xs text-mf-text-secondary opacity-50">·</span>}
+              {tagNames.map((name) => (
+                <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
+              ))}
+            </div>
+          </div>
         </div>
 
-        {/* title + select target */}
-        <button
-          type="button"
-          onClick={handleSelect}
-          className="flex-1 min-w-0 text-left flex items-center gap-1.5 min-h-[20px]"
-        >
-          {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
-          {editing ? (
-            <input
-              ref={inputRef}
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              onBlur={handleCommitRename}
-              onKeyDown={handleRenameKeyDown}
-              onClick={(e) => e.stopPropagation()}
-              className="flex-1 bg-mf-panel-bg text-sm text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
-            />
-          ) : (
-            <span
-              className={cn(
-                'truncate text-sm',
-                isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-              )}
-            >
-              {chat.title || 'Untitled session'}
+        <div data-testid="session-row-actions" className="self-center flex items-center justify-end gap-2 min-w-0">
+          {/* PR badge */}
+          {createdPrUrl && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  role="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    window.open(createdPrUrl, '_blank');
+                  }}
+                  className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
+                  aria-label="Open PR"
+                >
+                  <GitPullRequest size={12} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Open PR</TooltipContent>
+            </Tooltip>
+          )}
+
+          <div className="w-[104px] h-6 shrink-0 flex items-center justify-end">
+            {/* time — visible when not hovered */}
+            <span className="text-xs text-mf-text-secondary tabular-nums whitespace-nowrap group-hover:hidden">
+              {formatRelativeTime(chat.updatedAt)}
+            </span>
+
+            {/* hover actions (Tag / Rename / Archive) */}
+            <div className={cn('items-center gap-0.5 hidden group-hover:flex', archiving && 'flex')}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    ref={tagButtonRef}
+                    onClick={openTagPopover}
+                    className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+                    aria-label="Edit tags"
+                  >
+                    <TagIcon size={14} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Tags</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleStartRename}
+                    className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+                    aria-label="Rename session"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Rename</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleArchive}
+                    disabled={archiving}
+                    className={cn(
+                      'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors',
+                      archiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
+                    )}
+                    aria-label="Archive session"
+                  >
+                    {archiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Archive</TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
+
+          {chat.displayStatus === 'waiting' && (
+            <span className="shrink-0 px-2 py-1 rounded-full text-xs font-medium border border-mf-warning text-mf-warning">
+              Waiting
             </span>
           )}
-        </button>
-
-        {/* worktree pill */}
-        {chat.worktreePath && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-mf-input-bg border border-mf-border font-mono text-xs text-mf-text-secondary max-w-[140px] truncate"
-                tabIndex={0}
-              >
-                <GitBranch size={10} className="shrink-0" />
-                {chat.worktreePath.split('/').pop()}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{chat.worktreePath}</TooltipContent>
-          </Tooltip>
-        )}
-
-        {/* PR badge */}
-        {createdPrUrl && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                role="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  window.open(createdPrUrl, '_blank');
-                }}
-                className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
-                aria-label="Open PR"
-              >
-                <GitPullRequest size={12} />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>Open PR</TooltipContent>
-          </Tooltip>
-        )}
-
-        {/* time — visible when not hovered */}
-        <span className="shrink-0 text-xs text-mf-text-secondary tabular-nums group-hover:hidden">
-          {formatRelativeTime(chat.updatedAt)}
-        </span>
-
-        {/* hover actions (Tag / Rename / Archive) */}
-        <div className={cn('shrink-0 items-center gap-0.5 hidden group-hover:flex', archiving && 'flex')}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                ref={tagButtonRef}
-                onClick={openTagPopover}
-                className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
-                aria-label="Edit tags"
-              >
-                <TagIcon size={14} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Tags</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={handleStartRename}
-                className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors"
-                aria-label="Rename session"
-              >
-                <Pencil size={14} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Rename</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={handleArchive}
-                disabled={archiving}
-                className={cn(
-                  'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors',
-                  archiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
-                )}
-                aria-label="Archive session"
-              >
-                {archiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Archive</TooltipContent>
-          </Tooltip>
         </div>
-
-        {chat.displayStatus === 'waiting' && (
-          <span className="shrink-0 px-2 py-1 rounded-full text-xs font-medium border border-mf-warning text-mf-warning">
-            Waiting
-          </span>
-        )}
-      </div>
-
-      {/* tag row — visible if has tags, OR on hover (with ghost when empty) */}
-      <div
-        ref={tagRowRef}
-        onClick={openTagPopover}
-        className={cn(
-          'items-center gap-1 px-3 pb-1.5 flex-wrap',
-          chat.tags && chat.tags.length > 0 ? 'flex' : 'hidden group-hover:flex',
-        )}
-      >
-        {(chat.tags ?? []).map((name) => (
-          <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
-        ))}
-        {(!chat.tags || chat.tags.length === 0) && (
-          <span className="text-xs text-mf-text-secondary opacity-60">+ tag</span>
-        )}
       </div>
 
       {popoverRect && <TagPopover chatId={chat.id} anchorRect={popoverRect} onClose={closeTagPopover} />}

--- a/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
+++ b/packages/desktop/src/renderer/components/panels/ProjectGroup.tsx
@@ -1,279 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Plus,
-  Archive,
-  Pencil,
-  ChevronDown,
-  ChevronRight,
-  Bot,
-  GitBranch,
-  GitPullRequest,
-  Clock,
-  Loader2,
-  Pin,
-  Trash2,
-} from 'lucide-react';
+import React, { useCallback } from 'react';
+import { Plus, ChevronDown, ChevronRight, Trash2 } from 'lucide-react';
 import type { Project, Chat } from '@qlan-ro/mainframe-types';
-import type { SessionStatus } from '../../store/chats';
-import { useChatsStore } from '../../store';
-import { useTabsStore } from '../../store/tabs';
-import { useAdaptersStore } from '../../store/adapters';
 import { daemonClient } from '../../lib/client';
 import { getDefaultModelForAdapter } from '../../lib/adapters';
-import { archiveChat, renameChat } from '../../lib/api';
-import { deleteDraft } from '../chat/assistant-ui/composer/composer-drafts.js';
 import { deleteProjectWithCleanup } from '../../lib/delete-project';
-import { cn } from '../../lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
-import { getAdapterLabel } from '../../lib/adapters';
-import { createLogger } from '../../lib/logger';
-
-const log = createLogger('renderer:project-group');
-
-function SessionStatusDot({
-  status,
-  worktreeMissing,
-  isUnread,
-}: {
-  status: SessionStatus;
-  worktreeMissing?: boolean;
-  isUnread?: boolean;
-}) {
-  const isWorking = status === 'working' || status === 'waiting';
-  return (
-    <div className="w-3 h-3 shrink-0 flex items-center justify-center">
-      {worktreeMissing ? (
-        <div data-testid="chat-status-missing" className="w-2 h-2 rounded-full bg-mf-destructive" />
-      ) : isWorking ? (
-        <Loader2 data-testid="chat-status-working" size={12} className="text-mf-accent animate-spin" />
-      ) : (
-        <div
-          data-testid="chat-status-idle"
-          className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary opacity-40')}
-        />
-      )}
-    </div>
-  );
-}
-
-function formatRelativeTime(isoString: string): string {
-  const date = new Date(isoString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-
-  if (date.toDateString() === now.toDateString()) return `Today ${time}`;
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return `Yesterday ${time}`;
-  if (diffDays < 7) return `${date.toLocaleDateString([], { weekday: 'long' })} ${time}`;
-  if (diffDays < 14) return 'Last week';
-  if (date.getFullYear() === now.getFullYear()) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
-interface ChatRowProps {
-  chat: Chat;
-  isActive: boolean;
-  adapters: import('@qlan-ro/mainframe-types').AdapterInfo[];
-  onSelect: (chatId: string, title?: string) => void;
-  isArchiving?: boolean;
-  onArchive: (e: React.MouseEvent, chatId: string) => void;
-  onContextMenu?: (e: React.MouseEvent, sessionId: string | undefined, chatId?: string) => void;
-  registerRenameCallback?: (chatId: string, trigger: () => void) => void;
-  unregisterRenameCallback?: (chatId: string) => void;
-}
-
-function ChatRow({
-  chat,
-  isActive,
-  isArchiving,
-  adapters,
-  onSelect,
-  onArchive,
-  onContextMenu,
-  registerRenameCallback,
-  unregisterRenameCallback,
-}: ChatRowProps) {
-  const [editing, setEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleStartRename = useCallback(
-    (e?: React.MouseEvent) => {
-      e?.stopPropagation();
-      setEditTitle(chat.title || '');
-      setEditing(true);
-      requestAnimationFrame(() => inputRef.current?.select());
-    },
-    [chat.title],
-  );
-
-  useEffect(() => {
-    registerRenameCallback?.(chat.id, handleStartRename);
-    return () => unregisterRenameCallback?.(chat.id);
-  }, [chat.id, handleStartRename, registerRenameCallback, unregisterRenameCallback]);
-
-  const updateChat = useChatsStore((s) => s.updateChat);
-  const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
-  const isUnread = unreadChatIds.has(chat.id);
-  const createdPrUrl = useChatsStore((s) => {
-    const prs = s.detectedPrs.get(chat.id);
-    return prs?.find((p) => p.source === 'created')?.url ?? null;
-  });
-
-  const handleCommitRename = useCallback(() => {
-    setEditing(false);
-    const trimmed = editTitle.trim();
-    if (trimmed && trimmed !== chat.title) {
-      updateChat({ ...chat, title: trimmed });
-      useTabsStore.getState().updateTabLabel(`chat:${chat.id}`, trimmed);
-      renameChat(chat.id, trimmed).catch((err) => log.warn('rename failed', { err: String(err) }));
-    }
-  }, [chat, editTitle, updateChat]);
-
-  const handleRenameKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') handleCommitRename();
-      if (e.key === 'Escape') setEditing(false);
-    },
-    [handleCommitRename],
-  );
-
-  return (
-    <div
-      data-testid="chat-list-item"
-      onContextMenu={(e) => onContextMenu?.(e, chat.claudeSessionId, chat.id)}
-      className={cn(
-        'group w-full rounded-mf-input transition-colors flex items-center gap-2 ml-2',
-        isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover/50',
-      )}
-    >
-      <button
-        type="button"
-        onClick={() => onSelect(chat.id, chat.title)}
-        className="flex-1 min-w-0 px-3 py-1.5 text-left rounded-mf-input"
-      >
-        <div className="flex items-center gap-2">
-          <SessionStatusDot
-            status={chat.displayStatus ?? 'idle'}
-            worktreeMissing={chat.worktreeMissing}
-            isUnread={isUnread}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1">
-              {editing ? (
-                <input
-                  ref={inputRef}
-                  value={editTitle}
-                  onChange={(e) => setEditTitle(e.target.value)}
-                  onBlur={handleCommitRename}
-                  onKeyDown={handleRenameKeyDown}
-                  onClick={(e) => e.stopPropagation()}
-                  className="w-full bg-mf-panel-bg text-mf-small text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
-                />
-              ) : (
-                <div className="flex items-center gap-1 min-w-0">
-                  {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
-                  {createdPrUrl && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          role="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            window.open(createdPrUrl, '_blank');
-                          }}
-                          className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
-                          aria-label="Open PR"
-                        >
-                          <GitPullRequest size={12} />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>Open PR</TooltipContent>
-                    </Tooltip>
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        className={cn(
-                          'text-mf-small truncate',
-                          isActive ? 'text-mf-text-primary font-medium' : 'text-mf-text-secondary',
-                          isUnread && !isActive ? 'font-semibold text-mf-text-primary' : '',
-                        )}
-                        tabIndex={0}
-                      >
-                        {chat.title || 'Untitled session'}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>{chat.title || 'Untitled session'}</TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
-            </div>
-            <div className="text-mf-status text-mf-text-secondary mt-0.5 flex items-center gap-1 overflow-hidden">
-              <Bot size={10} className="shrink-0" />
-              <span className="truncate">{getAdapterLabel(chat.adapterId, adapters)}</span>
-              {chat.worktreePath && (
-                <>
-                  <span className="shrink-0">{'·'}</span>
-                  <GitBranch size={10} className="shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="truncate max-w-[100px]" tabIndex={0}>
-                        {chat.worktreePath.split('/').pop()}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{chat.worktreePath}</TooltipContent>
-                  </Tooltip>
-                </>
-              )}
-              <span className="shrink-0">{'·'}</span>
-              <Clock size={10} className="shrink-0" />
-              <span className="shrink-0">{formatRelativeTime(chat.updatedAt)}</span>
-            </div>
-          </div>
-        </div>
-      </button>
-      {chat.displayStatus === 'waiting' && (
-        <span className="shrink-0 mr-2 px-2 py-1 rounded-full text-xs font-medium border border-mf-warning text-mf-warning">
-          Waiting
-        </span>
-      )}
-      <div className={cn('shrink-0 mr-1 flex items-center gap-0.5', isArchiving ? 'flex' : 'hidden group-hover:flex')}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleStartRename}
-              className="w-6 h-6 rounded flex items-center justify-center hover:bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary transition-colors shrink-0"
-              aria-label="Rename session"
-            >
-              <Pencil size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Rename session</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={(e) => onArchive(e, chat.id)}
-              disabled={isArchiving}
-              className={cn(
-                'w-6 h-6 rounded flex items-center justify-center text-mf-text-secondary transition-colors shrink-0',
-                isArchiving ? '' : 'hover:bg-mf-hover hover:text-mf-text-primary',
-              )}
-              aria-label="Archive session"
-            >
-              {isArchiving ? <Loader2 size={14} className="animate-spin" /> : <Archive size={14} />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Archive session</TooltipContent>
-        </Tooltip>
-      </div>
-    </div>
-  );
-}
+import { FlatSessionRow } from './FlatSessionRow';
 
 interface ProjectGroupProps {
   project: Project;
@@ -284,6 +16,8 @@ interface ProjectGroupProps {
   onContextMenu?: (e: React.MouseEvent, sessionId: string | undefined, chatId?: string) => void;
   registerRenameCallback?: (chatId: string, trigger: () => void) => void;
   unregisterRenameCallback?: (chatId: string) => void;
+  registerOpenTagPopover?: (chatId: string, trigger: (rect: DOMRect) => void) => void;
+  unregisterOpenTagPopover?: (chatId: string) => void;
 }
 
 export const ProjectGroup = React.memo(function ProjectGroup({
@@ -295,64 +29,9 @@ export const ProjectGroup = React.memo(function ProjectGroup({
   onContextMenu,
   registerRenameCallback,
   unregisterRenameCallback,
+  registerOpenTagPopover,
+  unregisterOpenTagPopover,
 }: ProjectGroupProps): React.ReactElement {
-  const activeChatId = useChatsStore((s) => s.activeChatId);
-  const setActiveChat = useChatsStore((s) => s.setActiveChat);
-  const removeChat = useChatsStore((s) => s.removeChat);
-  const adapters = useAdaptersStore((s) => s.adapters);
-
-  const handleSelectChat = useCallback(
-    (chatId: string, title?: string) => {
-      setActiveChat(chatId);
-      useTabsStore.getState().openChatTab(chatId, title);
-      daemonClient.resumeChat(chatId);
-    },
-    [setActiveChat],
-  );
-
-  const [archivingIds, setArchivingIds] = useState<Set<string>>(new Set());
-
-  const handleArchiveChat = useCallback(
-    (e: React.MouseEvent, chatId: string) => {
-      e.stopPropagation();
-      if (archivingIds.has(chatId)) return;
-      const chat = chats.find((c) => c.id === chatId);
-      let deleteWorktree = true;
-      if (chat?.worktreePath) {
-        const choice = window.confirm(
-          `This session has a worktree at:\n${chat.worktreePath}\n\nOK = Archive and delete worktree\nCancel = Archive only (keep worktree)`,
-        );
-        deleteWorktree = choice;
-      }
-      setArchivingIds((prev) => new Set(prev).add(chatId));
-      archiveChat(chatId, deleteWorktree)
-        .then(() => {
-          const wasActive = activeChatId === chatId;
-          removeChat(chatId);
-          deleteDraft(chatId);
-          useTabsStore.getState().closeTab(`chat:${chatId}`);
-          if (wasActive) {
-            const next = chats
-              .filter((c) => c.id !== chatId)
-              .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
-            if (next) {
-              setActiveChat(next.id);
-              useTabsStore.getState().openChatTab(next.id, next.title);
-            }
-          }
-        })
-        .catch((err) => {
-          log.warn('archive failed', { err: String(err) });
-          setArchivingIds((prev) => {
-            const next = new Set(prev);
-            next.delete(chatId);
-            return next;
-          });
-        });
-    },
-    [chats, removeChat, archivingIds, activeChatId, setActiveChat],
-  );
-
   const handleNewSession = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -437,18 +116,17 @@ export const ProjectGroup = React.memo(function ProjectGroup({
             <div className="pl-6 py-1 text-mf-status text-mf-text-secondary">No sessions</div>
           ) : (
             chats.map((chat) => (
-              <ChatRow
-                key={chat.id}
-                chat={chat}
-                isActive={activeChatId === chat.id}
-                isArchiving={archivingIds.has(chat.id)}
-                adapters={adapters}
-                onSelect={handleSelectChat}
-                onArchive={handleArchiveChat}
-                onContextMenu={onContextMenu}
-                registerRenameCallback={registerRenameCallback}
-                unregisterRenameCallback={unregisterRenameCallback}
-              />
+              <div key={chat.id} className="ml-2">
+                <FlatSessionRow
+                  chat={chat}
+                  projectName={project.name}
+                  onContextMenu={onContextMenu}
+                  registerRenameCallback={registerRenameCallback}
+                  unregisterRenameCallback={unregisterRenameCallback}
+                  registerOpenTagPopover={registerOpenTagPopover}
+                  unregisterOpenTagPopover={unregisterOpenTagPopover}
+                />
+              </div>
             ))
           )}
         </div>

--- a/packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx
+++ b/packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo } from 'react';
+import { useTagsStore } from '../../store/tags';
+import { useChatsStore, useProjectsStore } from '../../store';
+import { TagPill } from '../tags/TagPill';
+import type { TagColor, SyntheticTag } from '@qlan-ro/mainframe-types';
+
+export function SessionFilterBar(): React.ReactElement {
+  const projects = useProjectsStore((s) => s.projects);
+  const chats = useChatsStore((s) => s.chats);
+  const detectedPrs = useChatsStore((s) => s.detectedPrs);
+
+  const registry = useTagsStore((s) => s.registry);
+  const registryLoaded = useTagsStore((s) => s.registryLoaded);
+  const refreshRegistry = useTagsStore((s) => s.refreshRegistry);
+
+  const selectedProject = useTagsStore((s) => s.selectedProject);
+  const selectedTags = useTagsStore((s) => s.selectedTags);
+  const selectedSynthetic = useTagsStore((s) => s.selectedSynthetic);
+  const setSelectedProject = useTagsStore((s) => s.setSelectedProject);
+  const toggleTag = useTagsStore((s) => s.toggleTag);
+  const toggleSynthetic = useTagsStore((s) => s.toggleSynthetic);
+
+  useEffect(() => {
+    if (!registryLoaded) void refreshRegistry();
+  }, [registryLoaded, refreshRegistry]);
+
+  // Tags currently in use across the active project scope.
+  const tagsInUse = useMemo(() => {
+    const scoped = selectedProject ? chats.filter((c) => c.projectId === selectedProject) : chats;
+    const set = new Set<string>();
+    for (const c of scoped) for (const t of c.tags ?? []) set.add(t);
+    return [...set].sort();
+  }, [chats, selectedProject]);
+
+  const hasAnyWorktree = useMemo(() => chats.some((c) => Boolean(c.worktreePath)), [chats]);
+  const hasAnyPr = useMemo(() => chats.some((c) => (detectedPrs.get(c.id)?.length ?? 0) > 0), [chats, detectedPrs]);
+
+  const colorByName = useMemo(() => {
+    const m = new Map<string, TagColor>();
+    for (const t of registry) m.set(t.name, t.color);
+    return m;
+  }, [registry]);
+
+  const showTagsRow = tagsInUse.length > 0 || hasAnyWorktree || hasAnyPr;
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 border-b border-mf-divider">
+      <div className="flex items-center gap-1 overflow-x-auto">
+        <span className="text-xs text-mf-text-secondary uppercase mr-1">Project</span>
+        <button
+          type="button"
+          onClick={() => setSelectedProject(null)}
+          className={
+            selectedProject === null
+              ? 'px-2 py-0.5 rounded-full text-xs bg-mf-accent text-white'
+              : 'px-2 py-0.5 rounded-full text-xs border border-mf-border text-mf-text-secondary hover:bg-mf-hover'
+          }
+        >
+          All
+        </button>
+        {projects.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => setSelectedProject(p.id)}
+            className={
+              selectedProject === p.id
+                ? 'px-2 py-0.5 rounded-full text-xs bg-mf-accent text-white whitespace-nowrap'
+                : 'px-2 py-0.5 rounded-full text-xs border border-mf-border text-mf-text-secondary hover:bg-mf-hover whitespace-nowrap'
+            }
+          >
+            {p.name}
+          </button>
+        ))}
+      </div>
+      {showTagsRow && (
+        <div className="flex items-center gap-1 flex-wrap">
+          <span className="text-xs text-mf-text-secondary uppercase mr-1">Tags</span>
+          {tagsInUse.map((name) => (
+            <TagPill
+              key={name}
+              label={name}
+              color={colorByName.get(name) ?? 'gray'}
+              variant="filter"
+              active={selectedTags.has(name)}
+              onClick={() => toggleTag(name)}
+            />
+          ))}
+          {hasAnyPr && (
+            <TagPill
+              label="has-pr"
+              color="gray"
+              variant="filter"
+              active={selectedSynthetic.has('has-pr')}
+              onClick={() => toggleSynthetic('has-pr' as SyntheticTag)}
+            />
+          )}
+          {hasAnyWorktree && (
+            <TagPill
+              label="has-worktree"
+              color="gray"
+              variant="filter"
+              active={selectedSynthetic.has('has-worktree')}
+              onClick={() => toggleSynthetic('has-worktree' as SyntheticTag)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx
+++ b/packages/desktop/src/renderer/components/panels/SessionFilterBar.tsx
@@ -1,22 +1,20 @@
 import React, { useEffect, useMemo } from 'react';
 import { useTagsStore } from '../../store/tags';
-import { useChatsStore, useProjectsStore } from '../../store';
+import { useChatsStore } from '../../store';
 import { TagPill } from '../tags/TagPill';
 import type { TagColor, SyntheticTag } from '@qlan-ro/mainframe-types';
 
 export function SessionFilterBar(): React.ReactElement {
-  const projects = useProjectsStore((s) => s.projects);
   const chats = useChatsStore((s) => s.chats);
   const detectedPrs = useChatsStore((s) => s.detectedPrs);
+  const filterProjectId = useChatsStore((s) => s.filterProjectId);
 
   const registry = useTagsStore((s) => s.registry);
   const registryLoaded = useTagsStore((s) => s.registryLoaded);
   const refreshRegistry = useTagsStore((s) => s.refreshRegistry);
 
-  const selectedProject = useTagsStore((s) => s.selectedProject);
   const selectedTags = useTagsStore((s) => s.selectedTags);
   const selectedSynthetic = useTagsStore((s) => s.selectedSynthetic);
-  const setSelectedProject = useTagsStore((s) => s.setSelectedProject);
   const toggleTag = useTagsStore((s) => s.toggleTag);
   const toggleSynthetic = useTagsStore((s) => s.toggleSynthetic);
 
@@ -26,11 +24,11 @@ export function SessionFilterBar(): React.ReactElement {
 
   // Tags currently in use across the active project scope.
   const tagsInUse = useMemo(() => {
-    const scoped = selectedProject ? chats.filter((c) => c.projectId === selectedProject) : chats;
+    const scoped = filterProjectId ? chats.filter((c) => c.projectId === filterProjectId) : chats;
     const set = new Set<string>();
     for (const c of scoped) for (const t of c.tags ?? []) set.add(t);
     return [...set].sort();
-  }, [chats, selectedProject]);
+  }, [chats, filterProjectId]);
 
   const hasAnyWorktree = useMemo(() => chats.some((c) => Boolean(c.worktreePath)), [chats]);
   const hasAnyPr = useMemo(() => chats.some((c) => (detectedPrs.get(c.id)?.length ?? 0) > 0), [chats, detectedPrs]);
@@ -43,68 +41,38 @@ export function SessionFilterBar(): React.ReactElement {
 
   const showTagsRow = tagsInUse.length > 0 || hasAnyWorktree || hasAnyPr;
 
+  if (!showTagsRow) return <></>;
+
   return (
-    <div className="flex flex-col gap-1 px-3 py-2 border-b border-mf-divider">
-      <div className="flex items-center gap-1 overflow-x-auto">
-        <span className="text-xs text-mf-text-secondary uppercase mr-1">Project</span>
-        <button
-          type="button"
-          onClick={() => setSelectedProject(null)}
-          className={
-            selectedProject === null
-              ? 'px-2 py-0.5 rounded-full text-xs bg-mf-accent text-white'
-              : 'px-2 py-0.5 rounded-full text-xs border border-mf-border text-mf-text-secondary hover:bg-mf-hover'
-          }
-        >
-          All
-        </button>
-        {projects.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            onClick={() => setSelectedProject(p.id)}
-            className={
-              selectedProject === p.id
-                ? 'px-2 py-0.5 rounded-full text-xs bg-mf-accent text-white whitespace-nowrap'
-                : 'px-2 py-0.5 rounded-full text-xs border border-mf-border text-mf-text-secondary hover:bg-mf-hover whitespace-nowrap'
-            }
-          >
-            {p.name}
-          </button>
-        ))}
-      </div>
-      {showTagsRow && (
-        <div className="flex items-center gap-1 flex-wrap">
-          <span className="text-xs text-mf-text-secondary uppercase mr-1">Tags</span>
-          {tagsInUse.map((name) => (
-            <TagPill
-              key={name}
-              label={name}
-              color={colorByName.get(name) ?? 'gray'}
-              variant="filter"
-              active={selectedTags.has(name)}
-              onClick={() => toggleTag(name)}
-            />
-          ))}
-          {hasAnyPr && (
-            <TagPill
-              label="has-pr"
-              color="gray"
-              variant="filter"
-              active={selectedSynthetic.has('has-pr')}
-              onClick={() => toggleSynthetic('has-pr' as SyntheticTag)}
-            />
-          )}
-          {hasAnyWorktree && (
-            <TagPill
-              label="has-worktree"
-              color="gray"
-              variant="filter"
-              active={selectedSynthetic.has('has-worktree')}
-              onClick={() => toggleSynthetic('has-worktree' as SyntheticTag)}
-            />
-          )}
-        </div>
+    <div className="flex items-center gap-1 flex-wrap px-3 py-2 border-b border-mf-divider">
+      <span className="text-xs text-mf-text-secondary uppercase mr-1">Tags</span>
+      {tagsInUse.map((name) => (
+        <TagPill
+          key={name}
+          label={name}
+          color={colorByName.get(name) ?? 'gray'}
+          variant="filter"
+          active={selectedTags.has(name)}
+          onClick={() => toggleTag(name)}
+        />
+      ))}
+      {hasAnyPr && (
+        <TagPill
+          label="has-pr"
+          color="gray"
+          variant="filter"
+          active={selectedSynthetic.has('has-pr')}
+          onClick={() => toggleSynthetic('has-pr' as SyntheticTag)}
+        />
+      )}
+      {hasAnyWorktree && (
+        <TagPill
+          label="has-worktree"
+          color="gray"
+          variant="filter"
+          active={selectedSynthetic.has('has-worktree')}
+          onClick={() => toggleSynthetic('has-worktree' as SyntheticTag)}
+        />
       )}
     </div>
   );

--- a/packages/desktop/src/renderer/components/tags/TagPill.tsx
+++ b/packages/desktop/src/renderer/components/tags/TagPill.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type { TagColor } from '@qlan-ro/mainframe-types';
+import { cn } from '../../lib/utils';
+
+const COLOR_BG: Record<TagColor, string> = {
+  blue: 'bg-mf-tag-blue text-white',
+  red: 'bg-mf-tag-red text-white',
+  purple: 'bg-mf-tag-purple text-white',
+  violet: 'bg-mf-tag-violet text-white',
+  amber: 'bg-mf-tag-amber text-black',
+  teal: 'bg-mf-tag-teal text-white',
+  cyan: 'bg-mf-tag-cyan text-black',
+  green: 'bg-mf-tag-green text-white',
+  pink: 'bg-mf-tag-pink text-white',
+  orange: 'bg-mf-tag-orange text-white',
+};
+
+const COLOR_DOT: Record<TagColor | 'gray', string> = {
+  blue: 'bg-mf-tag-blue',
+  red: 'bg-mf-tag-red',
+  purple: 'bg-mf-tag-purple',
+  violet: 'bg-mf-tag-violet',
+  amber: 'bg-mf-tag-amber',
+  teal: 'bg-mf-tag-teal',
+  cyan: 'bg-mf-tag-cyan',
+  green: 'bg-mf-tag-green',
+  pink: 'bg-mf-tag-pink',
+  orange: 'bg-mf-tag-orange',
+  gray: 'bg-mf-text-secondary',
+};
+
+interface Props {
+  label: string;
+  color: TagColor | 'gray';
+  variant: 'row' | 'filter';
+  active?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+}
+
+export function TagPill({ label, color, variant, active, onClick, onContextMenu }: Props): React.ReactElement {
+  if (variant === 'row') {
+    const cls = color === 'gray' ? 'bg-mf-text-secondary text-white' : COLOR_BG[color];
+    return (
+      <span
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer', cls)}
+      >
+        {label}
+      </span>
+    );
+  }
+  // filter variant
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs border transition-colors',
+        active
+          ? 'border-mf-accent bg-mf-hover text-mf-text-primary'
+          : 'border-mf-border text-mf-text-secondary hover:bg-mf-hover',
+      )}
+    >
+      <span className={cn('w-1.5 h-1.5 rounded-full', COLOR_DOT[color])} />
+      {label}
+    </button>
+  );
+}

--- a/packages/desktop/src/renderer/components/tags/TagPopover.tsx
+++ b/packages/desktop/src/renderer/components/tags/TagPopover.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Check } from 'lucide-react';
-import type { Tag } from '@qlan-ro/mainframe-types';
+import type { Tag, TagColor } from '@qlan-ro/mainframe-types';
+import { TAG_PALETTE } from '@qlan-ro/mainframe-types';
 import { useTagsStore } from '../../store/tags';
 import { useChatsStore } from '../../store';
+import { updateTag, deleteTag } from '../../lib/api/tags-api';
 import { cn } from '../../lib/utils';
 import { createLogger } from '../../lib/logger';
 
@@ -25,6 +27,11 @@ export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactE
   const [query, setQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [registryMenu, setRegistryMenu] = useState<{ x: number; y: number; tagName: string } | null>(null);
+  const [recolorPanel, setRecolorPanel] = useState<{ x: number; y: number; tagName: string } | null>(null);
+
+  const allChats = useChatsStore((s) => s.chats);
+  const updateChatStore = useChatsStore((s) => s.updateChat);
 
   useEffect(() => {
     void refreshRegistry();
@@ -83,6 +90,47 @@ export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactE
     setQuery('');
   }
 
+  async function renameTag(from: string, to: string): Promise<void> {
+    setError(null);
+    try {
+      await updateTag(from, { rename: to });
+      for (const c of allChats) {
+        if (c.tags?.includes(from)) {
+          const next = Array.from(new Set(c.tags.map((t) => (t === from ? to : t))));
+          updateChatStore({ ...c, tags: next });
+        }
+      }
+      await refreshRegistry();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed');
+    }
+  }
+
+  async function recolorTag(name: string, color: TagColor): Promise<void> {
+    setError(null);
+    try {
+      await updateTag(name, { color });
+      await refreshRegistry();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Recolor failed');
+    }
+  }
+
+  async function removeTag(name: string): Promise<void> {
+    setError(null);
+    try {
+      await deleteTag(name);
+      for (const c of allChats) {
+        if (c.tags?.includes(name)) {
+          updateChatStore({ ...c, tags: c.tags.filter((t) => t !== name) });
+        }
+      }
+      await refreshRegistry();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    }
+  }
+
   return (
     <div
       role="dialog"
@@ -110,6 +158,11 @@ export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactE
             key={t.name}
             type="button"
             onClick={() => void toggle(t.name)}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setRegistryMenu({ x: e.clientX, y: e.clientY, tagName: t.name });
+            }}
             className={cn('w-full flex items-center justify-between gap-2 px-2 py-1 rounded hover:bg-mf-hover text-sm')}
           >
             <span className="flex items-center gap-2">
@@ -128,6 +181,81 @@ export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactE
         >
           + Create tag &quot;{lower}&quot;
         </button>
+      )}
+      {registryMenu && (
+        <div
+          style={{ position: 'fixed', left: registryMenu.x, top: registryMenu.y }}
+          className="z-[60] rounded-mf-input border border-mf-border bg-mf-panel-bg shadow-lg p-1 min-w-[140px]"
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="w-full text-left px-2 py-1 rounded hover:bg-mf-hover text-sm text-mf-text-primary"
+            onClick={() => {
+              const current = registryMenu.tagName;
+              setRegistryMenu(null);
+              const next = window.prompt(`Rename "${current}" to:`, current);
+              if (!next || next.trim() === current) return;
+              const trimmed = next.trim();
+              if (registry.some((t) => t.name === trimmed)) {
+                if (!window.confirm(`Merge "${current}" into "${trimmed}"?`)) return;
+              }
+              void renameTag(current, trimmed);
+            }}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            className="w-full text-left px-2 py-1 rounded hover:bg-mf-hover text-sm text-mf-text-primary"
+            onClick={() => {
+              setRecolorPanel({ x: registryMenu.x, y: registryMenu.y, tagName: registryMenu.tagName });
+              setRegistryMenu(null);
+            }}
+          >
+            Change color
+          </button>
+          <button
+            type="button"
+            className="w-full text-left px-2 py-1 rounded hover:bg-mf-hover text-sm text-mf-destructive"
+            onClick={() => {
+              const name = registryMenu.tagName;
+              setRegistryMenu(null);
+              if (!window.confirm(`Delete tag "${name}"? This removes it from all sessions.`)) return;
+              void removeTag(name);
+            }}
+          >
+            Delete from all sessions
+          </button>
+        </div>
+      )}
+      {recolorPanel && (
+        <div
+          style={{ position: 'fixed', left: recolorPanel.x, top: recolorPanel.y }}
+          className="z-[60] rounded-mf-input border border-mf-border bg-mf-panel-bg shadow-lg p-2"
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="text-xs text-mf-text-secondary uppercase tracking-wide px-1 pb-1">
+            Recolor &quot;{recolorPanel.tagName}&quot;
+          </div>
+          <div className="grid grid-cols-5 gap-1">
+            {TAG_PALETTE.map((c) => (
+              <button
+                key={c}
+                type="button"
+                aria-label={`Set color ${c}`}
+                className={`w-5 h-5 rounded-full bg-mf-tag-${c} hover:scale-110 transition-transform`}
+                onClick={() => {
+                  const name = recolorPanel.tagName;
+                  setRecolorPanel(null);
+                  void recolorTag(name, c);
+                }}
+              />
+            ))}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/desktop/src/renderer/components/tags/TagPopover.tsx
+++ b/packages/desktop/src/renderer/components/tags/TagPopover.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Check } from 'lucide-react';
+import type { Tag } from '@qlan-ro/mainframe-types';
+import { useTagsStore } from '../../store/tags';
+import { useChatsStore } from '../../store';
+import { cn } from '../../lib/utils';
+import { createLogger } from '../../lib/logger';
+
+const log = createLogger('renderer:tag-popover');
+
+interface Props {
+  chatId: string;
+  anchorRect: DOMRect;
+  onClose: () => void;
+}
+
+export function TagPopover({ chatId, anchorRect, onClose }: Props): React.ReactElement {
+  const registry = useTagsStore((s) => s.registry);
+  const refreshRegistry = useTagsStore((s) => s.refreshRegistry);
+  const applyToChat = useTagsStore((s) => s.applyToChat);
+
+  const chat = useChatsStore((s) => s.chats.find((c) => c.id === chatId));
+  const updateChat = useChatsStore((s) => s.updateChat);
+
+  const [query, setQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    void refreshRegistry();
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [refreshRegistry]);
+
+  // Close on outside click
+  useEffect(() => {
+    function onDocClick(): void {
+      onClose();
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [onClose]);
+
+  const lower = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    if (!lower) return registry;
+    return registry.filter((t) => t.name.includes(lower));
+  }, [registry, lower]);
+
+  const exactMatch = useMemo(() => registry.some((t) => t.name === lower), [registry, lower]);
+  const showCreate = lower.length > 0 && !exactMatch;
+
+  const applied = new Set(chat?.tags ?? []);
+  const previousTags = chat?.tags;
+
+  async function commit(nextTags: string[]): Promise<void> {
+    if (!chat) return;
+    setError(null);
+    updateChat({ ...chat, tags: nextTags }); // optimistic
+    try {
+      await applyToChat(chat.id, nextTags);
+    } catch (err) {
+      // rollback
+      if (previousTags !== undefined) {
+        updateChat({ ...chat, tags: previousTags });
+      }
+      const message = err instanceof Error ? err.message : 'Failed to update tags';
+      log.warn('apply tags failed', { err: String(err) });
+      setError(message);
+    }
+  }
+
+  async function toggle(name: string): Promise<void> {
+    const next = new Set(applied);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    await commit([...next]);
+  }
+
+  async function createAndApply(): Promise<void> {
+    if (!lower) return;
+    const next = [...(chat?.tags ?? []), lower];
+    await commit(next);
+    setQuery('');
+  }
+
+  return (
+    <div
+      role="dialog"
+      style={{ position: 'fixed', left: anchorRect.left, top: anchorRect.bottom + 4 }}
+      className="z-50 w-64 rounded-mf-input border border-mf-border bg-mf-panel-bg shadow-lg p-2"
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="text-xs text-mf-text-secondary uppercase tracking-wide px-2 py-1">Tag session</div>
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+          if (e.key === 'Enter' && showCreate) void createAndApply();
+        }}
+        placeholder="# Find or create..."
+        className="w-full bg-mf-input-bg text-sm px-2 py-1 rounded outline-none border border-mf-border text-mf-text-primary"
+      />
+      {error && <div className="text-xs text-mf-destructive px-2 py-1">{error}</div>}
+      <div className="max-h-64 overflow-y-auto mt-1">
+        {filtered.map((t: Tag) => (
+          <button
+            key={t.name}
+            type="button"
+            onClick={() => void toggle(t.name)}
+            className={cn('w-full flex items-center justify-between gap-2 px-2 py-1 rounded hover:bg-mf-hover text-sm')}
+          >
+            <span className="flex items-center gap-2">
+              <span className={cn('w-1.5 h-1.5 rounded-full', `bg-mf-tag-${t.color}`)} />
+              <span className="text-mf-text-primary">{t.name}</span>
+            </span>
+            {applied.has(t.name) && <Check size={12} className="text-mf-accent" />}
+          </button>
+        ))}
+      </div>
+      {showCreate && (
+        <button
+          type="button"
+          onClick={() => void createAndApply()}
+          className="w-full text-left px-2 py-1 rounded hover:bg-mf-hover text-sm text-mf-text-secondary mt-1 border-t border-mf-border"
+        >
+          + Create tag &quot;{lower}&quot;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -40,6 +40,17 @@
   --color-mf-info: var(--mf-info);
   --color-mf-ring: var(--mf-ring);
 
+  --color-mf-tag-blue: var(--mf-tag-blue);
+  --color-mf-tag-red: var(--mf-tag-red);
+  --color-mf-tag-purple: var(--mf-tag-purple);
+  --color-mf-tag-violet: var(--mf-tag-violet);
+  --color-mf-tag-amber: var(--mf-tag-amber);
+  --color-mf-tag-teal: var(--mf-tag-teal);
+  --color-mf-tag-cyan: var(--mf-tag-cyan);
+  --color-mf-tag-green: var(--mf-tag-green);
+  --color-mf-tag-pink: var(--mf-tag-pink);
+  --color-mf-tag-orange: var(--mf-tag-orange);
+
   --spacing-mf-gap: var(--mf-gap-panel);
 
   --radius-mf-panel: var(--mf-radius-panel);
@@ -124,6 +135,18 @@
     --mf-overlay: oklch(0 0 0);
     --mf-info: oklch(0.714 0.143 255);
     --mf-ring: var(--mf-accent);
+
+    /* Tag palette */
+    --mf-tag-blue: oklch(0.65 0.18 250);
+    --mf-tag-red: oklch(0.65 0.22 25);
+    --mf-tag-purple: oklch(0.65 0.22 305);
+    --mf-tag-violet: oklch(0.62 0.20 285);
+    --mf-tag-amber: oklch(0.78 0.16 75);
+    --mf-tag-teal: oklch(0.70 0.15 185);
+    --mf-tag-cyan: oklch(0.75 0.13 215);
+    --mf-tag-green: oklch(0.72 0.19 150);
+    --mf-tag-pink: oklch(0.72 0.18 350);
+    --mf-tag-orange: oklch(0.72 0.18 50);
 
     /* Spacing */
     --mf-gap-panel: 4px;

--- a/packages/desktop/src/renderer/lib/api/index.ts
+++ b/packages/desktop/src/renderer/lib/api/index.ts
@@ -98,3 +98,5 @@ export {
   attachWorktree,
   deleteWorktree,
 } from './worktree-api';
+
+export { listTags, createTag, updateTag, deleteTag, getChatTags, setChatTags } from './tags-api';

--- a/packages/desktop/src/renderer/lib/api/tags-api.ts
+++ b/packages/desktop/src/renderer/lib/api/tags-api.ts
@@ -1,0 +1,67 @@
+import type { Tag, TagColor } from '@qlan-ro/mainframe-types';
+import { API_BASE } from './http';
+import { createLogger } from '../logger';
+
+const log = createLogger('renderer:api');
+
+export async function listTags(): Promise<Tag[]> {
+  const res = await fetch(`${API_BASE}/api/tags`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+
+export async function createTag(name: string, color?: TagColor): Promise<Tag> {
+  log.info('createTag', { name, color });
+  const res = await fetch(`${API_BASE}/api/tags`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, color }),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()).data;
+}
+
+export async function updateTag(name: string, patch: { rename?: string; color?: TagColor }): Promise<Tag> {
+  log.info('updateTag', { name, patch });
+  const res = await fetch(`${API_BASE}/api/tags/${encodeURIComponent(name)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()).data;
+}
+
+export async function deleteTag(name: string): Promise<void> {
+  log.info('deleteTag', { name });
+  const res = await fetch(`${API_BASE}/api/tags/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+export async function getChatTags(chatId: string): Promise<string[]> {
+  const res = await fetch(`${API_BASE}/api/chats/${chatId}/tags`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()).data;
+}
+
+export async function setChatTags(chatId: string, tags: string[]): Promise<string[]> {
+  log.info('setChatTags', { chatId, tags });
+  const res = await fetch(`${API_BASE}/api/chats/${chatId}/tags`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tags }),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(json.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()).data;
+}

--- a/packages/desktop/src/renderer/store/tags.test.ts
+++ b/packages/desktop/src/renderer/store/tags.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTagsStore } from './tags';
+
+vi.mock('../lib/api/tags-api', () => ({
+  listTags: vi.fn().mockResolvedValue([{ name: 'feature', color: 'blue', createdAt: 'x' }]),
+  setChatTags: vi.fn().mockResolvedValue(['feature']),
+  createTag: vi.fn(),
+  deleteTag: vi.fn(),
+  updateTag: vi.fn(),
+  getChatTags: vi.fn(),
+}));
+
+describe('tags store', () => {
+  beforeEach(() => {
+    useTagsStore.setState({
+      registry: [],
+      registryLoaded: false,
+      selectedTags: new Set(),
+      selectedSynthetic: new Set(),
+      selectedProject: null,
+    });
+  });
+
+  it('refreshRegistry hydrates the registry', async () => {
+    await useTagsStore.getState().refreshRegistry();
+    expect(useTagsStore.getState().registry.map((t) => t.name)).toEqual(['feature']);
+    expect(useTagsStore.getState().registryLoaded).toBe(true);
+  });
+
+  it('toggleTag adds and removes from selectedTags', () => {
+    useTagsStore.getState().toggleTag('feature');
+    expect(useTagsStore.getState().selectedTags.has('feature')).toBe(true);
+    useTagsStore.getState().toggleTag('feature');
+    expect(useTagsStore.getState().selectedTags.has('feature')).toBe(false);
+  });
+
+  it('toggleSynthetic adds and removes from selectedSynthetic', () => {
+    useTagsStore.getState().toggleSynthetic('has-pr');
+    expect(useTagsStore.getState().selectedSynthetic.has('has-pr')).toBe(true);
+    useTagsStore.getState().toggleSynthetic('has-pr');
+    expect(useTagsStore.getState().selectedSynthetic.has('has-pr')).toBe(false);
+  });
+
+  it('setSelectedProject updates project filter', () => {
+    useTagsStore.getState().setSelectedProject('p1');
+    expect(useTagsStore.getState().selectedProject).toBe('p1');
+    useTagsStore.getState().setSelectedProject(null);
+    expect(useTagsStore.getState().selectedProject).toBeNull();
+  });
+
+  it('clearFilters resets selection but not registry', async () => {
+    await useTagsStore.getState().refreshRegistry();
+    useTagsStore.getState().toggleTag('feature');
+    useTagsStore.getState().toggleSynthetic('has-pr');
+    useTagsStore.getState().setSelectedProject('p1');
+    useTagsStore.getState().clearFilters();
+    const s = useTagsStore.getState();
+    expect(s.selectedTags.size).toBe(0);
+    expect(s.selectedSynthetic.size).toBe(0);
+    expect(s.selectedProject).toBeNull();
+    expect(s.registry.length).toBeGreaterThan(0);
+  });
+
+  it('applyToChat calls setChatTags and refreshes registry', async () => {
+    const api = await import('../lib/api/tags-api');
+    await useTagsStore.getState().applyToChat('c1', ['feature']);
+    expect(api.setChatTags).toHaveBeenCalledWith('c1', ['feature']);
+    expect(api.listTags).toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/renderer/store/tags.ts
+++ b/packages/desktop/src/renderer/store/tags.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import type { Tag, SyntheticTag } from '@qlan-ro/mainframe-types';
+import { listTags, setChatTags as apiSetChatTags } from '../lib/api/tags-api';
+import { createLogger } from '../lib/logger';
+
+const log = createLogger('store:tags');
+
+interface TagsState {
+  registry: Tag[];
+  registryLoaded: boolean;
+
+  selectedProject: string | null; // null = "All"
+  selectedTags: Set<string>;
+  selectedSynthetic: Set<SyntheticTag>;
+
+  refreshRegistry: () => Promise<void>;
+  toggleTag: (name: string) => void;
+  toggleSynthetic: (name: SyntheticTag) => void;
+  setSelectedProject: (id: string | null) => void;
+  clearFilters: () => void;
+
+  applyToChat: (chatId: string, tags: string[]) => Promise<void>;
+}
+
+export const useTagsStore = create<TagsState>((set, get) => ({
+  registry: [],
+  registryLoaded: false,
+  selectedProject: null,
+  selectedTags: new Set(),
+  selectedSynthetic: new Set(),
+
+  async refreshRegistry() {
+    try {
+      const registry = await listTags();
+      set({ registry, registryLoaded: true });
+    } catch (err) {
+      log.warn('refreshRegistry failed', { err: String(err) });
+    }
+  },
+
+  toggleTag(name: string) {
+    const next = new Set(get().selectedTags);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    set({ selectedTags: next });
+  },
+
+  toggleSynthetic(name: SyntheticTag) {
+    const next = new Set(get().selectedSynthetic);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    set({ selectedSynthetic: next });
+  },
+
+  setSelectedProject(id: string | null) {
+    set({ selectedProject: id });
+  },
+
+  clearFilters() {
+    set({
+      selectedTags: new Set(),
+      selectedSynthetic: new Set(),
+      selectedProject: null,
+    });
+  },
+
+  async applyToChat(chatId: string, tags: string[]) {
+    try {
+      await apiSetChatTags(chatId, tags);
+      await get().refreshRegistry();
+    } catch (err) {
+      log.warn('applyToChat failed', { err: String(err) });
+      throw err;
+    }
+  },
+}));

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,11 +28,14 @@
     "prepublishOnly": "pnpm run build",
     "clean": "rm -rf dist",
     "dev": "tsc --watch",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "pino": "^10.3.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/types/src/__tests__/tags.test.ts
+++ b/packages/types/src/__tests__/tags.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { TAG_PALETTE, RESERVED_TAG_PREFIX, SYNTHETIC_TAGS } from '../tags.js';
+
+describe('tag constants', () => {
+  it('TAG_PALETTE is non-empty and immutable', () => {
+    expect(TAG_PALETTE.length).toBeGreaterThan(0);
+    expect(Object.isFrozen(TAG_PALETTE)).toBe(true);
+  });
+  it('RESERVED_TAG_PREFIX is "has-"', () => {
+    expect(RESERVED_TAG_PREFIX).toBe('has-');
+  });
+  it('SYNTHETIC_TAGS contains has-pr and has-worktree only', () => {
+    expect([...SYNTHETIC_TAGS].sort()).toEqual(['has-pr', 'has-worktree']);
+  });
+});

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -40,6 +40,8 @@ export interface Chat {
   effort?: ChatEffort;
   /** PRs detected in the session's tool_results (created via `gh pr create` or merely mentioned). */
   detectedPrs?: DetectedPr[];
+  /** User-source tags applied to this chat. Synthetic chips (has-pr, has-worktree) are NOT included. */
+  tags?: string[];
 }
 
 export interface Project {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapter.js';
+export * from './tags.js';
 export * from './device.js';
 export * from './chat.js';
 export * from './display.js';

--- a/packages/types/src/tags.ts
+++ b/packages/types/src/tags.ts
@@ -13,7 +13,8 @@ export const TAG_PALETTE = Object.freeze([
 export type TagColor = (typeof TAG_PALETTE)[number];
 
 /** Used for synthetic chips in the filter bar — outside the user palette so it signals "system" visually. */
-export const SYNTHETIC_TAG_COLOR: TagColor | 'gray' = 'gray';
+export const SYNTHETIC_TAG_COLOR = 'gray' as const;
+export type SyntheticTagColor = typeof SYNTHETIC_TAG_COLOR;
 export const RESERVED_TAG_PREFIX = 'has-';
 
 export const SYNTHETIC_TAGS = Object.freeze(['has-pr', 'has-worktree'] as const);

--- a/packages/types/src/tags.ts
+++ b/packages/types/src/tags.ts
@@ -1,0 +1,26 @@
+export const TAG_PALETTE = Object.freeze([
+  'blue',
+  'red',
+  'purple',
+  'violet',
+  'amber',
+  'teal',
+  'cyan',
+  'green',
+  'pink',
+  'orange',
+] as const);
+export type TagColor = (typeof TAG_PALETTE)[number];
+
+/** Used for synthetic chips in the filter bar — outside the user palette so it signals "system" visually. */
+export const SYNTHETIC_TAG_COLOR: TagColor | 'gray' = 'gray';
+export const RESERVED_TAG_PREFIX = 'has-';
+
+export const SYNTHETIC_TAGS = Object.freeze(['has-pr', 'has-worktree'] as const);
+export type SyntheticTag = (typeof SYNTHETIC_TAGS)[number];
+
+export interface Tag {
+  name: string;
+  color: TagColor;
+  createdAt: string;
+}

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 


### PR DESCRIPTION
## Summary

Adds user-defined tags on session rows + a synthetic-chip filter bar for `has-pr` / `has-worktree`. Closes #64.

- New `tags` + `chat_tags` SQLite tables (additive migration; cascade on chat delete, cascade on tag rename).
- `TagsRepository` (registry CRUD with idempotent upsert + atomic merge-on-rename) and `ChatTagsRepository` (associations + AND-intersect filter, archived-excluded `listInUse`).
- HTTP routes: `GET/POST /api/tags`, `PATCH/DELETE /api/tags/:name`, `GET/PUT /api/chats/:id/tags`. Extended `GET /api/chats?project=&tags=&synthetic=` with strict-AND filtering. Tag value Zod refinement enforces `^[a-z0-9-]+$`.
- Frontend: `tags-api` client, Zustand `tags` store (registry + selection state), `TagPill`, `TagPopover` (search + create + right-click Rename/Recolor/Delete), `SessionFilterBar` (tag chips + synthetic chips), `Tags...` item in row right-click menu.
- `FlatSessionRow` refactor: worktree pill + PR badge in title row, `<adapter> · <tags>` always-visible metadata row below.
- Worktree pill flicker fix: stable measurement on the row container instead of the title (which changed width when the pill toggled). Hysteresis prevents boundary jitter.
- Replaced `ProjectGroup`'s inline `ChatRow` with `FlatSessionRow` so the new tag UI works in both grouped and flat views (-316 lines of duplication).
- Worktree icon unified: `FolderGit` (used by the statusbar) now also in the session-row pill, matching the composer.

Design: `docs/superpowers/specs/2026-05-05-session-row-tagging-design.md`
Plan: `docs/superpowers/plans/2026-05-05-session-row-tagging.md`

## Test plan

- [x] All package tests pass (types 3, core 1324, desktop 597 — 1924 total)
- [x] Full monorepo build clean
- [ ] Right-click session row → `Tags...` opens popover; create + apply works
- [ ] Click tag row of a session opens popover; empty session shows `+ tag` ghost on hover
- [ ] Filter bar tag chips + `has-pr` + `has-worktree` strict-AND
- [ ] "No sessions match these filters" + Clear button when filters yield empty
- [ ] Worktree pill in title row, PR badge after it; metadata row shows adapter · tags always
- [ ] Resize sessions panel narrower — worktree pill hides cleanly without flickering
- [ ] Right-click registry row in popover → Rename / Change color / Delete from all sessions
- [ ] Reload app → filter selection clears, registry persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)