### PR TITLE
feat: better UX for specifying CLI paths (#159)

### DIFF
--- a/.changeset/cli-executable-path.md
+++ b/.changeset/cli-executable-path.md
@@ -1,0 +1,7 @@
+---
+"@qlan-ro/mainframe-core": minor
+"@qlan-ro/mainframe-desktop": minor
+"@qlan-ro/mainframe-types": patch
+---
+
+Resolve and persist absolute CLI executable paths at daemon startup; Settings shows the full path with a daemon-side file Browse; PATH fallback preserved.

--- a/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
+++ b/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { settingRoutes } from '../../server/routes/settings.js';
+import { clearResolveMemo } from '../../adapters/resolve-executable.js';
 import type { RouteContext } from '../../server/routes/types.js';
 
 function createMockContext(): RouteContext {
@@ -37,9 +38,14 @@ describe('GET /api/settings/providers - resolvedExecutable', () => {
   let ctx: RouteContext;
 
   beforeEach(() => {
+    clearResolveMemo();
     ctx = createMockContext();
     // No registered adapters by default
     (ctx.adapters.getAll as any).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    clearResolveMemo();
   });
 
   it('includes resolvedExecutable with source="config" when executablePath is configured', async () => {

--- a/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
+++ b/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { settingRoutes } from '../../server/routes/settings.js';
+import type { RouteContext } from '../../server/routes/types.js';
+
+function createMockContext(): RouteContext {
+  return {
+    db: {
+      projects: { get: vi.fn() },
+      chats: { list: vi.fn() },
+      settings: {
+        get: vi.fn(),
+        getByCategory: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+      },
+    } as any,
+    chats: { getChat: vi.fn(), on: vi.fn() } as any,
+    adapters: { get: vi.fn(), list: vi.fn(), getAll: vi.fn() } as any,
+  };
+}
+
+function mockRes() {
+  const res: any = {
+    json: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+  };
+  return res;
+}
+
+function extractHandler(router: any, method: string, routePath: string) {
+  const layer = router.stack.find((l: any) => l.route?.path === routePath && l.route?.methods[method]);
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack[0].handle;
+}
+
+describe('GET /api/settings/providers - resolvedExecutable', () => {
+  let ctx: RouteContext;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+    // No registered adapters by default
+    (ctx.adapters.getAll as any).mockReturnValue([]);
+  });
+
+  it('includes resolvedExecutable with source="config" when executablePath is configured', async () => {
+    // Stub settings: claude has a configured executablePath
+    (ctx.db.settings.getByCategory as any).mockReturnValue({
+      'claude.executablePath': '/custom/claude',
+    });
+    // settings.get is called by resolveAdapterExecutable to read provider.<id>.executablePath
+    (ctx.db.settings.get as any).mockImplementation((category: string, key: string) => {
+      if (category === 'provider' && key === 'claude.executablePath') return '/custom/claude';
+      return null;
+    });
+
+    const router = settingRoutes(ctx);
+    const handler = extractHandler(router, 'get', '/api/settings/providers');
+    const res = mockRes();
+    const next = vi.fn();
+
+    await handler({ params: {}, query: {} }, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const call = res.json.mock.calls[0][0];
+    expect(call.success).toBe(true);
+    expect(call.data.claude.resolvedExecutable).toBeDefined();
+    expect(call.data.claude.resolvedExecutable.source).toBe('config');
+  });
+
+  it('includes resolvedExecutable with source="fallback" when detection fails', async () => {
+    // No provider settings stored; registry returns an adapter whose binary cannot be found
+    (ctx.db.settings.getByCategory as any).mockReturnValue({});
+    (ctx.db.settings.get as any).mockReturnValue(null);
+    // Registry surfaces the unknown adapter id so it appears in the union
+    (ctx.adapters.getAll as any).mockReturnValue([{ id: 'definitely-not-real-xyz' }]);
+
+    const router = settingRoutes(ctx);
+    const handler = extractHandler(router, 'get', '/api/settings/providers');
+    const res = mockRes();
+    const next = vi.fn();
+
+    await handler({ params: {}, query: {} }, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const call = res.json.mock.calls[0][0];
+    expect(call.success).toBe(true);
+    expect(call.data['definitely-not-real-xyz'].resolvedExecutable).toBeDefined();
+    expect(call.data['definitely-not-real-xyz'].resolvedExecutable.source).toBe('fallback');
+  });
+});

--- a/packages/core/src/__tests__/routes/settings.test.ts
+++ b/packages/core/src/__tests__/routes/settings.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub out executable resolution so GET /api/settings/providers tests don't
+// spawn real child processes and hit unpredictable timeouts.
+vi.mock('../../adapters/resolve-executable.js', () => ({
+  resolveAdapterExecutable: vi.fn().mockResolvedValue({ path: 'claude', source: 'fallback', valid: false }),
+  defaultRun: vi.fn(),
+  BARE_NAMES: { claude: 'claude', codex: 'codex', gemini: 'gemini', opencode: 'opencode' },
+}));
+
 import { settingRoutes } from '../../server/routes/settings.js';
 import type { RouteContext } from '../../server/routes/types.js';
 
@@ -15,7 +24,7 @@ function createMockContext(): RouteContext {
       },
     } as any,
     chats: { getChat: vi.fn(), on: vi.fn() } as any,
-    adapters: { get: vi.fn(), list: vi.fn() } as any,
+    adapters: { get: vi.fn(), list: vi.fn(), getAll: vi.fn().mockReturnValue([]) } as any,
   };
 }
 
@@ -41,7 +50,7 @@ describe('settingRoutes', () => {
   });
 
   describe('GET /api/settings/providers', () => {
-    it('returns grouped provider settings', () => {
+    it('returns grouped provider settings', async () => {
       (ctx.db.settings.getByCategory as any).mockReturnValue({
         'claude.defaultModel': 'opus',
         'claude.defaultMode': 'normal',
@@ -52,16 +61,17 @@ describe('settingRoutes', () => {
       const handler = extractHandler(router, 'get', '/api/settings/providers');
       const res = mockRes();
 
-      handler({ params: {}, query: {} }, res, vi.fn());
+      await handler({ params: {}, query: {} }, res, vi.fn());
 
       expect(ctx.db.settings.getByCategory).toHaveBeenCalledWith('provider');
       const call = res.json.mock.calls[0][0];
       expect(call.success).toBe(true);
-      expect(call.data.claude).toEqual({ defaultModel: 'opus', defaultMode: 'normal' });
-      expect(call.data.gemini).toEqual({ defaultModel: 'pro' });
+      // resolvedExecutable is now added per adapter; use toMatchObject to tolerate the new key
+      expect(call.data.claude).toMatchObject({ defaultModel: 'opus', defaultMode: 'normal' });
+      expect(call.data.gemini).toMatchObject({ defaultModel: 'pro' });
     });
 
-    it('maps legacy skipPermissions to defaultMode yolo', () => {
+    it('maps legacy skipPermissions to defaultMode yolo', async () => {
       (ctx.db.settings.getByCategory as any).mockReturnValue({
         'claude.skipPermissions': 'true',
       });
@@ -70,14 +80,14 @@ describe('settingRoutes', () => {
       const handler = extractHandler(router, 'get', '/api/settings/providers');
       const res = mockRes();
 
-      handler({ params: {}, query: {} }, res, vi.fn());
+      await handler({ params: {}, query: {} }, res, vi.fn());
 
       const call = res.json.mock.calls[0][0];
       expect(call.data.claude.defaultMode).toBe('yolo');
       expect(call.data.claude.skipPermissions).toBeUndefined();
     });
 
-    it('does not override existing defaultMode with skipPermissions', () => {
+    it('does not override existing defaultMode with skipPermissions', async () => {
       (ctx.db.settings.getByCategory as any).mockReturnValue({
         'claude.skipPermissions': 'true',
         'claude.defaultMode': 'default',
@@ -88,14 +98,14 @@ describe('settingRoutes', () => {
       const handler = extractHandler(router, 'get', '/api/settings/providers');
       const res = mockRes();
 
-      handler({ params: {}, query: {} }, res, vi.fn());
+      await handler({ params: {}, query: {} }, res, vi.fn());
 
       const call = res.json.mock.calls[0][0];
       expect(call.data.claude.defaultMode).toBe('default');
       expect(call.data.claude.defaultPlanMode).toBe('true');
     });
 
-    it('skips keys without a dot separator', () => {
+    it('skips keys without a dot separator', async () => {
       (ctx.db.settings.getByCategory as any).mockReturnValue({
         noDotsHere: 'value',
         'claude.model': 'opus',
@@ -105,11 +115,12 @@ describe('settingRoutes', () => {
       const handler = extractHandler(router, 'get', '/api/settings/providers');
       const res = mockRes();
 
-      handler({ params: {}, query: {} }, res, vi.fn());
+      await handler({ params: {}, query: {} }, res, vi.fn());
 
       const call = res.json.mock.calls[0][0];
       expect(call.data.noDotsHere).toBeUndefined();
-      expect(call.data.claude).toEqual({ model: 'opus' });
+      // resolvedExecutable is now added per adapter; use toMatchObject to tolerate the new key
+      expect(call.data.claude).toMatchObject({ model: 'opus' });
     });
   });
 

--- a/packages/core/src/__tests__/routes/settings.test.ts
+++ b/packages/core/src/__tests__/routes/settings.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // spawn real child processes and hit unpredictable timeouts.
 vi.mock('../../adapters/resolve-executable.js', () => ({
   resolveAdapterExecutable: vi.fn().mockResolvedValue({ path: 'claude', source: 'fallback', valid: false }),
+  resolveAdapterExecutableCached: vi.fn().mockResolvedValue({ path: 'claude', source: 'fallback', valid: false }),
+  clearResolveMemo: () => {},
   defaultRun: vi.fn(),
   BARE_NAMES: { claude: 'claude', codex: 'codex', gemini: 'gemini', opencode: 'opencode' },
 }));

--- a/packages/core/src/adapters/__tests__/resolve-executable.test.ts
+++ b/packages/core/src/adapters/__tests__/resolve-executable.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveAdapterExecutable, backfillAdapterExecutables, BARE_NAMES } from '../resolve-executable.js';
+
+type SettingsStub = {
+  store: Map<string, string>;
+  get: (c: string, k: string) => string | null;
+  set: (c: string, k: string, v: string) => void;
+};
+function settingsStub(initial: Record<string, string> = {}): SettingsStub {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    get: (c, k) => store.get(`${c}.${k}`) ?? null,
+    set: (c, k, v) => void store.set(`${c}.${k}`, v),
+  };
+}
+
+describe('resolveAdapterExecutable', () => {
+  it('uses a configured path and validates via --version', async () => {
+    const runner = vi.fn(async (cmd: string, args: string[]) => {
+      if (args.includes('--version')) return { ok: true, stdout: 'claude 1.2.3\n' };
+      return { ok: false, stdout: '' };
+    });
+    const s = settingsStub({ 'provider.claude.executablePath': '/usr/local/bin/claude' });
+    const r = await resolveAdapterExecutable('claude', { settings: s, run: runner, platform: 'darwin' });
+    expect(r).toEqual({ path: '/usr/local/bin/claude', source: 'config', valid: true, version: '1.2.3' });
+    expect(runner).toHaveBeenCalledWith('/usr/local/bin/claude', ['--version'], expect.anything());
+  });
+
+  it('detects via which on posix and reports detected', async () => {
+    const runner = vi.fn(async (cmd: string, args: string[]) => {
+      if (cmd === 'which') return { ok: true, stdout: '/opt/homebrew/bin/claude\n' };
+      if (args.includes('--version')) return { ok: true, stdout: 'claude 9.9.9\n' };
+      return { ok: false, stdout: '' };
+    });
+    const r = await resolveAdapterExecutable('claude', { settings: settingsStub(), run: runner, platform: 'darwin' });
+    expect(r).toEqual({ path: '/opt/homebrew/bin/claude', source: 'detected', valid: true, version: '9.9.9' });
+    expect(runner).toHaveBeenCalledWith('which', ['claude'], expect.anything());
+  });
+
+  it('detects via where on win32', async () => {
+    const runner = vi.fn(async (cmd: string) => {
+      if (cmd === 'where') return { ok: true, stdout: 'C:\\bin\\codex.exe\r\n' };
+      return { ok: true, stdout: 'codex 1.0.0' };
+    });
+    const r = await resolveAdapterExecutable('codex', { settings: settingsStub(), run: runner, platform: 'win32' });
+    expect(r.source).toBe('detected');
+    expect(r.path).toBe('C:\\bin\\codex.exe');
+  });
+
+  it('falls back to bare name when nothing is found', async () => {
+    const runner = vi.fn(async () => ({ ok: false, stdout: '' }));
+    const r = await resolveAdapterExecutable('claude', { settings: settingsStub(), run: runner, platform: 'darwin' });
+    expect(r).toEqual({ path: 'claude', source: 'fallback', valid: false });
+  });
+});
+
+describe('backfillAdapterExecutables', () => {
+  it('writes detected absolute path only when config is empty (idempotent)', async () => {
+    const runner = vi.fn(async (cmd: string, args: string[]) => {
+      if (cmd === 'which') return { ok: true, stdout: '/opt/homebrew/bin/claude\n' };
+      if (args.includes('--version')) return { ok: true, stdout: 'claude 1.0.0' };
+      return { ok: false, stdout: '' };
+    });
+    const s = settingsStub();
+    await backfillAdapterExecutables(['claude'], { settings: s, run: runner, platform: 'darwin' });
+    expect(s.get('provider', 'claude.executablePath')).toBe('/opt/homebrew/bin/claude');
+
+    const runner2 = vi.fn(async () => ({ ok: true, stdout: '/somewhere/else/claude\n' }));
+    await backfillAdapterExecutables(['claude'], { settings: s, run: runner2, platform: 'darwin' });
+    expect(s.get('provider', 'claude.executablePath')).toBe('/opt/homebrew/bin/claude');
+  });
+
+  it('does not backfill when detection fails', async () => {
+    const runner = vi.fn(async () => ({ ok: false, stdout: '' }));
+    const s = settingsStub();
+    await backfillAdapterExecutables(['codex'], { settings: s, run: runner, platform: 'linux' });
+    expect(s.get('provider', 'codex.executablePath')).toBeNull();
+  });
+});
+
+it('exposes a bare-name map', () => {
+  expect(BARE_NAMES.claude).toBe('claude');
+  expect(BARE_NAMES.codex).toBe('codex');
+});
+
+it('defaultRun returns ok:false for a nonexistent binary (no throw)', async () => {
+  const { defaultRun } = await import('../resolve-executable.js');
+  const r = await defaultRun('definitely-not-a-real-binary-xyz', ['--version'], { timeoutMs: 2000 });
+  expect(r.ok).toBe(false);
+  expect(typeof r.stdout).toBe('string');
+});

--- a/packages/core/src/adapters/__tests__/resolve-executable.test.ts
+++ b/packages/core/src/adapters/__tests__/resolve-executable.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { resolveAdapterExecutable, backfillAdapterExecutables, BARE_NAMES } from '../resolve-executable.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  resolveAdapterExecutable,
+  resolveAdapterExecutableCached,
+  clearResolveMemo,
+  backfillAdapterExecutables,
+  BARE_NAMES,
+} from '../resolve-executable.js';
 
 type SettingsStub = {
   store: Map<string, string>;
@@ -76,6 +82,47 @@ describe('backfillAdapterExecutables', () => {
     const s = settingsStub();
     await backfillAdapterExecutables(['codex'], { settings: s, run: runner, platform: 'linux' });
     expect(s.get('provider', 'codex.executablePath')).toBeNull();
+  });
+});
+
+describe('resolveAdapterExecutableCached', () => {
+  beforeEach(() => clearResolveMemo());
+  afterEach(() => clearResolveMemo());
+
+  it('memoizes within the TTL and re-resolves after clearResolveMemo()', async () => {
+    const runner = vi.fn(async (cmd: string, args: string[]) => {
+      if (cmd === 'which') return { ok: true, stdout: '/opt/homebrew/bin/claude\n' };
+      if (args.includes('--version')) return { ok: true, stdout: 'claude 1.0.0' };
+      return { ok: false, stdout: '' };
+    });
+    const s = settingsStub();
+
+    const first = await resolveAdapterExecutableCached('claude', { settings: s, run: runner, platform: 'darwin' });
+    const callsAfterFirst = runner.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    const second = await resolveAdapterExecutableCached('claude', { settings: s, run: runner, platform: 'darwin' });
+    expect(second).toBe(first);
+    // Cache hit: runner not invoked again within TTL.
+    expect(runner.mock.calls.length).toBe(callsAfterFirst);
+
+    clearResolveMemo();
+    await resolveAdapterExecutableCached('claude', { settings: s, run: runner, platform: 'darwin' });
+    // Re-resolution after clear invokes the runner again.
+    expect(runner.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+
+  it('keys the memo by adapter id', async () => {
+    const runner = vi.fn(async (cmd: string, args: string[]) => {
+      if (cmd === 'which') return { ok: true, stdout: `/bin/${args[0]}\n` };
+      if (args.includes('--version')) return { ok: true, stdout: '1.0.0' };
+      return { ok: false, stdout: '' };
+    });
+    const s = settingsStub();
+    const claude = await resolveAdapterExecutableCached('claude', { settings: s, run: runner, platform: 'darwin' });
+    const codex = await resolveAdapterExecutableCached('codex', { settings: s, run: runner, platform: 'darwin' });
+    expect(claude.path).toBe('/bin/claude');
+    expect(codex.path).toBe('/bin/codex');
   });
 });
 

--- a/packages/core/src/adapters/resolve-executable.ts
+++ b/packages/core/src/adapters/resolve-executable.ts
@@ -1,0 +1,85 @@
+import { execFile } from 'node:child_process';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('resolve-executable');
+
+export const BARE_NAMES: Record<string, string> = {
+  claude: 'claude',
+  codex: 'codex',
+  gemini: 'gemini',
+  opencode: 'opencode',
+};
+
+export interface RunResult {
+  ok: boolean;
+  stdout: string;
+}
+export interface ResolverDeps {
+  settings: { get(c: string, k: string): string | null; set(c: string, k: string, v: string): void };
+  run: (cmd: string, args: string[], opts?: { timeoutMs?: number }) => Promise<RunResult>;
+  platform?: NodeJS.Platform;
+}
+export interface ResolvedExecutable {
+  path: string;
+  source: 'config' | 'detected' | 'fallback';
+  valid: boolean;
+  version?: string;
+}
+
+export function defaultRun(cmd: string, args: string[], opts?: { timeoutMs?: number }): Promise<RunResult> {
+  return new Promise((resolve) => {
+    execFile(cmd, args, { timeout: opts?.timeoutMs ?? 5000 }, (err, stdout) => {
+      resolve({ ok: !err, stdout: typeof stdout === 'string' ? stdout : '' });
+    });
+  });
+}
+
+function parseVersion(stdout: string): string | undefined {
+  const m = stdout.match(/(\d+\.\d+\.\d+)/);
+  return m?.[1];
+}
+
+async function validate(path: string, run: ResolverDeps['run']): Promise<{ valid: boolean; version?: string }> {
+  const r = await run(path, ['--version'], { timeoutMs: 5000 });
+  if (!r.ok) return { valid: false };
+  const version = parseVersion(r.stdout);
+  return version ? { valid: true, version } : { valid: true };
+}
+
+export async function resolveAdapterExecutable(adapterId: string, deps: ResolverDeps): Promise<ResolvedExecutable> {
+  const bare = BARE_NAMES[adapterId] ?? adapterId;
+  const configured = deps.settings.get('provider', `${adapterId}.executablePath`);
+  if (configured) {
+    const v = await validate(configured, deps.run);
+    return { path: configured, source: 'config', ...v };
+  }
+  const platform = deps.platform ?? process.platform;
+  const finder = platform === 'win32' ? 'where' : 'which';
+  const found = await deps.run(finder, [bare], { timeoutMs: 5000 });
+  if (found.ok) {
+    const abs = found.stdout
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)[0];
+    if (abs) {
+      const v = await validate(abs, deps.run);
+      return { path: abs, source: 'detected', ...v };
+    }
+  }
+  return { path: bare, source: 'fallback', valid: false };
+}
+
+export async function backfillAdapterExecutables(adapterIds: string[], deps: ResolverDeps): Promise<void> {
+  for (const id of adapterIds) {
+    try {
+      if (deps.settings.get('provider', `${id}.executablePath`)) continue;
+      const r = await resolveAdapterExecutable(id, deps);
+      if (r.source === 'detected') {
+        deps.settings.set('provider', `${id}.executablePath`, r.path);
+        log.info({ adapterId: id, path: r.path }, 'backfilled adapter executable path');
+      }
+    } catch (err) {
+      log.warn({ err, adapterId: id }, 'executable backfill failed for adapter');
+    }
+  }
+}

--- a/packages/core/src/adapters/resolve-executable.ts
+++ b/packages/core/src/adapters/resolve-executable.ts
@@ -69,6 +69,30 @@ export async function resolveAdapterExecutable(adapterId: string, deps: Resolver
   return { path: bare, source: 'fallback', valid: false };
 }
 
+const RESOLVE_MEMO_TTL_MS = 5000;
+const resolveMemo = new Map<string, { at: number; value: ResolvedExecutable }>();
+
+/**
+ * Short-TTL memo around `resolveAdapterExecutable`. The settings GET endpoint is
+ * polled and resolution spawns child processes (up to ~5s timeout each), so a
+ * 5s in-process cache keeps a burst of polls from re-spawning. `resolveAdapterExecutable`
+ * itself stays pure/unmemoized for tests.
+ */
+export async function resolveAdapterExecutableCached(
+  adapterId: string,
+  deps: ResolverDeps,
+): Promise<ResolvedExecutable> {
+  const hit = resolveMemo.get(adapterId);
+  if (hit && Date.now() - hit.at < RESOLVE_MEMO_TTL_MS) return hit.value;
+  const value = await resolveAdapterExecutable(adapterId, deps);
+  resolveMemo.set(adapterId, { at: Date.now(), value });
+  return value;
+}
+
+export function clearResolveMemo(): void {
+  resolveMemo.clear();
+}
+
 export async function backfillAdapterExecutables(adapterIds: string[], deps: ResolverDeps): Promise<void> {
   for (const id of adapterIds) {
     try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'node:events';
 import { ensureAuthSecret, getConfig, getDataDir } from './config.js';
 import { DatabaseManager } from './db/index.js';
 import { AdapterRegistry } from './adapters/index.js';
+import { backfillAdapterExecutables, defaultRun } from './adapters/resolve-executable.js';
 import { ChatManager } from './chat/index.js';
 import { AttachmentStore } from './attachment/index.js';
 import { createServerManager } from './server/index.js';
@@ -130,6 +131,15 @@ async function main(): Promise<void> {
   // Failure here must not prevent the daemon from serving requests.
   backfillWorktreeRelationships(db.projects).catch((err) => {
     logger.warn({ err }, 'Worktree relationship backfill failed');
+  });
+
+  // Non-blocking: resolve + persist absolute CLI paths for registered adapters
+  // so spawns are explicit. Failure must not block serving requests.
+  backfillAdapterExecutables(
+    adapters.getAll().map((a) => a.id),
+    { settings: db.settings, run: defaultRun },
+  ).catch((err) => {
+    logger.warn({ err }, 'Adapter executable backfill failed');
   });
 
   if (config.tunnel === true) {

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -7,7 +7,7 @@ import { GENERAL_DEFAULTS, NOTIFICATION_DEFAULTS, type NotificationConfig } from
 import type { RouteContext } from './types.js';
 import { validate, UpdateProviderSettingsBody, UpdateGeneralSettingsBody } from './schemas.js';
 import { asyncHandler } from './async-handler.js';
-import { resolveAdapterExecutable, defaultRun } from '../../adapters/resolve-executable.js';
+import { resolveAdapterExecutableCached, defaultRun } from '../../adapters/resolve-executable.js';
 
 // Per-group validation so a single bad leaf doesn't discard the user's other
 // valid overrides on read.
@@ -123,11 +123,15 @@ export function settingRoutes(ctx: RouteContext): Router {
       }
       const ids = new Set<string>(Object.keys(providers));
       for (const a of ctx.adapters.getAll()) ids.add(a.id);
+      const idList = Array.from(ids);
+      const resolved = await Promise.all(
+        idList.map((id) => resolveAdapterExecutableCached(id, { settings: ctx.db.settings, run: defaultRun })),
+      );
       const out: Record<string, Record<string, unknown>> = {};
-      for (const id of ids) {
+      idList.forEach((id, i) => {
         out[id] = { ...(providers[id] ?? {}) };
-        out[id].resolvedExecutable = await resolveAdapterExecutable(id, { settings: ctx.db.settings, run: defaultRun });
-      }
+        out[id].resolvedExecutable = resolved[i];
+      });
       res.json({ success: true, data: out });
     }),
   );

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -7,6 +7,7 @@ import { GENERAL_DEFAULTS, NOTIFICATION_DEFAULTS, type NotificationConfig } from
 import type { RouteContext } from './types.js';
 import { validate, UpdateProviderSettingsBody, UpdateGeneralSettingsBody } from './schemas.js';
 import { asyncHandler } from './async-handler.js';
+import { resolveAdapterExecutable, defaultRun } from '../../adapters/resolve-executable.js';
 
 // Per-group validation so a single bad leaf doesn't discard the user's other
 // valid overrides on read.
@@ -100,26 +101,36 @@ export function settingRoutes(ctx: RouteContext): Router {
   });
 
   // Provider defaults
-  router.get('/api/settings/providers', (_req: Request, res: Response) => {
-    const raw = ctx.db.settings.getByCategory('provider');
-    const providers: Record<string, Record<string, unknown>> = {};
-    for (const [key, value] of Object.entries(raw)) {
-      const dotIdx = key.indexOf('.');
-      if (dotIdx === -1) continue;
-      const adapterId = key.slice(0, dotIdx);
-      const field = key.slice(dotIdx + 1);
-      if (!providers[adapterId]) providers[adapterId] = {};
-      providers[adapterId][field] = value;
-    }
-    for (const id of Object.keys(providers)) {
-      const provider = providers[id]!;
-      if (provider.skipPermissions === 'true' && !provider.defaultMode) {
-        provider.defaultMode = 'yolo';
+  router.get(
+    '/api/settings/providers',
+    asyncHandler(async (_req: Request, res: Response) => {
+      const raw = ctx.db.settings.getByCategory('provider');
+      const providers: Record<string, Record<string, unknown>> = {};
+      for (const [key, value] of Object.entries(raw)) {
+        const dotIdx = key.indexOf('.');
+        if (dotIdx === -1) continue;
+        const adapterId = key.slice(0, dotIdx);
+        const field = key.slice(dotIdx + 1);
+        if (!providers[adapterId]) providers[adapterId] = {};
+        providers[adapterId][field] = value;
       }
-      delete provider.skipPermissions;
-    }
-    res.json({ success: true, data: providers });
-  });
+      for (const id of Object.keys(providers)) {
+        const provider = providers[id]!;
+        if (provider.skipPermissions === 'true' && !provider.defaultMode) {
+          provider.defaultMode = 'yolo';
+        }
+        delete provider.skipPermissions;
+      }
+      const ids = new Set<string>(Object.keys(providers));
+      for (const a of ctx.adapters.getAll()) ids.add(a.id);
+      const out: Record<string, Record<string, unknown>> = {};
+      for (const id of ids) {
+        out[id] = { ...(providers[id] ?? {}) };
+        out[id].resolvedExecutable = await resolveAdapterExecutable(id, { settings: ctx.db.settings, run: defaultRun });
+      }
+      res.json({ success: true, data: out });
+    }),
+  );
 
   router.put('/api/settings/providers/:adapterId', (req: Request, res: Response) => {
     const { adapterId } = req.params;

--- a/packages/desktop/src/renderer/components/DirectoryPickerModal.tsx
+++ b/packages/desktop/src/renderer/components/DirectoryPickerModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ChevronRight, ChevronDown, Folder, X } from 'lucide-react';
+import { ChevronRight, ChevronDown, Folder, File, X } from 'lucide-react';
 import { browseFilesystem, type BrowseEntry } from '../lib/api/files-api';
 import { createLogger } from '../lib/logger';
 
@@ -8,6 +8,7 @@ const log = createLogger('renderer:dir-picker');
 interface DirNode {
   name: string;
   path: string;
+  type: 'file' | 'directory';
   children?: DirNode[];
   loading?: boolean;
   expanded?: boolean;
@@ -17,15 +18,18 @@ interface DirectoryPickerModalProps {
   open: boolean;
   onSelect: (path: string) => void;
   onCancel: () => void;
+  mode?: 'directory' | 'file';
 }
 
 export function DirectoryPickerModal({
   open,
   onSelect,
   onCancel,
+  mode = 'directory',
 }: DirectoryPickerModalProps): React.ReactElement | null {
   const [roots, setRoots] = useState<DirNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [selectedType, setSelectedType] = useState<'file' | 'directory' | null>(null);
   const [homePath, setHomePath] = useState<string>('');
 
   // Escape key to close
@@ -41,74 +45,87 @@ export function DirectoryPickerModal({
   useEffect(() => {
     if (!open) return;
     setSelectedPath(null);
-    browseFilesystem()
+    setSelectedType(null);
+    browseFilesystem(undefined, { includeFiles: mode === 'file' })
       .then((result) => {
         setHomePath(result.path);
-        setRoots(result.entries.map((e: BrowseEntry) => ({ name: e.name, path: e.path })));
+        const entries = mode === 'file' ? result.entries : result.entries.filter((e: BrowseEntry) => e.type !== 'file');
+        setRoots(entries.map((e: BrowseEntry) => ({ name: e.name, path: e.path, type: e.type ?? 'directory' })));
       })
       .catch((err) => log.warn('failed to load home directory', { err: String(err) }));
-  }, [open]);
+  }, [open, mode]);
 
-  const toggleExpand = useCallback(async (node: DirNode, indexPath: number[]) => {
-    setRoots((prev) => {
-      const next = structuredClone(prev);
-      let target = next;
-      for (let i = 0; i < indexPath.length - 1; i++) {
-        target = target[indexPath[i]!]!.children!;
-      }
-      const n = target[indexPath[indexPath.length - 1]!]!;
+  const toggleExpand = useCallback(
+    async (node: DirNode, indexPath: number[]) => {
+      if (node.type === 'file') return;
+      setRoots((prev) => {
+        const next = structuredClone(prev);
+        let target = next;
+        for (let i = 0; i < indexPath.length - 1; i++) {
+          target = target[indexPath[i]!]!.children!;
+        }
+        const n = target[indexPath[indexPath.length - 1]!]!;
 
-      if (n.expanded) {
-        n.expanded = false;
-        return next;
-      }
+        if (n.expanded) {
+          n.expanded = false;
+          return next;
+        }
 
-      if (n.children) {
+        if (n.children) {
+          n.expanded = true;
+          return next;
+        }
+
+        n.loading = true;
         n.expanded = true;
+
+        browseFilesystem(n.path, { includeFiles: mode === 'file' })
+          .then((result) => {
+            setRoots((prev2) => {
+              const next2 = structuredClone(prev2);
+              let t = next2;
+              for (let i = 0; i < indexPath.length - 1; i++) {
+                t = t[indexPath[i]!]!.children!;
+              }
+              const node2 = t[indexPath[indexPath.length - 1]!]!;
+              const childEntries =
+                mode === 'file' ? result.entries : result.entries.filter((e: BrowseEntry) => e.type !== 'file');
+              node2.children = childEntries.map((e: BrowseEntry) => ({
+                name: e.name,
+                path: e.path,
+                type: e.type ?? 'directory',
+              }));
+              node2.loading = false;
+              return next2;
+            });
+          })
+          .catch((err) => {
+            log.warn('failed to load directory', { err: String(err), path: n.path });
+            setRoots((prev2) => {
+              const next2 = structuredClone(prev2);
+              let t = next2;
+              for (let i = 0; i < indexPath.length - 1; i++) {
+                t = t[indexPath[i]!]!.children!;
+              }
+              const node2 = t[indexPath[indexPath.length - 1]!]!;
+              node2.loading = false;
+              node2.children = [];
+              return next2;
+            });
+          });
+
         return next;
-      }
-
-      n.loading = true;
-      n.expanded = true;
-
-      browseFilesystem(n.path)
-        .then((result) => {
-          setRoots((prev2) => {
-            const next2 = structuredClone(prev2);
-            let t = next2;
-            for (let i = 0; i < indexPath.length - 1; i++) {
-              t = t[indexPath[i]!]!.children!;
-            }
-            const node2 = t[indexPath[indexPath.length - 1]!]!;
-            node2.children = result.entries.map((e: BrowseEntry) => ({ name: e.name, path: e.path }));
-            node2.loading = false;
-            return next2;
-          });
-        })
-        .catch((err) => {
-          log.warn('failed to load directory', { err: String(err), path: n.path });
-          setRoots((prev2) => {
-            const next2 = structuredClone(prev2);
-            let t = next2;
-            for (let i = 0; i < indexPath.length - 1; i++) {
-              t = t[indexPath[i]!]!.children!;
-            }
-            const node2 = t[indexPath[indexPath.length - 1]!]!;
-            node2.loading = false;
-            node2.children = [];
-            return next2;
-          });
-        });
-
-      return next;
-    });
-  }, []);
+      });
+    },
+    [mode],
+  );
 
   if (!open) return null;
 
   const renderNode = (node: DirNode, indexPath: number[]): React.ReactElement => {
     const depth = indexPath.length - 1;
     const isSelected = selectedPath === node.path;
+    const isFile = node.type === 'file';
 
     return (
       <div key={node.path}>
@@ -116,13 +133,20 @@ export function DirectoryPickerModal({
           data-testid={`dir-entry-${node.path}`}
           onClick={() => {
             setSelectedPath(node.path);
-            void toggleExpand(node, indexPath);
+            setSelectedType(node.type);
+            if (!isFile) void toggleExpand(node, indexPath);
           }}
           className={`w-full flex items-center gap-1 px-2 py-1 text-mf-body text-left hover:bg-mf-hover/50 transition-colors ${isSelected ? 'bg-mf-hover text-mf-text-primary font-medium' : 'text-mf-text-secondary'}`}
           style={{ paddingLeft: `${depth * 16 + 8}px` }}
         >
-          {node.expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          <Folder size={14} />
+          {isFile ? (
+            <span style={{ width: 14 }} />
+          ) : node.expanded ? (
+            <ChevronDown size={14} />
+          ) : (
+            <ChevronRight size={14} />
+          )}
+          {isFile ? <File size={14} /> : <Folder size={14} />}
           <span className="truncate">{node.name}</span>
         </button>
         {node.expanded && node.children && (
@@ -184,7 +208,7 @@ export function DirectoryPickerModal({
             <button
               data-testid="dir-picker-select-btn"
               onClick={() => selectedPath && onSelect(selectedPath)}
-              disabled={!selectedPath}
+              disabled={mode === 'file' ? selectedType !== 'file' : !selectedPath}
               className="px-3 py-1.5 text-mf-body bg-mf-accent text-white rounded-mf-card disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
             >
               Select

--- a/packages/desktop/src/renderer/components/__tests__/DirectoryPickerModal.test.tsx
+++ b/packages/desktop/src/renderer/components/__tests__/DirectoryPickerModal.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/api/files-api', () => ({
+  browseFilesystem: vi.fn(),
+}));
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { DirectoryPickerModal } from '../DirectoryPickerModal';
+import { browseFilesystem } from '../../lib/api/files-api';
+
+const mockEntries = [
+  { name: 'projects', path: '/home/user/projects', type: 'directory' as const },
+  { name: 'documents', path: '/home/user/documents', type: 'directory' as const },
+  { name: 'claude', path: '/usr/local/bin/claude', type: 'file' as const },
+  { name: 'node', path: '/usr/local/bin/node', type: 'file' as const },
+];
+
+beforeEach(() => {
+  vi.mocked(browseFilesystem).mockReset();
+  vi.mocked(browseFilesystem).mockResolvedValue({
+    path: '/home/user',
+    entries: mockEntries,
+  });
+});
+
+describe('DirectoryPickerModal: default mode (no mode prop)', () => {
+  it('renders only directories, not files', async () => {
+    render(<DirectoryPickerModal open onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('projects')).toBeInTheDocument());
+
+    expect(screen.getByText('documents')).toBeInTheDocument();
+    expect(screen.queryByText('claude')).not.toBeInTheDocument();
+    expect(screen.queryByText('node')).not.toBeInTheDocument();
+  });
+
+  it('calls browseFilesystem without includeFiles on initial load', async () => {
+    render(<DirectoryPickerModal open onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(browseFilesystem).toHaveBeenCalled());
+
+    const call = vi.mocked(browseFilesystem).mock.calls[0]!;
+    // Called with no args or with opts where includeFiles is falsy
+    const opts = call[1] as { includeFiles?: boolean } | undefined;
+    expect(opts?.includeFiles).toBeFalsy();
+  });
+
+  it('selecting a directory enables confirm and calls onSelect with directory path', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<DirectoryPickerModal open onSelect={onSelect} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('projects')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('dir-entry-/home/user/projects'));
+
+    const selectBtn = screen.getByTestId('dir-picker-select-btn');
+    expect(selectBtn).not.toBeDisabled();
+    await user.click(selectBtn);
+
+    expect(onSelect).toHaveBeenCalledWith('/home/user/projects');
+  });
+});
+
+describe('DirectoryPickerModal: mode="file"', () => {
+  it('renders both file and directory entries', async () => {
+    render(<DirectoryPickerModal open mode="file" onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('projects')).toBeInTheDocument());
+
+    expect(screen.getByText('documents')).toBeInTheDocument();
+    expect(screen.getByText('claude')).toBeInTheDocument();
+    expect(screen.getByText('node')).toBeInTheDocument();
+  });
+
+  it('calls browseFilesystem with includeFiles: true', async () => {
+    render(<DirectoryPickerModal open mode="file" onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(browseFilesystem).toHaveBeenCalled());
+
+    const call = vi.mocked(browseFilesystem).mock.calls[0]!;
+    const opts = call[1] as { includeFiles?: boolean } | undefined;
+    expect(opts?.includeFiles).toBe(true);
+  });
+
+  it('confirm is disabled when a directory is highlighted', async () => {
+    const user = userEvent.setup();
+    render(<DirectoryPickerModal open mode="file" onSelect={vi.fn()} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('projects')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('dir-entry-/home/user/projects'));
+
+    expect(screen.getByTestId('dir-picker-select-btn')).toBeDisabled();
+  });
+
+  it('selecting a file enables confirm and calls onSelect with the file absolute path', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<DirectoryPickerModal open mode="file" onSelect={onSelect} onCancel={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('claude')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('dir-entry-/usr/local/bin/claude'));
+
+    const selectBtn = screen.getByTestId('dir-picker-select-btn');
+    expect(selectBtn).not.toBeDisabled();
+    await user.click(selectBtn);
+
+    expect(onSelect).toHaveBeenCalledWith('/usr/local/bin/claude');
+  });
+});

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -10,6 +10,7 @@ import { getModelOptions } from '../../lib/adapters';
 import type { ProviderConfig } from '@qlan-ro/mainframe-types';
 import { ModelDropdown } from './ModelDropdown';
 import { MODE_OPTIONS } from './constants';
+import { DirectoryPickerModal } from '../DirectoryPickerModal';
 
 const EMPTY_CONFIG: ProviderConfig = {};
 
@@ -20,6 +21,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
   const adapter = adapters.find((entry) => entry.id === adapterId);
   const models = getModelOptions(adapterId, adapters);
   const [conflicts, setConflicts] = useState<string[]>([]);
+  const [showBinaryPicker, setShowBinaryPicker] = useState(false);
 
   useEffect(() => {
     getConfigConflicts(adapterId)
@@ -38,21 +40,38 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
     [adapterId, config, setProviderConfig],
   );
 
+  const handlePickBinary = useCallback(
+    (p: string) => {
+      setShowBinaryPicker(false);
+      update({ executablePath: p });
+    },
+    [update],
+  );
+
   return (
     <div className="space-y-4">
       {/* Executable Path */}
       <div className="space-y-1.5">
         <label className="text-mf-small text-mf-text-secondary">Executable Path</label>
-        <input
-          type="text"
-          value={config.executablePath ?? ''}
-          onChange={(e) => update({ executablePath: e.target.value || undefined })}
-          placeholder={adapterId}
-          className="w-full px-3 py-1.5 text-mf-small bg-mf-input-bg text-mf-text-primary border border-mf-border rounded-mf-input focus:outline-none focus:border-mf-accent"
-        />
-        <p className="text-mf-status text-mf-text-secondary">
-          Full path to the CLI binary. Leave empty to use system PATH.
-        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={config.executablePath ?? ''}
+            onChange={(e) => update({ executablePath: e.target.value || undefined })}
+            placeholder={adapterId}
+            className="flex-1 px-3 py-1.5 text-mf-small bg-mf-input-bg text-mf-text-primary border border-mf-border rounded-mf-input focus:outline-none focus:border-mf-accent"
+          />
+          <button
+            type="button"
+            onClick={() => setShowBinaryPicker(true)}
+            className="px-3 py-1.5 text-mf-small bg-mf-input-bg text-mf-text-secondary border border-mf-border rounded-mf-input hover:text-mf-text-primary hover:border-mf-accent transition-colors"
+          >
+            Browse…
+          </button>
+        </div>
+        {config.resolvedExecutable?.source === 'fallback' && (
+          <p className="text-mf-status text-mf-text-secondary">Not found on PATH — Browse to select the binary</p>
+        )}
       </div>
 
       {/* Config conflict warning */}
@@ -137,6 +156,13 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
           ))}
         </div>
       </div>
+
+      <DirectoryPickerModal
+        open={showBinaryPicker}
+        mode="file"
+        onSelect={handlePickBinary}
+        onCancel={() => setShowBinaryPicker(false)}
+      />
     </div>
   );
 }

--- a/packages/desktop/src/renderer/components/settings/__tests__/ProviderSection.test.tsx
+++ b/packages/desktop/src/renderer/components/settings/__tests__/ProviderSection.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ProviderSection } from '../ProviderSection';
+import { useSettingsStore } from '../../../store/settings';
+
+const { updateProviderSettings, adaptersState } = vi.hoisted(() => ({
+  updateProviderSettings: vi.fn().mockResolvedValue(undefined),
+  adaptersState: {
+    adapters: [{ id: 'claude', name: 'Claude', capabilities: { planMode: true }, models: [] }],
+  },
+}));
+
+vi.mock('../../../lib/api', () => ({
+  getConfigConflicts: vi.fn().mockResolvedValue([]),
+  updateProviderSettings,
+}));
+
+vi.mock('../../../store/adapters', () => ({
+  useAdaptersStore: (selector: (state: typeof adaptersState) => unknown) => selector(adaptersState),
+}));
+
+vi.mock('../../DirectoryPickerModal', () => ({
+  DirectoryPickerModal: ({
+    open,
+    mode,
+    onSelect,
+    onCancel,
+  }: {
+    open: boolean;
+    mode?: string;
+    onSelect: (path: string) => void;
+    onCancel: () => void;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="dir-picker-modal" data-mode={mode}>
+        <button type="button" onClick={() => onSelect('/usr/bin/claude')}>
+          Pick
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  },
+}));
+
+describe('ProviderSection — executable path', () => {
+  beforeEach(() => {
+    updateProviderSettings.mockClear();
+    adaptersState.adapters = [{ id: 'claude', name: 'Claude', capabilities: { planMode: true }, models: [] }];
+    useSettingsStore.setState({
+      isOpen: false,
+      activeTab: 'providers',
+      selectedProvider: 'claude',
+      providers: {},
+      general: { worktreeDir: '.worktrees' },
+      loading: false,
+    });
+  });
+
+  it('prefills input with executablePath and hides the not-found message when valid config', () => {
+    useSettingsStore.setState({
+      providers: {
+        claude: {
+          executablePath: '/opt/homebrew/bin/claude',
+          resolvedExecutable: { path: '/opt/homebrew/bin/claude', source: 'config', valid: true },
+        },
+      },
+    });
+
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+
+    const input = screen.getByPlaceholderText('claude') as HTMLInputElement;
+    expect(input.value).toBe('/opt/homebrew/bin/claude');
+    expect(screen.queryByText(/not found on path/i)).toBeNull();
+  });
+
+  it('shows not-found message when source is fallback', () => {
+    useSettingsStore.setState({
+      providers: {
+        claude: {
+          executablePath: '',
+          resolvedExecutable: { path: 'claude', source: 'fallback', valid: false },
+        },
+      },
+    });
+
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+
+    expect(screen.getByText(/not found on path — browse to select the binary/i)).toBeInTheDocument();
+  });
+
+  it('Browse button opens DirectoryPickerModal with mode=file and persists selection via update', async () => {
+    useSettingsStore.setState({
+      providers: {
+        claude: {
+          executablePath: '',
+          resolvedExecutable: { path: 'claude', source: 'fallback', valid: false },
+        },
+      },
+    });
+
+    render(<ProviderSection adapterId="claude" label="Claude" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /browse/i }));
+
+    const modal = await screen.findByTestId('dir-picker-modal');
+    expect(modal).toHaveAttribute('data-mode', 'file');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pick' }));
+
+    await waitFor(() => {
+      expect(updateProviderSettings).toHaveBeenCalledWith('claude', { executablePath: '/usr/bin/claude' });
+    });
+    expect(useSettingsStore.getState().providers.claude?.executablePath).toBe('/usr/bin/claude');
+  });
+});

--- a/packages/desktop/src/renderer/components/settings/__tests__/ProviderSection.test.tsx
+++ b/packages/desktop/src/renderer/components/settings/__tests__/ProviderSection.test.tsx
@@ -55,7 +55,14 @@ describe('ProviderSection — executable path', () => {
       activeTab: 'providers',
       selectedProvider: 'claude',
       providers: {},
-      general: { worktreeDir: '.worktrees' },
+      general: {
+        worktreeDir: '.worktrees',
+        notifications: {
+          chat: { taskComplete: true, sessionError: true },
+          permission: { toolRequest: true, userQuestion: true, planApproval: true },
+          other: { plugin: true },
+        },
+      },
       loading: false,
     });
   });

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,11 +1,19 @@
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'yolo';
 
+export interface ResolvedExecutable {
+  path: string;
+  source: 'config' | 'detected' | 'fallback';
+  valid: boolean;
+  version?: string;
+}
+
 export interface ProviderConfig {
   defaultModel?: string;
   defaultMode?: 'default' | 'acceptEdits' | 'yolo';
   defaultPlanMode?: 'true' | 'false';
   executablePath?: string;
   systemPrompt?: string;
+  resolvedExecutable?: ResolvedExecutable;
 }
 
 export interface NotificationConfig {


### PR DESCRIPTION
## Summary
- **Centralized resolver** (`packages/core/src/adapters/resolve-executable.ts`): resolves an adapter CLI's absolute path via `which`/`where` (respects `$PATH`), validates with `--version`. Deps-injected, unit-tested.
- **Daemon-startup backfill**: non-blocking pass writes the detected absolute path into `provider.<id>.executablePath` only when unset (idempotent, never overwrites). Spawns become explicit; failure can't block serving.
- **Settings GET** exposes additive `resolvedExecutable { path, source, valid, version? }` per adapter (parallelized + 5s memo so the polled endpoint never serializes subprocess timeouts). Existing fields + `skipPermissions` normalization preserved.
- **Settings UI** (`ProviderSection`): path input prefilled with the absolute path; **Browse…** opens the existing daemon-side `DirectoryPickerModal` (new `mode="file"` prop — renderer may be remote, so no Electron picker); the only message is `Not found on PATH — Browse to select the binary` for the fallback case.
- **Spawn hot path unchanged**: `session.ts`/`lifecycle-manager` untouched; `$PATH` bare-name fallback preserved as last resort; resolver is never called on chat start (no added latency). Spawn-regression tests 14/14 green.

Single canonical `ProviderConfig`/`ResolvedExecutable` in `@qlan-ro/mainframe-types`. `DirectoryPickerModal` default `mode` keeps project-add callers byte-identical.

## Test plan
- core build clean; `resolve-executable`/`settings`/`settings-resolved-executable` 43 pass; `DirectoryPickerModal`/`ProviderSection` 10 pass; spawn regression (`session-spawn-args`, `claude-spawn-args`) 14 pass; desktop tsc clean for touched files
- [x] Fresh start with `claude` on PATH → Settings shows the absolute path prefilled, no message
- [x] Remove from PATH + clear setting + restart → "Not found on PATH" shown; Browse picks the binary and persists it
- [x] Existing project-add directory picker unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)