### PR TITLE
fix(core/claude): preserve model contextWindow after probe

### DIFF
--- a/.changeset/context-window-probe-merge.md
+++ b/.changeset/context-window-probe-merge.md
@@ -1,0 +1,16 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+fix(core/claude): preserve model `contextWindow` after probe
+
+The CLI's `claude` model probe doesn't report `contextWindow`, so the
+probed catalog replaced the static one with entries that had no window
+size. The renderer then fell back to a 200k default, and any chat on a
+1M model (e.g. `default` → Opus 4.7 1M, `opus[1m]`, `sonnet[1m]`)
+showed its context bar pegged at 100% as soon as usage crossed 200k —
+even though the real window had ~720k headroom left.
+
+`ClaudeAdapter.probeModels()` now reconciles probed entries with the
+static catalog by id, falling back to a description sniff (`"1M
+context"`) for IDs unknown to the static list.

--- a/.changeset/context-window-probe-merge.md
+++ b/.changeset/context-window-probe-merge.md
@@ -1,16 +1,23 @@
 ---
 '@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
 ---
 
-fix(core/claude): preserve model `contextWindow` after probe
+fix: don't peg context bar at 100% on 1M models
 
-The CLI's `claude` model probe doesn't report `contextWindow`, so the
-probed catalog replaced the static one with entries that had no window
-size. The renderer then fell back to a 200k default, and any chat on a
-1M model (e.g. `default` → Opus 4.7 1M, `opus[1m]`, `sonnet[1m]`)
-showed its context bar pegged at 100% as soon as usage crossed 200k —
-even though the real window had ~720k headroom left.
+The Claude CLI's model probe doesn't report `contextWindow`, so the
+probed catalog replaced the static one with entries that had no
+window size. The renderer then fell back to a hardcoded 200k default,
+so any chat on a 1M model (e.g. `default` → Opus 4.7 1M, `opus[1m]`,
+`sonnet[1m]`) showed its context bar pegged at 100% as soon as usage
+crossed 200k — even though the real window had ~720k headroom left.
 
-`ClaudeAdapter.probeModels()` now reconciles probed entries with the
-static catalog by id, falling back to a description sniff (`"1M
-context"`) for IDs unknown to the static list.
+Two changes:
+
+- `ClaudeAdapter.probeModels()` now reconciles probed entries with
+  the static catalog by id, with a description-string fallback
+  (`"1M context"`) for ids unknown to the static list.
+- `getModelContextWindow()` returns `undefined` for unknown models
+  instead of silently defaulting to 200k. `ChatSessionBar` hides the
+  progress segments and percentage when the window is unknown and
+  the CLI hasn't reported a usage percentage of its own.

