### PR TITLE
fix(desktop): use FolderGit icon for composer worktree button in both states

### DIFF
--- a/.changeset/composer-worktree-icon.md
+++ b/.changeset/composer-worktree-icon.md
@@ -1,0 +1,10 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(desktop): always render `FolderGit` icon for the composer worktree button
+
+The button previously swapped between `FolderGit` (when a worktree path
+existed) and `GitBranch` (when it didn't), which made the affordance read
+as two different actions. The button is the same control either way, so
+the icon is now `FolderGit` in both states.

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/ComposerCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { ArrowUp, Square, Paperclip, Shield, X, AlertTriangle, CopySlash, FolderGit, GitBranch } from 'lucide-react';
+import { ArrowUp, Square, Paperclip, Shield, X, AlertTriangle, CopySlash, FolderGit } from 'lucide-react';
 import { createLogger } from '../../../../lib/logger';
 
 const log = createLogger('renderer:composer');
@@ -446,7 +446,7 @@ export function ComposerCard() {
                     }`}
                     aria-label={chat?.worktreePath ? `Worktree on branch ${chat.branchName}` : 'Worktree isolation'}
                   >
-                    {chat?.worktreePath ? <FolderGit size={14} /> : <GitBranch size={14} />}
+                    <FolderGit size={14} />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top">


### PR DESCRIPTION
## Summary
- The composer worktree button toggled between `FolderGit` (when `chat.worktreePath` existed) and `GitBranch` (when it didn't).
- It's the same button performing the same action — the icon switch made it read as two different controls.
- Now always renders `FolderGit`; tooltip still differentiates the two states.

## Test plan
- [x] Open a chat without a worktree → button shows `FolderGit`, tooltip says "Worktree isolation".
- [x] Open a chat with a worktree → button shows `FolderGit`, tooltip says "Worktree on branch <name>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)