### PR TITLE
fix(core): skip claude session-file rename for codex worktrees

### DIFF
--- a/.changeset/codex-worktree-no-rename.md
+++ b/.changeset/codex-worktree-no-rename.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix ENOENT when creating a worktree from a running Codex session. `enableWorktree`/`attachWorktree` now skip the Claude-specific session file rename for non-Claude adapters; Codex resumes by `threadId + cwd` and doesn't need files relocated.

--- a/packages/core/src/__tests__/chat/mid-session-worktree.test.ts
+++ b/packages/core/src/__tests__/chat/mid-session-worktree.test.ts
@@ -78,6 +78,26 @@ describe('mid-session enableWorktree', () => {
       branchName: 'my-branch',
     });
   });
+
+  it('skips moveSessionFiles for non-claude adapters but still stops/restarts', async () => {
+    const { moveSessionFiles } = await import('../../workspace/index.js');
+    (moveSessionFiles as ReturnType<typeof vi.fn>).mockClear();
+
+    const chat = makeChat({ adapterId: 'codex', claudeSessionId: 'thread-1' });
+    const active: ActiveChat = { chat, session: { isSpawned: true, kill: vi.fn() } as any };
+    const deps = makeDeps(active);
+
+    const manager = new ChatConfigManager(deps);
+    await manager.enableWorktree('chat-1', 'main', 'my-branch');
+
+    expect(deps.stopChat).toHaveBeenCalledWith('chat-1');
+    expect(moveSessionFiles).not.toHaveBeenCalled();
+    expect(deps.db.chats.update).toHaveBeenCalledWith('chat-1', {
+      worktreePath: '/repo/.worktrees/my-branch',
+      branchName: 'my-branch',
+    });
+    expect(deps.startChat).toHaveBeenCalledWith('chat-1');
+  });
 });
 
 describe('mid-session attachWorktree', () => {
@@ -119,5 +139,25 @@ describe('mid-session attachWorktree', () => {
       worktreePath: '/repo/.worktrees/existing-branch',
       branchName: 'existing-branch',
     });
+  });
+
+  it('skips moveSessionFiles for non-claude adapters but still stops/restarts', async () => {
+    const { moveSessionFiles } = await import('../../workspace/index.js');
+    (moveSessionFiles as ReturnType<typeof vi.fn>).mockClear();
+
+    const chat = makeChat({ adapterId: 'codex', claudeSessionId: 'thread-2' });
+    const active: ActiveChat = { chat, session: { isSpawned: true, kill: vi.fn() } as any };
+    const deps = makeDeps(active);
+
+    const manager = new ChatConfigManager(deps);
+    await manager.attachWorktree('chat-1', '/repo/.worktrees/existing-branch', 'existing-branch');
+
+    expect(deps.stopChat).toHaveBeenCalledWith('chat-1');
+    expect(moveSessionFiles).not.toHaveBeenCalled();
+    expect(deps.db.chats.update).toHaveBeenCalledWith('chat-1', {
+      worktreePath: '/repo/.worktrees/existing-branch',
+      branchName: 'existing-branch',
+    });
+    expect(deps.startChat).toHaveBeenCalledWith('chat-1');
   });
 });

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -115,15 +115,19 @@ export class ChatConfigManager {
     if (!project) throw new Error('Project not found');
 
     if (active.chat.claudeSessionId) {
-      // Mid-session path: stop, create worktree, move session files, restart
+      // Mid-session path: stop, create worktree, move session files (claude only), restart.
+      // Codex resumes by threadId + cwd and stores rollouts under ~/.codex/sessions/<date>/
+      // (not project-keyed), so there is nothing to relocate.
       await this.deps.stopChat(chatId);
 
       const worktreeDir = this.deps.db.settings.get('general', 'worktreeDir') ?? GENERAL_DEFAULTS.worktreeDir;
       const info = createWorktree(project.path, chatId, worktreeDir, baseBranch, branchName);
 
-      const oldProjectDir = getClaudeProjectDir(project.path);
-      const newProjectDir = getClaudeProjectDir(info.worktreePath);
-      await moveSessionFiles(active.chat.claudeSessionId, oldProjectDir, newProjectDir);
+      if (active.chat.adapterId === 'claude') {
+        const oldProjectDir = getClaudeProjectDir(project.path);
+        const newProjectDir = getClaudeProjectDir(info.worktreePath);
+        await moveSessionFiles(active.chat.claudeSessionId, oldProjectDir, newProjectDir);
+      }
 
       active.chat.worktreePath = info.worktreePath;
       active.chat.branchName = info.branchName;
@@ -159,9 +163,11 @@ export class ChatConfigManager {
 
       await this.deps.stopChat(chatId);
 
-      const oldProjectDir = getClaudeProjectDir(project.path);
-      const newProjectDir = getClaudeProjectDir(worktreePath);
-      await moveSessionFiles(active.chat.claudeSessionId, oldProjectDir, newProjectDir);
+      if (active.chat.adapterId === 'claude') {
+        const oldProjectDir = getClaudeProjectDir(project.path);
+        const newProjectDir = getClaudeProjectDir(worktreePath);
+        await moveSessionFiles(active.chat.claudeSessionId, oldProjectDir, newProjectDir);
+      }
 
       active.chat.worktreePath = worktreePath;
       active.chat.branchName = branchName;


### PR DESCRIPTION
## Summary
- Creating a worktree from a running Codex session crashed with `ENOENT: rename '~/.claude/projects/<encoded>/<id>.jsonl' -> '.../-worktrees-<branch>/<id>.jsonl'`. That path is Claude-only — Codex stores rollouts under `~/.codex/sessions/<date>/rollout-*-<threadId>.jsonl` and resumes by `threadId + cwd`, so no file relocation is required.
- `enableWorktree` / `attachWorktree` in `chat/config-manager.ts` now gate `moveSessionFiles` on `adapterId === 'claude'`. The stop → create-worktree → restart flow still runs for all adapters; on restart the lifecycle manager spawns the adapter with `cwd = chat.worktreePath`, and the Codex `thread/resume` call picks up the new cwd.

Closes #183.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-core test src/__tests__/chat/mid-session-worktree.test.ts` (6/6 pass; two new cases verify the codex adapter skips `moveSessionFiles` but still stops + restarts).
- [x] `pnpm --filter @qlan-ro/mainframe-core build` clean.
- [ ] Manual: enable worktree on a live Codex chat and confirm it resumes in the worktree cwd without ENOENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)