### PR TITLE
feat(desktop): redesign session row + fix stale tags on resume

### DIFF
--- a/.changeset/session-row-pr-pill.md
+++ b/.changeset/session-row-pr-pill.md
@@ -1,0 +1,13 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Session row redesign: PR pill, accent worktree pill, dynamic tag overflow, and stale-tag fix
+
+- New PR pill in session row matches the chat header `PrBadge` styling and links to the detected PR.
+- Worktree pill uses the accent colour for clearer visual distinction from user tags.
+- Tags share the title row with smart capping: title trims at 50% only when tags need the space, otherwise tags expand into the available width with a `+N` overflow that opens the tag popover.
+- Status dot is now vertically centred against the entire row (title + metadata).
+- Time column stacks day-label and time on two lines and uses short weekdays.
+- Daemon: `PUT /api/chats/:id/tags` now syncs the in-memory active chat so a subsequent `chat.updated` emission (e.g. from `resumeChat`) no longer broadcasts stale tags and clobber the renderer store.

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -479,6 +479,17 @@ export class ChatManager {
     return this.enrichChat(chat);
   }
 
+  /**
+   * Sync the in-memory tags of a cached active chat. The tags route persists
+   * to the DB, but `activeChats[id].chat.tags` would otherwise stay stale and
+   * a later `chat.updated` emission (e.g. from resumeChat) would broadcast the
+   * old tags and clobber the renderer's store.
+   */
+  syncChatTags(chatId: string, tags: string[]): void {
+    const active = this.activeChats.get(chatId);
+    if (active) active.chat.tags = tags;
+  }
+
   getEffectivePath(chatId: string): string | null {
     const chat = this.getChat(chatId);
     if (!chat) return null;

--- a/packages/core/src/server/routes/tags.ts
+++ b/packages/core/src/server/routes/tags.ts
@@ -85,7 +85,9 @@ export function tagRoutes(ctx: RouteContext): Router {
     const chatId = param(req, 'id');
     try {
       ctx.db.chatTags.setForChat(chatId, parsed.data.tags, ctx.db.tags);
-      res.json({ success: true, data: ctx.db.chatTags.listForChat(chatId) });
+      const persisted = ctx.db.chatTags.listForChat(chatId);
+      ctx.chats.syncChatTags(chatId, persisted);
+      res.json({ success: true, data: persisted });
     } catch (err) {
       logger.warn({ err, chatId }, 'set chat tags failed');
       res.status(400).json({ success: false, error: String((err as Error).message) });

--- a/packages/core/src/server/routes/tags.ts
+++ b/packages/core/src/server/routes/tags.ts
@@ -86,7 +86,7 @@ export function tagRoutes(ctx: RouteContext): Router {
     try {
       ctx.db.chatTags.setForChat(chatId, parsed.data.tags, ctx.db.tags);
       const persisted = ctx.db.chatTags.listForChat(chatId);
-      ctx.chats.syncChatTags(chatId, persisted);
+      ctx.chats?.syncChatTags?.(chatId, persisted);
       res.json({ success: true, data: persisted });
     } catch (err) {
       logger.warn({ err, chatId }, 'set chat tags failed');

--- a/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
+++ b/packages/desktop/src/__tests__/components/ProjectGroupHeader.test.tsx
@@ -159,7 +159,7 @@ describe('ProjectGroup header layout', () => {
     expect(screen.queryByText('+ tag')).not.toBeInTheDocument();
   });
 
-  it('shows the adapter label before tags on the session row metadata line', () => {
+  it('renders the adapter label on the metadata sub-row and tags inline with the title', () => {
     render(
       <TooltipProvider>
         <ProjectGroup
@@ -171,12 +171,14 @@ describe('ProjectGroup header layout', () => {
       </TooltipProvider>,
     );
 
-    expect(screen.getByText('Claude CLI')).toBeInTheDocument();
-    expect(screen.getByText('frontend')).toBeInTheDocument();
-    expect(screen.getByText('·')).toBeInTheDocument();
+    const metadataRow = screen.getByTestId('session-row-metadata');
+    const tagsRow = screen.getByTestId('session-row-tags');
+
+    expect(metadataRow).toHaveTextContent('Claude CLI');
+    expect(tagsRow).toHaveTextContent('frontend');
   });
 
-  it('pushes the worktree pill to the right while allowing the title to use available space', () => {
+  it('places the worktree pill on the metadata sub-row and lets the title row carry tags', () => {
     render(
       <TooltipProvider>
         <ProjectGroup
@@ -189,64 +191,28 @@ describe('ProjectGroup header layout', () => {
     );
 
     const title = screen.getByText('A very long session title');
-    const worktree = screen.getByText('feat-tags');
-    const pill = worktree.parentElement;
-
-    expect(title.parentElement).toBe(pill?.closest('button'));
-    expect(title.className).toContain('flex-1');
-    expect(title.className).not.toContain('max-w-[50%]');
-    expect(pill?.className).toContain('ml-auto');
-    expect(pill?.className).toContain('rounded-full');
-    expect(pill?.className).toContain('px-2.5');
-    expect(pill?.className).toContain('bg-mf-hover');
-    expect(pill?.className).toContain('text-mf-text-secondary');
-    expect(title.parentElement?.parentElement?.className).toContain('grid-cols-[12px_minmax(0,1fr)]');
-  });
-
-  it('hides the worktree pill when the available title width drops below the threshold', async () => {
-    // The row container is narrow enough that, after subtracting the status dot,
-    // gaps, and the pill's natural width, the title would have <56px (the hysteresis
-    // hide threshold). Specifically: 200 - 28 - 120 = 52 < 56.
-    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement): number {
-      return this.dataset.testid === 'session-title-row' ? 200 : 0;
-    });
-    vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement): number {
-      return this.dataset.testid === 'worktree-pill' ? 120 : 0;
-    });
-
-    render(
-      <TooltipProvider>
-        <ProjectGroup
-          project={mockProject}
-          chats={[{ ...mockChat, worktreePath: '/repo/.worktrees/feat-tags' }]}
-          collapsed={false}
-          onToggleCollapse={vi.fn()}
-        />
-      </TooltipProvider>,
-    );
-
-    for (const callback of resizeObserverCallbacks) {
-      callback([], {} as ResizeObserver);
-    }
-
     const pill = screen.getByTestId('worktree-pill');
-    expect(pill.className).toContain('opacity-0');
-    expect(pill).toHaveAttribute('aria-hidden', 'true');
+    const metadataRow = screen.getByTestId('session-row-metadata');
+    const titleRow = screen.getByTestId('session-title-row');
+
+    expect(metadataRow).toContainElement(pill);
+    expect(titleRow).toContainElement(title);
+    expect(pill.className).toContain('rounded');
+    expect(pill.className).toContain('bg-mf-accent');
+    expect(pill.className).toContain('text-white');
   });
 
   it('keeps the right-side time and hover actions in a centered area outside content rows', () => {
     renderGroup();
 
     const time = screen.getByText('Jan 1, 2024');
-    const slot = time.parentElement;
+    const slot = time.closest('div');
     const metadataRow = screen.getByTestId('session-row-metadata');
     const actionsArea = screen.getByTestId('session-row-actions');
 
-    expect(slot?.className).toContain('w-[104px]');
-    expect(slot?.className).toContain('h-6');
+    expect(slot?.className).toContain('w-[72px]');
     expect(slot?.className).toContain('shrink-0');
     expect(slot?.className).toContain('justify-end');
-    expect(time.className).toContain('whitespace-nowrap');
     expect(actionsArea.className).toContain('self-center');
     expect(actionsArea).toContainElement(slot);
     expect(metadataRow).not.toContainElement(slot);

--- a/packages/desktop/src/renderer/components/chat/PrBadge.tsx
+++ b/packages/desktop/src/renderer/components/chat/PrBadge.tsx
@@ -30,11 +30,7 @@ export function PrBadge({ chatId }: PrBadgeProps): React.ReactElement | null {
             <button
               type="button"
               onClick={() => openUrl(pr.url)}
-              className={
-                pr.source === 'created'
-                  ? 'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a7f37] text-white hover:bg-[#2ea043] transition-colors'
-                  : 'flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-mf-text-secondary opacity-40 text-white hover:opacity-60 transition-colors'
-              }
+              className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a7f37] text-white hover:bg-[#2ea043] transition-colors"
               aria-label={`Open PR #${pr.number} in ${pr.owner}/${pr.repo}`}
             >
               <GitPullRequest size={10} className="shrink-0" />

--- a/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
+++ b/packages/desktop/src/renderer/components/panels/ChatsPanel.tsx
@@ -585,7 +585,7 @@ export function ChatsPanel(): React.ReactElement {
       <SessionFilterBar />
 
       {/* Session list */}
-      <div className="flex-1 overflow-y-auto px-[10px]">
+      <div className="flex-1 overflow-y-auto px-[10px] py-2">
         {projects.length === 0 ? (
           <div className="py-4 text-center text-mf-text-secondary text-mf-label">No projects yet.</div>
         ) : chats.length === 0 && (selectedTags.size > 0 || selectedSynthetic.size > 0) ? (

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Archive, FolderGit, GitPullRequest, Loader2, Pencil, Pin, Tag as TagIcon } from 'lucide-react';
 import type { Chat } from '@qlan-ro/mainframe-types';
 import { useChatsStore } from '../../store';
@@ -17,21 +17,22 @@ import { TagPopover } from '../tags/TagPopover';
 
 const log = createLogger('renderer:flat-session-row');
 
-function formatRelativeTime(isoString: string): string {
+function formatRelativeTime(isoString: string): { primary: string; secondary?: string } {
   const date = new Date(isoString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
   const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-  if (date.toDateString() === now.toDateString()) return `Today ${time}`;
+  if (date.toDateString() === now.toDateString()) return { primary: 'Today', secondary: time };
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return `Yesterday ${time}`;
-  if (diffDays < 7) return `${date.toLocaleDateString([], { weekday: 'long' })} ${time}`;
-  if (diffDays < 14) return 'Last week';
-  if (date.getFullYear() === now.getFullYear()) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+  if (date.toDateString() === yesterday.toDateString()) return { primary: 'Yesterday', secondary: time };
+  if (diffDays < 7) return { primary: date.toLocaleDateString([], { weekday: 'short' }), secondary: time };
+  if (diffDays < 14) return { primary: 'Last week' };
+  if (date.getFullYear() === now.getFullYear())
+    return { primary: date.toLocaleDateString([], { month: 'short', day: 'numeric' }) };
+  return { primary: date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' }) };
 }
 
 interface FlatSessionRowProps {
@@ -148,9 +149,15 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const updateChat = useChatsStore((s) => s.updateChat);
   const unreadChatIds = useChatsStore((s) => s.unreadChatIds);
   const isUnread = unreadChatIds.has(chat.id);
-  const createdPrUrl = useChatsStore((s) => {
+  const prUrl = useChatsStore((s) => {
     const prs = s.detectedPrs.get(chat.id);
-    return prs?.find((p) => p.source === 'created')?.url ?? null;
+    if (!prs || prs.length === 0) return null;
+    return (prs.find((p) => p.source === 'created') ?? prs[0])?.url ?? null;
+  });
+  const prNumber = useChatsStore((s) => {
+    const prs = s.detectedPrs.get(chat.id);
+    if (!prs || prs.length === 0) return null;
+    return (prs.find((p) => p.source === 'created') ?? prs[0])?.number ?? null;
   });
 
   const handleCommitRename = useCallback(() => {
@@ -193,50 +200,31 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
   const hasTags = tagNames.length > 0;
   const adapterLabel = getAdapterLabel(chat.adapterId, adapters);
   const worktreeName = chat.worktreePath?.split('/').pop();
-  const worktreePillRef = useRef<HTMLSpanElement>(null);
-  const titleRowRef = useRef<HTMLDivElement>(null);
-  const [hideWorktreePill, setHideWorktreePill] = useState(false);
 
-  useEffect(() => {
-    if (!worktreeName || editing) {
-      setHideWorktreePill(false);
-      return;
+  // Tag row gets a full-width dedicated row. If pills overflow, hide trailing
+  // ones and render a +N overflow pill that opens the existing TagPopover.
+  const tagRowRef = useRef<HTMLDivElement>(null);
+  const [visibleTagCount, setVisibleTagCount] = useState(tagNames.length);
+
+  useLayoutEffect(() => {
+    setVisibleTagCount(tagNames.length);
+  }, [tagNames.length]);
+
+  useLayoutEffect(() => {
+    const el = tagRowRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => setVisibleTagCount(tagNames.length));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [tagNames.length]);
+
+  useLayoutEffect(() => {
+    const el = tagRowRef.current;
+    if (!el) return;
+    if (el.scrollWidth > el.clientWidth + 1 && visibleTagCount > 0) {
+      setVisibleTagCount((c) => c - 1);
     }
-
-    // Only observe the row container — its width is independent of pill visibility,
-    // which avoids the show/hide feedback loop. The pill's own width is content-driven
-    // (depends on `worktreeName` length, capped at 140px) and stable per render.
-    const STATUS_DOT_AND_GAPS = 28; // 12px dot + ~16px of grid gap + flex gaps
-    const MIN_TITLE_WIDTH = 80; // titles below this are uncomfortable to read
-    const HYSTERESIS_BUFFER = 24; // larger than typical sub-pixel resize jitter
-
-    const update = (): void => {
-      const container = titleRowRef.current;
-      const pill = worktreePillRef.current;
-      if (!container || !pill) return;
-      const containerWidth = container.clientWidth;
-      // scrollWidth gives the pill's natural rendered width even when hidden via opacity.
-      const pillWidth = pill.scrollWidth;
-      if (containerWidth === 0 || pillWidth === 0) return;
-      const availableForTitle = containerWidth - STATUS_DOT_AND_GAPS - pillWidth;
-      setHideWorktreePill((wasHidden) => {
-        const showThreshold = MIN_TITLE_WIDTH;
-        const hideThreshold = MIN_TITLE_WIDTH - HYSTERESIS_BUFFER;
-        return wasHidden ? availableForTitle < showThreshold : availableForTitle < hideThreshold;
-      });
-    };
-
-    update();
-
-    if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', update);
-      return () => window.removeEventListener('resize', update);
-    }
-
-    const observer = new ResizeObserver(update);
-    if (titleRowRef.current) observer.observe(titleRowRef.current);
-    return () => observer.disconnect();
-  }, [editing, worktreeName]);
+  });
 
   return (
     <div
@@ -248,32 +236,28 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
         isActive ? 'bg-mf-hover' : 'hover:bg-mf-hover',
       )}
     >
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5">
-        <div className="min-w-0">
-          <div
-            ref={titleRowRef}
-            data-testid="session-title-row"
-            className="grid grid-cols-[12px_minmax(0,1fr)] items-center gap-2"
-          >
-            {/* status dot */}
-            <div className="w-3 h-3 shrink-0 flex items-center justify-center">
-              {chat.worktreeMissing ? (
-                <div className="w-2 h-2 rounded-full bg-mf-destructive" />
-              ) : isWorking ? (
-                <Loader2 size={12} className="text-mf-accent animate-spin" />
-              ) : (
-                <div
-                  className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary')}
-                  style={!isUnread ? { opacity: 0.4 } : undefined}
-                />
-              )}
-            </div>
+      <div className="grid grid-cols-[12px_minmax(0,1fr)_auto] items-center gap-2 px-3 py-1.5">
+        {/* status dot — vertically centered across title + metadata */}
+        <div className="w-3 h-3 shrink-0 flex items-center justify-center">
+          {chat.worktreeMissing ? (
+            <div className="w-2 h-2 rounded-full bg-mf-destructive" />
+          ) : isWorking ? (
+            <Loader2 size={12} className="text-mf-accent animate-spin" />
+          ) : (
+            <div
+              className={cn('w-2 h-2 rounded-full', isUnread ? 'bg-mf-accent' : 'bg-mf-text-secondary')}
+              style={!isUnread ? { opacity: 0.4 } : undefined}
+            />
+          )}
+        </div>
 
+        <div className="min-w-0 space-y-2">
+          <div data-testid="session-title-row" className="flex items-center min-w-0 gap-2">
             {/* title + select target */}
             <button
               type="button"
               onClick={handleSelect}
-              className="relative flex-1 min-w-0 text-left flex items-center gap-1.5 min-h-[20px]"
+              className={cn('min-w-0 text-left flex items-center gap-1.5 min-h-[20px]', hasTags && 'max-w-[50%]')}
             >
               {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
               {editing ? (
@@ -305,68 +289,90 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
                   </TooltipContent>
                 </Tooltip>
               )}
-
-              {chat.worktreePath && worktreeName && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      ref={worktreePillRef}
-                      data-testid="worktree-pill"
-                      aria-hidden={hideWorktreePill}
-                      className={cn(
-                        'ml-auto shrink-0 inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-mf-hover border border-mf-border text-xs text-mf-text-secondary max-w-[140px] min-w-0',
-                        hideWorktreePill && 'absolute right-0 opacity-0 pointer-events-none',
-                      )}
-                    >
-                      <FolderGit size={10} className="shrink-0 opacity-70" />
-                      <span className="min-w-0 truncate">{worktreeName}</span>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>{chat.worktreePath}</TooltipContent>
-                </Tooltip>
-              )}
             </button>
+
+            {hasTags && (
+              <div
+                ref={tagRowRef}
+                data-testid="session-row-tags"
+                className="flex-1 min-w-0 flex items-center gap-1 overflow-hidden whitespace-nowrap"
+              >
+                {tagNames.slice(0, visibleTagCount).map((name) => (
+                  <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
+                ))}
+                {visibleTagCount < tagNames.length && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        role="button"
+                        onClick={openTagPopover}
+                        className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full border border-mf-border text-xs font-medium cursor-pointer bg-mf-hover text-mf-text-secondary hover:text-mf-text-primary"
+                        aria-label="Show all tags"
+                      >
+                        +{tagNames.length - visibleTagCount}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Show all tags</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            )}
           </div>
 
-          {/* metadata row */}
-          <div data-testid="session-row-metadata" className="grid grid-cols-[12px_minmax(0,1fr)] items-center gap-2">
-            <div className="w-3" />
-            <div className="min-w-0 flex items-center gap-1 flex-wrap">
-              <span className="text-xs text-mf-text-secondary opacity-80">{adapterLabel}</span>
-              {hasTags && <span className="text-xs text-mf-text-secondary opacity-50">·</span>}
-              {tagNames.map((name) => (
-                <TagPill key={name} label={name} color={colorOf(name)} variant="row" />
-              ))}
-            </div>
+          {/* metadata row: adapter + worktree + PR */}
+          <div data-testid="session-row-metadata" className="min-w-0 flex items-center gap-1 flex-wrap">
+            <span className="shrink-0 text-xs font-medium text-mf-text-secondary opacity-80">{adapterLabel}</span>
+
+            {chat.worktreePath && worktreeName && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    data-testid="worktree-pill"
+                    className="shrink-0 inline-flex items-center gap-1 h-[18px] px-1.5 rounded text-[10px] font-medium bg-mf-accent text-white max-w-[180px] min-w-0"
+                  >
+                    <FolderGit size={10} className="shrink-0" />
+                    <span className="min-w-0 truncate">{worktreeName}</span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{chat.worktreePath}</TooltipContent>
+              </Tooltip>
+            )}
+
+            {prUrl && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="button"
+                    data-testid="pr-pill"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      window.open(prUrl, '_blank');
+                    }}
+                    className="shrink-0 inline-flex items-center gap-1 h-[18px] px-1.5 rounded text-[10px] font-medium cursor-pointer transition-colors bg-[#1a7f37] text-white hover:bg-[#2ea043]"
+                    aria-label="Open PR"
+                  >
+                    <GitPullRequest size={10} className="shrink-0" />
+                    <span>#{prNumber}</span>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Open PR</TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </div>
 
         <div data-testid="session-row-actions" className="self-center flex items-center justify-end gap-2 min-w-0">
-          {/* PR badge */}
-          {createdPrUrl && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  role="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    window.open(createdPrUrl, '_blank');
-                  }}
-                  className="shrink-0 text-[#1a7f37] hover:opacity-70 cursor-pointer"
-                  aria-label="Open PR"
-                >
-                  <GitPullRequest size={12} />
+          <div className="w-[72px] h-8 shrink-0 flex items-center justify-end">
+            {/* time — visible when not hovered (stacked: weekday/label on top, time below) */}
+            {(() => {
+              const t = formatRelativeTime(chat.updatedAt);
+              return (
+                <span className="text-xs text-mf-text-secondary tabular-nums whitespace-nowrap leading-tight text-right group-hover:hidden flex flex-col items-end">
+                  <span>{t.primary}</span>
+                  {t.secondary && <span>{t.secondary}</span>}
                 </span>
-              </TooltipTrigger>
-              <TooltipContent>Open PR</TooltipContent>
-            </Tooltip>
-          )}
-
-          <div className="w-[104px] h-6 shrink-0 flex items-center justify-end">
-            {/* time — visible when not hovered */}
-            <span className="text-xs text-mf-text-secondary tabular-nums whitespace-nowrap group-hover:hidden">
-              {formatRelativeTime(chat.updatedAt)}
-            </span>
+              );
+            })()}
 
             {/* hover actions (Tag / Rename / Archive) */}
             <div className={cn('items-center gap-0.5 hidden group-hover:flex', archiving && 'flex')}>

--- a/packages/desktop/src/renderer/components/tags/TagPill.tsx
+++ b/packages/desktop/src/renderer/components/tags/TagPill.tsx
@@ -45,7 +45,10 @@ export function TagPill({ label, color, variant, active, onClick, onContextMenu 
       <span
         onClick={onClick}
         onContextMenu={onContextMenu}
-        className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer', cls)}
+        className={cn(
+          'inline-flex items-center px-2 py-0.5 rounded-full border border-transparent text-xs font-medium cursor-pointer',
+          cls,
+        )}
       >
         {label}
       </span>


### PR DESCRIPTION
## Summary

- **Session row layout**: title shares the row with tags. Title caps at 50% only when tags need the room; otherwise tags expand into available width with a `+N` overflow pill that opens the tag popover. Worktree + PR pills moved to a metadata sub-row with the adapter label. Status dot is now vertically centered against the entire row (title + metadata).
- **Pills**: new PR pill in the row links to the detected PR; worktree pill uses the accent color so it's visually distinct from user tags. Both share the compact `PrBadge` geometry (`rounded`, `text-[10px]`, fixed `h-[18px]` for pixel-equal heights).
- **Time column**: stacks day-label and time on two lines (`Mon` / `1:34 AM`) with short weekday abbreviations, freeing horizontal space.
- **Daemon tag-cache fix**: `PUT /api/chats/:id/tags` now syncs `activeChats[chatId].chat.tags`. Before this, clicking a row triggered `resumeChat` → `chat.updated` → renderer overwrote its store with stale (pre-tag) tags from the cached active chat, which surfaced as "tags disappear on click".

## Test plan

- [x] Open a session with a long title and many tags — title truncates at 50%, tags use the rest with `+N` overflow.
- [x] Open a session with a short title — tags expand into the empty space.
- [x] Tag a session, click another session, click back — tags persist (no longer wiped by `chat.updated`).
- [x] Click `+N` pill — tag popover opens anchored to it.
- [x] Click PR pill — opens the detected PR URL.
- [x] Status dot stays vertically centered as row height changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)