### PR TITLE
ci: fix node-gyp/native build failures on main after #330

### DIFF
--- a/.changeset/ci-node-gyp-toolchain.md
+++ b/.changeset/ci-node-gyp-toolchain.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: install node-gyp before native deps build (node-pty has no Linux prebuild); use --ignore-scripts in JS-only jobs (version, publish-types). Fixes red main after the dependency bump (#330).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # node-pty has no Linux prebuild and compiles via `node-gyp rebuild`.
+      # node-gyp is not on the install-script PATH on the runner, so install
+      # it globally before native deps are built.
+      - run: npm install -g node-gyp
+
       - run: pnpm install --frozen-lockfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -22,8 +22,11 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
+      # Only builds/publishes the pure-TS types package; no native code.
+      # Skip lifecycle scripts so node-pty/better-sqlite3 (no Linux prebuild)
+      # don't need a native toolchain here.
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # node-pty has no Linux prebuild and compiles via `node-gyp rebuild`;
+      # node-gyp is not on the install-script PATH on the runner.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:
@@ -86,6 +91,10 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      # node-pty has no Linux prebuild and compiles via `node-gyp rebuild`;
+      # node-gyp is not on the install-script PATH on the runner.
+      - run: npm install -g node-gyp
 
       - run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,10 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      # This job only runs `changeset version`; it never builds native code.
+      # Skip lifecycle scripts so node-pty/better-sqlite3 (no Linux prebuild)
+      # don't need a native toolchain here.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
PR #330 turned `main` red. Two workflows fail at `pnpm install --frozen-lockfile`:
- **CI / build-and-test** — failure
- **Version Packages / version** — failure

Both die with `node-pty@1.1.0 install: sh: 1: node-gyp: not found`.

## Root cause
`node-pty@1.1.0` ships **no Linux prebuild** (only darwin/win32), so on Linux it always compiles via `node scripts/prebuild.js || node-gyp rebuild`. `node-gyp` is not on the PATH that pnpm uses to run dependency install scripts. #330 bumped `node-gyp` 11.5.0 → 12.3.0, which changed the dependency graph so its bin is no longer resolvable there. (`changeset-check` had the same issue; it was already patched with `--ignore-scripts` in #330.)

## Fix
- **build-and-test, release** (genuinely build/package native code): `npm install -g node-gyp` before `pnpm install`.
- **version, publish-types** (never build native — only `changeset version` / pure-TS types): `pnpm install --frozen-lockfile --ignore-scripts`.

`release.yml`/`publish-types.yml` weren't red yet but have the identical latent failure and would block the next release — fixed proactively in the same PR.

## Test plan
- [ ] CI `build-and-test` passes on this PR (proves node-gyp fix builds node-pty/better-sqlite3 on Linux)
- [ ] `pnpm changeset status` (changeset-check) passes
- [ ] After merge: `Version Packages` workflow goes green on main
- [ ] Next release run exercises `release.yml` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)