### PR TITLE
fix(core): send queued-message snapshot on chat.resume

### DIFF
--- a/.changeset/fix-resume-snapshot.md
+++ b/.changeset/fix-resume-snapshot.md
@@ -1,0 +1,19 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Send `message.queued.snapshot` on `chat.resume` so the composer banner
+reconverges on the daemon's truth whenever the client re-opens a chat.
+
+Previously only the (rarely-used) `subscribe` WS handler emitted this
+snapshot; `chat.resume` (which the desktop fires every time a chat view
+mounts) just added the chat to the subscription set without seeding the
+queue state. The result: a queued message that the CLI processed while
+the client was unsubscribed (because the user had switched chats) would
+stay stranded in the composer banner forever, even though the daemon
+had already pruned the ref. The bubble's `metadata.queued` flag silently
+cleared on re-entry — `useChatSession` HTTP-refetches messages from
+JSONL, which never carries that transient flag — so the user saw a
+stuck composer entry alongside a clean message bubble.
+
+The two WS handlers now share a private `sendQueuedSnapshot` helper.

--- a/packages/core/src/__tests__/ws-inbound-flow.test.ts
+++ b/packages/core/src/__tests__/ws-inbound-flow.test.ts
@@ -258,6 +258,58 @@ describe('WS inbound flows', () => {
     b.close();
   }, 10_000);
 
