### PR TITLE
fix(core): preserve question & answer text in AskUserQuestion parsing

### DIFF
--- a/.changeset/quick-trees-ask.md
+++ b/.changeset/quick-trees-ask.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix AskUserQuestion answered-question rendering losing the question and answer text. The result parser used a blind regex that broke whenever a question or answer contained a double quote (the question text was truncated/dropped) and split every answer on commas (mangling free-text answers). It now anchors on the exact known question strings from the tool input, preserves free-text answers verbatim, and only comma-splits multi-select answers.

--- a/packages/core/src/messages/__tests__/parse-ask-user-question.test.ts
+++ b/packages/core/src/messages/__tests__/parse-ask-user-question.test.ts
@@ -44,6 +44,74 @@ describe('parseAskUserQuestionResult', () => {
     ]);
   });
 
+  describe('anchored parsing with known questions', () => {
+    it('preserves a question whose text contains double quotes (real session data)', () => {
+      const q = '"Prepare Release Bugs" is ambiguous to me — what do you want done?';
+      const s = `${PREFIX}"${q}"="1. cannot paste/attach images anymore in composer"${SUFFIX}`;
+      expect(parseAskUserQuestionResult(s, [{ question: q, multiSelect: false }])).toEqual([
+        { question: q, answer: ['1. cannot paste/attach images anymore in composer'] },
+      ]);
+    });
+
+    it('keeps free-text answers verbatim, including internal commas and quotes (real session data)', () => {
+      const q1 = 'When you try to paste or attach an image in the composer, what exactly happens?';
+      const q2 = 'Which entry points are broken?';
+      const a1 =
+        'nothing happens at all, but forgot to mention that i run on that debug/queued-messages branch which also contains latest main';
+      const a2 =
+        'both, paperclip works until i choose the image i want to upload. once i hit "open" nothing shows up in the composer';
+      const s = `${PREFIX}"${q1}"="${a1}", "${q2}"="${a2}"${SUFFIX}`;
+      expect(
+        parseAskUserQuestionResult(s, [
+          { question: q1, multiSelect: false },
+          { question: q2, multiSelect: false },
+        ]),
+      ).toEqual([
+        { question: q1, answer: [a1] },
+        { question: q2, answer: [a2] },
+      ]);
+    });
+
+    it('splits multi-select answers by comma only for multiSelect questions', () => {
+      const s = `${PREFIX}"Pick"="Red,Blue"${SUFFIX}`;
+      expect(
+        parseAskUserQuestionResult(s, [
+          { question: 'Pick', multiSelect: true, options: [{ label: 'Red' }, { label: 'Blue' }] },
+        ]),
+      ).toEqual([{ question: 'Pick', answer: ['Red', 'Blue'] }]);
+    });
+
+    it('extracts preview and notes on the anchored path', () => {
+      const s = `${PREFIX}"Layout?"="Grid" selected preview:\n<div>grid</div> user notes: prefer dense, "Theme?"="Dark"${SUFFIX}`;
+      expect(
+        parseAskUserQuestionResult(s, [
+          { question: 'Layout?', multiSelect: false },
+          { question: 'Theme?', multiSelect: false },
+        ]),
+      ).toEqual([
+        { question: 'Layout?', answer: ['Grid'], preview: '<div>grid</div>', notes: 'prefer dense' },
+        { question: 'Theme?', answer: ['Dark'] },
+      ]);
+    });
+
+    it('omits questions the user did not answer', () => {
+      const s = `${PREFIX}"Q1"="A1"${SUFFIX}`;
+      expect(
+        parseAskUserQuestionResult(s, [
+          { question: 'Q1', multiSelect: false },
+          { question: 'Q2', multiSelect: false },
+        ]),
+      ).toEqual([{ question: 'Q1', answer: ['A1'] }]);
+    });
+
+    it('falls back to legacy parsing when no question matches', () => {
+      const s = `${PREFIX}"Different"="X"${SUFFIX}`;
+      expect(parseAskUserQuestionResult(s, [{ question: 'Unrelated', multiSelect: false }])).toEqual([
+        { question: 'Different', answer: ['X'] },
+      ]);
+    });
+  });
+
   it('returns [] for non-AskUserQuestion or malformed content, never throws', () => {
     expect(parseAskUserQuestionResult('')).toEqual([]);
     expect(parseAskUserQuestionResult('totally unrelated tool output')).toEqual([]);

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -4,7 +4,7 @@ import type { GroupedMessage } from './message-grouping.js';
 import type { PartEntry } from './tool-grouping.js';
 import { groupToolCallParts, groupTaskChildren } from './tool-grouping.js';
 import { truncateToolContent } from './truncate-tool-content.js';
-import { parseAskUserQuestionResult } from './parse-ask-user-question.js';
+import { parseAskUserQuestionResult, type KnownQuestion } from './parse-ask-user-question.js';
 
 const INTERNAL_USER_RE = /<mainframe-command[\s>]/;
 
@@ -31,8 +31,24 @@ export function categorizeToolCall(
   return 'default';
 }
 
+function extractKnownQuestions(toolInput: unknown): KnownQuestion[] | undefined {
+  if (typeof toolInput !== 'object' || toolInput === null) return undefined;
+  const q = (toolInput as { questions?: unknown }).questions;
+  if (!Array.isArray(q)) return undefined;
+  return q
+    .filter((item): item is { question: string } => typeof item?.question === 'string')
+    .map((item) => {
+      const i = item as { question: string; multiSelect?: boolean; options?: { label: string }[] };
+      return { question: i.question, multiSelect: i.multiSelect, options: i.options };
+    });
+}
+
 /** Build a ToolCallResult from a tool_result content block. */
-export function toToolCallResult(block: MessageContent & { type: 'tool_result' }, toolName?: string): ToolCallResult {
+export function toToolCallResult(
+  block: MessageContent & { type: 'tool_result' },
+  toolName?: string,
+  toolInput?: unknown,
+): ToolCallResult {
   const t = truncateToolContent(block.content);
   return {
     content: t.content,
@@ -41,7 +57,9 @@ export function toToolCallResult(block: MessageContent & { type: 'tool_result' }
     ...(block.structuredPatch && { structuredPatch: block.structuredPatch }),
     ...(block.originalFile && { originalFile: block.originalFile }),
     ...(block.modifiedFile && { modifiedFile: block.modifiedFile }),
-    ...(toolName === 'AskUserQuestion' ? { askUserQuestion: parseAskUserQuestionResult(block.content) } : {}),
+    ...(toolName === 'AskUserQuestion'
+      ? { askUserQuestion: parseAskUserQuestionResult(block.content, extractKnownQuestions(toolInput)) }
+      : {}),
   };
 }
 
@@ -86,7 +104,7 @@ export function convertAssistantContent(grouped: GroupedMessage, categories?: To
         category: block.name === 'AskUserQuestion' && resultBlock ? 'default' : baseCategory,
         ...withParentId(block.parentToolUseId),
       };
-      if (resultBlock) call.result = toToolCallResult(resultBlock, block.name);
+      if (resultBlock) call.result = toToolCallResult(resultBlock, block.name, block.input);
       content.push(call);
     }
   }

--- a/packages/core/src/messages/parse-ask-user-question.ts
+++ b/packages/core/src/messages/parse-ask-user-question.ts
@@ -4,11 +4,93 @@ const PREFIX = 'User has answered your questions: ';
 const SUFFIX = ". You can now continue with the user's answers in mind.";
 const PAIR = /"([^"]*)"="([^"]*)"/g;
 
-export function parseAskUserQuestionResult(content: string): AskUserQuestionAnswer[] {
-  if (typeof content !== 'string' || !content.startsWith(PREFIX)) return [];
+export interface KnownQuestion {
+  question: string;
+  multiSelect?: boolean;
+  options?: { label: string }[];
+}
+
+function stripBody(content: string): string | undefined {
+  if (typeof content !== 'string' || !content.startsWith(PREFIX)) return undefined;
   let body = content.slice(PREFIX.length);
   if (body.endsWith(SUFFIX)) body = body.slice(0, -SUFFIX.length);
+  return body;
+}
 
+function splitAnswer(raw: string, multiSelect: boolean | undefined): string[] {
+  if (!multiSelect) {
+    // Free-text / single-select answers are kept verbatim — they routinely
+    // contain commas and quotes (e.g. pasted prose, "Other" text).
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? [trimmed] : [raw];
+  }
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return parts.length > 0 ? parts : [raw];
+}
+
+function extractPreviewNotes(segment: string): { answer: string; preview?: string; notes?: string } {
+  const previewMatch = segment.match(/selected preview:\r?\n([\s\S]*?)(?: user notes: |$)/);
+  const notesMatch = segment.match(/user notes: ([\s\S]*?)\s*,?\s*$/);
+  const cutAt = segment.search(/ selected preview:| user notes: /);
+  let answer = cutAt === -1 ? segment : segment.slice(0, cutAt);
+  // Drop the answer's structural closing quote.
+  if (answer.endsWith('"')) answer = answer.slice(0, -1);
+  const out: { answer: string; preview?: string; notes?: string } = { answer };
+  const preview = previewMatch?.[1]?.trim();
+  const notes = notesMatch?.[1]?.trim();
+  if (preview) out.preview = preview;
+  if (notes) out.notes = notes;
+  return out;
+}
+
+/**
+ * Anchored parse: locate each known question by its exact text, then take the
+ * answer as everything up to the next known question's marker. Robust to
+ * quotes and commas inside both question and answer text.
+ */
+function parseAnchored(body: string, questions: KnownQuestion[]): AskUserQuestionAnswer[] | undefined {
+  const out: AskUserQuestionAnswer[] = [];
+  let cursor = 0;
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i]!;
+    const marker = `"${q.question}"="`;
+    const mIdx = body.indexOf(marker, cursor);
+    if (mIdx === -1) continue; // unanswered question — omit
+    const ansStart = mIdx + marker.length;
+
+    // Boundary: the start of the next answered question's marker, which is
+    // preceded by `", ` (this answer's closing quote + separator).
+    let segEnd = body.length;
+    for (let j = i + 1; j < questions.length; j++) {
+      const nextMarker = `"${questions[j]!.question}"="`;
+      const sepIdx = body.indexOf(`, ${nextMarker}`, ansStart);
+      if (sepIdx !== -1) {
+        segEnd = sepIdx;
+        break;
+      }
+      const bare = body.indexOf(nextMarker, ansStart);
+      if (bare !== -1) {
+        segEnd = bare;
+        break;
+      }
+    }
+
+    const segment = body.slice(ansStart, segEnd);
+    const { answer, preview, notes } = extractPreviewNotes(segment);
+    const entry: AskUserQuestionAnswer = { question: q.question, answer: splitAnswer(answer, q.multiSelect) };
+    if (preview) entry.preview = preview;
+    if (notes) entry.notes = notes;
+    out.push(entry);
+    cursor = segEnd;
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/** Legacy regex parse — fallback when question metadata is unavailable. */
+function parseLegacy(body: string): AskUserQuestionAnswer[] {
   const matches: { q: string; a: string; start: number; end: number }[] = [];
   PAIR.lastIndex = 0;
   let m: RegExpExecArray | null;
@@ -21,7 +103,6 @@ export function parseAskUserQuestionResult(content: string): AskUserQuestionAnsw
   for (let i = 0; i < matches.length; i++) {
     const cur = matches[i]!;
     const next = matches[i + 1];
-    // tail = text between this pair's closing quote and the start of the next pair (or end of body)
     const tail = body.slice(cur.end, next ? next.start : body.length);
 
     const previewMatch = tail.match(/selected preview:\r?\n([\s\S]*?)(?: user notes: |$)/);
@@ -42,4 +123,14 @@ export function parseAskUserQuestionResult(content: string): AskUserQuestionAnsw
     out.push(entry);
   }
   return out;
+}
+
+export function parseAskUserQuestionResult(content: string, questions?: KnownQuestion[]): AskUserQuestionAnswer[] {
+  const body = stripBody(content);
+  if (body === undefined) return [];
+  if (questions && questions.length > 0) {
+    const anchored = parseAnchored(body, questions);
+    if (anchored) return anchored;
+  }
+  return parseLegacy(body);
 }


### PR DESCRIPTION
## Summary
The answered-AskUserQuestion card in chat showed the header but a garbled/missing question and answer.

**Root cause (reproduced with real session data):** `parseAskUserQuestionResult` blind-regex-parsed the ambiguous `"q"="a"` result string. When a question contained a `"` the question text was truncated/dropped; when an answer contained `"` it was truncated; and every answer was split on `,`, mangling free-text answers. Example from a real session: question `"Prepare Release Bugs" is ambiguous…` parsed to ` is ambiguous…` (leading text lost); a free-text answer was split mid-sentence.

**Fix:** anchor parsing on the exact known question strings from the tool input (available at the call site as the tool_use `input.questions`):
- locate each question verbatim, take the answer up to the next question's marker — robust to quotes/commas in both,
- keep single/free-text answers verbatim,
- only comma-split multi-select questions,
- fall back to the legacy regex when question metadata is absent (backward compatible).

Verified end-to-end through the real `toToolCallResult` pipeline with this session's actual tool_use/tool_result data.

## Test plan
- [x] New TDD tests using the real session strings (quoted question, free-text answers with commas/quotes, multi-select, preview/notes, unanswered, legacy fallback). RED → GREEN.
- [x] Full core message suites: 166/166 pass; changed files typecheck clean.
- [ ] Manual: open a chat with an AskUserQuestion whose question contains quotes; confirm the answered card shows the full question and answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)