### PR TITLE
fix(core): keep pinned/effort fresh in active chat cache (#187)

### DIFF
--- a/.changeset/session-pin-stale-cache.md
+++ b/.changeset/session-pin-stale-cache.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix sessions silently unpinning themselves after navigating away and back. `PATCH /api/chats/:id/pinned` updated SQLite but left the in-memory cached chat (`activeChats[id].chat.pinned`) stale; the next `resumeChat` broadcast `chat.updated` with the old `pinned: false` and clobbered the renderer. Same hole existed for `PATCH /api/chats/:id/effort`. Added `ChatManager.syncChatFields(chatId, partial)` and call it from both routes after the DB write, mirroring the existing `syncChatTags` pattern.

--- a/packages/core/src/__tests__/chat-manager-sync-fields.test.ts
+++ b/packages/core/src/__tests__/chat-manager-sync-fields.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { DatabaseManager } from '../db/index.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import { ChatManager } from '../chat/chat-manager.js';
+import type { ActiveChat } from '../chat/types.js';
+
+function makeDb(chat: Record<string, unknown> | null): DatabaseManager {
+  return {
+    chats: {
+      list: vi.fn().mockReturnValue([]),
+      get: vi.fn().mockReturnValue(chat),
+      create: vi.fn(),
+      update: vi.fn(),
+      archive: vi.fn(),
+      addMention: vi.fn(),
+    },
+    projects: {
+      list: vi.fn(),
+      get: vi.fn(),
+      getByPath: vi.fn(),
+      create: vi.fn(),
+      remove: vi.fn(),
+      removeWithChats: vi.fn(),
+      updateLastOpened: vi.fn(),
+    },
+    settings: { get: vi.fn(), getByCategory: vi.fn(), set: vi.fn(), delete: vi.fn() },
+  } as unknown as DatabaseManager;
+}
+
+function makeAdapters(): AdapterRegistry {
+  return {
+    get: vi.fn().mockReturnValue(undefined),
+    list: vi.fn(),
+    all: vi.fn().mockReturnValue([]),
+  } as unknown as AdapterRegistry;
+}
+
+describe('ChatManager.syncChatFields', () => {
+  it('updates cached active chat fields so a later chat.updated emission is not stale', () => {
+    const cached = { id: 'c1', projectId: 'p1', status: 'active', pinned: false };
+    const db = makeDb(cached);
+    const manager = new ChatManager(db, makeAdapters());
+    // Inject an active chat directly — going through loadChat would require a
+    // full adapter session. The bug under test is purely about cache freshness.
+    const activeChats = (manager as unknown as { activeChats: Map<string, ActiveChat> }).activeChats;
+    activeChats.set('c1', { chat: { ...cached } } as unknown as ActiveChat);
+
+    manager.syncChatFields('c1', { pinned: true });
+
+    expect(activeChats.get('c1')?.chat.pinned).toBe(true);
+    // getChat reads from the cache when present — proves resumeChat would emit fresh data.
+    expect(manager.getChat('c1')).toMatchObject({ pinned: true });
+  });
+
+  it('is a no-op when the chat is not in the active cache', () => {
+    const db = makeDb({ id: 'c1', projectId: 'p1', status: 'active', pinned: false });
+    const manager = new ChatManager(db, makeAdapters());
+
+    expect(() => manager.syncChatFields('c1', { pinned: true })).not.toThrow();
+  });
+
+  it('merges partial updates without dropping unrelated fields', () => {
+    const cached = { id: 'c1', projectId: 'p1', status: 'active', pinned: false, effort: 'low', title: 'keep me' };
+    const db = makeDb(cached);
+    const manager = new ChatManager(db, makeAdapters());
+    const activeChats = (manager as unknown as { activeChats: Map<string, ActiveChat> }).activeChats;
+    activeChats.set('c1', { chat: { ...cached } } as unknown as ActiveChat);
+
+    manager.syncChatFields('c1', { effort: 'high' });
+
+    const cachedNow = activeChats.get('c1')?.chat as unknown as Record<string, unknown>;
+    expect(cachedNow.effort).toBe('high');
+    expect(cachedNow.title).toBe('keep me');
+    expect(cachedNow.pinned).toBe(false);
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -504,6 +504,18 @@ export class ChatManager {
     if (active) active.chat.tags = tags;
   }
 
+  /**
+   * Apply a partial DB-backed update to the in-memory cached chat. Same reason
+   * as syncChatTags: any field persisted via a PATCH route that isn't mirrored
+   * here will be clobbered the next time `resumeChat` re-emits `chat.updated`
+   * from the stale cache.
+   */
+  syncChatFields(chatId: string, partial: Partial<Chat>): void {
+    const active = this.activeChats.get(chatId);
+    if (!active) return;
+    Object.assign(active.chat, partial);
+  }
+
   getEffectivePath(chatId: string): string | null {
     const chat = this.getChat(chatId);
     if (!chat) return null;

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -145,6 +145,7 @@ export function chatRoutes(ctx: RouteContext): Router {
         res.status(404).json({ success: false, error: 'Chat not found' });
         return;
       }
+      ctx.chats?.syncChatFields?.(chatId, { pinned: parsed.data.pinned });
       res.json({ success: true, data: chat });
     } catch (err) {
       logger.warn({ err, chatId }, 'Failed to update pinned state');
@@ -169,6 +170,7 @@ export function chatRoutes(ctx: RouteContext): Router {
         res.status(404).json({ success: false, error: 'Chat not found' });
         return;
       }
+      ctx.chats?.syncChatFields?.(chatId, { effort: effortUpdate as Chat['effort'] });
       res.json({ success: true, data: chat });
     } catch (err) {
       logger.warn({ err, chatId }, 'Failed to update effort');


### PR DESCRIPTION
## Summary
- Sessions silently unpinned themselves after navigating away and back. `PATCH /api/chats/:id/pinned` updated SQLite but left `activeChats[id].chat.pinned` stale; the next `resumeChat` re-emitted `chat.updated` from the cache and clobbered the renderer's optimistic flip back to `false`.
- Same hole existed for `PATCH /api/chats/:id/effort`.
- Adds `ChatManager.syncChatFields(chatId, partial)` and calls it from both routes after the DB write — mirrors the existing `syncChatTags` pattern (whose code comment already warned about this exact failure mode).

Closes #187.

## Test plan
- [x] New `chat-manager-sync-fields.test.ts` covers cache update, no-op when chat isn't active, and partial-merge safety (3 tests, passing).
- [ ] Manual: pin a session, switch to another, click the pinned session — pin sticks.
- [ ] Manual: change effort on a session, switch away, click back — effort sticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)