### PR TITLE
fix(desktop): use a mode-appropriate title for the directory picker

### DIFF
--- a/.changeset/dir-picker-title.md
+++ b/.changeset/dir-picker-title.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Fix the executable-path browse dialog in Settings showing "Select Project Directory". `DirectoryPickerModal` now accepts a `title` prop and defaults to "Select File" in file mode; the provider executable picker passes "Select &lt;Provider&gt; Executable".

--- a/packages/desktop/src/renderer/components/DirectoryPickerModal.tsx
+++ b/packages/desktop/src/renderer/components/DirectoryPickerModal.tsx
@@ -19,6 +19,7 @@ interface DirectoryPickerModalProps {
   onSelect: (path: string) => void;
   onCancel: () => void;
   mode?: 'directory' | 'file';
+  title?: string;
 }
 
 export function DirectoryPickerModal({
@@ -26,7 +27,9 @@ export function DirectoryPickerModal({
   onSelect,
   onCancel,
   mode = 'directory',
+  title,
 }: DirectoryPickerModalProps): React.ReactElement | null {
+  const resolvedTitle = title ?? (mode === 'file' ? 'Select File' : 'Select Project Directory');
   const [roots, setRoots] = useState<DirNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [selectedType, setSelectedType] = useState<'file' | 'directory' | null>(null);
@@ -182,8 +185,12 @@ export function DirectoryPickerModal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-mf-border">
-          <h2 className="text-mf-body font-semibold text-mf-text-primary">Select Project Directory</h2>
-          <button data-testid="directory-picker-close" onClick={onCancel} className="text-mf-text-secondary hover:text-mf-text-primary transition-colors">
+          <h2 className="text-mf-body font-semibold text-mf-text-primary">{resolvedTitle}</h2>
+          <button
+            data-testid="directory-picker-close"
+            onClick={onCancel}
+            className="text-mf-text-secondary hover:text-mf-text-primary transition-colors"
+          >
             <X size={16} />
           </button>
         </div>

--- a/packages/desktop/src/renderer/components/__tests__/DirectoryPickerModal.test.tsx
+++ b/packages/desktop/src/renderer/components/__tests__/DirectoryPickerModal.test.tsx
@@ -99,6 +99,18 @@ describe('DirectoryPickerModal: mode="file"', () => {
     expect(screen.getByTestId('dir-picker-select-btn')).toBeDisabled();
   });
 
+  it('uses a file-mode title by default in file mode (no "Project Directory" wording)', async () => {
+    render(<DirectoryPickerModal open mode="file" onSelect={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('claude')).toBeInTheDocument());
+    expect(screen.queryByText(/project directory/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/select file/i)).toBeInTheDocument();
+  });
+
+  it('renders a caller-supplied title verbatim', async () => {
+    render(<DirectoryPickerModal open mode="file" title="Select Executable" onSelect={vi.fn()} onCancel={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Select Executable')).toBeInTheDocument());
+  });
+
   it('selecting a file enables confirm and calls onSelect with the file absolute path', async () => {
     const onSelect = vi.fn();
     const user = userEvent.setup();

--- a/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
+++ b/packages/desktop/src/renderer/components/settings/ProviderSection.tsx
@@ -165,6 +165,7 @@ export function ProviderSection({ adapterId, label }: { adapterId: string; label
       <DirectoryPickerModal
         open={showBinaryPicker}
         mode="file"
+        title={`Select ${label} Executable`}
         onSelect={handlePickBinary}
         onCancel={() => setShowBinaryPicker(false)}
       />


### PR DESCRIPTION
## Summary
The "Browse…" dialog for the executable path in Settings → Providers (added in #159) was showing the heading **"Select Project Directory"** because `DirectoryPickerModal` is shared with the project picker and its title was hardcoded.

**Fix:** `DirectoryPickerModal` now accepts an optional `title` prop with a mode-based default (`"Select File"` in file mode, `"Select Project Directory"` in directory mode — preserves existing project-picker text). The provider executable picker passes `"Select <Provider> Executable"`.

## Test plan
- [x] TDD: new tests assert (a) file mode no longer renders "Project Directory" by default, (b) a caller-supplied `title` renders verbatim. RED → GREEN.
- [x] `DirectoryPickerModal` + `ProviderSection` suites: 12/12 pass.
- [ ] Manual: Settings → Providers → "Browse…" — confirm heading is "Select <Provider> Executable". Add Project → confirm heading is still "Select Project Directory".

Fixes #159 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)