### PR TITLE
fix(desktop): rename input survives new-message re-sort (#185)

### DIFF
--- a/.changeset/fix-rename-survives-message.md
+++ b/.changeset/fix-rename-survives-message.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(sessions): renaming a session no longer exits editor mode when a new message arrives (#185). The rename input now survives the list re-sort that follows an `updatedAt` bump, commits on outside pointerdown instead of blur, and is no longer nested inside a `<button>` (invalid HTML).

--- a/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
+++ b/packages/desktop/src/renderer/components/panels/FlatSessionRow.tsx
@@ -171,6 +171,29 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
     [handleCommitRename],
   );
 
+  // Keep focus on the rename input across DOM reorders (e.g. list re-sort when
+  // a new message bumps this row's updatedAt). Without this, the input loses
+  // focus when React moves the row via insertBefore and onBlur would commit.
+  useLayoutEffect(() => {
+    if (editing && inputRef.current && document.activeElement !== inputRef.current) {
+      inputRef.current.focus();
+    }
+  });
+
+  // Commit on outside pointerdown instead of onBlur — blur fires on programmatic
+  // focus loss (list reorder) and would exit edit mode unintentionally.
+  useEffect(() => {
+    if (!editing) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const input = inputRef.current;
+      if (input && e.target instanceof Node && !input.contains(e.target)) {
+        handleCommitRename();
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [editing, handleCommitRename]);
+
   const isActive = activeChatId === chat.id;
   const isWorking = chat.displayStatus === 'working' || chat.displayStatus === 'waiting';
 
@@ -246,26 +269,29 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
 
         <div className="min-w-0 space-y-2">
           <div data-testid="session-title-row" className="flex items-center min-w-0 gap-2">
-            {/* title + select target */}
-            <button
-              type="button"
-              data-testid={`chats-session-select-${chat.id}`}
-              onClick={handleSelect}
-              className={cn('min-w-0 text-left flex items-center gap-1.5 min-h-[20px]', hasTags && 'max-w-[50%]')}
-            >
-              {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
-              {editing ? (
+            {/* title + select target. The rename input is rendered as a sibling
+                — not a child of <button> — to keep the HTML valid. */}
+            {editing ? (
+              <div className={cn('min-w-0 flex items-center gap-1.5 min-h-[20px]', hasTags && 'max-w-[50%]')}>
+                {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
                 <input
                   ref={inputRef}
                   data-testid={`chats-session-rename-input-${chat.id}`}
                   value={editTitle}
                   onChange={(e) => setEditTitle(e.target.value)}
-                  onBlur={handleCommitRename}
                   onKeyDown={handleRenameKeyDown}
                   onClick={(e) => e.stopPropagation()}
                   className="flex-1 bg-mf-panel-bg text-sm text-mf-text-primary border border-mf-accent rounded px-1 py-0 outline-none"
                 />
-              ) : (
+              </div>
+            ) : (
+              <button
+                type="button"
+                data-testid={`chats-session-select-${chat.id}`}
+                onClick={handleSelect}
+                className={cn('min-w-0 text-left flex items-center gap-1.5 min-h-[20px]', hasTags && 'max-w-[50%]')}
+              >
+                {chat.pinned && <Pin size={10} className="shrink-0 text-mf-accent" />}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
@@ -283,8 +309,8 @@ export const FlatSessionRow = React.memo(function FlatSessionRow({
                     {chat.title || 'Untitled session'}
                   </TooltipContent>
                 </Tooltip>
-              )}
-            </button>
+              </button>
+            )}
 
             {hasTags && (
               <div

--- a/packages/desktop/src/renderer/components/panels/__tests__/FlatSessionRow.test.tsx
+++ b/packages/desktop/src/renderer/components/panels/__tests__/FlatSessionRow.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Chat } from '@qlan-ro/mainframe-types';
+import { renameChat } from '../../../lib/api';
 
 // vi.hoisted runs before vi.mock factories are executed, so these variables
 // are safe to reference inside factory closures.
@@ -281,5 +282,61 @@ describe('FlatSessionRow: non-optimistic archive', () => {
     // Spinner gone, button re-enabled
     expect(archiveBtn.querySelector('.animate-spin')).toBeNull();
     expect(archiveBtn).not.toBeDisabled();
+  });
+});
+
+describe('FlatSessionRow: rename input survives re-renders', () => {
+  it('stays in edit mode and keeps focus when the chat prop updates (e.g. new message bumps updatedAt)', async () => {
+    const chat = makeChat();
+    let triggerRename: (() => void) | undefined;
+    const register = (_id: string, fn: () => void) => {
+      triggerRename = fn;
+    };
+
+    const { rerender } = render(<FlatSessionRow chat={chat} registerRenameCallback={register} />);
+
+    act(() => triggerRename!());
+
+    const input = await screen.findByTestId('chats-session-rename-input-chat-1');
+    expect(document.activeElement).toBe(input);
+
+    // Simulate a new message: parent re-renders with a fresh chat object + new updatedAt.
+    // Pre-fix, the input would lose focus on blur and exit edit mode.
+    rerender(
+      <FlatSessionRow
+        chat={{ ...chat, updatedAt: '2026-01-03T00:00:00Z', displayStatus: 'working' }}
+        registerRenameCallback={register}
+      />,
+    );
+
+    // Still editing, still focused.
+    expect(screen.getByTestId('chats-session-rename-input-chat-1')).toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByTestId('chats-session-rename-input-chat-1'));
+    expect(vi.mocked(renameChat)).not.toHaveBeenCalled();
+  });
+
+  it('commits on outside pointerdown', async () => {
+    const chat = makeChat();
+    let triggerRename: (() => void) | undefined;
+    const register = (_id: string, fn: () => void) => {
+      triggerRename = fn;
+    };
+
+    render(
+      <div>
+        <FlatSessionRow chat={chat} registerRenameCallback={register} />
+        <div data-testid="outside">outside</div>
+      </div>,
+    );
+
+    act(() => triggerRename!());
+    const input = await screen.findByTestId('chats-session-rename-input-chat-1');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Renamed');
+
+    fireEvent.pointerDown(screen.getByTestId('outside'));
+
+    expect(vi.mocked(renameChat)).toHaveBeenCalledWith('chat-1', 'Renamed');
+    expect(screen.queryByTestId('chats-session-rename-input-chat-1')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- When a new message arrives in the session being renamed, `chat.updatedAt` updates → `flatChats` re-sorts → React moves the keyed row via `insertBefore` → the focused `<input>` loses focus → `onBlur` commits and exits edit mode.
- Lift the rename `<input>` out of its wrapping `<button>` (invalid HTML; nested interactive content compounds focus loss).
- Replace `onBlur` commit with a document `pointerdown` listener that commits only on a real outside click.
- Re-acquire focus via `useLayoutEffect` while editing, so any programmatic focus loss is restored synchronously.

Fixes #185.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-desktop exec vitest run src/renderer/components/panels/__tests__/FlatSessionRow.test.tsx` — 6/6 pass, including two new regressions: rename input keeps focus when the chat prop updates (new message), and outside `pointerdown` still commits.
- [ ] Manual: start renaming a session, send a message into it from another window/agent, confirm the input stays focused and editable; click outside to commit; press Esc to cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)