### PR TITLE
fix(core/todos): tolerate malformed JSON columns

### DIFF
--- a/.changeset/todos-malformed-json-resilience.md
+++ b/.changeset/todos-malformed-json-resilience.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Tolerate malformed JSON in todos columns. `parseTodo` now routes `labels`, `assignees`, and `dependencies` through `safeJsonArray`, which defaults to `[]` and logs the offending row instead of throwing. Historical writes left some rows with double-encoded values that crashed `JSON.parse` and took down the whole Tasks panel; one bad row no longer hides the rest.

--- a/packages/core/src/__tests__/plugins/builtin/todos.test.ts
+++ b/packages/core/src/__tests__/plugins/builtin/todos.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import type { PluginManifest } from '@qlan-ro/mainframe-types';
 import request from 'supertest';
 import express from 'express';
+import Database from 'better-sqlite3';
 
 const todosManifest: PluginManifest = {
   id: 'todos',
@@ -108,6 +109,28 @@ describe('todos plugin routes', () => {
     await request(app).delete(`/todos/${id}`);
     const list = await request(app).get('/todos?projectId=proj-1');
     expect(list.body.todos).toHaveLength(0);
+  });
+
+  it('GET /todos tolerates a row with malformed JSON columns', async () => {
+    const { app } = makeApp();
+    await request(app)
+      .post('/todos')
+      .send({ projectId: 'proj-1', title: 'Good todo', labels: ['ok'] });
+    const bad = await request(app).post('/todos').send({ projectId: 'proj-1', title: 'Corrupt todo' });
+    const badId = bad.body.todo.id as string;
+
+    // Simulate the historical double-encoded value seen in production data.
+    const raw = new Database(join(tmpDir, 'data.db'));
+    raw.prepare('UPDATE todos SET labels = ? WHERE id = ?').run('[\\"workflows\\",\\"design\\"]', badId);
+    raw.close();
+
+    const res = await request(app).get('/todos?projectId=proj-1');
+    expect(res.status).toBe(200);
+    expect(res.body.todos).toHaveLength(2);
+    const corrupt = res.body.todos.find((t: { id: string }) => t.id === badId);
+    expect(corrupt.labels).toEqual([]);
+    const good = res.body.todos.find((t: { title: string }) => t.title === 'Good todo');
+    expect(good.labels).toEqual(['ok']);
   });
 
   it('POST /todos/:id/start-session creates a chat and emits event', async () => {

--- a/packages/core/src/plugins/builtin/todos/index.ts
+++ b/packages/core/src/plugins/builtin/todos/index.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from '@qlan-ro/mainframe-types';
+import type { Logger } from 'pino';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
@@ -45,11 +46,26 @@ CREATE TABLE IF NOT EXISTS todos (
   updated_at TEXT NOT NULL
 );`;
 
-const parseTodo = (r: TodoRow): Todo => ({
+/**
+ * Parse a JSON array column defensively. Historical writes left some rows with
+ * double-encoded values (e.g. `[\"a\"]`) that crash `JSON.parse`. A single bad
+ * row must not take down the entire board, so fall back to `[]` and log.
+ */
+function safeJsonArray<T>(raw: string, column: string, todoId: string, logger?: Logger): T[] {
+  try {
+    const parsed = JSON.parse(raw || '[]');
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch (err) {
+    logger?.warn({ err: String(err), todoId, column, raw }, 'todos: malformed JSON column, defaulting to []');
+    return [];
+  }
+}
+
+const parseTodo = (r: TodoRow, logger?: Logger): Todo => ({
   ...r,
-  labels: JSON.parse(r.labels) as string[],
-  assignees: JSON.parse(r.assignees) as string[],
-  dependencies: JSON.parse(r.dependencies || '[]') as number[],
+  labels: safeJsonArray<string>(r.labels, 'labels', r.id, logger),
+  assignees: safeJsonArray<string>(r.assignees, 'assignees', r.id, logger),
+  dependencies: safeJsonArray<number>(r.dependencies, 'dependencies', r.id, logger),
 });
 
 const TodoSchema = z.object({
@@ -110,7 +126,7 @@ function registerTodoRoutes(ctx: PluginContext): void {
     const rows = ctx.db
       .prepare<TodoRow>('SELECT * FROM todos WHERE project_id = ? ORDER BY status, order_index, created_at')
       .all(projectId);
-    res.json({ todos: rows.map(parseTodo) });
+    res.json({ todos: rows.map((row) => parseTodo(row, ctx.logger)) });
   });
 
   r.post('/todos', (req, res) => {
@@ -147,7 +163,7 @@ function registerTodoRoutes(ctx: PluginContext): void {
         now,
       );
     const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id)!;
-    const todo = parseTodo(row);
+    const todo = parseTodo(row, ctx.logger);
     res.status(201).json({ todo });
   });
 
@@ -206,7 +222,7 @@ function registerTodoRoutes(ctx: PluginContext): void {
     vals.push(id);
     ctx.db.prepare(`UPDATE todos SET ${sets.join(', ')} WHERE id = ?`).run(...vals);
     const row = ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE id = ?').get(id)!;
-    const updated = parseTodo(row);
+    const updated = parseTodo(row, ctx.logger);
     if (d.status !== undefined && d.status !== existingRow.status) {
       ctx.ui.notify({
         title: `#${updated.number} ${updated.title}`,
@@ -233,14 +249,14 @@ function registerTodoRoutes(ctx: PluginContext): void {
       res.status(404).json({ error: 'Not found' });
       return;
     }
-    const todo = parseTodo(row);
+    const todo = parseTodo(row, ctx.logger);
     if (status === 'done' && todo.dependencies.length > 0) {
       const openDeps = todo.dependencies
         .map((num) =>
           ctx.db.prepare<TodoRow>('SELECT * FROM todos WHERE number = ? AND project_id = ?').get(num, todo.project_id),
         )
         .filter((r): r is TodoRow => r !== undefined)
-        .map(parseTodo)
+        .map((r) => parseTodo(r, ctx.logger))
         .filter((d) => d.status !== 'done');
       if (openDeps.length > 0) {
         const names = openDeps.map((d) => `#${d.number} ${d.title}`).join(', ');
@@ -273,7 +289,7 @@ function registerSessionRoute(ctx: PluginContext): void {
       res.status(403).json({ error: 'chat:create capability required' });
       return;
     }
-    const todo = parseTodo(row);
+    const todo = parseTodo(row, ctx.logger);
     const depTodos =
       todo.dependencies.length > 0
         ? todo.dependencies
@@ -283,7 +299,7 @@ function registerSessionRoute(ctx: PluginContext): void {
                 .get(num, todo.project_id),
             )
             .filter((r): r is TodoRow => r !== undefined)
-            .map(parseTodo)
+            .map((r) => parseTodo(r, ctx.logger))
         : [];
     const { chatId } = await ctx.services.chats.createChat({ projectId: parsed.data.projectId });
     res.json({ chatId, initialMessage: buildInitialMessage(todo, depTodos) });


### PR DESCRIPTION
## Summary
- Wraps `labels` / `assignees` / `dependencies` JSON parsing in `safeJsonArray`, which returns `[]` and logs the offending row instead of throwing.
- One historically-corrupt row (e.g. double-encoded value from an earlier write) no longer crashes `GET /todos` and takes down the whole Tasks panel.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test -- src/__tests__/plugins/builtin/todos.test.ts` (7 passed, includes new "tolerates a row with malformed JSON columns" case)
- [ ] Manually seed a malformed row in dev DB and confirm the panel renders the remaining todos with a warning log.