### PR TITLE
fix(desktop): enrich render-process-gone log payload

### DIFF
--- a/.changeset/renderer-crash-logging.md
+++ b/.changeset/renderer-crash-logging.md
@@ -1,0 +1,11 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(desktop): enrich `render-process-gone` log payload
+
+When the renderer crashes, the main-process log now also records the
+URL, renderer OS PID, app uptime, RSS, and crashpad dumps directory.
+The renderer PID matches the `pid` field in
+`~/Library/Logs/DiagnosticReports/*.ips` so a crash log entry can be
+matched to its system crash report without guessing by timestamp.

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -210,7 +210,21 @@ function createWindow(): void {
   // ErrorBoundary only catches render errors, not process-level crashes like OOM
   // or GPU-killed). Log the reason so we can diagnose recurring cases.
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
-    log.error({ reason: details.reason, exitCode: details.exitCode }, 'renderer process gone');
+    const wc = mainWindow?.webContents;
+    // rendererPid matches the `pid` field in ~/Library/Logs/DiagnosticReports/*.ips,
+    // so the next crash self-correlates with its crashpad report.
+    log.error(
+      {
+        reason: details.reason,
+        exitCode: details.exitCode,
+        url: wc?.getURL(),
+        rendererPid: wc?.getOSProcessId(),
+        appUptimeSec: Math.round(process.uptime()),
+        rss: process.memoryUsage().rss,
+        crashDumpsDir: app.getPath('crashDumps'),
+      },
+      'renderer process gone',
+    );
   });
 
   if (process.env.NODE_ENV !== 'development') {


### PR DESCRIPTION
## Summary
- The `render-process-gone` handler logged only `reason` and `exitCode`, which made it hard to correlate a crash with the macOS crashpad `.ips` report.
- Adds `url`, `rendererPid` (matches `pid` in `~/Library/Logs/DiagnosticReports/*.ips`), `appUptimeSec`, `rss`, and `crashDumpsDir` to the log payload.
- Diagnostic-only change; no behavior change.

## Test plan
- [x] Force a renderer crash (e.g. `process.crash()` from devtools).
- [x] Confirm the main-process log entry includes the new fields.
- [x] Confirm `rendererPid` matches the `pid` in the corresponding `~/Library/Logs/DiagnosticReports/*.ips` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)