### PR TITLE
fix(desktop): restore composer image attachments after assistant-ui 0.14

### DIFF
--- a/.changeset/fair-otters-attach.md
+++ b/.changeset/fair-otters-attach.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix composer image attachments silently failing after the assistant-ui 0.14 upgrade. The library's new `fileMatchesAccept` only treats the literal `*` as a universal wildcard, so the adapter's `*/*` accept string rejected every file and nothing appeared in the composer for both the paperclip button and paste.
+
+Attachment rejections (file too large, unreadable, unsupported type) now surface as an error toast instead of failing silently.

--- a/packages/desktop/src/__tests__/components/composer/attachment-adapter.test.tsx
+++ b/packages/desktop/src/__tests__/components/composer/attachment-adapter.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import React, { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  useComposerRuntime,
+  useExternalStoreRuntime,
+} from '@assistant-ui/react';
+import { createAttachmentAdapter } from '../../../renderer/components/chat/assistant-ui/composer/attachment-adapter';
+
+// Regression: assistant-ui 0.14 gates addAttachment through fileMatchesAccept,
+// which only treats the literal '*' as a universal wildcard. The previous
+// adapter declared the star-slash-star accept string, so every image/file was
+// rejected and nothing appeared in the composer (both paperclip and paste).
+// This drives the REAL library composer runtime: addAttachment must surface a
+// rendered attachment.
+
+const PNG_FILE = new File([Uint8Array.from([1, 2, 3])], 'shot.png', { type: 'image/png' });
+
+function AddOnMount() {
+  const composer = useComposerRuntime();
+  useEffect(() => {
+    void composer.addAttachment(PNG_FILE);
+  }, [composer]);
+  return null;
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime({
+    isRunning: false,
+    messages: [],
+    onNew: vi.fn(),
+    adapters: { attachments: createAttachmentAdapter() },
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <AddOnMount />
+      <ComposerPrimitive.Attachments
+        components={{
+          Image: () => <div data-testid="attachment-thumb" />,
+          Attachment: () => <div data-testid="attachment-thumb" />,
+        }}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+describe('createAttachmentAdapter', () => {
+  it('accepts an image so it renders in the composer', async () => {
+    render(<Harness />);
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-thumb')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/desktop/src/__tests__/components/composer/attachment-rejection-toast.test.tsx
+++ b/packages/desktop/src/__tests__/components/composer/attachment-rejection-toast.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React, { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { AssistantRuntimeProvider, useComposerRuntime, useExternalStoreRuntime } from '@assistant-ui/react';
+import { createAttachmentAdapter } from '../../../renderer/components/chat/assistant-ui/composer/attachment-adapter';
+import { AttachmentRejectionToaster } from '../../../renderer/components/chat/assistant-ui/composer/AttachmentRejectionToaster';
+import { useToastStore } from '../../../renderer/store/toasts';
+
+// An oversized file (> 5 MB) is rejected by the adapter; the rejection must
+// surface as an error toast via assistant-ui's attachmentAddError event.
+const HUGE_FILE = new File([new Uint8Array(6 * 1024 * 1024)], 'huge.png', { type: 'image/png' });
+
+function AddOnMount() {
+  const composer = useComposerRuntime();
+  useEffect(() => {
+    void composer.addAttachment(HUGE_FILE).catch(() => {});
+  }, [composer]);
+  return null;
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime({
+    isRunning: false,
+    messages: [],
+    onNew: vi.fn(),
+    adapters: { attachments: createAttachmentAdapter() },
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <AttachmentRejectionToaster />
+      <AddOnMount />
+    </AssistantRuntimeProvider>
+  );
+}
+
+describe('AttachmentRejectionToaster', () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it('shows an error toast when an attachment is rejected', async () => {
+    render(<Harness />);
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts;
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0]!.type).toBe('error');
+      expect(toasts[0]!.description).toMatch(/too large/i);
+    });
+  });
+});

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/MainframeRuntimeProvider.tsx
@@ -1,12 +1,8 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import {
-  AssistantRuntimeProvider,
-  useExternalStoreRuntime,
-  type AppendMessage,
-  type PendingAttachment,
-  type CompleteAttachment,
-} from '@assistant-ui/react';
-import type { AttachmentAdapter, ExternalStoreThreadListAdapter } from '@assistant-ui/react';
+import { AssistantRuntimeProvider, useExternalStoreRuntime, type AppendMessage } from '@assistant-ui/react';
+import type { ExternalStoreThreadListAdapter } from '@assistant-ui/react';
+import { createAttachmentAdapter, FILE_SIZE_LIMIT_MB } from './composer/attachment-adapter.js';
+import { AttachmentRejectionToaster } from './composer/AttachmentRejectionToaster.js';
 import { useChatSession } from '../../../hooks/useChatSession';
 import { convertMessage } from './convert-message';
 import { daemonClient } from '../../../lib/client';
@@ -26,11 +22,9 @@ interface MainframeRuntimeProviderProps {
   children: React.ReactNode;
 }
 
-const MAX_SIZE = 5 * 1024 * 1024;
 const DATA_URL_RE = /^data:([^;]+);base64,(.+)$/;
 const IMAGE_COORDINATE_NOTE_RE =
   /\[Image:\s*original\s+\d+x\d+,\s*displayed at\s+\d+x\d+\.\s*Multiply coordinates by\s+[0-9.]+\s+to map to original image\.\]/g;
-const FILE_SIZE_LIMIT_MB = 5;
 
 interface MainframeRuntimeContextValue {
   chatId: string;
@@ -107,15 +101,6 @@ function appendCapturesToAttachments(captures: ReadonlyArray<SandboxCaptureLike>
   return `[Preview captures: ${labels.join(', ')}]\n\n`;
 }
 
-function readFileAsDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-}
-
 function formatComposerError(error: unknown): string {
   const fallback = `Attachment upload failed. Files must be ${FILE_SIZE_LIMIT_MB}MB or smaller.`;
   const raw = error instanceof Error ? error.message : String(error ?? '');
@@ -151,40 +136,7 @@ export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeP
     setComposerError(null);
   }, [chatId]);
 
-  const attachmentAdapter = useMemo<AttachmentAdapter>(
-    () => ({
-      accept: '*/*',
-      async add({ file }) {
-        if (file.size > MAX_SIZE) {
-          setComposerError(`"${file.name}" is too large. Max file size is ${FILE_SIZE_LIMIT_MB}MB.`);
-          throw new Error(`File too large (max ${FILE_SIZE_LIMIT_MB}MB)`);
-        }
-        const dataUrl = await readFileAsDataUrl(file);
-        const isImage = file.type.startsWith('image/');
-        return {
-          id: crypto.randomUUID(),
-          type: isImage ? 'image' : 'document',
-          name: file.name,
-          contentType: file.type || 'application/octet-stream',
-          file,
-          content: isImage ? [{ type: 'image', image: dataUrl }] : [{ type: 'text', text: dataUrl }],
-          status: { type: 'requires-action', reason: 'composer-send' },
-        } satisfies PendingAttachment;
-      },
-      async remove() {},
-      async send(attachment) {
-        return {
-          id: attachment.id,
-          type: attachment.type as 'image' | 'document',
-          name: attachment.name,
-          contentType: attachment.contentType,
-          content: attachment.content ?? [],
-          status: { type: 'complete' },
-        } satisfies CompleteAttachment;
-      },
-    }),
-    [setComposerError],
-  );
+  const attachmentAdapter = useMemo(() => createAttachmentAdapter(), []);
 
   const onNew = useCallback(
     async (message: AppendMessage) => {
@@ -386,6 +338,7 @@ export function MainframeRuntimeProvider({ chatId, children }: MainframeRuntimeP
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <AttachmentRejectionToaster />
       {AllToolUIs.map((ToolUI, i) => (
         <ToolUI key={i} />
       ))}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/AttachmentRejectionToaster.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/AttachmentRejectionToaster.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useComposerRuntime } from '@assistant-ui/react';
+import { useToastStore } from '../../../../store/toasts';
+
+const REASON_TITLE: Record<string, string> = {
+  'no-adapter': 'Attachments unavailable',
+  'not-accepted': 'Unsupported file',
+  'adapter-error': 'Attachment rejected',
+};
+
+/**
+ * Surfaces assistant-ui attachment-add rejections (too large, unreadable,
+ * unsupported type) as error toasts. Rendered inside AssistantRuntimeProvider.
+ */
+export function AttachmentRejectionToaster(): null {
+  const composer = useComposerRuntime();
+
+  useEffect(() => {
+    return composer.unstable_on('attachmentAddError', (e) => {
+      const title = REASON_TITLE[e.reason] ?? 'Attachment rejected';
+      useToastStore.getState().add('error', title, e.message);
+    });
+  }, [composer]);
+
+  return null;
+}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/composer/attachment-adapter.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/composer/attachment-adapter.ts
@@ -1,0 +1,51 @@
+import type { AttachmentAdapter, PendingAttachment, CompleteAttachment } from '@assistant-ui/react';
+
+export const FILE_SIZE_LIMIT_MB = 5;
+const MAX_SIZE = FILE_SIZE_LIMIT_MB * 1024 * 1024;
+
+// assistant-ui's fileMatchesAccept only treats the literal '*' as a universal
+// wildcard; the MIME-style '*/*' rejects every file, silently blocking all
+// composer attachments.
+const ACCEPT_ALL = '*';
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export function createAttachmentAdapter(): AttachmentAdapter {
+  return {
+    accept: ACCEPT_ALL,
+    async add({ file }) {
+      if (file.size > MAX_SIZE) {
+        throw new Error(`"${file.name}" is too large. Max file size is ${FILE_SIZE_LIMIT_MB}MB.`);
+      }
+      const dataUrl = await readFileAsDataUrl(file);
+      const isImage = file.type.startsWith('image/');
+      return {
+        id: crypto.randomUUID(),
+        type: isImage ? 'image' : 'document',
+        name: file.name,
+        contentType: file.type || 'application/octet-stream',
+        file,
+        content: isImage ? [{ type: 'image', image: dataUrl }] : [{ type: 'text', text: dataUrl }],
+        status: { type: 'requires-action', reason: 'composer-send' },
+      } satisfies PendingAttachment;
+    },
+    async remove() {},
+    async send(attachment) {
+      return {
+        id: attachment.id,
+        type: attachment.type as 'image' | 'document',
+        name: attachment.name,
+        contentType: attachment.contentType,
+        content: attachment.content ?? [],
+        status: { type: 'complete' },
+      } satisfies CompleteAttachment;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **Root cause:** the dependency bump in #330 upgraded `@assistant-ui/react` `0.12.19 → 0.14.5`. In 0.14, `BaseComposerRuntimeCore.addAttachment` gates every file through `fileMatchesAccept(file, adapter.accept)` and throws on failure. That predicate only treats the **literal `'*'`** as a universal wildcard — `'*/*'` evaluates to `false` for every real MIME type. Our adapter declared `accept: '*/*'`, so all attachments were silently rejected before rendering (both the paperclip button and paste showed nothing).
- **Fix:** extracted the attachment adapter into `composer/attachment-adapter.ts` using the library's real wildcard `'*'`.
- **UX:** add-rejections (file too large, unreadable, unsupported type) now surface as an error toast via assistant-ui's `attachmentAddError` event (`AttachmentRejectionToaster`), instead of failing silently. Removed the dead inline-banner path for add-rejections.

## Test plan
- [x] New TDD test drives the **real** assistant-ui composer runtime: an image now attaches and renders.
- [x] New TDD test: an oversized file fires an error toast through the `attachmentAddError` event.
- [x] 144/144 chat + composer tests pass; changed production files typecheck clean.
- [x] Manual: build & launch the Electron app, paste an image and attach via paperclip, confirm thumbnail appears; attach a >5MB file and confirm the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)