+  it('chat.resume emits message.queued.snapshot so composer rehydrates on chat re-entry', async () => {
+    const adapter = new MockAdapter();
+    const { httpServer, chats } = createStack(adapter);
+    server = httpServer;
+    const port = await startServer(server);
+
+    // Pre-seed a queued ref as if a prior session had sent one. This mirrors
+    // the real bug: user sends a queued message in chat A, switches away
+    // (so the renderer's composer keeps the entry in its local map), then
+    // returns. Without the fix, chat.resume re-subscribes but never sends
+    // a snapshot, so the composer keeps whatever stale state it had — even
+    // after the CLI processed the message and the daemon pruned the ref.
+    const ref = {
+      uuid: 'preseeded-uuid',
+      chatId: 'test-chat',
+      messageId: 'm1',
+      content: 'hi',
+      timestamp: new Date().toISOString(),
+    };
+    (chats as unknown as { queuedRefs: Map<string, typeof ref> }).queuedRefs.set(ref.uuid, ref);
+
+    const { socket, events } = await connectWsCollecting(port);
+    ws = socket;
+    socket.send(JSON.stringify({ type: 'chat.resume', chatId: 'test-chat' }));
+    await sleep(150);
+
+    const snapshot = events.find((e) => e.type === 'message.queued.snapshot');
+    expect(snapshot).toBeDefined();
+    expect((snapshot as { chatId: string }).chatId).toBe('test-chat');
+    expect((snapshot as { refs: Array<{ uuid: string }> }).refs.map((r) => r.uuid)).toEqual(['preseeded-uuid']);
+  }, 10_000);
+
+  it('chat.resume snapshot is empty when daemon has no queued refs (clears stranded composer entries)', async () => {
+    const adapter = new MockAdapter();
+    const { httpServer } = createStack(adapter);
+    server = httpServer;
+    const port = await startServer(server);
+
+    // No refs pre-seeded — this is the scenario the user hit: the daemon
+    // already pruned the ref while the client was unsubscribed, so on
+    // re-entry the snapshot must be empty to converge the renderer's
+    // stale composer state down to nothing.
+    const { socket, events } = await connectWsCollecting(port);
+    ws = socket;
+    socket.send(JSON.stringify({ type: 'chat.resume', chatId: 'test-chat' }));
+    await sleep(150);
+
+    const snapshot = events.find((e) => e.type === 'message.queued.snapshot');
+    expect(snapshot).toBeDefined();
+    expect((snapshot as { refs: unknown[] }).refs).toEqual([]);
+  }, 10_000);
+
   it('invalid WS message sends back error type', async () => {
     const adapter = new MockAdapter();
     const events = await setup(adapter);

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -151,6 +151,13 @@ export class WebSocketManager {
       case 'chat.resume': {
         client.subscriptions.add(event.chatId);
         await this.chats.resumeChat(event.chatId);
+        // Rehydrate queued-message state for this client. Without this, a
+        // user switching away from and back to a chat would see stale
+        // `queuedMessages` entries (the renderer fetches fresh messages
+        // via REST which drops the transient `metadata.queued` flag, but
+        // the composer banner is driven by a separate map that only
+        // updates from snapshot events).
+        this.sendQueuedSnapshot(client, event.chatId);
         break;
       }
 
@@ -221,18 +228,7 @@ export class WebSocketManager {
 
       case 'subscribe': {
         client.subscriptions.add(event.chatId);
-        // Rehydrate queued-message state for this client — the daemon is the
-        // source of truth; the renderer's Zustand store may have drifted
-        // during a WS disconnect.
-        const refs = this.chats.getQueuedForChat(event.chatId);
-        const snapshot: DaemonEvent = {
-          type: 'message.queued.snapshot',
-          chatId: event.chatId,
-          refs,
-        };
-        if (client.ws.readyState === WebSocket.OPEN) {
-          client.ws.send(JSON.stringify(snapshot));
-        }
+        this.sendQueuedSnapshot(client, event.chatId);
         break;
       }
 
@@ -340,6 +336,18 @@ export class WebSocketManager {
   private sendError(ws: WebSocket, message: string): void {
     if (ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'error', error: message }));
+    }
+  }
+
+  /** Send the daemon's current queued-message refs for a chat to a single
+   *  client. Used by both `subscribe` and `chat.resume` so the composer
+   *  banner reconverges on the daemon's truth whenever the client (re)opens
+   *  the chat — prevents stale entries from surviving a chat-switch. */
+  private sendQueuedSnapshot(client: ClientConnection, chatId: string): void {
+    const refs = this.chats.getQueuedForChat(chatId);
+    const snapshot: DaemonEvent = { type: 'message.queued.snapshot', chatId, refs };
+    if (client.ws.readyState === WebSocket.OPEN) {
+      client.ws.send(JSON.stringify(snapshot));
     }
   }
 }


### PR DESCRIPTION
## Bug

Queued message stays stuck in the composer banner forever after the user switches chats and comes back, even though the CLI processed the message and the daemon pruned the ref. The bubble's "Queued" pill silently disappears on re-entry, but the composer keeps showing the stale entry.

## Root cause

Two WS handlers can put a chat into a client's subscription set:

| Handler | Adds subscription? | Sends `message.queued.snapshot`? |
|---|---|---|
| `subscribe` | ✓ | ✓ |
| `chat.resume` (fired every time the desktop opens a chat view) | ✓ | **✗** |

So `chat.resume` re-subscribed the client but never seeded its `queuedMessages` map. If the CLI processed a queued message while the user was on another chat, the daemon pruned the ref and broadcast `message.queued.processed` — but with `subs=0` for that chat, the broadcast was dropped. On re-entry:

- `useChatSession` HTTP-refetched messages via `getChatMessages` and `setMessages` → bubble pill cleared because the JSONL replay doesn't carry the transient `metadata.queued` flag.
- `chat.resume` re-subscribed → no snapshot → composer banner stayed at whatever stale state the client had.

Traced live on a real session ([QUEUE-TRACE] instrumentation on `debug/queued-message-tracing`):

```
11:51:35  message.queued                  subs=1   ✓ received
11:51:38  message.queued.snapshot         subs=1   ✓ received
            ↓ user switches away ↓
11:52:13  message.queued.processed        subs=0   ✗ dropped
11:54:12  message.queued.snapshot (empty) subs=0   ✗ dropped
            ↓ user returns ↓
                (no event for K4FDim... ever again — chat.resume re-subscribed but no snapshot)
```

## Fix

Extract `sendQueuedSnapshot(client, chatId)` and call it from both `subscribe` and `chat.resume`. On every (re-)entry to a chat, the renderer's `queuedMessages` map reconverges on the daemon's truth.

## Tests

`ws-inbound-flow.test.ts` — two new tests:

1. **Pre-seed a queued ref + `chat.resume`** → assert snapshot arrives with the ref (rehydration on legitimate state).
2. **No refs + `chat.resume`** → assert snapshot arrives with empty `refs` (clears stranded entries — the exact failure mode reported).

All 1507 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)