### PR TITLE
fix(import): surface worktree sessions, fix dates, show worktree (#186)

### DIFF
--- a/.changeset/import-sessions-186.md
+++ b/.changeset/import-sessions-186.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+'@qlan-ro/mainframe-types': patch
+---
+
+Import External Sessions: surface sessions from deleted worktrees and project subdirectories by scanning every encoded `~/.claude/projects/` directory whose prefix matches the project, then filtering by the session's own `cwd`. Drop the `new Date()` timestamp fallback that silently labelled missing-timestamp sessions as "Today"; use the JSONL file's `stat().mtime` as the always-real anchor. The popover now also displays the worktree (or subdirectory) the session ran in, and the relative-time formatter uses a single millisecond basis so "Yesterday" never appears before "Today" anymore.

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -319,7 +319,8 @@ describe('listExternalSessions', () => {
       ]);
 
       const result = await listExternalSessions('/test/project', ['skip']);
-      // 'skip' is excluded, only 'keep' should be processed
+      expect(result).toHaveLength(1);
+      expect(result[0]!.sessionId).toBe('keep');
       expect(mockStat).toHaveBeenCalledTimes(1);
     });
 
@@ -366,7 +367,8 @@ describe('listExternalSessions', () => {
       mockJsonlFile([JSON.stringify({ type: 'system', timestamp: '2026-01-01T00:00:00Z' })]);
 
       const result = await listExternalSessions('/test/project', []);
-      // Only session.jsonl should be processed
+      // Only session.jsonl is scanned; the system-type entry yields no firstPrompt → session dropped.
+      expect(result).toEqual([]);
       expect(mockStat).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+import { homedir } from 'node:os';
 import { listExternalSessions } from '../plugins/builtin/claude/external-sessions.js';
 
 vi.mock('node:fs/promises', () => ({
@@ -68,12 +70,18 @@ describe('listExternalSessions', () => {
             modified: '2026-01-02T00:00:00Z',
             gitBranch: 'main',
             isSidechain: false,
+            projectPath: '/test/project',
           },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return [] as unknown as never;
+      });
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('abc-123');
       expect(result[0]!.adapterId).toBe('claude');
@@ -87,13 +95,23 @@ describe('listExternalSessions', () => {
       const index = {
         version: 1,
         entries: [
-          { sessionId: 'keep-me', firstPrompt: 'Keep', created: '2026-01-01T00:00:00Z' },
-          { sessionId: 'exclude-me', firstPrompt: 'Exclude', created: '2026-01-01T00:00:00Z' },
+          { sessionId: 'keep-me', firstPrompt: 'Keep', created: '2026-01-01T00:00:00Z', projectPath: '/test/project' },
+          {
+            sessionId: 'exclude-me',
+            firstPrompt: 'Exclude',
+            created: '2026-01-01T00:00:00Z',
+            projectPath: '/test/project',
+          },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return [] as unknown as never;
+      });
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project'], ['exclude-me']);
+      const result = await listExternalSessions('/test/project', ['exclude-me']);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('keep-me');
     });
@@ -102,13 +120,30 @@ describe('listExternalSessions', () => {
       const index = {
         version: 1,
         entries: [
-          { sessionId: 'main-session', firstPrompt: 'Real', created: '2026-01-01T00:00:00Z', isSidechain: false },
-          { sessionId: 'sidechain', firstPrompt: 'Side', created: '2026-01-01T00:00:00Z', isSidechain: true },
+          {
+            sessionId: 'main-session',
+            firstPrompt: 'Real',
+            created: '2026-01-01T00:00:00Z',
+            isSidechain: false,
+            projectPath: '/test/project',
+          },
+          {
+            sessionId: 'sidechain',
+            firstPrompt: 'Side',
+            created: '2026-01-01T00:00:00Z',
+            isSidechain: true,
+            projectPath: '/test/project',
+          },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return [] as unknown as never;
+      });
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('main-session');
     });
@@ -117,13 +152,30 @@ describe('listExternalSessions', () => {
       const index = {
         version: 1,
         entries: [
-          { sessionId: 'older', firstPrompt: 'Old', created: '2026-01-01T00:00:00Z', modified: '2026-01-01T00:00:00Z' },
-          { sessionId: 'newer', firstPrompt: 'New', created: '2026-01-02T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
+          {
+            sessionId: 'older',
+            firstPrompt: 'Old',
+            created: '2026-01-01T00:00:00Z',
+            modified: '2026-01-01T00:00:00Z',
+            projectPath: '/test/project',
+          },
+          {
+            sessionId: 'newer',
+            firstPrompt: 'New',
+            created: '2026-01-02T00:00:00Z',
+            modified: '2026-01-03T00:00:00Z',
+            projectPath: '/test/project',
+          },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return [] as unknown as never;
+      });
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result[0]!.sessionId).toBe('newer');
       expect(result[1]!.sessionId).toBe('older');
     });
@@ -132,13 +184,23 @@ describe('listExternalSessions', () => {
       const index = {
         version: 1,
         entries: [
-          { sessionId: 'with-prompt', firstPrompt: 'Hello', created: '2026-01-01T00:00:00Z' },
-          { sessionId: 'no-prompt', created: '2026-01-01T00:00:00Z' },
+          {
+            sessionId: 'with-prompt',
+            firstPrompt: 'Hello',
+            created: '2026-01-01T00:00:00Z',
+            projectPath: '/test/project',
+          },
+          { sessionId: 'no-prompt', created: '2026-01-01T00:00:00Z', projectPath: '/test/project' },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return [] as unknown as never;
+      });
       mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('with-prompt');
     });
@@ -154,32 +216,48 @@ describe('listExternalSessions', () => {
             firstPrompt: 'Main',
             created: '2026-01-01T00:00:00Z',
             modified: '2026-01-01T00:00:00Z',
+            projectPath: '/test/project',
           },
           {
             sessionId: 'shared',
             firstPrompt: 'Shared',
             created: '2026-01-02T00:00:00Z',
             modified: '2026-01-02T00:00:00Z',
+            projectPath: '/test/project',
           },
         ],
       };
       const indexWorktree = {
         version: 1,
         entries: [
-          { sessionId: 'wt-1', firstPrompt: 'WT', created: '2026-01-03T00:00:00Z', modified: '2026-01-03T00:00:00Z' },
+          {
+            sessionId: 'wt-1',
+            firstPrompt: 'WT',
+            created: '2026-01-03T00:00:00Z',
+            modified: '2026-01-03T00:00:00Z',
+            projectPath: '/test/project/.worktrees/feat',
+          },
           {
             sessionId: 'shared',
             firstPrompt: 'Shared',
             created: '2026-01-02T00:00:00Z',
             modified: '2026-01-02T00:00:00Z',
+            projectPath: '/test/project',
           },
         ],
       };
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) {
+          return ['-test-project', '-test-project--worktrees-feat'] as unknown as never;
+        }
+        return [] as unknown as never;
+      });
       mockReadFile
         .mockResolvedValueOnce(JSON.stringify(indexMain) as unknown as ArrayBuffer)
         .mockResolvedValueOnce(JSON.stringify(indexWorktree) as unknown as ArrayBuffer);
 
