### PR TITLE
feat(desktop): render fullview plugin zone as overlay modal

### DIFF
--- a/.changeset/fullview-as-modal.md
+++ b/.changeset/fullview-as-modal.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Render fullview plugin zone as an overlay modal instead of replacing the center layout.

--- a/docs/superpowers/plans/2026-05-07-fullview-as-modal.md
+++ b/docs/superpowers/plans/2026-05-07-fullview-as-modal.md
@@ -1,0 +1,490 @@
+# Fullview Plugin Zone as Modal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the `'fullview'` plugin zone as an overlay modal (like `ReviewPanel`) instead of taking over the center area of the app.
+
+**Architecture:** Add a new `FullviewModal` component that reads `activeFullviewId` from the existing plugin store and renders the active plugin's component inside a centered overlay card. Mount it at the app root next to `ReviewPanel`. Remove the center-area takeover branch in `Layout.tsx`. Store, registration, and `LeftRail` toggle behavior stay unchanged.
+
+**Tech Stack:** React, TypeScript, Zustand, Tailwind, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-fullview-as-modal-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/desktop/src/renderer/components/modals/FullviewModal.tsx` | **Create** | Overlay modal shell — backdrop, centered card, header (uppercase label + X), body renders `<PluginView />` |
+| `packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx` | **Create** | Vitest integration tests |
+| `packages/desktop/src/renderer/components/modals/index.ts` | **Modify** | Export `FullviewModal` |
+| `packages/desktop/src/renderer/App.tsx` | **Modify** | Mount `<FullviewModal />` next to existing global components |
+| `packages/desktop/src/renderer/components/Layout.tsx` | **Modify** | Remove `activeFullviewId` conditional (lines ~115-119) |
+
+---
+
+## Task 1: Write failing integration tests for `FullviewModal`
+
+**Files:**
+- Test: `packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx`
+
+- [ ] **Step 1: Create the test file**
+
+Create `packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FullviewModal } from './FullviewModal';
+import { usePluginLayoutStore } from '../../store/plugins';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
+
+// PluginView mounts real plugin React trees (TodosPanel etc.) which pull in
+// daemon clients and other heavy modules. The modal's behaviour is what we
+// test here — plugin rendering is covered elsewhere.
+vi.mock('../plugins/PluginView', () => ({
+  PluginView: ({ pluginId }: { pluginId: string }) => (
+    <div data-testid="plugin-view">{pluginId}</div>
+  ),
+}));
+
+function makeContribution(pluginId: string, label: string): PluginUIContribution {
+  return {
+    pluginId,
+    panelId: 'panel-1',
+    zone: 'fullview',
+    label,
+    icon: undefined,
+  };
+}
+
+function resetStore(): void {
+  usePluginLayoutStore.setState({
+    contributions: [],
+    actions: [],
+    triggeredAction: null,
+    activeFullviewId: null,
+  });
+}
+
+describe('FullviewModal Integration', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('renders nothing when no fullview is active', () => {
+    const { container } = render(<FullviewModal />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the plugin and uppercased label when activated', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    expect(screen.getByTestId('plugin-view')).toHaveTextContent('todos');
+
+    const heading = screen.getByText('Todos');
+    expect(heading.className).toMatch(/uppercase/);
+  });
+
+  it('closes when the X button is clicked', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByTestId('fullview-modal-backdrop'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('does not close when clicking inside the card', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByTestId('plugin-view'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBe('todos');
+  });
+
+  it('closes when Escape is pressed', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('falls back to pluginId in header when no contribution label is found', () => {
+    usePluginLayoutStore.setState({
+      contributions: [],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+    expect(screen.getByText('todos')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- FullviewModal.integration`
+Expected: FAIL — module `./FullviewModal` does not exist.
+
+---
+
+## Task 2: Implement `FullviewModal`
+
+**Files:**
+- Create: `packages/desktop/src/renderer/components/modals/FullviewModal.tsx`
+
+- [ ] **Step 1: Create `FullviewModal.tsx`**
+
+Create `packages/desktop/src/renderer/components/modals/FullviewModal.tsx`:
+
+```tsx
+import React, { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '../ui/button';
+import { PluginView } from '../plugins/PluginView';
+import { usePluginLayoutStore } from '../../store/plugins';
+
+export const FullviewModal: React.FC = () => {
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
+  const contributions = usePluginLayoutStore((s) => s.contributions);
+  const activateFullview = usePluginLayoutStore((s) => s.activateFullview);
+
+  const close = (): void => {
+    if (activeFullviewId) {
+      activateFullview(activeFullviewId);
+    }
+  };
+
+  useEffect(() => {
+    if (!activeFullviewId) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFullviewId]);
+
+  if (!activeFullviewId) return null;
+
+  const contribution = contributions.find(
+    (c) => c.pluginId === activeFullviewId && c.zone === 'fullview',
+  );
+  const label = contribution?.label ?? activeFullviewId;
+
+  return (
+    <div
+      data-testid="fullview-modal-backdrop"
+      onClick={close}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-mf-overlay/60"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-5/6 w-5/6 flex-col rounded-lg border border-mf-border bg-mf-app-bg shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-mf-border px-4 py-2">
+          <span className="text-xs font-medium uppercase tracking-wide text-mf-text-secondary">
+            {label}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={close}
+            aria-label="Close"
+            className="hover:bg-mf-hover"
+          >
+            <X size={14} />
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-hidden">
+          <PluginView pluginId={activeFullviewId} />
+        </div>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test -- FullviewModal.integration`
+Expected: PASS — all 7 tests green.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/modals/FullviewModal.tsx \
+        packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx
+git commit -m "feat(desktop): add FullviewModal for plugin fullview zone"
+```
+
+---
+
+## Task 3: Export `FullviewModal` from modals barrel
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/modals/index.ts`
+
+- [ ] **Step 1: Add the export**
+
+Edit `packages/desktop/src/renderer/components/modals/index.ts`. Current content:
+
+```ts
+export { ReviewPanel } from './ReviewPanel';
+export { ReviewPanelHeader } from './ReviewPanelHeader';
+export { FileTree } from './FileTree';
+export { DiffView } from './DiffView';
+```
+
+Add a line so the file becomes:
+
+```ts
+export { ReviewPanel } from './ReviewPanel';
+export { ReviewPanelHeader } from './ReviewPanelHeader';
+export { FileTree } from './FileTree';
+export { DiffView } from './DiffView';
+export { FullviewModal } from './FullviewModal';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/modals/index.ts
+git commit -m "feat(desktop): export FullviewModal from modals barrel"
+```
+
+---
+
+## Task 4: Mount `FullviewModal` in `App.tsx`
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/App.tsx`
+
+- [ ] **Step 1: Import `FullviewModal`**
+
+Edit `packages/desktop/src/renderer/App.tsx`. Locate the import block at the top (lines 1-17). Add this import after the existing component imports (e.g. after line 17):
+
+```ts
+import { FullviewModal } from './components/modals';
+```
+
+- [ ] **Step 2: Render the modal**
+
+Find the JSX returned from `App` (lines 65-77). Insert `<FullviewModal />` inside the `<TooltipProvider>`, after `<Layout … />` and before `<SearchPalette />`. The block becomes:
+
+```tsx
+  return (
+    <ErrorBoundary>
+      <TooltipProvider delayDuration={200} skipDelayDuration={100} disableHoverableContent>
+        <Layout centerPanel={<CenterPanel />} />
+        <FullviewModal />
+        <SearchPalette />
+        <SettingsModal />
+        <TutorialOverlay />
+        <ConnectionOverlay />
+        <Toaster />
+        <PluginGlobalComponents />
+      </TooltipProvider>
+    </ErrorBoundary>
+  );
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop build`
+Expected: no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/desktop/src/renderer/App.tsx
+git commit -m "feat(desktop): mount FullviewModal at app root"
+```
+
+---
+
+## Task 5: Remove fullview branch from `Layout.tsx`
+
+**Files:**
+- Modify: `packages/desktop/src/renderer/components/Layout.tsx` (lines ~84, 115-119)
+
+- [ ] **Step 1: Inspect the current branch**
+
+Read `packages/desktop/src/renderer/components/Layout.tsx`. The relevant section currently looks like:
+
+```tsx
+export function Layout({ centerPanel }: LayoutProps): React.ReactElement {
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
+  // ...
+
+          <div className="flex-1 flex flex-col overflow-hidden pb-mf-gap">
+            {activeFullviewId ? (
+              <div className="flex-1 bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                <PluginView pluginId={activeFullviewId} />
+              </div>
+            ) : (
+              <>
+                {/* Upper area: horizontal Group with left col + center + right col */}
+                <Group orientation="horizontal" className="flex-1">
+                  ...
+                </Group>
+                ...
+              </>
+            )}
+          </div>
+```
+
+- [ ] **Step 2: Delete the `activeFullviewId` line**
+
+Remove this line (currently around line 84):
+
+```tsx
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
+```
+
+- [ ] **Step 3: Unwrap the conditional**
+
+Replace the `{activeFullviewId ? (...) : (<>...</>)}` block with the contents of the false branch (the existing `<Group …>` plus everything after it that was inside the fragment). Keep the wrapping `<div className="flex-1 flex flex-col overflow-hidden pb-mf-gap">`.
+
+After the edit, the section looks like:
+
+```tsx
+          <div className="flex-1 flex flex-col overflow-hidden pb-mf-gap">
+            {/* Upper area: horizontal Group with left col + center + right col */}
+            <Group orientation="horizontal" className="flex-1">
+              ...
+            </Group>
+            ...
+          </div>
+```
+
+- [ ] **Step 4: Remove now-unused imports**
+
+If `PluginView` is no longer referenced anywhere in `Layout.tsx`, delete its import (search the file for `PluginView` to confirm). If `usePluginLayoutStore` is no longer referenced, remove it too. Run:
+
+```bash
+pnpm --filter @qlan-ro/mainframe-desktop exec tsc --noEmit
+```
+
+Expected: no errors. The TS6133 / no-unused-vars rule will surface anything you missed.
+
+- [ ] **Step 5: Smoke-test the UI manually**
+
+Start the dev server (`pnpm dev` from the repo root or whichever script you use locally). Verify:
+
+1. App loads with the normal layout visible.
+2. Click the Todos icon in the LeftRail → modal overlay appears with `TODOS` (uppercase) label and X button. Underlying layout still visible behind the dimmed backdrop.
+3. Click the X → modal closes, layout unchanged.
+4. Re-open, press Escape → modal closes.
+5. Re-open, click backdrop (outside the card) → modal closes.
+6. Re-open, click inside the card / on a TODO → modal stays open.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/desktop/src/renderer/components/Layout.tsx
+git commit -m "refactor(desktop): remove fullview takeover from Layout (now rendered as modal)"
+```
+
+---
+
+## Task 6: Add a changeset
+
+**Files:**
+- Create: `.changeset/fullview-as-modal.md` (filename will differ — `pnpm changeset` generates it)
+
+- [ ] **Step 1: Run `pnpm changeset`**
+
+Run: `pnpm changeset`
+
+Select `@qlan-ro/mainframe-desktop` with bump type **patch** (UI behaviour change, no API surface change).
+
+Summary line:
+```
+Render fullview plugin zone as an overlay modal instead of replacing the center layout.
+```
+
+- [ ] **Step 2: Commit the changeset**
+
+```bash
+git add .changeset/
+git commit -m "chore: changeset for fullview-as-modal"
+```
+
+---
+
+## Task 7: Run full test suite + typecheck
+
+- [ ] **Step 1: Typecheck the workspace**
+
+Run: `pnpm build`
+Expected: all packages build with no TS errors.
+
+- [ ] **Step 2: Run desktop tests**
+
+Run: `pnpm --filter @qlan-ro/mainframe-desktop test`
+Expected: all tests pass, including the new `FullviewModal.integration` suite and the existing `plugins.test.ts` (which is untouched and should still pass — store contract unchanged).
+
+If `plugins.test.ts` references `activeFullviewId` behavior that is intact, no edits are needed. If it fails, re-read the test and reconcile against the unchanged store — do **not** modify the store.
+
+- [ ] **Step 3: If everything is green, you're done.**
+
+The branch should now contain:
+- 1 new component file
+- 1 new test file
+- 4 modified files (`modals/index.ts`, `App.tsx`, `Layout.tsx`, plus the changeset)
+- 5 commits
+
+---
+
+## Self-Review Checklist (already run by author)
+
+- **Spec coverage:** Every section of the spec maps to a task — `FullviewModal` (Task 2), barrel export (Task 3), App mount (Task 4), Layout cleanup (Task 5), tests (Task 1), changeset (Task 6). ✓
+- **Placeholders:** None. Every step contains exact code or commands. ✓
+- **Type consistency:** `activeFullviewId`, `activateFullview`, `contributions`, `PluginUIContribution.label/zone/pluginId/panelId` all match `store/plugins.ts` and `@qlan-ro/mainframe-types`. ✓
+- **Unchanged surfaces:** `LeftRail`, store, `UIZone`, `TodosPanel`, `PluginView` — no changes proposed, matches spec "Unchanged" list. ✓

--- a/docs/superpowers/specs/2026-05-07-fullview-as-modal-design.md
+++ b/docs/superpowers/specs/2026-05-07-fullview-as-modal-design.md
@@ -1,0 +1,86 @@
+# Fullview Plugin Zone as Modal
+
+**Date:** 2026-05-07
+**Status:** Design
+
+## Problem
+
+The `'fullview'` plugin zone currently takes over the entire center area of the app: when a user clicks the todos icon in the LeftRail, `Layout.tsx` swaps the normal panel layout for `<PluginView pluginId={activeFullviewId} />`. This loses the user's surrounding context (chat panels, side zones, etc.) and feels heavier than warranted.
+
+We want the same activation surface and store mechanism, but render the contribution as an overlay modal — like `ReviewPanel` — so the underlying layout stays visible behind a dimmed backdrop.
+
+## Scope
+
+The change applies to the entire `'fullview'` zone concept, not just todos. Today todos is the only plugin registering in `'fullview'`, but any future plugin contributing to that zone will get the same modal treatment.
+
+## Design
+
+### Rendering surface
+
+A new component `FullviewModal` (`packages/desktop/src/renderer/components/modals/FullviewModal.tsx`) renders the active fullview plugin as an overlay modal:
+
+- **Backdrop:** `fixed inset-0 bg-mf-overlay/60 z-50 flex items-center justify-center`
+- **Card:** `flex h-5/6 w-5/6 flex-col rounded-lg border border-mf-border bg-mf-app-bg shadow-2xl` (matches `ReviewPanel` shell exactly)
+- **Header:** thin chrome bar above the plugin body
+  - Left: `{label}` from the active plugin contribution, styled `uppercase` via Tailwind (e.g. `text-xs uppercase tracking-wide text-mf-text-secondary`)
+  - Right: `X` close button (lucide `X` icon, same treatment as `ReviewPanelHeader`)
+- **Body:** `<PluginView pluginId={activeFullviewId} />` filling the remaining height
+
+The label is read from `usePluginLayoutStore`'s `contributions` array — find the contribution whose `pluginId === activeFullviewId` and `zone === 'fullview'`. The modal styles `label` as uppercase in the header so plugins keep human-readable labels in their manifest.
+
+### Mounting
+
+`FullviewModal` is mounted at the app root in `App.tsx`, alongside `ReviewPanel`. It is not part of `Layout`. This keeps the underlying layout fully rendered behind the overlay.
+
+### Close behavior
+
+The modal closes via:
+
+- Click on backdrop (outside the card)
+- `Escape` key (global keydown listener while open)
+- Click on the `X` button in the header
+
+All three call `activateFullview(activeFullviewId)`, which toggles the current id off (existing store behavior — see `plugins.ts:91-94`).
+
+### Layout changes
+
+`Layout.tsx` removes the `activeFullviewId ?` conditional (lines 115-119). The center area always renders the normal panel layout. The modal is no longer Layout's concern.
+
+### Unchanged
+
+- **Store** (`store/plugins.ts`) — `activeFullviewId`, `activateFullview`, contribution registration all unchanged.
+- **LeftRail** (`components/LeftRail.tsx`) — buttons still toggle `activateFullview`. Active state still derived from `activeFullviewId`. Visual treatment unchanged.
+- **`UIZone` type** — `'fullview'` literal kept. Renaming would touch the public plugin manifest contract, types, and tests for no functional gain.
+- **`PluginView`** — unchanged. Still renders the registered fullview component for the given pluginId.
+- **TodosPanel** — unchanged. Its existing internal header sits below the new modal chrome bar.
+
+### Multiple fullview plugins
+
+Existing semantics preserved: only one `activeFullviewId` at a time. If two plugins register in `'fullview'`, each gets its own LeftRail button; activating one closes the other.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/desktop/src/renderer/components/modals/FullviewModal.tsx` | **New** — overlay modal shell with header + close handlers |
+| `packages/desktop/src/renderer/components/modals/index.ts` | Export `FullviewModal` |
+| `packages/desktop/src/renderer/App.tsx` | Mount `<FullviewModal />` next to `<ReviewPanel />` |
+| `packages/desktop/src/renderer/components/Layout.tsx` | Remove `activeFullviewId` branch (lines 115-119); always render normal panel layout |
+
+## Testing
+
+- Existing `plugins.test.ts` continues to pass (store contract unchanged).
+- New integration test (`FullviewModal.integration.test.tsx`) parallel to `ReviewPanel.integration.test.tsx`:
+  - Modal not rendered when `activeFullviewId === null`
+  - Modal rendered with header label (uppercase) and close button when `activateFullview('todos')` called
+  - Backdrop click closes the modal
+  - Escape key closes the modal
+  - Close button closes the modal
+  - Header shows the contribution's `label`, styled uppercase
+
+## Out of scope
+
+- Renaming `UIZone`'s `'fullview'` literal
+- Changing the LeftRail button behavior or styling
+- Modifying the todos plugin's internal layout or header
+- Animations / transitions on open/close

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { getActiveProjectId } from './hooks/useActiveProjectId.js';
 import { daemonClient } from './lib/client';
 import { getDefaultModelForAdapter } from './lib/adapters';
 import { PluginGlobalComponents } from './components/plugins/PluginGlobalComponents';
+import { FullviewModal } from './components/modals';
 
 export default function App(): React.ReactElement {
   useAppInit();
@@ -66,6 +67,7 @@ export default function App(): React.ReactElement {
     <ErrorBoundary>
       <TooltipProvider delayDuration={200} skipDelayDuration={100} disableHoverableContent>
         <Layout centerPanel={<CenterPanel />} />
+        <FullviewModal />
         <SearchPalette />
         <SettingsModal />
         <TutorialOverlay />

--- a/packages/desktop/src/renderer/components/Layout.tsx
+++ b/packages/desktop/src/renderer/components/Layout.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { PanelLeftOpen } from 'lucide-react';
 import { Panel, Group, Separator } from 'react-resizable-panels';
-import { usePluginLayoutStore } from '../store';
 import { useLayoutStore } from '../store/layout';
 import { useTabsStore } from '../store/tabs';
 import { TitleBar } from './TitleBar';
 import { LeftRail } from './LeftRail';
 import { RightRail } from './RightRail';
 import { StatusBar } from './StatusBar';
-import { PluginView } from './plugins/PluginView';
 import { Zone } from './zone/Zone';
 import { BottomResizeHandle } from './zone/BottomResizeHandle';
 import { DragProvider } from './zone/DragOverlay';
@@ -81,7 +79,6 @@ function CenterSplit({ centerPanel }: { centerPanel: React.ReactNode }): React.R
 }
 
 export function Layout({ centerPanel }: LayoutProps): React.ReactElement {
-  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
   const collapsed = useLayoutStore((s) => s.collapsed);
   const zones = useLayoutStore((s) => s.zones);
 
@@ -112,94 +109,86 @@ export function Layout({ centerPanel }: LayoutProps): React.ReactElement {
           <LeftRail />
 
           <div className="flex-1 flex flex-col overflow-hidden pb-mf-gap">
-            {activeFullviewId ? (
-              <div className="flex-1 bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                <PluginView pluginId={activeFullviewId} />
-              </div>
-            ) : (
-              <>
-                {/* Upper area: horizontal Group with left col + center + right col */}
-                <Group orientation="horizontal" className="flex-1">
-                  {hasLeft && (
-                    <>
-                      <Panel id="left-column" defaultSize="22%" maxSize="40%">
-                        <Group orientation="vertical">
-                          {hasLeftTop && (
-                            <Panel id="left-top" defaultSize="60%" minSize="20%">
-                              <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                                <Zone id="left-top" />
-                              </div>
-                            </Panel>
-                          )}
-                          {hasLeftTop && hasLeftBottom && <VerticalResizeHandle />}
-                          {hasLeftBottom && (
-                            <Panel id="left-bottom" defaultSize="40%" minSize="20%">
-                              <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                                <Zone id="left-bottom" />
-                              </div>
-                            </Panel>
-                          )}
-                        </Group>
-                      </Panel>
-                      <HorizontalResizeHandle />
-                    </>
-                  )}
-
-                  <Panel id="center">
-                    <CenterSplit centerPanel={centerPanel} />
+            {/* Upper area: horizontal Group with left col + center + right col */}
+            <Group orientation="horizontal" className="flex-1">
+              {hasLeft && (
+                <>
+                  <Panel id="left-column" defaultSize="22%" maxSize="40%">
+                    <Group orientation="vertical">
+                      {hasLeftTop && (
+                        <Panel id="left-top" defaultSize="60%" minSize="20%">
+                          <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                            <Zone id="left-top" />
+                          </div>
+                        </Panel>
+                      )}
+                      {hasLeftTop && hasLeftBottom && <VerticalResizeHandle />}
+                      {hasLeftBottom && (
+                        <Panel id="left-bottom" defaultSize="40%" minSize="20%">
+                          <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                            <Zone id="left-bottom" />
+                          </div>
+                        </Panel>
+                      )}
+                    </Group>
                   </Panel>
+                  <HorizontalResizeHandle />
+                </>
+              )}
 
-                  {hasRight && (
-                    <>
-                      <HorizontalResizeHandle />
-                      <Panel id="right-column" defaultSize="22%" minSize="10%" maxSize="40%">
-                        <Group orientation="vertical">
-                          {hasRightTop && (
-                            <Panel id="right-top" defaultSize="60%" minSize="20%">
-                              <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                                <Zone id="right-top" />
-                              </div>
-                            </Panel>
-                          )}
-                          {hasRightTop && hasRightBottom && <VerticalResizeHandle />}
-                          {hasRightBottom && (
-                            <Panel id="right-bottom" defaultSize="40%" minSize="20%">
-                              <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                                <Zone id="right-bottom" />
-                              </div>
-                            </Panel>
-                          )}
-                        </Group>
+              <Panel id="center">
+                <CenterSplit centerPanel={centerPanel} />
+              </Panel>
+
+              {hasRight && (
+                <>
+                  <HorizontalResizeHandle />
+                  <Panel id="right-column" defaultSize="22%" minSize="10%" maxSize="40%">
+                    <Group orientation="vertical">
+                      {hasRightTop && (
+                        <Panel id="right-top" defaultSize="60%" minSize="20%">
+                          <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                            <Zone id="right-top" />
+                          </div>
+                        </Panel>
+                      )}
+                      {hasRightTop && hasRightBottom && <VerticalResizeHandle />}
+                      {hasRightBottom && (
+                        <Panel id="right-bottom" defaultSize="40%" minSize="20%">
+                          <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                            <Zone id="right-bottom" />
+                          </div>
+                        </Panel>
+                      )}
+                    </Group>
+                  </Panel>
+                </>
+              )}
+            </Group>
+
+            {/* Bottom area: full width */}
+            {hasBottom && (
+              <>
+                <BottomResizeHandle onResize={handleBottomResize} />
+                <div style={{ height: bottomHeight, flexShrink: 0 }}>
+                  <Group orientation="horizontal">
+                    {hasBottomLeft && (
+                      <Panel id="bottom-left" defaultSize="50%" minSize="20%">
+                        <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                          <Zone id="bottom-left" />
+                        </div>
                       </Panel>
-                    </>
-                  )}
-                </Group>
-
-                {/* Bottom area: full width */}
-                {hasBottom && (
-                  <>
-                    <BottomResizeHandle onResize={handleBottomResize} />
-                    <div style={{ height: bottomHeight, flexShrink: 0 }}>
-                      <Group orientation="horizontal">
-                        {hasBottomLeft && (
-                          <Panel id="bottom-left" defaultSize="50%" minSize="20%">
-                            <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                              <Zone id="bottom-left" />
-                            </div>
-                          </Panel>
-                        )}
-                        {hasBottomLeft && hasBottomRight && <HorizontalResizeHandle />}
-                        {hasBottomRight && (
-                          <Panel id="bottom-right" defaultSize="50%" minSize="20%">
-                            <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
-                              <Zone id="bottom-right" />
-                            </div>
-                          </Panel>
-                        )}
-                      </Group>
-                    </div>
-                  </>
-                )}
+                    )}
+                    {hasBottomLeft && hasBottomRight && <HorizontalResizeHandle />}
+                    {hasBottomRight && (
+                      <Panel id="bottom-right" defaultSize="50%" minSize="20%">
+                        <div className="h-full bg-mf-panel-bg rounded-mf-panel overflow-hidden">
+                          <Zone id="bottom-right" />
+                        </div>
+                      </Panel>
+                    )}
+                  </Group>
+                </div>
               </>
             )}
           </div>

--- a/packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FullviewModal } from './FullviewModal';
+import { usePluginLayoutStore } from '../../store/plugins';
+import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
+
+// PluginView mounts real plugin React trees (TodosPanel etc.) which pull in
+// daemon clients and other heavy modules. The modal's behaviour is what we
+// test here — plugin rendering is covered elsewhere.
+vi.mock('../plugins/PluginView', () => ({
+  PluginView: ({ pluginId }: { pluginId: string }) => <div data-testid="plugin-view">{pluginId}</div>,
+}));
+
+function makeContribution(pluginId: string, label: string): PluginUIContribution {
+  return {
+    pluginId,
+    panelId: 'panel-1',
+    zone: 'fullview',
+    label,
+    icon: undefined,
+  };
+}
+
+function resetStore(): void {
+  usePluginLayoutStore.setState({
+    contributions: [],
+    actions: [],
+    triggeredAction: null,
+    activeFullviewId: null,
+  });
+}
+
+describe('FullviewModal Integration', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('renders nothing when no fullview is active', () => {
+    const { container } = render(<FullviewModal />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the plugin and uppercased label when activated', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    expect(screen.getByTestId('plugin-view')).toHaveTextContent('todos');
+
+    const heading = screen.getByText('Todos');
+    expect(heading.className).toMatch(/uppercase/);
+  });
+
+  it('closes when the X button is clicked', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByTestId('fullview-modal-backdrop'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('does not close when clicking inside the card', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.click(screen.getByTestId('plugin-view'));
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBe('todos');
+  });
+
+  it('closes when Escape is pressed', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('todos', 'Todos')],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(usePluginLayoutStore.getState().activeFullviewId).toBeNull();
+  });
+
+  it('falls back to pluginId in header when no contribution label is found', () => {
+    usePluginLayoutStore.setState({
+      contributions: [],
+      activeFullviewId: 'todos',
+    });
+
+    render(<FullviewModal />);
+    expect(screen.getByText('todos')).toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/modals/FullviewModal.integration.test.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { describe, it, beforeEach, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { FullviewModal } from './FullviewModal';
+import { FullviewModal, useFullviewHeaderSlot } from './FullviewModal';
 import { usePluginLayoutStore } from '../../store/plugins';
 import type { PluginUIContribution } from '@qlan-ro/mainframe-types';
 
 // PluginView mounts real plugin React trees (TodosPanel etc.) which pull in
 // daemon clients and other heavy modules. The modal's behaviour is what we
 // test here — plugin rendering is covered elsewhere.
+const PROBE_SLOT = <button data-testid="slot-action">Slot Action</button>;
+function HeaderSlotProbe(): React.ReactElement {
+  useFullviewHeaderSlot(PROBE_SLOT);
+  return <div data-testid="plugin-view">probe</div>;
+}
+
 vi.mock('../plugins/PluginView', () => ({
-  PluginView: ({ pluginId }: { pluginId: string }) => <div data-testid="plugin-view">{pluginId}</div>,
+  PluginView: ({ pluginId }: { pluginId: string }) => {
+    if (pluginId === 'probe') return <HeaderSlotProbe />;
+    return <div data-testid="plugin-view">{pluginId}</div>;
+  },
 }));
 
 function makeContribution(pluginId: string, label: string): PluginUIContribution {
@@ -115,5 +124,16 @@ describe('FullviewModal Integration', () => {
 
     render(<FullviewModal />);
     expect(screen.getByText('todos')).toBeInTheDocument();
+  });
+
+  it('renders header slot content registered by the active plugin', () => {
+    usePluginLayoutStore.setState({
+      contributions: [makeContribution('probe', 'Probe')],
+      activeFullviewId: 'probe',
+    });
+
+    render(<FullviewModal />);
+
+    expect(screen.getByTestId('slot-action')).toBeInTheDocument();
   });
 });

--- a/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
+++ b/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
@@ -1,13 +1,31 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '../ui/button';
 import { PluginView } from '../plugins/PluginView';
 import { usePluginLayoutStore } from '../../store/plugins';
 
+type SetSlot = (node: ReactNode) => void;
+const FullviewHeaderSlotContext = createContext<SetSlot | null>(null);
+
+/**
+ * Render `node` into the active FullviewModal header. No-op when not inside a
+ * FullviewModal. Caller should memoize `node` (e.g. via `useMemo`) to avoid
+ * spurious slot updates each render.
+ */
+export function useFullviewHeaderSlot(node: ReactNode): void {
+  const setSlot = useContext(FullviewHeaderSlotContext);
+  useEffect(() => {
+    if (!setSlot) return;
+    setSlot(node);
+    return () => setSlot(null);
+  }, [setSlot, node]);
+}
+
 export const FullviewModal: React.FC = () => {
   const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
   const contributions = usePluginLayoutStore((s) => s.contributions);
   const activateFullview = usePluginLayoutStore((s) => s.activateFullview);
+  const [headerSlot, setHeaderSlot] = useState<ReactNode>(null);
 
   const close = useCallback((): void => {
     if (activeFullviewId) {
@@ -45,14 +63,25 @@ export const FullviewModal: React.FC = () => {
       >
         <div className="flex items-center justify-between border-b border-mf-border px-4 py-2">
           <span className="text-xs font-medium uppercase tracking-wide text-mf-text-secondary">{label}</span>
-          <Button variant="ghost" size="sm" onClick={close} aria-label="Close" className="hover:bg-mf-hover">
-            <X size={14} />
-          </Button>
+          <div className="flex items-center gap-1">
+            {headerSlot}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={close}
+              aria-label="Close"
+              className="text-mf-text-secondary hover:bg-mf-panel-bg hover:text-mf-text-primary"
+            >
+              <X size={14} />
+            </Button>
+          </div>
         </div>
 
         {contribution && (
           <div className="flex-1 overflow-hidden">
-            <PluginView pluginId={activeFullviewId} />
+            <FullviewHeaderSlotContext.Provider value={setHeaderSlot}>
+              <PluginView pluginId={activeFullviewId} />
+            </FullviewHeaderSlotContext.Provider>
           </div>
         )}
       </div>

--- a/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
+++ b/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '../ui/button';
+import { PluginView } from '../plugins/PluginView';
+import { usePluginLayoutStore } from '../../store/plugins';
+
+export const FullviewModal: React.FC = () => {
+  const activeFullviewId = usePluginLayoutStore((s) => s.activeFullviewId);
+  const contributions = usePluginLayoutStore((s) => s.contributions);
+  const activateFullview = usePluginLayoutStore((s) => s.activateFullview);
+
+  const close = useCallback((): void => {
+    if (activeFullviewId) {
+      activateFullview(activeFullviewId);
+    }
+  }, [activeFullviewId, activateFullview]);
+
+  useEffect(() => {
+    if (!activeFullviewId) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [activeFullviewId, close]);
+
+  if (!activeFullviewId) return null;
+
+  const contribution = contributions.find((c) => c.pluginId === activeFullviewId && c.zone === 'fullview');
+  const label = contribution?.label ?? activeFullviewId;
+
+  return (
+    <div
+      data-testid="fullview-modal-backdrop"
+      onClick={close}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-mf-overlay/60"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-5/6 w-5/6 flex-col rounded-lg border border-mf-border bg-mf-app-bg shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-mf-border px-4 py-2">
+          <span className="text-xs font-medium uppercase tracking-wide text-mf-text-secondary">{label}</span>
+          <Button variant="ghost" size="sm" onClick={close} aria-label="Close" className="hover:bg-mf-hover">
+            <X size={14} />
+          </Button>
+        </div>
+
+        {contribution && (
+          <div className="flex-1 overflow-hidden">
+            <PluginView pluginId={activeFullviewId} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
+++ b/packages/desktop/src/renderer/components/modals/FullviewModal.tsx
@@ -35,6 +35,7 @@ export const FullviewModal: React.FC = () => {
   return (
     <div
       data-testid="fullview-modal-backdrop"
+      role="presentation"
       onClick={close}
       className="fixed inset-0 z-50 flex items-center justify-center bg-mf-overlay/60"
     >

--- a/packages/desktop/src/renderer/components/modals/index.ts
+++ b/packages/desktop/src/renderer/components/modals/index.ts
@@ -2,3 +2,4 @@ export { ReviewPanel } from './ReviewPanel';
 export { ReviewPanelHeader } from './ReviewPanelHeader';
 export { FileTree } from './FileTree';
 export { DiffView } from './DiffView';
+export { FullviewModal } from './FullviewModal';

--- a/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
+++ b/packages/desktop/src/renderer/components/todos/TodosPanel.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Plus } from 'lucide-react';
+import { useFullviewHeaderSlot } from '../modals/FullviewModal';
 import { createLogger } from '../../lib/logger';
 
 const log = createLogger('renderer:todos');
@@ -213,6 +214,24 @@ export function TodosPanel(): React.ReactElement {
     [activeProjectId],
   );
 
+  const newButton = useMemo(
+    () => (
+      <button
+        onClick={() => {
+          setEditingTodo(null);
+          setModalOpen(true);
+        }}
+        className="flex items-center gap-1.5 px-2 py-1 rounded-mf-card text-mf-body text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-panel-bg transition-colors"
+        aria-label="Create new task"
+      >
+        <Plus size={13} />
+        New
+      </button>
+    ),
+    [],
+  );
+  useFullviewHeaderSlot(newButton);
+
   if (!activeProjectId) {
     return (
       <div className="h-full flex items-center justify-center text-mf-text-secondary text-mf-small">
@@ -240,22 +259,6 @@ export function TodosPanel(): React.ReactElement {
 
   return (
     <div data-testid="todos-panel" className="h-full flex flex-col gap-px overflow-hidden bg-mf-app-bg">
-      {/* Header */}
-      <div className="h-11 px-4 flex items-center justify-between shrink-0 bg-mf-panel-bg">
-        <span className="text-mf-small text-mf-text-secondary uppercase tracking-wider">Tasks</span>
-        <button
-          onClick={() => {
-            setEditingTodo(null);
-            setModalOpen(true);
-          }}
-          className="flex items-center gap-1 px-2 py-1 rounded-mf-input text-mf-small text-mf-text-secondary hover:text-mf-text-primary hover:bg-mf-hover transition-colors"
-          aria-label="Create new task"
-        >
-          <Plus size={13} />
-          New
-        </button>
-      </div>
-
       {/* Filters */}
       <TodoFilterBar
         filters={filters}


### PR DESCRIPTION
## Summary

- Convert the `'fullview'` plugin zone (today: only the Todos kanban) from a center-area takeover into an overlay modal — same pattern as `ReviewPanel`. The underlying layout stays visible behind a dimmed backdrop.
- Add `useFullviewHeaderSlot` hook so a plugin can render header actions (e.g. Todos's `+ New`) into the modal chrome, eliminating the duplicate inline header.
- Style the `+ New` and `X` buttons to match the launch-config button hover (`hover:bg-mf-panel-bg`).

## Behavior

- LeftRail toggle still calls `activateFullview(pluginId)` — store contract unchanged.
- Modal closes on backdrop click, Escape key, or X button — all go through `activateFullview` to keep state in one place.
- `Layout.tsx` no longer special-cases `activeFullviewId`; the central panel layout always renders.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-07-fullview-as-modal-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-fullview-as-modal.md`

## Test plan

- [ ] Click the Todos icon in the LeftRail → modal opens with `TASKS` (uppercase) label, `+ New` and `X` buttons in the header bar
- [ ] Background layout (chats, side zones) remains visible behind the dimmed backdrop
- [ ] Hovering `+ New` / `X` shows the same near-black `bg-mf-panel-bg` hover used on launch-config controls
- [ ] Clicking `+ New` opens the create-task modal
- [ ] Closing the modal via Escape, backdrop click, X button, and re-clicking the LeftRail icon all work
- [ ] Opening another plugin in the future would show its label and any header actions it registers
- [ ] Desktop tests pass (`pnpm --filter @qlan-ro/mainframe-desktop test`) — currently 642/642

🤖 Generated with [Claude Code](https://claude.com/claude-code)