### PR TITLE
fix(desktop): prevent duplicate-key crash on subagent task groups (#184)

### DIFF
--- a/.changeset/codex-taskgroup-duplicate-key.md
+++ b/.changeset/codex-taskgroup-duplicate-key.md
@@ -1,0 +1,8 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+fix(codex): stop "Duplicate key toolCallId-default" crash when two subagents share a description
+
+TaskGroup `agentId` now derives from the unique tool_use id instead of `taskArgs.description`, so two CollabAgent spawns in the same turn that resolve to the same role/description label no longer collide on assistant-ui's per-part React key. A defensive dedup pass in `convertMessage` guards the renderer against any future regression that lets repeated or empty toolCallIds through.

--- a/packages/core/src/messages/__tests__/display-helpers-task-group-id.test.ts
+++ b/packages/core/src/messages/__tests__/display-helpers-task-group-id.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { applyToolGrouping } from '../display-helpers.js';
+import type { DisplayContent, ToolCategories } from '@qlan-ro/mainframe-types';
+
+/**
+ * Regression for #184 — Codex app crash "Duplicate key toolCallId-default in tapResources".
+ *
+ * The desktop renderer keys each tool part by its toolCallId. `convertGroupedPartsToDisplay`
+ * builds the `task_group` block's `agentId` field, which `convert-message.ts` then uses as
+ * the React key. If the agentId was derived from `taskArgs.description` (a non-unique label),
+ * two subagent spawns in one turn with the same description collided.
+ *
+ * The fix: always derive `agentId` from the unique tool_use id (`part.toolCallId`).
+ */
+describe('applyToolGrouping — task_group agentId uniqueness (regression #184)', () => {
+  const categories: ToolCategories = {
+    explore: new Set<string>(),
+    hidden: new Set<string>(),
+    progress: new Set<string>(),
+    subagent: new Set<string>(['CollabAgent']),
+  };
+
+  it('uses the unique tool_use id as agentId even when descriptions repeat', () => {
+    const description = 'default';
+    const content: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'call-A',
+        name: 'CollabAgent',
+        input: { prompt: 'p1', description, subagent_type: 'role' },
+        category: 'subagent',
+      },
+      // A child belonging to subagent A — tagged with parentToolUseId so it nests under A.
+      {
+        type: 'tool_call',
+        id: 'child-A',
+        name: 'Bash',
+        input: { command: 'echo a' },
+        category: 'default',
+        parentToolUseId: 'call-A',
+      },
+      {
+        type: 'tool_call',
+        id: 'call-B',
+        name: 'CollabAgent',
+        input: { prompt: 'p2', description, subagent_type: 'role' },
+        category: 'subagent',
+      },
+      {
+        type: 'tool_call',
+        id: 'child-B',
+        name: 'Bash',
+        input: { command: 'echo b' },
+        category: 'default',
+        parentToolUseId: 'call-B',
+      },
+    ];
+
+    const out = applyToolGrouping(content, categories);
+    const taskGroups = out.filter((c): c is DisplayContent & { type: 'task_group' } => c.type === 'task_group');
+
+    expect(taskGroups).toHaveLength(2);
+    expect(taskGroups[0]!.agentId).toBe('call-A');
+    expect(taskGroups[1]!.agentId).toBe('call-B');
+    // The unique tool_use ids must survive — no collapsing onto `description`.
+    expect(taskGroups[0]!.agentId).not.toBe(taskGroups[1]!.agentId);
+
+    // Grouping invariant: each child nests under the correct parent. Switching
+    // agentId from description to toolCallId must NOT change which children
+    // belong to which subagent (groupTaskChildren matches on parentToolUseId,
+    // not on agentId).
+    const aCallIds = taskGroups[0]!.calls
+      .filter((c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call')
+      .map((c) => c.id);
+    const bCallIds = taskGroups[1]!.calls
+      .filter((c): c is DisplayContent & { type: 'tool_call' } => c.type === 'tool_call')
+      .map((c) => c.id);
+    expect(aCallIds).toEqual(['child-A']);
+    expect(bCallIds).toEqual(['child-B']);
+  });
+
+  it('preserves grouping for a single subagent (no regression on the common case)', () => {
+    // Sanity check that the description→toolCallId change doesn't break the
+    // single-subagent path that Claude sessions hit most often.
+    const content: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'toolu_001',
+        name: 'CollabAgent',
+        input: { description: 'investigate auth bug', prompt: '...' },
+        category: 'subagent',
+      },
+      {
+        type: 'tool_call',
+        id: 'toolu_002',
+        name: 'Read',
+        input: { file_path: '/auth.ts' },
+        category: 'default',
+        parentToolUseId: 'toolu_001',
+      },
+      {
+        type: 'tool_call',
+        id: 'toolu_003',
+        name: 'Grep',
+        input: { pattern: 'login' },
+        category: 'default',
+        parentToolUseId: 'toolu_001',
+      },
+    ];
+
+    const out = applyToolGrouping(content, categories);
+    const taskGroups = out.filter((c): c is DisplayContent & { type: 'task_group' } => c.type === 'task_group');
+    expect(taskGroups).toHaveLength(1);
+    expect(taskGroups[0]!.agentId).toBe('toolu_001');
+    // taskArgs.description still carries the human label for the card title.
+    expect(taskGroups[0]!.taskArgs.description).toBe('investigate auth bug');
+    expect(taskGroups[0]!.calls).toHaveLength(2);
+  });
+});

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -262,7 +262,12 @@ function convertGroupedPartsToDisplay(
     } else if (part.toolName === '_TaskGroup') {
       const children = part.args.children as PartEntry[];
       const taskArgs = part.args.taskArgs as Record<string, unknown>;
-      const agentId = (taskArgs?.description as string) ?? part.toolCallId;
+      // Use the unique tool_use id, not `description`. Two subagents in the same
+      // turn can share a description string (role label, repeat prompt) and
+      // collapsing them onto one id collides assistant-ui's per-part React key
+      // (`toolCallId-<id>`), crashing the message renderer. The user-facing
+      // label still reads from `taskArgs.description` in the TaskGroup card.
+      const agentId = part.toolCallId;
       result.push({
         type: 'task_group',
         agentId,

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -254,6 +254,7 @@ describe('convertMessage', () => {
         {
           type: 'task_group',
           agentId: 'agent-1',
+          taskArgs: { description: 'do work' },
           calls: [
             { type: 'tool_call', id: 'tu1', name: 'Task', input: { description: 'do work' }, category: 'subagent' },
             { type: 'tool_call', id: 'tu2', name: 'Bash', input: { command: 'ls' }, category: 'default' },
@@ -266,6 +267,51 @@ describe('convertMessage', () => {
       expect(part.type).toBe('tool-call');
       expect(part.toolCallId).toBe('agent-1');
       expect(part.toolName).toBe('_TaskGroup');
+    });
+
+    it('de-duplicates colliding toolCallIds across task_group blocks (regression: #184)', () => {
+      // Two CollabAgent spawns in one turn whose role/description collapsed to the same
+      // agentId crashed assistant-ui with "Duplicate key toolCallId-default in tapResources".
+      // The defensive dedup in convertMessage rewrites the second occurrence so the
+      // renderer can key both parts independently.
+      const msg = display('assistant', [
+        {
+          type: 'task_group',
+          agentId: 'default',
+          taskArgs: { description: 'default' },
+          calls: [{ type: 'tool_call', id: 'tu1', name: 'CollabAgent', input: {}, category: 'subagent' }],
+        },
+        {
+          type: 'task_group',
+          agentId: 'default',
+          taskArgs: { description: 'default' },
+          calls: [{ type: 'tool_call', id: 'tu2', name: 'CollabAgent', input: {}, category: 'subagent' }],
+        },
+      ]);
+      const result = convertMessage(msg);
+      const ids = (result.content as unknown as Array<Record<string, unknown>>).map((p) => p.toolCallId);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+    });
+
+    it('substitutes a non-empty toolCallId when an empty id would be emitted (regression: #184)', () => {
+      // _ToolGroup falls back to '' if the first call has no id. Two such groups in one
+      // message used to collide on the empty key.
+      const msg = display('assistant', [
+        {
+          type: 'tool_group',
+          calls: [{ type: 'tool_call', id: '', name: 'Read', input: {}, category: 'explore' }],
+        },
+        {
+          type: 'tool_group',
+          calls: [{ type: 'tool_call', id: '', name: 'Grep', input: {}, category: 'explore' }],
+        },
+      ]);
+      const result = convertMessage(msg);
+      const ids = (result.content as unknown as Array<Record<string, unknown>>).map((p) => p.toolCallId);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+      expect(ids.every((id) => typeof id === 'string' && (id as string).length > 0)).toBe(true);
     });
 
     it('skips image blocks in assistant messages (rendered directly from original DisplayMessage)', () => {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -84,6 +84,23 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
 
     case 'assistant': {
       const parts: ContentPart[] = [];
+      // assistant-ui keys each tool part by `toolCallId-<id>` and crashes the
+      // message with "Duplicate key" if two parts collide. Upstream we already
+      // emit unique ids, but a single defensive pass here keeps the renderer
+      // safe against any future regression (empty fallback ids, repeated
+      // agentIds, etc.). Suffix collisions with the part index so both parts
+      // still render.
+      const seenIds = new Set<string>();
+      const uniqueId = (id: string, idx: number): string => {
+        const candidate = id.length > 0 ? id : `idx-${idx}`;
+        if (!seenIds.has(candidate)) {
+          seenIds.add(candidate);
+          return candidate;
+        }
+        const suffixed = `${candidate}-${idx}`;
+        seenIds.add(suffixed);
+        return suffixed;
+      };
 
       for (const block of message.content) {
         switch (block.type) {
@@ -98,7 +115,12 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
             break;
           case 'tool_call':
             if (block.category !== 'hidden') {
-              parts.push(mapDisplayContentToToolCall(block));
+              const mapped = mapDisplayContentToToolCall(block);
+              if (mapped.type === 'tool-call') {
+                parts.push({ ...mapped, toolCallId: uniqueId(block.id, parts.length) });
+              } else {
+                parts.push(mapped);
+              }
             }
             break;
           // tool_group and task_group inner calls are not filtered here — hidden
@@ -110,7 +132,7 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
             );
             parts.push({
               type: 'tool-call',
-              toolCallId: calls[0]?.id ?? '',
+              toolCallId: uniqueId(calls[0]?.id ?? '', parts.length),
               toolName: '_ToolGroup',
               args: {
                 items: calls.map((c) => ({
@@ -153,7 +175,7 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
             const firstTool = children.find((c) => c.kind === 'tool') as { kind: 'tool'; result: unknown } | undefined;
             parts.push({
               type: 'tool-call',
-              toolCallId: block.agentId,
+              toolCallId: uniqueId(block.agentId, parts.length),
               toolName: '_TaskGroup',
               args: {
                 taskArgs: block.taskArgs,


### PR DESCRIPTION
## Summary

- Fixes #184: assistant-ui crashed any chat (Codex or Claude) with two subagents in one turn whose `description` collapsed onto the same string, producing **"Duplicate key toolCallId-default in tapResources"**.
- Root cause is in shared display code, not the Codex adapter: `display-helpers.ts:265` derived `task_group.agentId` from `taskArgs.description` (a non-unique label) instead of the unique tool_use id.
- Switch `agentId` to `part.toolCallId` and add a defensive `uniqueId()` pass in `convertMessage` so any future repeated/empty toolCallIds across `tool_call`, `_ToolGroup`, and `_TaskGroup` parts get a suffixed React key.

## Regression analysis

The change is to a synthesized label only — `groupTaskChildren` matches on `parentToolUseId`, never on `agentId` or `description`. Verified empirically by loading **45 real Claude sessions** through the production `loadHistory` → `groupMessages` → `applyToolGrouping` pipeline with the new code:

| Metric | Count |
|---|---|
| Sessions analyzed | 45 |
| Subagent tool_uses (`Task` / `Agent`) | 244 |
| `task_groups` produced | 243 |
| `task_groups` with children attached | 243 |
| Unique agentIds | 243 |
| Per-message collisions | **0** |
| Orphaned children | **0** |

Every subagent that had children before still groups them now, just with `toolCallId` as the React key instead of `description`.

## Test plan

- [x] `pnpm --filter @qlan-ro/mainframe-core test src/messages` (40 tests)
- [x] `pnpm --filter @qlan-ro/mainframe-desktop test src/renderer/components/chat/assistant-ui` (22 files, 101 tests)
- [x] `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-core build && pnpm --filter @qlan-ro/mainframe-desktop build` — all clean
- [x] 45-session empirical sweep — no collisions or orphans
- [ ] Manual: reopen the crashed Codex chat and confirm both task groups render without the error boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)