-      const result = await listExternalSessions(['/test/project', '/test/project/.worktrees/feat'], []);
+      const result = await listExternalSessions('/test/project', []);
       const ids = result.map((s) => s.sessionId).sort();
       expect(ids).toEqual(['main-1', 'shared', 'wt-1']);
     });
@@ -187,12 +265,21 @@ describe('listExternalSessions', () => {
 
   describe('JSONL fallback (no sessions-index.json)', () => {
     it('returns empty when no index and no directory', async () => {
-      const result = await listExternalSessions(['/test/project'], []);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return [] as unknown as never;
+        throw new Error('ENOENT');
+      });
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toEqual([]);
     });
 
     it('scans JSONL files and extracts first user message', async () => {
-      mockReaddir.mockResolvedValue(['abc-123.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return ['abc-123.jsonl'] as unknown as never;
+      });
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-15T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
 
       const lines = [
@@ -200,12 +287,13 @@ describe('listExternalSessions', () => {
           type: 'user',
           timestamp: '2026-01-10T00:00:00Z',
           gitBranch: 'feat/test',
+          cwd: '/test/project',
           message: { content: [{ type: 'text', text: 'Fix the login bug' }] },
         }),
       ];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
       expect(result[0]!.sessionId).toBe('abc-123');
       expect(result[0]!.adapterId).toBe('claude');
@@ -215,26 +303,47 @@ describe('listExternalSessions', () => {
     });
 
     it('filters out excluded sessions in JSONL scan', async () => {
-      mockReaddir.mockResolvedValue(['keep.jsonl', 'skip.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return ['keep.jsonl', 'skip.jsonl'] as unknown as never;
+      });
+      mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
+      mockJsonlFile([
+        JSON.stringify({
+          type: 'user',
+          cwd: '/test/project',
+          timestamp: '2026-01-01T00:00:00Z',
+          message: { content: 'kept' },
+        }),
+      ]);
 
-      const result = await listExternalSessions(['/test/project'], ['skip']);
+      const result = await listExternalSessions('/test/project', ['skip']);
       // 'skip' is excluded, only 'keep' should be processed
       expect(mockStat).toHaveBeenCalledTimes(1);
     });
 
     it('filters out sidechain sessions in JSONL scan', async () => {
-      mockReaddir.mockResolvedValue(['side.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return ['side.jsonl'] as unknown as never;
+      });
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
 
       const lines = [JSON.stringify({ type: 'user', isSidechain: true, timestamp: '2026-01-01T00:00:00Z' })];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toEqual([]);
     });
 
     it('filters out non-session JSONL files (progress, queue-operation)', async () => {
-      mockReaddir.mockResolvedValue(['progress.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return ['progress.jsonl'] as unknown as never;
+      });
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
 
       const lines = [
@@ -243,20 +352,120 @@ describe('listExternalSessions', () => {
       ];
       mockJsonlFile(lines);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       expect(result).toEqual([]);
     });
 
     it('ignores non-jsonl files', async () => {
-      mockReaddir.mockResolvedValue(['readme.md', 'data.json', 'session.jsonl'] as unknown as Awaited<
-        ReturnType<typeof readdir>
-      >);
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+        return ['readme.md', 'data.json', 'session.jsonl'] as unknown as never;
+      });
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as Awaited<ReturnType<typeof stat>>);
       mockJsonlFile([JSON.stringify({ type: 'system', timestamp: '2026-01-01T00:00:00Z' })]);
 
-      const result = await listExternalSessions(['/test/project'], []);
+      const result = await listExternalSessions('/test/project', []);
       // Only session.jsonl should be processed
       expect(mockStat).toHaveBeenCalledTimes(1);
     });
+  });
+
+  describe('filesystem discovery', () => {
+    it('discovers sibling encoded dirs for the same project root', async () => {
+      const projectPath = '/Users/x/Projects/foo';
+      const projectsRoot = path.join(homedir(), '.claude', 'projects');
+      const encodedRoot = '-Users-x-Projects-foo';
+      const encodedWorktree = '-Users-x-Projects-foo--worktrees-feat-a';
+      const encodedOtherProject = '-Users-x-Projects-foo-web'; // sibling, NOT this project
+
+      mockReaddir.mockImplementation(async (p) => {
+        const s = String(p);
+        if (s === projectsRoot) {
+          return [encodedRoot, encodedWorktree, encodedOtherProject] as unknown as never;
+        }
+        if (s.endsWith(encodedRoot)) return ['root.jsonl'] as unknown as never;
+        if (s.endsWith(encodedWorktree)) return ['wt.jsonl'] as unknown as never;
+        if (s.endsWith(encodedOtherProject)) return ['other.jsonl'] as unknown as never;
+        return [] as unknown as never;
+      });
+      mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as never);
+      mockReadFile.mockRejectedValue(new Error('ENOENT')); // no sessions-index.json
+      mockAccess.mockResolvedValue(undefined);
+
+      let nextLines: string[] = [];
+      mockCreateInterface.mockImplementation(
+        () =>
+          ({
+            [Symbol.asyncIterator]: async function* () {
+              for (const line of nextLines) yield line;
+            },
+          }) as never,
+      );
+      mockCreateReadStream.mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith('root.jsonl')) {
+          nextLines = [
+            JSON.stringify({
+              type: 'user',
+              sessionId: 'root',
+              timestamp: '2026-01-01T00:00:00Z',
+              cwd: projectPath,
+              gitBranch: 'main',
+              message: { content: 'root prompt' },
+            }),
+          ];
+        } else if (s.endsWith('wt.jsonl')) {
+          nextLines = [
+            JSON.stringify({
+              type: 'user',
+              sessionId: 'wt',
+              timestamp: '2026-01-02T00:00:00Z',
+              cwd: '/Users/x/Projects/foo/.worktrees/feat-a',
+              gitBranch: 'feat-a',
+              message: { content: 'wt prompt' },
+            }),
+          ];
+        } else {
+          nextLines = [
+            JSON.stringify({
+              type: 'user',
+              sessionId: 'other',
+              timestamp: '2026-01-03T00:00:00Z',
+              cwd: '/Users/x/Projects/foo-web',
+              message: { content: 'other prompt' },
+            }),
+          ];
+        }
+        return { destroy: vi.fn() } as never;
+      });
+
+      const result = await listExternalSessions(projectPath, []);
+      const ids = result.map((s) => s.sessionId).sort();
+      expect(ids).toEqual(['root', 'wt']);
+      const wt = result.find((s) => s.sessionId === 'wt')!;
+      expect(wt.cwd).toBe('/Users/x/Projects/foo/.worktrees/feat-a');
+      expect(wt.gitBranch).toBe('feat-a');
+    });
+  });
+
+  it('falls back to file stat mtime when index entry has no timestamps', async () => {
+    const index = {
+      version: 1,
+      entries: [{ sessionId: 'no-dates', firstPrompt: 'Hi', projectPath: '/test/project' }],
+    };
+    mockReaddir.mockImplementation(async (p) => {
+      const s = String(p);
+      if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
+      return [] as unknown as never;
+    });
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+    mockStat.mockResolvedValue({ mtime: new Date('2025-12-31T00:00:00Z') } as never);
+    mockAccess.mockResolvedValue(undefined);
+
+    const result = await listExternalSessions('/test/project', []);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.modifiedAt).toBe('2025-12-31T00:00:00.000Z');
+    expect(result[0]!.createdAt).toBe('2025-12-31T00:00:00.000Z');
   });
 });

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -7,8 +7,6 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
   readdir: vi.fn(),
   stat: vi.fn(),
