### PR TITLE
fix(core): reconcile queued-message state on every result event

### DIFF
--- a/.changeset/queued-message-reconcile.md
+++ b/.changeset/queued-message-reconcile.md
@@ -1,0 +1,22 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+fix(core): reconcile queued-message state on every result event
+
+The previous gated sweep (`queueRemaining === 0`) couldn't escape the
+common stranded-state where a leftover `queuedRefs` entry kept the count
+non-zero and pinned `processState='working'` forever, while the renderer's
+composer banner showed stale rows that no event would ever clear.
+
+`onResult` now reconciles bidirectionally:
+- Cached `metadata.queued` with no matching ref → strip the flag and emit
+  `message.queued.processed(uuid)`.
+- `queuedRef` with no matching cached message → drop the ref and emit
+  `message.queued.processed(ref.uuid)`.
+- Always emits `message.queued.snapshot` so the renderer's
+  `queuedMessages` map converges on the daemon's truth — defends against
+  any out-of-order delivery between `message.queued` and
+  `message.queued.processed`.
+
+`processState` now uses the post-reconcile count.

--- a/packages/core/src/__tests__/queued-message-lifecycle.test.ts
+++ b/packages/core/src/__tests__/queued-message-lifecycle.test.ts
@@ -20,7 +20,9 @@ function makeSink(
   callbacks?: {
     onQueuedProcessed?: (chatId: string, uuid: string) => void;
     onQueuedCleared?: (chatId: string) => void;
-    getQueuedCount?: (chatId: string) => number;
+    getQueuedRefs?: (
+      chatId: string,
+    ) => Array<{ uuid: string; chatId: string; messageId: string; content: string; timestamp: string }>;
   },
 ) {
   const db: any = {
@@ -39,7 +41,7 @@ function makeSink(
     () => undefined,
     callbacks?.onQueuedProcessed,
     callbacks?.onQueuedCleared,
-    callbacks?.getQueuedCount,
+    callbacks?.getQueuedRefs as never,
   );
   const sink: SessionSink = handler.buildSink(chatId, vi.fn().mockResolvedValue(undefined));
   return { sink, messages, handler, db };
@@ -157,9 +159,13 @@ describe('Queued message cleanup — onResult must NOT prematurely clear', () =>
   it('does not strip metadata.queued from messages still waiting in the CLI queue', () => {
     const emit = emitEvent as unknown as (e: DaemonEvent) => void;
     // Real-world scenario: ChatManager has 2 entries in queuedRefs corresponding
-    // to the cached messages below. Pass that count via getQueuedCount so the
-    // sink knows the queue is non-empty and stays in 'working' / no sweep.
-    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedCount: () => 2 });
+    // to the cached messages below. Pass them via getQueuedRefs so reconcile
+    // sees both refs as live and leaves metadata.queued alone.
+    const refs = [
+      { uuid: 'uuid-B', chatId, messageId: 'mB', content: 'B', timestamp: '' },
+      { uuid: 'uuid-C', chatId, messageId: 'mC', content: 'C', timestamp: '' },
+    ];
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedRefs: () => refs });
     // Two queued messages, neither yet dequeued by the CLI
     messages.append(
       chatId,
@@ -186,10 +192,10 @@ describe('Queued message cleanup — onResult must NOT prematurely clear', () =>
 
   it('sweeps stranded metadata.queued flags when result fires with empty queuedRefs', () => {
     const emit = emitEvent as unknown as (e: DaemonEvent) => void;
-    // queuedRefs is empty (getQueuedCount=0). The cached message's metadata.queued
+    // queuedRefs is empty. The cached message's metadata.queued
     // flag is therefore stranded — happens when the CLI's isReplay ack arrived in
     // a uuid shape we didn't dispatch on. onResult must clean it up.
-    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedCount: () => 0 });
+    const { sink, messages } = makeSink(activeChats, chatId, emit, { getQueuedRefs: () => [] });
     messages.append(
       chatId,
       messages.createTransientMessage(chatId, 'user', [{ type: 'text', text: 'orphan' }], {

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -66,7 +66,7 @@ export class ChatManager {
       },
       (chatId, uuid) => this.handleQueuedProcessed(chatId, uuid),
       (chatId) => this.clearAllQueuedForChat(chatId),
-      (chatId) => this.getQueuedForChat(chatId).length,
+      (chatId) => this.getQueuedForChat(chatId),
     );
     this.planMode = new PlanModeHandler({
       permissions: this.permissions,

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -8,6 +8,7 @@ import type {
   MessageMetadata,
   ToolCategories,
   ContextUsage,
+  QueuedMessageRef,
 } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { MessageCache } from './message-cache.js';
@@ -53,7 +54,7 @@ export class EventHandler {
     private getToolCategories: (chatId: string) => ToolCategories | undefined = () => undefined,
     private onQueuedProcessed: (chatId: string, uuid: string) => void = () => {},
     private onQueuedCleared: (chatId: string) => void = () => {},
-    private getQueuedCount: (chatId: string) => number = () => 0,
+    private getQueuedRefs: (chatId: string) => QueuedMessageRef[] = () => [],
   ) {}
 
   setPushService(service: PushService): void {
@@ -84,7 +85,7 @@ export class EventHandler {
       this.getToolCategories,
       this.onQueuedProcessed,
       this.onQueuedCleared,
-      this.getQueuedCount,
+      this.getQueuedRefs,
       this.pushService,
     );
   }
@@ -114,7 +115,7 @@ function buildSessionSink(
   getToolCategories: (chatId: string) => ToolCategories | undefined,
   onQueuedProcessedCb: (chatId: string, uuid: string) => void,
   onQueuedClearedCb: (chatId: string) => void,
-  getQueuedCount: (chatId: string) => number,
+  getQueuedRefs: (chatId: string) => QueuedMessageRef[],
   pushService?: PushService,
 ): SessionSink {
   function emitDisplay(): void {
@@ -264,12 +265,60 @@ function buildSessionSink(
       // the AI finishes a turn, not only when the user sends a message.
       const now = new Date().toISOString();
 
-      // Result events fire per-turn. If the user queued more messages while the
-      // CLI was busy, the CLI will keep processing them — we must NOT flip to
-      // idle here, or the thinking indicator drops while the assistant is
-      // still streaming the next queued turn. The final result (when the queue
-      // drains) will set idle.
-      const queueRemaining = getQueuedCount(chatId);
+      // Reconcile cached metadata.queued ↔ chat-manager queuedRefs. The CLI's
+      // isReplay acks can race with our queuedRefs.set (the daemon registers
+      // the ref AFTER awaiting stdin.write; the CLI may already have ack'd),
+      // and renderer-side `queuedMessages` can drift from the daemon when
+      // events arrive out of order. We recompute the canonical state here on
+      // every result event:
+      //   1. cached msg has metadata.queued but no matching ref → orphan flag.
+      //      Strip the flag + emit message.queued.processed for the renderer.
+      //   2. ref has no matching cached msg → orphan ref. Drop it + ack.
+      //   3. Emit a queued.snapshot afterwards so the renderer's composer
+      //      converges on whatever refs the daemon believes are still live.
+      const refsBefore = getQueuedRefs(chatId);
+      const refUuids = new Set(refsBefore.map((r) => r.uuid));
+      const cached = messages.get(chatId) ?? [];
+      const cachedQueuedUuids = new Set<string>();
+      let displayChanged = false;
+
+      for (const m of cached) {
+        const u = m.metadata?.uuid;
+        if (m.metadata?.queued && typeof u === 'string') {
+          cachedQueuedUuids.add(u);
+          if (!refUuids.has(u)) {
+            delete (m.metadata as Record<string, unknown>).queued;
+            delete (m.metadata as Record<string, unknown>).uuid;
+            displayChanged = true;
+            log.warn({ chatId, uuid: u }, 'onResult: orphan metadata.queued (no matching ref) — clearing');
+            emitEvent({ type: 'message.queued.processed', chatId, uuid: u });
+            onQueuedProcessedCb(chatId, u);
+          }
+        }
+      }
+
+      for (const ref of refsBefore) {
+        if (!cachedQueuedUuids.has(ref.uuid)) {
+          log.warn({ chatId, uuid: ref.uuid }, 'onResult: orphan queuedRef (no matching cached message) — pruning');
+          emitEvent({ type: 'message.queued.processed', chatId, uuid: ref.uuid });
+          onQueuedProcessedCb(chatId, ref.uuid);
+        }
+      }
+
+      if (displayChanged) emitDisplay();
+
+      // Force renderer composer to converge on the daemon's refs. Defends
+      // against any out-of-order delivery / dedupe gap that could leave the
+      // renderer's queuedMessages map with stale entries.
+      const refsAfter = getQueuedRefs(chatId);
+      emitEvent({ type: 'message.queued.snapshot', chatId, refs: refsAfter });
+
+      // Result events fire per-turn. While queued messages are still pending
+      // we must NOT flip to idle here, or the thinking indicator drops while
+      // the assistant is still streaming the next queued turn. Use the count
+      // AFTER reconciliation so orphan refs don't pin the state to 'working'
+      // when the CLI is genuinely done.
+      const queueRemaining = refsAfter.length;
       const nextProcessState: 'idle' | 'working' = queueRemaining > 0 ? 'working' : 'idle';
 
       db.chats.update(chatId, {
@@ -287,27 +336,6 @@ function buildSessionSink(
       active.chat.processState = nextProcessState;
       active.chat.updatedAt = now;
 
-      // Belt-and-suspenders: when the queue is genuinely empty, sweep any
-      // message still flagged metadata.queued. These are stranded acks —
-      // happens when the CLI's isReplay event arrived in a uuid shape we
-      // didn't dispatch on, so the per-message flag was never cleared.
-      if (queueRemaining === 0) {
-        const cached = messages.get(chatId);
-        let swept = false;
-        if (cached) {
-          for (const m of cached) {
-            if (m.metadata?.queued) {
-              delete (m.metadata as Record<string, unknown>).queued;
-              delete (m.metadata as Record<string, unknown>).uuid;
-              swept = true;
-            }
-          }
-        }
-        if (swept) {
-          log.warn({ chatId }, 'onResult: swept stranded metadata.queued flags');
-          emitDisplay();
-        }
-      }
       // Check interrupted flag before clearing permissions (clear() wipes both).
       const wasInterrupted = permissions.clearInterrupted(chatId);
       // CLI process ended — clear stale permissions so displayStatus reflects


### PR DESCRIPTION
## Summary

Follow-up to #293. The gated sweep (`queueRemaining === 0`) couldn't escape the dominant stranded state — a leftover `queuedRefs` entry kept the count non-zero, which pinned `processState='working'` forever and left the composer banner showing stale rows that no event would clear.

`onResult` now reconciles bidirectionally on every result:

- **Cached `metadata.queued` with no matching ref** → strip the flag + emit `message.queued.processed(uuid)` so the renderer's composer drops it.
- **`queuedRef` with no matching cached message** → drop the ref + emit `message.queued.processed(ref.uuid)`.
- **Always emits `message.queued.snapshot`** afterwards so the renderer's `queuedMessages` map converges on the daemon's truth — defends against any out-of-order delivery between `message.queued` and `message.queued.processed`.

`processState` now uses the post-reconcile count, so orphan refs no longer pin the indicator.

### Known follow-up

Thinking-indicator-drops-mid-turn (when CLI ack's all queued messages via `isReplay` before emitting the merged turn's `result`) is **not** fully fixed by this change — `queuedRefs` is genuinely empty by the time `result` fires, so the indicator legitimately flips to idle. A separate fix tracking `pendingTurns` (or similar) is needed.

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-core build` clean
- [x] All queued-message tests pass (`queued-message-lifecycle.test.ts`, `queued-messages-and-thinking.test.ts`)
- [x] Existing test for "preserve metadata.queued while CLI queue still has it" updated to pass refs instead of count
- [ ] Manual: send 2-3 messages back-to-back, verify composer entries clear as CLI dequeues each

🤖 Generated with [Claude Code](https://claude.com/claude-code)