### PR TITLE
feat(core): list external sessions from worktrees of the active project

### DIFF
--- a/.changeset/import-worktree-sessions.md
+++ b/.changeset/import-worktree-sessions.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-types': patch
+---
+
+External Sessions now also lists sessions from worktrees of the active project.

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -73,7 +73,7 @@ describe('listExternalSessions', () => {
       };
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('abc-123');
       expect(result[0]!.adapterId).toBe('claude');
@@ -93,7 +93,7 @@ describe('listExternalSessions', () => {
       };
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions('/test/project', ['exclude-me']);
+      const result = await listExternalSessions(['/test/project'], ['exclude-me']);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('keep-me');
     });
@@ -108,7 +108,7 @@ describe('listExternalSessions', () => {
       };
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('main-session');
     });
@@ -123,7 +123,7 @@ describe('listExternalSessions', () => {
       };
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result[0]!.sessionId).toBe('newer');
       expect(result[1]!.sessionId).toBe('older');
     });
@@ -138,15 +138,56 @@ describe('listExternalSessions', () => {
       };
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('with-prompt');
     });
   });
 
+  describe('aggregation across multiple project paths', () => {
+    it('combines and dedupes sessions from multiple paths', async () => {
+      const indexMain = {
+        version: 1,
+        entries: [
+          {
+            sessionId: 'main-1',
+            firstPrompt: 'Main',
+            created: '2026-01-01T00:00:00Z',
+            modified: '2026-01-01T00:00:00Z',
+          },
+          {
+            sessionId: 'shared',
+            firstPrompt: 'Shared',
+            created: '2026-01-02T00:00:00Z',
+            modified: '2026-01-02T00:00:00Z',
+          },
+        ],
+      };
+      const indexWorktree = {
+        version: 1,
+        entries: [
+          { sessionId: 'wt-1', firstPrompt: 'WT', created: '2026-01-03T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
+          {
+            sessionId: 'shared',
+            firstPrompt: 'Shared',
+            created: '2026-01-02T00:00:00Z',
+            modified: '2026-01-02T00:00:00Z',
+          },
+        ],
+      };
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(indexMain) as unknown as ArrayBuffer)
+        .mockResolvedValueOnce(JSON.stringify(indexWorktree) as unknown as ArrayBuffer);
+
+      const result = await listExternalSessions(['/test/project', '/test/project/.worktrees/feat'], []);
+      const ids = result.map((s) => s.sessionId).sort();
+      expect(ids).toEqual(['main-1', 'shared', 'wt-1']);
+    });
+  });
+
   describe('JSONL fallback (no sessions-index.json)', () => {
     it('returns empty when no index and no directory', async () => {
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toEqual([]);
     });
 
@@ -164,7 +205,7 @@ describe('listExternalSessions', () => {
       ];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('abc-123');
       expect(result[0]!.adapterId).toBe('claude');
@@ -176,7 +217,7 @@ describe('listExternalSessions', () => {
     it('filters out excluded sessions in JSONL scan', async () => {
       mockReaddir.mockResolvedValue(['keep.jsonl', 'skip.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
 
-      const result = await listExternalSessions('/test/project', ['skip']);
+      const result = await listExternalSessions(['/test/project'], ['skip']);
       // 'skip' is excluded, only 'keep' should be processed
       expect(mockStat).toHaveBeenCalledTimes(1);
     });
@@ -188,7 +229,7 @@ describe('listExternalSessions', () => {
       const lines = [JSON.stringify({ type: 'user', isSidechain: true, timestamp: '2026-01-01T00:00:00Z' })];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toEqual([]);
     });
 
@@ -202,7 +243,7 @@ describe('listExternalSessions', () => {
       ];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       expect(result).toEqual([]);
     });
 
@@ -213,7 +254,7 @@ describe('listExternalSessions', () => {
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
       mockJsonlFile([JSON.stringify({ type: 'system', timestamp: '2026-01-01T00:00:00Z' })]);
 
-      const result = await listExternalSessions('/test/project', []);
+      const result = await listExternalSessions(['/test/project'], []);
       // Only session.jsonl should be processed
       expect(mockStat).toHaveBeenCalledTimes(1);
     });

--- a/packages/core/src/__tests__/external-session-service.test.ts
+++ b/packages/core/src/__tests__/external-session-service.test.ts
@@ -89,7 +89,25 @@ describe('ExternalSessionService', () => {
       chatsRepo.update(chat.id, { claudeSessionId: 'already-imported' });
 
       await service.scan(projectId);
-      expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith('/test/project', ['already-imported']);
+      expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith(['/test/project'], ['already-imported']);
+    });
+
+    it('passes worktree paths alongside the project path to the adapter', async () => {
+      const mod = await import('../workspace/worktree.js');
+      const spy = vi.spyOn(mod, 'getWorktrees').mockResolvedValue([
+        { path: '/test/project', branch: 'refs/heads/main' },
+        { path: '/test/project/.worktrees/feat-a', branch: 'refs/heads/feat-a' },
+        { path: '/test/project/.worktrees/feat-b', branch: 'refs/heads/feat-b' },
+      ]);
+      try {
+        await service.scan(projectId);
+        expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith(
+          ['/test/project', '/test/project/.worktrees/feat-a', '/test/project/.worktrees/feat-b'],
+          [],
+        );
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('returns empty array when adapter has no listExternalSessions', async () => {

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -3,6 +3,7 @@ import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import { createChildLogger } from '../logger.js';
 import { deriveTitleFromMessage, generateTitle } from './title-generator.js';
+import { getWorktrees } from '../workspace/worktree.js';
 
 const logger = createChildLogger('chat:external-sessions');
 
@@ -30,8 +31,9 @@ export class ExternalSessionService {
       if (!adapter.listExternalSessions) continue;
 
       const excludeIds = this.db.chats.getImportedSessionIds(projectId);
+      const paths = await this.collectProjectPaths(project.path);
       try {
-        const sessions = await adapter.listExternalSessions(project.path, excludeIds);
+        const sessions = await adapter.listExternalSessions(paths, excludeIds);
         for (const session of sessions) {
           session.adapterId = adapter.id;
         }
@@ -79,6 +81,17 @@ export class ExternalSessionService {
     }
 
     return chat;
+  }
+
+  private async collectProjectPaths(projectPath: string): Promise<string[]> {
+    try {
+      const worktrees = await getWorktrees(projectPath);
+      const paths = [projectPath, ...worktrees.map((w) => w.path)];
+      return Array.from(new Set(paths));
+    } catch (err) {
+      logger.warn({ err: String(err), projectPath }, 'failed to enumerate worktrees, scanning project root only');
+      return [projectPath];
+    }
   }
 
   private async generateImportTitle(chat: Chat, content: string, adapterId: string): Promise<void> {

--- a/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude-sdk/adapter.ts
@@ -215,28 +215,35 @@ export class ClaudeSdkAdapter implements Adapter {
     return deleteAgent(agentId, projectPath);
   }
 
-  async listExternalSessions(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]> {
-    try {
-      const sessions = await listSessions({ dir: projectPath });
-      const excludeSet = new Set(excludeSessionIds);
+  async listExternalSessions(projectPaths: string[], excludeSessionIds: string[]): Promise<ExternalSession[]> {
+    const excludeSet = new Set(excludeSessionIds);
+    const seen = new Set<string>();
+    const aggregated: ExternalSession[] = [];
 
-      return sessions
-        .filter((s: any) => !excludeSet.has(s.sessionId))
-        .map((s: any) => ({
-          sessionId: s.sessionId,
-          adapterId: this.id,
-          projectPath,
-          firstPrompt: s.firstPrompt,
-          summary: s.summary,
-          messageCount: s.messageCount,
-          createdAt: s.createdAt ?? new Date().toISOString(),
-          modifiedAt: s.modifiedAt ?? new Date().toISOString(),
-          gitBranch: s.gitBranch,
-          model: s.model,
-        }));
-    } catch (err) {
-      logger.warn({ err }, 'Failed to list external sessions via SDK');
-      return [];
+    for (const projectPath of Array.from(new Set(projectPaths))) {
+      try {
+        const sessions = await listSessions({ dir: projectPath });
+        for (const s of sessions as any[]) {
+          if (excludeSet.has(s.sessionId) || seen.has(s.sessionId)) continue;
+          seen.add(s.sessionId);
+          aggregated.push({
+            sessionId: s.sessionId,
+            adapterId: this.id,
+            projectPath,
+            firstPrompt: s.firstPrompt,
+            summary: s.summary,
+            messageCount: s.messageCount,
+            createdAt: s.createdAt ?? new Date().toISOString(),
+            modifiedAt: s.modifiedAt ?? new Date().toISOString(),
+            gitBranch: s.gitBranch,
+            model: s.model,
+          });
+        }
+      } catch (err) {
+        logger.warn({ err, projectPath }, 'Failed to list external sessions via SDK');
+      }
     }
+
+    return aggregated;
   }
 }

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -247,7 +247,7 @@ export class ClaudeAdapter implements Adapter {
     return skills.deleteAgent(agentId, projectPath);
   }
 
-  async listExternalSessions(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]> {
-    return listExternalSessions(projectPath, excludeSessionIds);
+  async listExternalSessions(projectPaths: string[], excludeSessionIds: string[]): Promise<ExternalSession[]> {
+    return listExternalSessions(projectPaths, excludeSessionIds);
   }
 }

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -130,7 +130,7 @@ function enrichWithContextWindow(probed: AdapterModel[]): AdapterModel[] {
 
 export class ClaudeAdapter implements Adapter {
   id = 'claude';
-  name = 'Claude CLI';
+  name = manifest.name;
   readonly capabilities = { planMode: true } as const;
 
   private sessions = new Set<ClaudeSession>();

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -32,18 +32,31 @@ function getProjectDir(projectPath: string): string {
   return path.join(homedir(), '.claude', 'projects', encodedPath);
 }
 
-/** Try sessions-index.json first; fall back to JSONL scan. */
+/** Try sessions-index.json first; fall back to JSONL scan. Aggregates across multiple paths. */
 export async function listExternalSessions(
-  projectPath: string,
+  projectPaths: string[],
   excludeSessionIds: string[],
 ): Promise<ExternalSession[]> {
-  const projectDir = getProjectDir(projectPath);
   const excludeSet = new Set(excludeSessionIds);
+  const uniquePaths = Array.from(new Set(projectPaths));
+  const aggregated: ExternalSession[] = [];
 
-  const fromIndex = await listFromIndex(projectDir, projectPath, excludeSet);
-  if (fromIndex !== null) return fromIndex;
+  for (const projectPath of uniquePaths) {
+    const projectDir = getProjectDir(projectPath);
+    const fromIndex = await listFromIndex(projectDir, projectPath, excludeSet);
+    const sessions = fromIndex ?? (await listFromJsonl(projectDir, projectPath, excludeSet));
+    aggregated.push(...sessions);
+  }
 
-  return listFromJsonl(projectDir, projectPath, excludeSet);
+  const seen = new Set<string>();
+  const deduped: ExternalSession[] = [];
+  for (const session of aggregated) {
+    if (seen.has(session.sessionId)) continue;
+    seen.add(session.sessionId);
+    deduped.push(session);
+  }
+
+  return deduped.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
 }
 
 async function listFromIndex(

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -88,24 +88,37 @@ export class CodexAdapter implements Adapter {
   // TODO: implement listAgents, createAgent, updateAgent, deleteAgent
   // TODO: implement listCommands
 
-  async listExternalSessions(projectPath: string, _excludeSessionIds: string[]): Promise<ExternalSession[]> {
+  async listExternalSessions(projectPaths: string[], _excludeSessionIds: string[]): Promise<ExternalSession[]> {
     let client: JsonRpcClient | null = null;
     try {
       client = await this.spawnTempAppServer();
-      const result = await client.request<ThreadListResult>('thread/list', {
-        cwd: projectPath,
-        archived: false,
-      });
-      return result.data.map((t) => ({
-        sessionId: t.id,
-        adapterId: this.id,
-        projectPath,
-        firstPrompt: t.name ?? t.preview,
-        summary: t.name ?? t.preview,
-        createdAt: new Date(t.createdAt).toISOString(),
-        modifiedAt: new Date(t.updatedAt).toISOString(),
-        model: t.model,
-      }));
+      const seen = new Set<string>();
+      const aggregated: ExternalSession[] = [];
+      for (const projectPath of Array.from(new Set(projectPaths))) {
+        try {
+          const result = await client.request<ThreadListResult>('thread/list', {
+            cwd: projectPath,
+            archived: false,
+          });
+          for (const t of result.data) {
+            if (seen.has(t.id)) continue;
+            seen.add(t.id);
+            aggregated.push({
+              sessionId: t.id,
+              adapterId: this.id,
+              projectPath,
+              firstPrompt: t.name ?? t.preview,
+              summary: t.name ?? t.preview,
+              createdAt: new Date(t.createdAt).toISOString(),
+              modifiedAt: new Date(t.updatedAt).toISOString(),
+              model: t.model,
+            });
+          }
+        } catch (err) {
+          log.warn({ err, projectPath }, 'codex: failed to list external sessions for path');
+        }
+      }
+      return aggregated;
     } catch (err) {
       log.warn({ err }, 'codex: failed to list external sessions');
       return [];

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -248,7 +248,7 @@ export interface Adapter {
   ): Promise<import('./skill.js').AgentConfig>;
   updateAgent?(agentId: string, projectPath: string, content: string): Promise<import('./skill.js').AgentConfig>;
   deleteAgent?(agentId: string, projectPath: string): Promise<void>;
-  listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>;
+  listExternalSessions?(projectPaths: string[], excludeSessionIds: string[]): Promise<ExternalSession[]>;
 
   /**
    * Factory for an adapter-specific plan-mode action handler.


### PR DESCRIPTION
## Summary
External Sessions popover now surfaces sessions from every worktree of the active project, not just the project root.

- `listExternalSessions` accepts a `string[]` of project paths and aggregates results, dedup'd by `sessionId`, sorted desc by modified time
- `ExternalSessionService.collectProjectPaths()` calls `getWorktrees(project.path)` and returns `[mainPath, ...worktreePaths]` deduped. Failure to enumerate worktrees logs and falls back to the project root
- Claude / Claude-SDK / Codex adapters updated to the array signature
- Two new tests: aggregation across paths in `claude-external-sessions.test.ts`; service-level worktree-path flow in `external-session-service.test.ts`
- No UI changes — the existing popover already shows `gitBranch` per session, so worktree-scoped sessions are distinguishable

Closes #174.

## Test plan
- [ ] Open the Import External Sessions popover for a project with active worktrees → sessions from each worktree appear alongside the main project's sessions
- [ ] Each row shows the correct `gitBranch` so you can tell them apart
- [ ] Importing a worktree-scoped session works the same as importing a root-scoped one
- [ ] A project with no worktrees still works (fallback path)

## Notes
- `pnpm --filter @qlan-ro/mainframe-core test` — 1388/1388 pass
- Stacks logically with #320 — both files modified depend on the manifest source-of-truth for adapter name. The single-line fix here (`name = manifest.name`) is duplicated with #320 but keeps each PR self-contained for review/revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)