--- a/packages/core/src/plugins/builtin/claude/__tests__/probe-context-window.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/probe-context-window.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AdapterModel } from '@qlan-ro/mainframe-types';
+
+vi.mock('../probe-models.js', () => ({
+  probeModels: vi.fn(),
+}));
+
+import { probeModels as doProbeModels } from '../probe-models.js';
+import { ClaudeAdapter } from '../adapter.js';
+
+const mockedProbe = vi.mocked(doProbeModels);
+
+describe('ClaudeAdapter.probeModels — contextWindow enrichment', () => {
+  beforeEach(() => {
+    mockedProbe.mockReset();
+  });
+
+  it('preserves contextWindow from the static catalog for known model IDs', async () => {
+    mockedProbe.mockResolvedValueOnce([
+      { id: 'default', label: 'Default', isDefault: true, description: 'Opus 4.7 with 1M context · Most capable' },
+      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { id: 'sonnet[1m]', label: 'Sonnet 4.6 (1M context)' },
+    ] satisfies AdapterModel[]);
+
+    const adapter = new ClaudeAdapter();
+    const probed = await adapter.probeModels();
+
+    expect(probed).not.toBeNull();
+    const byId = new Map(probed!.map((m) => [m.id, m]));
+    expect(byId.get('default')?.contextWindow).toBe(1_000_000);
+    expect(byId.get('claude-sonnet-4-6')?.contextWindow).toBe(200_000);
+    expect(byId.get('sonnet[1m]')?.contextWindow).toBe(1_000_000);
+  });
+
+  it('falls back to description sniff for unknown IDs', async () => {
+    mockedProbe.mockResolvedValueOnce([
+      { id: 'claude-future-1m', label: 'Future 1M', description: 'Future model with 1M context' },
+      { id: 'claude-future-small', label: 'Future Small', description: 'Faster everyday model' },
+    ] satisfies AdapterModel[]);
+
+    const adapter = new ClaudeAdapter();
+    const probed = await adapter.probeModels();
+    const byId = new Map(probed!.map((m) => [m.id, m]));
+    expect(byId.get('claude-future-1m')?.contextWindow).toBe(1_000_000);
+    expect(byId.get('claude-future-small')?.contextWindow).toBe(200_000);
+  });
+
+  it('respects an explicit contextWindow on the probed entry', async () => {
+    mockedProbe.mockResolvedValueOnce([
+      { id: 'claude-custom', label: 'Custom', contextWindow: 500_000 },
+    ] satisfies AdapterModel[]);
+
+    const adapter = new ClaudeAdapter();
+    const probed = await adapter.probeModels();
+    expect(probed![0]?.contextWindow).toBe(500_000);
+  });
+
+  it('listModels() returns enriched dynamic models after probe', async () => {
+    mockedProbe.mockResolvedValueOnce([{ id: 'default', label: 'Default', isDefault: true }] satisfies AdapterModel[]);
+
+    const adapter = new ClaudeAdapter();
+    await adapter.probeModels();
+    const listed = await adapter.listModels();
+    expect(listed[0]?.contextWindow).toBe(1_000_000);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -111,6 +111,23 @@ const CLAUDE_MODELS: AdapterModel[] = [
   { id: 'claude-3-5-haiku-20241022', label: 'Haiku 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
 ];
 
+// The CLI's model probe doesn't expose context window size — only a marketing
+// description like "Opus 4.7 with 1M context". Reconcile probed entries with
+// the static catalog so known IDs retain their authoritative window, and
+// unknown IDs fall back to a description sniff before the 200k default.
+function enrichWithContextWindow(probed: AdapterModel[]): AdapterModel[] {
+  const staticById = new Map(CLAUDE_MODELS.map((m) => [m.id, m]));
+  return probed.map((model) => {
+    if (model.contextWindow) return model;
+    const fromStatic = staticById.get(model.id)?.contextWindow;
+    if (fromStatic) return { ...model, contextWindow: fromStatic };
+    const window = /\b1m\b|1m context/i.test(model.description ?? '')
+      ? EXTENDED_CONTEXT_WINDOW
+      : DEFAULT_CONTEXT_WINDOW;
+    return { ...model, contextWindow: window };
+  });
+}
+
 export class ClaudeAdapter implements Adapter {
   id = 'claude';
   name = 'Claude CLI';
@@ -151,9 +168,9 @@ export class ClaudeAdapter implements Adapter {
   async probeModels(): Promise<AdapterModel[] | null> {
     const models = await doProbeModels('claude');
     if (models) {
-      this.dynamicModels = models;
+      this.dynamicModels = enrichWithContextWindow(models);
     }
-    return models;
+    return this.dynamicModels;
   }
 
   getToolCategories(): ToolCategories {

--- a/packages/desktop/src/__tests__/lib/adapters.test.ts
+++ b/packages/desktop/src/__tests__/lib/adapters.test.ts
@@ -35,8 +35,9 @@ describe('getModelContextWindow', () => {
     expect(getModelContextWindow('claude-opus-4-6', mockAdapters)).toBe(200_000);
   });
 
-  it('defaults to 200K for unknown models', () => {
-    expect(getModelContextWindow('unknown-model', mockAdapters)).toBe(200_000);
+  it('returns undefined for unknown models so callers can hide percentage UI', () => {
+    expect(getModelContextWindow('unknown-model', mockAdapters)).toBeUndefined();
+    expect(getModelContextWindow(undefined, mockAdapters)).toBeUndefined();
   });
 });
 

--- a/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
+++ b/packages/desktop/src/renderer/components/chat/ChatSessionBar.tsx
@@ -111,11 +111,15 @@ export function ChatSessionBar({ chatId }: ChatSessionBarProps): React.ReactElem
   const accentClass = ADAPTER_ACCENT[chat.adapterId] ?? 'bg-mf-text-secondary';
   const contextWindow = getModelContextWindow(chat.model, adapters);
   // Prefer CLI-reported usage percentage; fall back to token-estimate
+  // only when we know the window size — otherwise the bar would be a
+  // guess against a default that may not match the real model.
   const usagePct = cliContextUsage
     ? Math.min(100, Math.round(cliContextUsage.percentage))
-    : Math.min(100, Math.round(((chat.lastContextTokensInput ?? 0) / contextWindow) * 100));
-  const filledSegments = Math.round((usagePct / 100) * PROGRESS_SEGMENTS);
-  const progressColor = getProgressColor(usagePct);
+    : contextWindow
+      ? Math.min(100, Math.round(((chat.lastContextTokensInput ?? 0) / contextWindow) * 100))
+      : null;
+  const filledSegments = usagePct === null ? 0 : Math.round((usagePct / 100) * PROGRESS_SEGMENTS);
+  const progressColor = getProgressColor(usagePct ?? 0);
 
   return (
     <div data-testid="session-bar" className="h-7 flex items-center px-3 text-mf-status bg-mf-panel-bg shrink-0">
@@ -157,18 +161,20 @@ export function ChatSessionBar({ chatId }: ChatSessionBarProps): React.ReactElem
       {/* Right: token progress and actions */}
       <div className="flex items-center gap-1.5 flex-1 justify-end min-w-0">
         <ChatActions chatId={chatId} />
-        <div className="flex gap-px">
-          {Array.from({ length: PROGRESS_SEGMENTS }, (_, i) => (
-            <div
-              key={i}
-              className={cn(
-                'w-1 h-2 rounded-[1px]',
-                i < filledSegments ? progressColor : 'bg-mf-text-secondary opacity-15',
-              )}
-            />
-          ))}
-        </div>
-        {usagePct > 0 && (
+        {usagePct !== null && (
+          <div className="flex gap-px">
+            {Array.from({ length: PROGRESS_SEGMENTS }, (_, i) => (
+              <div
+                key={i}
+                className={cn(
+                  'w-1 h-2 rounded-[1px]',
+                  i < filledSegments ? progressColor : 'bg-mf-text-secondary opacity-15',
+                )}
+              />
+            ))}
+          </div>
+        )}
+        {usagePct !== null && usagePct > 0 && (
           <span data-testid="session-bar-context-pct" className="text-mf-text-secondary tabular-nums">
             {usagePct}%
           </span>

--- a/packages/desktop/src/renderer/lib/adapters.test.ts
+++ b/packages/desktop/src/renderer/lib/adapters.test.ts
@@ -36,6 +36,8 @@ describe('adapters model metadata', () => {
     expect(getAdapterLabel('unknown')).toBe('unknown');
     expect(getModelLabel('custom-model', adapters)).toBe('custom-model');
     expect(getModelLabel(undefined, adapters)).toBe('');
-    expect(getModelContextWindow('unknown-model', adapters)).toBe(200_000);
+    expect(getModelContextWindow('unknown-model', adapters)).toBeUndefined();
+    expect(getModelContextWindow(undefined, adapters)).toBeUndefined();
+    expect(getModelContextWindow('claude-opus-4-6', adapters)).toBe(200_000);
   });
 });

--- a/packages/desktop/src/renderer/lib/adapters.ts
+++ b/packages/desktop/src/renderer/lib/adapters.ts
@@ -69,7 +69,12 @@ export function getDefaultModelForAdapter(adapterId: string): string | undefined
   return adapter?.models.find((m) => m.isDefault)?.id ?? adapter?.models[0]?.id;
 }
 
-export function getModelContextWindow(modelId: string | undefined, adapters: AdapterInfo[]): number {
-  if (!modelId) return 200_000;
-  return getModelMetadata(adapters).get(modelId)?.contextWindow ?? 200_000;
+// Returns undefined when the window is unknown. Callers should hide
+// any percentage UI rather than fabricate one from a default — the
+// Claude CLI's probe historically omitted contextWindow for some
+// entries (notably the `default` alias), and rendering "100% used"
+// against a 200k fallback while the real window was 1M was misleading.
+export function getModelContextWindow(modelId: string | undefined, adapters: AdapterInfo[]): number | undefined {
+  if (!modelId) return undefined;
+  return getModelMetadata(adapters).get(modelId)?.contextWindow;
 }


### PR DESCRIPTION
## Summary

- Claude's model probe doesn't report `contextWindow`, so after the first probe the dynamic catalog replaced static entries with windowless ones.
- The renderer's `getModelContextWindow()` then fell back to `200_000` for any model, pegging the context bar at 100% as soon as real usage crossed 200k on a 1M model (`default` → Opus 4.7 1M, `opus[1m]`, `sonnet[1m]`).

Two changes:

1. **`ClaudeAdapter.probeModels()`** now reconciles probed entries with the static `CLAUDE_MODELS` catalog by id, with a description-string fallback (`"1M context"`) for ids unknown to the static list. Probe stays authoritative for the model set and capability flags; the static catalog stays authoritative for window size.
2. **`getModelContextWindow()`** returns `undefined` for unknown models instead of silently defaulting to 200k. `ChatSessionBar` hides the progress segments and percentage when the window is unknown and the CLI hasn't reported a usage percentage of its own — failing closed instead of producing a misleading number.

Repro that surfaced this: session `3f9fab3c…` on `model='default'` with `last_context_tokens_input = 280_749` displayed 100% in the session bar despite ~28% real usage of the 1M window.

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-core build` — clean
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` — clean
- [x] `pnpm --filter @qlan-ro/mainframe-core test` — 1386 passing, with 4 new cases in `probe-context-window.test.ts` (known ids, unknown ids with 1M description, explicit `contextWindow`, `listModels()` post-probe)
- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — 641 passing, with updated expectations in both `adapters.test.ts` files
- [x] Manual: open an existing chat on Opus 4.7 1M with >200k context tokens — bar should reflect real `<window>` percentage; for a model id missing from the static catalog, bar should hide instead of showing a fake number

🤖 Generated with [Claude Code](https://claude.com/claude-code)