### PR TITLE
fix: CMD-F global focus + archived chats reach renderer

### DIFF
--- a/.changeset/critical-bugs-find-archived.md
+++ b/.changeset/critical-bugs-find-archived.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix CMD-F not working when focus is outside the chat thread; archived sessions popover now receives data.

--- a/packages/core/src/db/__tests__/chats-tags.test.ts
+++ b/packages/core/src/db/__tests__/chats-tags.test.ts
@@ -76,4 +76,18 @@ describe('ChatsRepository — listFiltered invariant', () => {
     const chats = new ChatsRepository(db); // no chatTags
     expect(() => chats.listFiltered({ tagsAll: ['feature'] })).toThrow(/ChatTagsRepository/);
   });
+
+  it('listFiltered includes archived chats when includeArchived is true', () => {
+    const { projects, chats } = setup();
+    const p = projects.create('/tmp/p');
+    const active = chats.create(p.id, 'claude');
+    const archived = chats.create(p.id, 'claude');
+    chats.update(archived.id, { status: 'archived' });
+
+    const defaultList = chats.listFiltered({ projectId: p.id });
+    expect(defaultList.map((c) => c.id)).toEqual([active.id]);
+
+    const allList = chats.listFiltered({ projectId: p.id, includeArchived: true });
+    expect(allList.map((c) => c.id).sort()).toEqual([active.id, archived.id].sort());
+  });
 });

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -34,6 +34,7 @@ export interface ChatListFilters {
   projectId?: string;
   tagsAll?: string[];
   hasWorktree?: boolean;
+  includeArchived?: boolean;
 }
 
 function parseEffort(value: string | null | undefined): Chat['effort'] {
@@ -75,9 +76,12 @@ export class ChatsRepository {
   }
 
   listFiltered(filters: ChatListFilters): Chat[] {
-    const where: string[] = ["status != 'archived'"];
+    const where: string[] = [];
     const params: unknown[] = [];
 
+    if (!filters.includeArchived) {
+      where.push("status != 'archived'");
+    }
     if (filters.projectId) {
       where.push('project_id = ?');
       params.push(filters.projectId);
@@ -96,7 +100,7 @@ export class ChatsRepository {
       params.push(...ids);
     }
 
-    const sql = `SELECT ${CHAT_SELECT_FIELDS} FROM chats WHERE ${where.join(' AND ')} ORDER BY pinned DESC, updated_at DESC`;
+    const sql = `SELECT ${CHAT_SELECT_FIELDS} FROM chats${where.length ? ` WHERE ${where.join(' AND ')}` : ''} ORDER BY pinned DESC, updated_at DESC`;
     const rows = this.db.prepare(sql).all(...params) as RawChatRow[];
     const chats = this.mapRows(rows);
     this.populateBulkTags(chats);

--- a/packages/core/src/server/routes/__tests__/chats-filter.test.ts
+++ b/packages/core/src/server/routes/__tests__/chats-filter.test.ts
@@ -37,7 +37,7 @@ function makeApp() {
   // c2: tagged feature, no worktree
   // c3: tagged bug, has worktree
   // c4: untagged, has worktree (project p2)
-  // c5: archived (must never appear)
+  // c5: archived (now included so the archived sessions popover can render)
   const seed = (id: string, projectId: string, worktree: string | null, status = 'active'): void => {
     db.prepare(
       `INSERT INTO chats (id, adapter_id, project_id, status, created_at, updated_at, worktree_path)
@@ -61,12 +61,12 @@ function makeApp() {
 }
 
 describe('GET /api/chats — filtered list', () => {
-  it('no filters returns all non-archived chats', async () => {
+  it('no filters returns all chats including archived', async () => {
     const { app } = makeApp();
     const res = await request(app).get('/api/chats');
     expect(res.status).toBe(200);
     const ids = res.body.data.map((c: { id: string }) => c.id).sort();
-    expect(ids).toEqual(['c1', 'c2', 'c3', 'c4']);
+    expect(ids).toEqual(['c1', 'c2', 'c3', 'c4', 'c5']);
   });
 
   it('filters by project', async () => {
@@ -86,7 +86,7 @@ describe('GET /api/chats — filtered list', () => {
     const { app } = makeApp();
     const res = await request(app).get('/api/chats?synthetic=has-worktree');
     const ids = res.body.data.map((c: { id: string }) => c.id).sort();
-    expect(ids).toEqual(['c1', 'c3', 'c4']);
+    expect(ids).toEqual(['c1', 'c3', 'c4', 'c5']);
   });
 
   it('AND-combines tags + synthetic + project', async () => {
@@ -98,7 +98,7 @@ describe('GET /api/chats — filtered list', () => {
   it('ignores has-pr in synthetic (handled client-side)', async () => {
     const { app } = makeApp();
     const res = await request(app).get('/api/chats?synthetic=has-pr');
-    expect(res.body.data).toHaveLength(4);
+    expect(res.body.data).toHaveLength(5);
   });
 
   it('Chat.tags is populated on filtered results', async () => {

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -56,6 +56,7 @@ export function chatRoutes(ctx: RouteContext): Router {
       projectId: parsed.data.project,
       tagsAll,
       hasWorktree: synth.has('has-worktree'),
+      includeArchived: true,
     });
     res.json({ success: true, data: chats });
   });

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeThread.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { ThreadPrimitive, useThread } from '@assistant-ui/react';
 import { Loader2 } from 'lucide-react';
 import { useMainframeRuntime } from './MainframeRuntimeProvider';
@@ -83,10 +83,8 @@ export function MainframeThread() {
   const closeFindBar = useFindInChatStore((s) => s.close);
   const findBarOpen = useFindInChatStore((s) => s.isOpen);
 
-  // Intercept Cmd/Ctrl+F while the chat thread is focused — open find bar
-  // instead of the global search palette.
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
         e.preventDefault();
         e.stopPropagation();
@@ -96,15 +94,13 @@ export function MainframeThread() {
           openFindBar();
         }
       }
-    },
-    [findBarOpen, openFindBar, closeFindBar],
-  );
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [findBarOpen, openFindBar, closeFindBar]);
 
   return (
-    // Outer wrapper captures Cmd/Ctrl+F and routes it to the chat-local
-    // find bar, preventing the global search palette from opening when the
-    // user is focused on the chat thread.
-    <div className="h-full flex flex-col" onKeyDown={handleKeyDown}>
+    <div className="h-full flex flex-col">
       <FindBar />
       <ThreadPrimitive.Root className="flex-1 flex flex-col min-h-0">
         <ThreadPrimitive.Viewport autoScroll className="flex-1 overflow-y-auto scrollbar-on-hover">


### PR DESCRIPTION
## Summary
- `MainframeThread` CMD-F listener moves from a div `onKeyDown` to `window.addEventListener('keydown', ...)` so the shortcut fires regardless of where focus is. Still chat-scoped — the listener only mounts while a chat is on screen.
- `ChatsRepository.listFiltered` gains an `includeArchived` flag (default `false` preserves existing behavior). The global `/api/chats` route opts in, so the archived sessions popover finally receives the data it needs to render and reactivate.

Closes #155, #173.

## Test plan
- [ ] Focus the sidebar / settings / anywhere outside the chat thread, hit CMD-F → find bar opens
- [ ] Hit CMD-F again → find bar closes
- [ ] Archive a chat, open the archived sessions popover → archived chat appears, Restore button reactivates it
- [ ] Other lists (`/api/projects/:id/chats`) still exclude archived chats — no regressions in the active sessions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)