### PR TITLE
fix(desktop): preserve askUserQuestion when bridging tool results

### DIFF
--- a/.changeset/auq-render-result-mapping.md
+++ b/.changeset/auq-render-result-mapping.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Preserve `askUserQuestion` on AskUserQuestion tool-call results when bridging to assistant-ui. The desktop converter was flattening the result to its raw `content` string, which left the renderer with `answered=false` — the card stayed collapsed and non-clickable, hiding all questions and answers from the user even though the daemon parsed them correctly.

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -184,6 +184,29 @@ describe('convertMessage', () => {
       });
     });
 
+    it('preserves askUserQuestion on AskUserQuestion tool results', () => {
+      const answers = [
+        { question: 'Q with "quotes"?', answer: ['Free, text, with commas'] },
+        { question: 'Q2?', answer: ['A2'] },
+      ];
+      const msg = display('assistant', [
+        {
+          type: 'tool_call',
+          id: 'tu1',
+          name: 'AskUserQuestion',
+          input: { questions: [{ question: 'Q with "quotes"?' }, { question: 'Q2?' }] },
+          category: 'default',
+          result: { content: 'User has answered your questions: ...', isError: false, askUserQuestion: answers },
+        },
+      ]);
+      const result = convertMessage(msg);
+      const part = (result.content as unknown as Array<Record<string, unknown>>)[0]!;
+      expect(part.result).toEqual({
+        content: 'User has answered your questions: ...',
+        askUserQuestion: answers,
+      });
+    });
+
     it('converts error blocks to ERROR_PLACEHOLDER', () => {
       const msg = display('assistant', [{ type: 'error', message: 'something went wrong' }]);
       const result = convertMessage(msg);

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -24,7 +24,9 @@ function mapDisplayContentToToolCall(block: DisplayContent & { type: 'tool_call'
         }
       : block.result.truncated
         ? { content: block.result.content, truncated: true as const, fullBytes: block.result.fullBytes ?? 0 }
-        : block.result.content
+        : block.name === 'AskUserQuestion'
+          ? { content: block.result.content, askUserQuestion: block.result.askUserQuestion }
+          : block.result.content
     : undefined;
 
   return {


### PR DESCRIPTION
## Summary

Companion fix to #337. The core parser change landed, but the desktop converter that bridges daemon `DisplayContent` → assistant-ui `ContentPart` was flattening the tool result to its raw `content` string, dropping the parsed `askUserQuestion` array. The `AskUserQuestionToolCard` then saw `result` as a string, computed `answered = false`, and rendered as a disabled, collapsed "Quote scope" header that the user could not expand — hiding every question and answer for historical AUQ tool calls.

- Add an `AskUserQuestion` branch in `mapDisplayContentToToolCall` that keeps `{ content, askUserQuestion }` intact.
- Add a `convert-message.test.ts` case that pins the field through the bridge.

Reproduced on a real chat ("Todos Skill Setup" in the `mainframe` project): pre-fix the card showed only the header and was non-clickable; post-fix it expands and renders all 3 questions and 3 answer pills verbatim.

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — all 679 tests pass, new case included.
- [x] `pnpm --filter @qlan-ro/mainframe-desktop build` — clean.
- [x] Manual: opened the chat in the desktop app, confirmed the AUQ card now expands and shows the parsed Q/A pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)