-  access: vi.fn(),
-  constants: { R_OK: 4 },
 }));
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -23,14 +21,13 @@ vi.mock('node:readline', () => ({
   createInterface: vi.fn(),
 }));
 
-import { readFile, readdir, stat, access } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 
 const mockReadFile = vi.mocked(readFile);
 const mockReaddir = vi.mocked(readdir);
 const mockStat = vi.mocked(stat);
-const mockAccess = vi.mocked(access);
 const mockCreateReadStream = vi.mocked(createReadStream);
 const mockCreateInterface = vi.mocked(createInterface);
 
@@ -52,8 +49,9 @@ describe('listExternalSessions', () => {
     // Default: no index, no JSONL files
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
     mockReaddir.mockRejectedValue(new Error('ENOENT'));
-    // Default: JSONL files exist on disk (for sessions-index tests)
-    mockAccess.mockResolvedValue(undefined);
+    // Default: index-referenced JSONL files exist on disk with a known mtime.
+    // Individual tests can override mockStat when they care about the timestamp.
+    mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as never);
   });
 
   describe('from sessions-index.json', () => {
@@ -393,7 +391,6 @@ describe('listExternalSessions', () => {
       });
       mockStat.mockResolvedValue({ mtime: new Date('2026-01-01T00:00:00Z') } as never);
       mockReadFile.mockRejectedValue(new Error('ENOENT')); // no sessions-index.json
-      mockAccess.mockResolvedValue(undefined);
 
       let nextLines: string[] = [];
       mockCreateInterface.mockImplementation(
@@ -463,7 +460,6 @@ describe('listExternalSessions', () => {
     });
     mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
     mockStat.mockResolvedValue({ mtime: new Date('2025-12-31T00:00:00Z') } as never);
-    mockAccess.mockResolvedValue(undefined);
 
     const result = await listExternalSessions('/test/project', []);
     expect(result).toHaveLength(1);

--- a/packages/core/src/__tests__/external-session-service.test.ts
+++ b/packages/core/src/__tests__/external-session-service.test.ts
@@ -89,25 +89,7 @@ describe('ExternalSessionService', () => {
       chatsRepo.update(chat.id, { claudeSessionId: 'already-imported' });
 
       await service.scan(projectId);
-      expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith(['/test/project'], ['already-imported']);
-    });
-
-    it('passes worktree paths alongside the project path to the adapter', async () => {
-      const mod = await import('../workspace/worktree.js');
-      const spy = vi.spyOn(mod, 'getWorktrees').mockResolvedValue([
-        { path: '/test/project', branch: 'refs/heads/main' },
-        { path: '/test/project/.worktrees/feat-a', branch: 'refs/heads/feat-a' },
-        { path: '/test/project/.worktrees/feat-b', branch: 'refs/heads/feat-b' },
-      ]);
-      try {
-        await service.scan(projectId);
-        expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith(
-          ['/test/project', '/test/project/.worktrees/feat-a', '/test/project/.worktrees/feat-b'],
-          [],
-        );
-      } finally {
-        spy.mockRestore();
-      }
+      expect(mockAdapter.listExternalSessions).toHaveBeenCalledWith('/test/project', ['already-imported']);
     });
 
     it('returns empty array when adapter has no listExternalSessions', async () => {

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -3,7 +3,6 @@ import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import { createChildLogger } from '../logger.js';
 import { deriveTitleFromMessage, generateTitle } from './title-generator.js';
-import { getWorktrees } from '../workspace/worktree.js';
 
 const logger = createChildLogger('chat:external-sessions');
 
@@ -29,11 +28,9 @@ export class ExternalSessionService {
 
     for (const adapter of allAdapters) {
       if (!adapter.listExternalSessions) continue;
-
       const excludeIds = this.db.chats.getImportedSessionIds(projectId);
-      const paths = await this.collectProjectPaths(project.path);
       try {
-        const sessions = await adapter.listExternalSessions(paths, excludeIds);
+        const sessions = await adapter.listExternalSessions(project.path, excludeIds);
         for (const session of sessions) {
           session.adapterId = adapter.id;
         }
@@ -81,17 +78,6 @@ export class ExternalSessionService {
     }
 
     return chat;
-  }
-
-  private async collectProjectPaths(projectPath: string): Promise<string[]> {
-    try {
-      const worktrees = await getWorktrees(projectPath);
-      const paths = [projectPath, ...worktrees.map((w) => w.path)];
-      return Array.from(new Set(paths));
-    } catch (err) {
-      logger.warn({ err: String(err), projectPath }, 'failed to enumerate worktrees, scanning project root only');
-      return [projectPath];
-    }
   }
 
   private async generateImportTitle(chat: Chat, content: string, adapterId: string): Promise<void> {

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -247,7 +247,7 @@ export class ClaudeAdapter implements Adapter {
     return skills.deleteAgent(agentId, projectPath);
   }
 
-  async listExternalSessions(projectPaths: string[], excludeSessionIds: string[]): Promise<ExternalSession[]> {
-    return listExternalSessions(projectPaths, excludeSessionIds);
+  async listExternalSessions(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]> {
+    return listExternalSessions(projectPath, excludeSessionIds);
   }
 }

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -1,4 +1,4 @@
-import { access, constants, readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import path from 'node:path';
@@ -35,7 +35,12 @@ function projectsRoot(): string {
   return path.join(homedir(), '.claude', 'projects');
 }
 
-/** Belongs to this project if cwd equals the root or is nested under it. */
+/**
+ * Belongs to this project if cwd equals the root or is nested under it.
+ * Claude writes cwd as a native path matching the OS where it ran, so we use
+ * `path.sep` rather than a hardcoded '/' — Mainframe stores projectPath in the
+ * same native form, so both sides share separators on the host that scans.
+ */
 function cwdBelongsToProject(cwd: string | undefined, projectPath: string): boolean {
   if (!cwd) return false;
   if (cwd === projectPath) return true;
@@ -125,11 +130,7 @@ async function listFromIndex(
       const s = await stat(jsonlPath);
       fileMtimeIso = s.mtime.toISOString();
     } catch {
-      try {
-        await access(jsonlPath, constants.R_OK);
-      } catch {
-        continue; // JSONL deleted — skip ghost entry
-      }
+      continue; // JSONL deleted/unreachable — skip ghost index entry
     }
 
     const indexMtimeIso = typeof entry.fileMtime === 'number' ? new Date(entry.fileMtime).toISOString() : undefined;

--- a/packages/core/src/plugins/builtin/claude/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/claude/external-sessions.ts
@@ -27,24 +27,48 @@ interface SessionIndex {
   entries: SessionIndexEntry[];
 }
 
-function getProjectDir(projectPath: string): string {
-  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
-  return path.join(homedir(), '.claude', 'projects', encodedPath);
+function encodePath(p: string): string {
+  return p.replace(/[^a-zA-Z0-9-]/g, '-');
 }
 
-/** Try sessions-index.json first; fall back to JSONL scan. Aggregates across multiple paths. */
+function projectsRoot(): string {
+  return path.join(homedir(), '.claude', 'projects');
+}
+
+/** Belongs to this project if cwd equals the root or is nested under it. */
+function cwdBelongsToProject(cwd: string | undefined, projectPath: string): boolean {
+  if (!cwd) return false;
+  if (cwd === projectPath) return true;
+  return cwd.startsWith(projectPath + path.sep);
+}
+
+/** Discover every encoded dir under ~/.claude/projects whose prefix matches the project. */
+async function discoverProjectDirs(projectPath: string): Promise<string[]> {
+  const root = projectsRoot();
+  const encodedPrefix = encodePath(projectPath);
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => name === encodedPrefix || name.startsWith(encodedPrefix + '-'))
+    .map((name) => path.join(root, name));
+}
+
+/** Scan all matching dirs for the project; verify each session by cwd. */
 export async function listExternalSessions(
-  projectPaths: string[],
+  projectPath: string,
   excludeSessionIds: string[],
 ): Promise<ExternalSession[]> {
   const excludeSet = new Set(excludeSessionIds);
-  const uniquePaths = Array.from(new Set(projectPaths));
+  const candidateDirs = await discoverProjectDirs(projectPath);
   const aggregated: ExternalSession[] = [];
 
-  for (const projectPath of uniquePaths) {
-    const projectDir = getProjectDir(projectPath);
-    const fromIndex = await listFromIndex(projectDir, projectPath, excludeSet);
-    const sessions = fromIndex ?? (await listFromJsonl(projectDir, projectPath, excludeSet));
+  for (const dir of candidateDirs) {
+    const fromIndex = await listFromIndex(dir, projectPath, excludeSet);
+    const sessions = fromIndex ?? (await listFromJsonl(dir, projectPath, excludeSet));
     aggregated.push(...sessions);
   }
 
@@ -52,6 +76,7 @@ export async function listExternalSessions(
   const deduped: ExternalSession[] = [];
   for (const session of aggregated) {
     if (seen.has(session.sessionId)) continue;
+    if (!cwdBelongsToProject(session.cwd, projectPath)) continue;
     seen.add(session.sessionId);
     deduped.push(session);
   }
@@ -70,7 +95,7 @@ async function listFromIndex(
   try {
     raw = await readFile(indexPath, 'utf-8');
   } catch {
-    return null; // No index — use fallback
+    return null;
   }
 
   let index: SessionIndex;
@@ -86,31 +111,47 @@ async function listFromIndex(
     return null;
   }
 
-  // Empty index — fall through to JSONL scan
   if (index.entries.length === 0) return null;
 
   const candidates = index.entries.filter(
     (e) => e.sessionId && !excludeSet.has(e.sessionId) && !e.isSidechain && e.firstPrompt,
   );
 
-  // Verify JSONL files exist on disk — the index can reference deleted sessions
   const verified: ExternalSession[] = [];
   for (const entry of candidates) {
     const jsonlPath = entry.fullPath ?? path.join(projectDir, entry.sessionId + '.jsonl');
+    let fileMtimeIso: string | undefined;
     try {
-      await access(jsonlPath, constants.R_OK);
+      const s = await stat(jsonlPath);
+      fileMtimeIso = s.mtime.toISOString();
     } catch {
-      continue; // JSONL deleted — skip ghost entry
+      try {
+        await access(jsonlPath, constants.R_OK);
+      } catch {
+        continue; // JSONL deleted — skip ghost entry
+      }
     }
+
+    const indexMtimeIso = typeof entry.fileMtime === 'number' ? new Date(entry.fileMtime).toISOString() : undefined;
+
+    const createdAt = entry.created ?? entry.modified ?? indexMtimeIso ?? fileMtimeIso;
+    const modifiedAt = entry.modified ?? indexMtimeIso ?? fileMtimeIso ?? entry.created;
+    if (!createdAt || !modifiedAt) {
+      // Without any real timestamp, omit the session rather than fake "now".
+      logger.warn({ sessionId: entry.sessionId }, 'no timestamp available for session, skipping');
+      continue;
+    }
+
     verified.push({
       sessionId: entry.sessionId,
       adapterId: 'claude',
       projectPath,
+      cwd: entry.projectPath,
       firstPrompt: entry.firstPrompt,
       summary: entry.summary,
       messageCount: entry.messageCount,
-      createdAt: entry.created ?? new Date().toISOString(),
-      modifiedAt: entry.modified ?? entry.created ?? new Date().toISOString(),
+      createdAt,
+      modifiedAt,
       gitBranch: entry.gitBranch || undefined,
     });
   }
@@ -118,7 +159,6 @@ async function listFromIndex(
   return verified.sort((a, b) => new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime());
 }
 
-/** Scan *.jsonl files, reading the first user message from each for metadata. */
 async function listFromJsonl(
   projectDir: string,
   projectPath: string,
@@ -142,8 +182,8 @@ async function listFromJsonl(
     try {
       const session = await extractSessionMeta(filePath, sessionId, projectPath);
       if (session) sessions.push(session);
-    } catch {
-      // Skip unreadable files
+    } catch (err) {
+      logger.warn({ err: String(err), filePath }, 'failed to read external session file');
     }
   }
 
@@ -162,6 +202,7 @@ async function extractSessionMeta(
   let firstPrompt: string | undefined;
   let createdAt: string | undefined;
   let gitBranch: string | undefined;
+  let cwd: string | undefined;
   let isSidechain = false;
   let linesRead = 0;
 
@@ -170,7 +211,7 @@ async function extractSessionMeta(
     for await (const line of rl) {
       if (!line.trim()) continue;
       linesRead++;
-      if (linesRead > 30) break;
+      if (linesRead > 50) break;
 
       try {
         const entry = JSON.parse(line);
@@ -182,18 +223,17 @@ async function extractSessionMeta(
 
         if (!createdAt && entry.timestamp) createdAt = entry.timestamp;
         if (!gitBranch && entry.gitBranch) gitBranch = entry.gitBranch;
+        if (!cwd && entry.cwd) cwd = entry.cwd;
 
         if (!firstPrompt && entry.type === 'user' && entry.message?.content) {
-          // Skip entries from parent sessions (subagent JSONLs interleave parent entries)
           if (entry.sessionId && entry.sessionId !== sessionId) continue;
-
           const content = entry.message.content;
           const raw = extractRawText(content, 2000);
           const cleaned = raw ? stripCommandBoilerplate(raw) : undefined;
           if (cleaned) firstPrompt = cleaned.slice(0, 500);
         }
 
-        if (firstPrompt && createdAt && gitBranch) break;
+        if (firstPrompt && createdAt && gitBranch && cwd) break;
       } catch {
         // Skip malformed lines
       }
@@ -203,15 +243,13 @@ async function extractSessionMeta(
   }
 
   if (isSidechain) return null;
-
-  // Non-session JSONL files (progress, queue-operation, file-history-snapshot)
-  // don't contain user messages — skip them.
   if (!firstPrompt) return null;
 
   return {
     sessionId,
     adapterId: 'claude',
     projectPath,
+    cwd,
     firstPrompt,
     createdAt: createdAt ?? modifiedAt,
     modifiedAt,
@@ -230,16 +268,10 @@ function extractRawText(content: unknown, limit = 200): string | undefined {
   return undefined;
 }
 
-/**
- * Strip Claude CLI command boilerplate from message text.
- * Sessions that start with /clear, /model, etc. embed XML tags like
- * `<local-command-caveat>`, `<command-name>`, `<command-message>`,
- * `<command-args>`, `<local-command-stdout>` before the real user text.
- */
 function stripCommandBoilerplate(text: string): string {
   return text
-    .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '') // matched open/close tags with content
-    .replace(/<[^>]+>/g, '') // self-closing or orphan tags
+    .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
+    .replace(/<[^>]+>/g, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -88,35 +88,33 @@ export class CodexAdapter implements Adapter {
   // TODO: implement listAgents, createAgent, updateAgent, deleteAgent
   // TODO: implement listCommands
 
-  async listExternalSessions(projectPaths: string[], _excludeSessionIds: string[]): Promise<ExternalSession[]> {
+  async listExternalSessions(projectPath: string, _excludeSessionIds: string[]): Promise<ExternalSession[]> {
     let client: JsonRpcClient | null = null;
     try {
       client = await this.spawnTempAppServer();
       const seen = new Set<string>();
       const aggregated: ExternalSession[] = [];
-      for (const projectPath of Array.from(new Set(projectPaths))) {
-        try {
-          const result = await client.request<ThreadListResult>('thread/list', {
-            cwd: projectPath,
-            archived: false,
+      try {
+        const result = await client.request<ThreadListResult>('thread/list', {
+          cwd: projectPath,
+          archived: false,
+        });
+        for (const t of result.data) {
+          if (seen.has(t.id)) continue;
+          seen.add(t.id);
+          aggregated.push({
+            sessionId: t.id,
+            adapterId: this.id,
+            projectPath,
+            firstPrompt: t.name ?? t.preview,
+            summary: t.name ?? t.preview,
+            createdAt: new Date(t.createdAt).toISOString(),
+            modifiedAt: new Date(t.updatedAt).toISOString(),
+            model: t.model,
           });
-          for (const t of result.data) {
-            if (seen.has(t.id)) continue;
-            seen.add(t.id);
-            aggregated.push({
-              sessionId: t.id,
-              adapterId: this.id,
-              projectPath,
-              firstPrompt: t.name ?? t.preview,
-              summary: t.name ?? t.preview,
-              createdAt: new Date(t.createdAt).toISOString(),
-              modifiedAt: new Date(t.updatedAt).toISOString(),
-              model: t.model,
-            });
-          }
-        } catch (err) {
-          log.warn({ err, projectPath }, 'codex: failed to list external sessions for path');
         }
+      } catch (err) {
+        log.warn({ err, projectPath }, 'codex: failed to list external sessions for path');
       }
       return aggregated;
     } catch (err) {

--- a/packages/desktop/src/renderer/components/panels/ImportSessionsPopover.tsx
+++ b/packages/desktop/src/renderer/components/panels/ImportSessionsPopover.tsx
@@ -16,19 +16,39 @@ function cleanPromptDisplay(text: string): string {
 
 function formatRelativeTime(isoString: string): string {
   const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const MIN = 60 * 1000;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
   const time = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-  if (date.toDateString() === now.toDateString()) return `Today ${time}`;
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return `Yesterday ${time}`;
-  if (diffDays < 7) return `${date.toLocaleDateString([], { weekday: 'long' })} ${time}`;
-  if (diffDays < 14) return 'Last week';
-  if (date.getFullYear() === now.getFullYear()) return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  if (diffMs < HOUR) {
+    const mins = Math.max(1, Math.floor(diffMs / MIN));
+    return `${mins}m ago`;
+  }
+  if (diffMs < DAY) {
+    const hours = Math.floor(diffMs / HOUR);
+    return `${hours}h ago`;
+  }
+  if (diffMs < 2 * DAY) return `Yesterday ${time}`;
+  if (diffMs < 7 * DAY) {
+    const days = Math.floor(diffMs / DAY);
+    return `${days}d ago`;
+  }
+  if (date.getFullYear() === now.getFullYear()) {
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
   return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function worktreeLabel(cwd: string | undefined, projectPath: string | undefined): string | null {
+  if (!cwd || !projectPath) return null;
+  if (cwd === projectPath) return null; // root — no label
+  const prefix = projectPath.endsWith('/') ? projectPath : projectPath + '/';
+  if (cwd.startsWith(prefix)) return cwd.slice(prefix.length);
+  return cwd;
 }
 
 interface ImportSessionsPopoverProps {
@@ -65,6 +85,11 @@ export function ImportSessionsPopover({
       .catch((err) => log.warn('failed to fetch external sessions', { err: String(err) }))
       .finally(() => setLoading(false));
   }, [selectedProjectId]);
+
+  const selectedProject = useMemo(
+    () => projects.find((p) => p.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId],
+  );
 
   const handleImport = useCallback(
     async (session: ExternalSession) => {
@@ -144,10 +169,28 @@ export function ImportSessionsPopover({
                     {session.gitBranch && (
                       <>
                         <GitBranch size={10} className="shrink-0" />
-                        <span className="truncate max-w-[100px]">{session.gitBranch}</span>
+                        <span className="truncate max-w-[100px]" data-testid="external-session-branch">
+                          {session.gitBranch}
+                        </span>
                         <span>{'·'}</span>
                       </>
                     )}
+                    {(() => {
+                      const label = worktreeLabel(session.cwd, selectedProject?.path);
+                      if (!label) return null;
+                      return (
+                        <>
+                          <span
+                            className="truncate max-w-[140px] font-mono"
+                            data-testid="external-session-worktree"
+                            title={session.cwd}
+                          >
+                            {label}
+                          </span>
+                          <span>{'·'}</span>
+                        </>
+                      );
+                    })()}
                     <Clock size={10} className="shrink-0" />
                     <span>{formatRelativeTime(session.modifiedAt)}</span>
                   </div>

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -212,7 +212,8 @@ export interface AdapterModel {
 export interface ExternalSession {
   sessionId: string; // CLI's native session UUID
   adapterId: string; // Which adapter discovered this session
-  projectPath: string;
+  projectPath: string; // Project root the session was attributed to (Mainframe-side)
+  cwd?: string; // Working directory the session actually ran in (worktree, subdir, or root)
   firstPrompt?: string; // First user message (truncated)
   summary?: string; // AI-generated summary if available
   messageCount?: number;
@@ -255,7 +256,7 @@ export interface Adapter {
   ): Promise<import('./skill.js').AgentConfig>;
   updateAgent?(agentId: string, projectPath: string, content: string): Promise<import('./skill.js').AgentConfig>;
   deleteAgent?(agentId: string, projectPath: string): Promise<void>;
-  listExternalSessions?(projectPaths: string[], excludeSessionIds: string[]): Promise<ExternalSession[]>;
+  listExternalSessions?(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]>;
 
   /**
    * Factory for an adapter-specific plan-mode action handler.


### PR DESCRIPTION
## Summary

Three fixes for Import External Sessions (#186):

- **Missing sessions**: discovery now globs every encoded `~/.claude/projects/` directory whose prefix matches the project — not just live git worktrees — so sessions from deleted worktrees and subdirectory cwds (e.g. `packages/core`) show up. Ambiguous prefix matches (e.g. `mainframe` vs `mainframe-web`) are filtered out by the session's own `cwd` field as ground truth.
- **Wrong dates**: dropped the `new Date().toISOString()` fallback that silently labelled missing-timestamp sessions as "Today". Index entries now fall back to `fileMtime` → JSONL file `stat().mtime` → `created`; sessions with no real timestamp are dropped with a warning instead of given a fake "now". Renderer's `formatRelativeTime` unified on a single ms basis (`5m ago` / `3h ago` / `Yesterday HH:MM` / `Nd ago` / `Mon D`) so "Yesterday" can never appear before "Today".
- **Worktree attribution**: `ExternalSession.cwd` carries the session's real working directory; popover renders the path relative to the project root between the branch and the time.

Adapter contract tightened: `listExternalSessions` now takes a single `projectPath` and owns its own per-adapter discovery (Codex updated to match). `ExternalSessionService.collectProjectPaths` and the `getWorktrees` call gone.

Closes #186

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test` — 1419/1419 pass
- [x] `pnpm --filter @qlan-ro/mainframe-desktop test` — 713/713 pass
- [ ] Manual: open Import in a project with many historical worktrees; verify count is materially larger than before, dates make sense, and worktree labels appear for sub-cwd / worktree sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)