### PR TITLE
fix(desktop): rebuild better-sqlite3 against Electron's ABI when packaging

### DIFF
--- a/.changeset/package-rebuild-better-sqlite3.md
+++ b/.changeset/package-rebuild-better-sqlite3.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Rebuild `better-sqlite3` against Electron's ABI when packaging. The `package` script only ran `electron-rebuild -o node-pty`, so the bundled `better-sqlite3` kept its Node-ABI prebuild and the packaged app crashed on launch with `NODE_MODULE_VERSION 137 ... requires 145`. It is now rebuilt with the module dir pointed at `@qlan-ro/mainframe-core` (where it is a declared dependency, since pnpm hoists it out of the desktop package) and `-f` to bypass a stale `.forge-meta` cache that was silently skipping the build.

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:playwright": "playwright test -c playwright-ct.config.ts",
-    "package": "electron-rebuild -o node-pty && electron-builder",
+    "package": "electron-rebuild -o node-pty && electron-rebuild -m ../core -o better-sqlite3 -f -v $(node -p \"require('electron/package.json').version\") && electron-builder",
     "postinstall": "node scripts/fix-pty-permissions.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The packaged macOS app crashed immediately at launch:

```
Error: The module .../Resources/node_modules/better-sqlite3/build/Release/better_sqlite3.node
was compiled against a different Node.js version using NODE_MODULE_VERSION 137.
This version of Node.js requires NODE_MODULE_VERSION 145.
```

The `package` script only ran `electron-rebuild -o node-pty`, so the bundled `better-sqlite3` shipped with its Node-ABI prebuild and the daemon FATAL-d at `require('better-sqlite3')` under Electron's ABI 145.

## Fix

Add a second `electron-rebuild` step that targets `better-sqlite3`:

```diff
- "package": "electron-rebuild -o node-pty && electron-builder",
+ "package": "electron-rebuild -o node-pty && electron-rebuild -m ../core -o better-sqlite3 -f -v $(node -p \"require('electron/package.json').version\") && electron-builder",
```

Three non-obvious bits — each of which was tried first and didn't work:

- **`-m ../core` is required.** `better-sqlite3` is a `@qlan-ro/mainframe-core` dependency. pnpm hoists it to the workspace root and does **not** symlink it into `packages/desktop/node_modules`, so `electron-rebuild -o better-sqlite3` from the desktop package can't find it. Pointing the module dir at `../core` (which declares it) resolves through pnpm to the same hoisted store copy that `extraResources` then bundles.
- **electron-builder's own internal rebuild doesn't fix it.** The bundled `better-sqlite3` is copied verbatim via `extraResources` (`from: ../../node_modules/better-sqlite3`), bypassing electron-builder's `@electron/rebuild` pass. The rebuild must happen on the store copy *before* `electron-builder` runs.
- **`-f` (force) is mandatory.** `build/Release/.forge-meta` (e.g. `arm64--145`) is a cache that makes `electron-rebuild` silently no-op while the real `.node` is still the wrong ABI. The first rebuild attempts printed "✔ Rebuild Complete" but did not actually touch the binary.

## Verification

- Rebuilt the store copy and loaded it via `ELECTRON_RUN_AS_NODE=1 electron -e "..."` → `abi=145 rows=1`.
- Verified the bundled binary inside `dist/mac-arm64/Mainframe.app/Contents/Resources/node_modules/better-sqlite3/build/Release/better_sqlite3.node` loads the same way under Electron's runtime.
- Packaged and installed the resulting `.app`; daemon reaches `Daemon ready` with no `NODE_MODULE_VERSION` FATAL.

## Out of scope (future work worth tracking)

While debugging this I also found two unrelated env-pollution footguns worth a follow-up — flagging here, not addressed in this PR:

- `electron.vite.config.ts`'s `dynamicCspPlugin` reads `process.env.VITE_DAEMON_HTTP_PORT` at build time and bakes it into the renderer CSP. If a dev env has it set (e.g. to the Playwright-CT port `31444`), production builds silently ship a CSP that blocks the real daemon.
- `packages/desktop/src/main/index.ts`'s `resolveShellEnv()` passes the user's login-shell env to the spawned daemon, so an ambient `MAINFRAME_DATA_DIR=~/.mainframe_dev` pulls the production app into the dev data dir (and that dir's `config.json`-pinned port). Both symptoms look identical to a "still broken" build but are environmental, not code regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)