### PR TITLE
fix(desktop): codex review fixes for Check for Updates menu

### DIFF
--- a/.changeset/check-for-updates-codex-review.md
+++ b/.changeset/check-for-updates-codex-review.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix four issues in the Check-for-Updates menu shipped in v0.18.0: the View-menu devtools filter was case-sensitive and didn't strip the item at runtime; existing submenu items lost their `type: 'separator'`, `click` handlers, and other properties when rebuilt; and the manual-check in-flight flag could leak permanently if `electron-updater` resolved without firing a terminal event. The filter is now case-insensitive, submenu items are passed through losslessly, and a 60-second watchdog clears the flag.

--- a/packages/desktop/src/main/auto-updater.test.ts
+++ b/packages/desktop/src/main/auto-updater.test.ts
@@ -103,6 +103,20 @@ describe('auto-updater manual check', () => {
     expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
+  it('watchdog clears in-flight flag if no terminal event fires within 60s', async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import('./auto-updater.js');
+      mod.initAutoUpdater(mockWindow);
+      await mod.checkForUpdatesManual(mockWindow);
+      expect(mod.isManualCheckInFlight()).toBe(true);
+      vi.advanceTimersByTime(60_000);
+      expect(mod.isManualCheckInFlight()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('checkForUpdatesManual is a no-op in development mode', async () => {
     process.env.NODE_ENV = 'development';
     const mod = await import('./auto-updater.js');

--- a/packages/desktop/src/main/auto-updater.ts
+++ b/packages/desktop/src/main/auto-updater.ts
@@ -16,6 +16,9 @@ export type UpdateStatus =
 
 let manualCheckInFlight = false;
 let manualCheckWindow: BrowserWindow | null = null;
+let manualCheckTimeout: NodeJS.Timeout | null = null;
+
+const MANUAL_CHECK_TIMEOUT_MS = 60_000;
 
 export function isManualCheckInFlight(): boolean {
   return manualCheckInFlight;
@@ -24,6 +27,10 @@ export function isManualCheckInFlight(): boolean {
 function clearManualFlag(): void {
   manualCheckInFlight = false;
   manualCheckWindow = null;
+  if (manualCheckTimeout) {
+    clearTimeout(manualCheckTimeout);
+    manualCheckTimeout = null;
+  }
 }
 
 function showUpToDateDialog(window: BrowserWindow): void {
@@ -139,6 +146,13 @@ export async function checkForUpdatesManual(window: BrowserWindow): Promise<void
   }
   manualCheckInFlight = true;
   manualCheckWindow = window;
+  // Watchdog: if checkForUpdates() resolves null (e.g. updater disabled or
+  // another check already in progress) and no terminal event fires, the flag
+  // would otherwise leak forever and break every subsequent click.
+  manualCheckTimeout = setTimeout(() => {
+    log.warn('manual update check timed out without a terminal event; clearing flag');
+    clearManualFlag();
+  }, MANUAL_CHECK_TIMEOUT_MS);
   try {
     await autoUpdater.checkForUpdates();
   } catch (err: unknown) {

--- a/packages/desktop/src/main/menu.ts
+++ b/packages/desktop/src/main/menu.ts
@@ -24,23 +24,25 @@ export function buildApplicationMenu(getWindow: () => BrowserWindow | null): voi
 
   const newItems = menu.items.map((topItem): Electron.MenuItemConstructorOptions | Electron.MenuItem => {
     if (topItem.label === 'View' && topItem.submenu && isProduction) {
+      // Pass live MenuItem instances through; buildFromTemplate accepts MenuItem
+      // at every nesting level, so we preserve type/click/submenu/etc. losslessly.
+      // Electron normalizes role to lowercase at runtime, so we compare case-insensitively.
       return {
         label: 'View',
-        submenu: topItem.submenu.items
-          .filter((sub) => sub.role !== 'toggleDevTools')
-          .map((sub) => ({ role: sub.role, label: sub.label, accelerator: sub.accelerator ?? undefined })),
+        submenu: topItem.submenu.items.filter(
+          (sub) => (sub.role ?? '').toLowerCase() !== 'toggledevtools',
+        ) as unknown as Electron.MenuItemConstructorOptions[],
       };
     }
     if (topItem.role === 'help' && topItem.submenu) {
-      const helpSubmenu = topItem.submenu.items.map((sub) => ({
-        role: sub.role,
-        label: sub.label,
-        accelerator: sub.accelerator ?? undefined,
-      }));
       return {
         label: topItem.label || 'Help',
         role: 'help' as const,
-        submenu: [checkForUpdatesItem, { type: 'separator' as const }, ...helpSubmenu],
+        submenu: [
+          checkForUpdatesItem,
+          { type: 'separator' as const },
+          ...topItem.submenu.items,
+        ] as unknown as Electron.MenuItemConstructorOptions[],
       };
     }
     return topItem;


### PR DESCRIPTION
## Summary

Follow-up fixes for the Check-for-Updates menu shipped in #299 / v0.18.0. Codex review (run after #299 merged) flagged four real issues that this PR addresses:

- **`menu.ts` — case-sensitive devtools filter.** The filter compared `sub.role !== 'toggleDevTools'` but Electron normalizes the role on the default menu. Devtools wasn't actually being stripped in production. Now case-insensitive: `(sub.role ?? '').toLowerCase() !== 'toggledevtools'`.
- **`menu.ts` — submenu items destroyed by property-stripping rebuild.** Existing submenu items were being remapped to `{ role, label, accelerator }`, which dropped `type: 'separator'`, `click` handlers, `enabled`, etc. Separators became blank menu items; built-in Help links were inert. Fix: pass live `MenuItem` instances through `Menu.buildFromTemplate` (it accepts them at every nesting level), losslessly preserving everything.
- **`auto-updater.ts` — in-flight flag leak.** `autoUpdater.checkForUpdates()` can resolve `null` without firing a terminal event (e.g., when the updater is inactive). The previous code left `manualCheckInFlight` permanently set, silently no-op'ing every later manual check. Added a 60s watchdog that clears the flag if no terminal event fires.
- **`auto-updater.test.ts` — new test** covering the watchdog using `vi.useFakeTimers()` / `vi.advanceTimersByTime(60_000)`.

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-desktop test src/main/auto-updater.test.ts` — 8/8 passing
- [x] `npx tsc --noEmit -p tsconfig.node.json` — clean
- [ ] Manual: production build → confirm "Toggle Developer Tools" is gone from View menu
- [ ] Manual: production build → confirm Help submenu separators render correctly
- [ ] Manual: trigger a stuck update check → confirm flag clears after 60s and a fresh click works

🤖 Generated with [Claude Code](https://claude.com/claude-code)