### PR TITLE
Tech-debt remediation batch 2: git consolidation + message-pipeline sentinel removal (WS5, WS14a/b)

### DIFF
--- a/.changeset/ws14a-error-sentinel.md
+++ b/.changeset/ws14a-error-sentinel.md
@@ -1,0 +1,14 @@
+---
+"@qlan-ro/mainframe-desktop": patch
+---
+
+refactor(desktop): carry error message directly instead of sentinel round-trip (WS14a)
+
+The renderer destroyed an `error` block's message into an opaque frozen text
+sentinel (`\0__MF_ERROR__`) at conversion, then string-compared that sentinel at
+render time and re-scanned every message via `getExternalStoreMessages` to recover
+the message it had already discarded. Now `convert-message` carries `block.message`
+directly in the text part, and `MainframeText` identifies an error part by checking
+the current message's own blocks (no cross-message scan, no magic string). Removes
+`ERROR_PLACEHOLDER` and `findErrorMessage`. The `permission_request` placeholder is
+left for the broader WS14b/c grouping refactor. No behavior change.

--- a/.changeset/ws14b-grouping-passthrough.md
+++ b/.changeset/ws14b-grouping-passthrough.md
@@ -1,0 +1,19 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+refactor(core): replace grouping sentinel round-trip with passthrough entry (WS14b)
+
+`applyToolGrouping` flattened DisplayContent into a parallel PartEntry model that
+only modeled text and tool-calls, smuggling every other content kind
+(thinking/image/skill_loaded/…) through grouping as a magic `\0ng:N` text string
+indexed into a side array, then decoding it back in two places via a regex.
+
+Replaces that with a first-class `{ type: 'passthrough'; content }` PartEntry
+variant: non-groupable content rides through grouping carrying its own data and
+parentToolUseId, and decodes by returning `part.content` directly. Removes the
+`nonGroupable` side array, the `\0ng:` encoding, and `NG_SENTINEL_RE`.
+
+Pure refactor — output is byte-identical, guarded by the WS14b characterization
+suite (positional interleaving, run-breaking, _TaskProgress splice, task_group
+nesting, #184 agentId). Core tests 1627 pass.

--- a/.changeset/ws5-git-consolidation.md
+++ b/.changeset/ws5-git-consolidation.md
@@ -1,0 +1,22 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+refactor(core): consolidate git layer - shared parsers, single base-branch detection, async worktree exec (WS5)
+
+The git route layer duplicated parsing and base-branch logic, and the worktree
+helper talked to git three different ways including blocking sync I/O on the
+daemon event loop.
+
+- Extract byte-identical `isNotGitRepo`, `parseDiffNameStatus`, `parseStatusLines`
+  and the porcelain bucket parser (typo `parsePortcelainStatus` fixed to
+  `parseStatusBuckets`) into one shared `git/git-parse.ts`, with direct unit tests.
+- Replace the three copies of the `['main','master']` merge-base loop with a single
+  `GitService.detectBaseBranch()`; routes consume it. Response shapes unchanged.
+- Migrate `workspace/worktree.ts` off `execFileSync`/`mkdirSync` and its private
+  `promisify(execFile)` onto the canonical async `execGit` + `fs/promises`;
+  `createWorktree` and `getWorktrees` no longer block the event loop. Callers in
+  `config-manager.ts` await accordingly.
+- Remove the dead, unexported `isGitRepo` helper (zero callers).
+
+Pure refactor; behavior preserved. Full build green, core tests 1611 pass.

--- a/packages/core/src/__tests__/git/git-service.test.ts
+++ b/packages/core/src/__tests__/git/git-service.test.ts
@@ -256,4 +256,60 @@ describe('GitService', () => {
       expect(result).toEqual({ aborted: false });
     });
   });
+
+  describe('detectBaseBranch()', () => {
+    beforeEach(() => {
+      // Reset implementation (not just calls) so prior tests' mockResolvedValue don't bleed in.
+      mockGit.raw.mockReset();
+    });
+
+    it('returns main branch when main has a merge-base with HEAD', async () => {
+      mockGit.raw.mockResolvedValueOnce('abc123\n'); // merge-base main HEAD succeeds
+
+      const svc = GitService.forProject('/fake/path');
+      const result = await svc.detectBaseBranch();
+
+      expect(result).toEqual({ baseBranch: 'main', mergeBase: 'abc123' });
+      expect(mockGit.raw).toHaveBeenCalledTimes(1);
+      expect(mockGit.raw).toHaveBeenCalledWith(['merge-base', 'main', 'HEAD']);
+    });
+
+    it('falls back to master when main has no merge-base', async () => {
+      mockGit.raw
+        .mockRejectedValueOnce(new Error('no common ancestor')) // main fails
+        .mockResolvedValueOnce('def456\n'); // master succeeds
+
+      const svc = GitService.forProject('/fake/path');
+      const result = await svc.detectBaseBranch();
+
+      expect(result).toEqual({ baseBranch: 'master', mergeBase: 'def456' });
+      expect(mockGit.raw).toHaveBeenCalledTimes(2);
+      expect(mockGit.raw).toHaveBeenNthCalledWith(1, ['merge-base', 'main', 'HEAD']);
+      expect(mockGit.raw).toHaveBeenNthCalledWith(2, ['merge-base', 'master', 'HEAD']);
+    });
+
+    it('returns null when neither main nor master has a merge-base', async () => {
+      mockGit.raw
+        .mockRejectedValueOnce(new Error('no common ancestor')) // main fails
+        .mockRejectedValueOnce(new Error('no common ancestor')); // master fails
+
+      const svc = GitService.forProject('/fake/path');
+      const result = await svc.detectBaseBranch();
+
+      expect(result).toBeNull();
+    });
+
+    it('prefers main over master (main wins when both would resolve)', async () => {
+      // Both would succeed, but main is checked first and short-circuits
+      mockGit.raw
+        .mockResolvedValueOnce('sha999\n') // main succeeds
+        .mockResolvedValueOnce('sha111\n'); // master (never reached)
+
+      const svc = GitService.forProject('/fake/path');
+      const result = await svc.detectBaseBranch();
+
+      expect(result).toEqual({ baseBranch: 'main', mergeBase: 'sha999' });
+      expect(mockGit.raw).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/__tests__/routes/git-diff.test.ts
+++ b/packages/core/src/__tests__/routes/git-diff.test.ts
@@ -5,6 +5,7 @@ import type { RouteContext } from '../../server/routes/types.js';
 const mockSvc = {
   diff: vi.fn(),
   mergeBase: vi.fn(),
+  detectBaseBranch: vi.fn(),
   currentBranch: vi.fn(),
   statusRaw: vi.fn(),
   show: vi.fn(),
@@ -111,7 +112,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   it('returns { main, worktree } shape for each changed file', async () => {
     const { readFile } = await import('node:fs/promises');
     const nameStatusOutput = 'M\tsrc/foo.ts';
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockResolvedValueOnce(nameStatusOutput);
     mockSvc.show.mockResolvedValueOnce('original content');
     (readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce('modified content');
@@ -137,7 +138,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
 
   it('returns empty main for added files', async () => {
     const { readFile } = await import('node:fs/promises');
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockResolvedValueOnce('A\tsrc/new.ts');
     (readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce('new file content');
 
@@ -158,7 +159,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   });
 
   it('returns empty worktree for deleted files', async () => {
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockResolvedValueOnce('D\tsrc/gone.ts');
     mockSvc.show.mockResolvedValueOnce('old content');
 
@@ -178,7 +179,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   });
 
   it('uses worktree path when chat has a worktree', async () => {
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockResolvedValueOnce('');
 
     const ctx = createCtx('/some/project', '/some/project/.worktrees/feat-x');
@@ -195,7 +196,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   });
 
   it('filters to specific files when files array is provided', async () => {
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockResolvedValueOnce('');
 
     const ctx = createCtx('/some/project');
@@ -225,7 +226,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   });
 
   it('returns empty diffs when no merge base is found', async () => {
-    mockSvc.mergeBase.mockResolvedValue(null);
+    mockSvc.detectBaseBranch.mockResolvedValue(null);
 
     const ctx = createCtx('/some/project');
     const router = gitRoutes(ctx);
@@ -239,7 +240,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
   });
 
   it('returns 400 when git diff fails', async () => {
-    mockSvc.mergeBase.mockResolvedValueOnce('abc123');
+    mockSvc.detectBaseBranch.mockResolvedValueOnce({ baseBranch: 'main', mergeBase: 'abc123' });
     mockSvc.diff.mockRejectedValueOnce(new Error('not a git repository'));
 
     const ctx = createCtx('/some/project');

--- a/packages/core/src/__tests__/workspace/worktree-create.test.ts
+++ b/packages/core/src/__tests__/workspace/worktree-create.test.ts
@@ -35,7 +35,7 @@ describe('createWorktree', () => {
   });
 
   it('creates worktree with explicit baseBranch and branchName', async () => {
-    const info = createWorktree(repoDir, 'test1234', '.worktrees', defaultBranch, 'feat/my-feature');
+    const info = await createWorktree(repoDir, 'test1234', '.worktrees', defaultBranch, 'feat/my-feature');
     expect(info.branchName).toBe('feat/my-feature');
     expect(info.worktreePath).toContain('.worktrees');
 
@@ -55,7 +55,7 @@ describe('createWorktree', () => {
     execFileSync('git', ['commit', '--allow-empty', '-m', 'develop-commit'], { cwd: repoDir, stdio: 'pipe' });
     execFileSync('git', ['checkout', defaultBranch], { cwd: repoDir, stdio: 'pipe' });
 
-    const info = createWorktree(repoDir, 'test5678', '.worktrees', 'develop', 'feat/from-develop');
+    const info = await createWorktree(repoDir, 'test5678', '.worktrees', 'develop', 'feat/from-develop');
     expect(info.branchName).toBe('feat/from-develop');
 
     const log = execFileSync('git', ['log', '--oneline', '-1', 'feat/from-develop'], {
@@ -68,9 +68,23 @@ describe('createWorktree', () => {
   });
 
   it('uses sanitized branch name for worktree directory name', async () => {
-    const info = createWorktree(repoDir, 'abcdef12rest', '.worktrees', defaultBranch, 'session/abcdef12');
+    const info = await createWorktree(repoDir, 'abcdef12rest', '.worktrees', defaultBranch, 'session/abcdef12');
     expect(info.worktreePath).toContain('session-abcdef12');
     expect(info.worktreePath).not.toContain('abcdef12rest');
     await removeWorktree(repoDir, info.worktreePath, info.branchName);
+  });
+
+  it('does not block the event loop: a concurrent microtask runs while createWorktree awaits', async () => {
+    const order: string[] = [];
+    const p = createWorktree(repoDir, 'concurrent01', '.worktrees', defaultBranch, 'feat/concurrent').then(
+      async (info) => {
+        order.push('createWorktree');
+        await removeWorktree(repoDir, info.worktreePath, info.branchName);
+      },
+    );
+    await Promise.resolve();
+    order.push('concurrent');
+    await p;
+    expect(order).toEqual(['concurrent', 'createWorktree']);
   });
 });

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -121,7 +121,7 @@ export class ChatConfigManager {
       await this.deps.stopChat(chatId);
 
       const worktreeDir = this.deps.db.settings.get('general', 'worktreeDir') ?? GENERAL_DEFAULTS.worktreeDir;
-      const info = createWorktree(project.path, chatId, worktreeDir, baseBranch, branchName);
+      const info = await createWorktree(project.path, chatId, worktreeDir, baseBranch, branchName);
 
       if (active.chat.adapterId === 'claude') {
         const oldProjectDir = getClaudeProjectDir(project.path);
@@ -144,7 +144,7 @@ export class ChatConfigManager {
     }
 
     const worktreeDir = this.deps.db.settings.get('general', 'worktreeDir') ?? GENERAL_DEFAULTS.worktreeDir;
-    const info = createWorktree(project.path, chatId, worktreeDir, baseBranch, branchName);
+    const info = await createWorktree(project.path, chatId, worktreeDir, baseBranch, branchName);
     active.chat.worktreePath = info.worktreePath;
     active.chat.branchName = info.branchName;
     this.deps.db.chats.update(chatId, { worktreePath: info.worktreePath, branchName: info.branchName });

--- a/packages/core/src/git/git-parse.test.ts
+++ b/packages/core/src/git/git-parse.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { isNotGitRepo, parseDiffNameStatus, parseStatusLines, parseStatusBuckets } from './git-parse.js';
+
+describe('isNotGitRepo', () => {
+  it('returns true for "not a git repository" error', () => {
+    const err = new Error('fatal: not a git repository (or any of the parent directories): .git');
+    expect(isNotGitRepo(err)).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    const err = new Error('Permission denied');
+    expect(isNotGitRepo(err)).toBe(false);
+  });
+
+  it('returns false for string values (message property undefined)', () => {
+    // Strings coerced via 'as' cast: .message is undefined, typeof check returns false
+    expect(isNotGitRepo('not a git repository')).toBe(false);
+    expect(isNotGitRepo(42)).toBe(false);
+  });
+});
+
+describe('parseDiffNameStatus', () => {
+  it('parses a simple modified file', () => {
+    const output = 'M\tsrc/foo.ts';
+    expect(parseDiffNameStatus(output)).toEqual([{ status: 'M', path: 'src/foo.ts' }]);
+  });
+
+  it('parses added and deleted files', () => {
+    const output = 'A\tsrc/new.ts\nD\tsrc/gone.ts';
+    expect(parseDiffNameStatus(output)).toEqual([
+      { status: 'A', path: 'src/new.ts' },
+      { status: 'D', path: 'src/gone.ts' },
+    ]);
+  });
+
+  it('parses renamed files (R status) with oldPath', () => {
+    const output = 'R100\tsrc/old.ts\tsrc/new.ts';
+    expect(parseDiffNameStatus(output)).toEqual([{ status: 'R', path: 'src/new.ts', oldPath: 'src/old.ts' }]);
+  });
+
+  it('parses copied files (C status) with oldPath', () => {
+    const output = 'C100\tsrc/original.ts\tsrc/copy.ts';
+    expect(parseDiffNameStatus(output)).toEqual([{ status: 'C', path: 'src/copy.ts', oldPath: 'src/original.ts' }]);
+  });
+
+  it('filters out empty-path entries', () => {
+    const output = 'M\tsrc/foo.ts\nM\t';
+    const result = parseDiffNameStatus(output);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.path).toBe('src/foo.ts');
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseDiffNameStatus('')).toEqual([]);
+  });
+
+  it('handles multiple files', () => {
+    const output = 'M\tsrc/foo.ts\nA\tsrc/bar.ts\nD\tsrc/baz.ts';
+    const result = parseDiffNameStatus(output);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ status: 'M', path: 'src/foo.ts' });
+    expect(result[1]).toEqual({ status: 'A', path: 'src/bar.ts' });
+    expect(result[2]).toEqual({ status: 'D', path: 'src/baz.ts' });
+  });
+});
+
+describe('parseStatusLines', () => {
+  it('parses a modified file', () => {
+    // "M " = staged modify; code = "M " trimmed = "M"
+    const output = 'M  src/foo.ts';
+    expect(parseStatusLines(output)).toEqual([{ status: 'M', path: 'src/foo.ts' }]);
+  });
+
+  it('parses multiple files with various statuses', () => {
+    const output = 'M  src/staged.ts\n M src/unstaged.ts\n?? src/new.ts';
+    const result = parseStatusLines(output);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ status: 'M', path: 'src/staged.ts' });
+    expect(result[1]).toEqual({ status: 'M', path: 'src/unstaged.ts' });
+    expect(result[2]).toEqual({ status: '??', path: 'src/new.ts' });
+  });
+
+  it('parses renamed files with " -> " arrow notation', () => {
+    const output = 'R  src/old.ts -> src/new.ts';
+    const result = parseStatusLines(output);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ status: 'R', path: 'src/new.ts', oldPath: 'src/old.ts' });
+  });
+
+  it('parses copied files with " -> " arrow notation', () => {
+    const output = 'C  src/original.ts -> src/copy.ts';
+    const result = parseStatusLines(output);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ status: 'C', path: 'src/copy.ts', oldPath: 'src/original.ts' });
+  });
+
+  it('filters out directory entries (trailing slash)', () => {
+    const output = 'M  src/foo.ts\nA  src/dir/';
+    const result = parseStatusLines(output);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.path).toBe('src/foo.ts');
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseStatusLines('')).toEqual([]);
+  });
+});
+
+describe('parseStatusBuckets', () => {
+  it('returns empty buckets for empty output', () => {
+    expect(parseStatusBuckets('')).toEqual({ staged: [], unstaged: [], untracked: [] });
+  });
+
+  it('puts ?? files in untracked', () => {
+    const output = '?? src/new.ts';
+    expect(parseStatusBuckets(output)).toEqual({
+      staged: [],
+      unstaged: [],
+      untracked: ['src/new.ts'],
+    });
+  });
+
+  it('puts staged-only files in staged, not unstaged', () => {
+    // "M " = index=M, working=' ' => staged, not unstaged
+    const output = 'M  src/staged.ts';
+    const result = parseStatusBuckets(output);
+    expect(result.staged).toContain('src/staged.ts');
+    expect(result.unstaged).not.toContain('src/staged.ts');
+    expect(result.untracked).not.toContain('src/staged.ts');
+  });
+
+  it('puts working-tree-only files in unstaged, not staged', () => {
+    // " M" = index=' ', working='M' => unstaged, not staged
+    const output = ' M src/unstaged.ts';
+    const result = parseStatusBuckets(output);
+    expect(result.staged).not.toContain('src/unstaged.ts');
+    expect(result.unstaged).toContain('src/unstaged.ts');
+    expect(result.untracked).not.toContain('src/unstaged.ts');
+  });
+
+  it('puts MM files in both staged and unstaged', () => {
+    // "MM" = index=M, working=M => both staged and unstaged
+    const output = 'MM src/both.ts';
+    const result = parseStatusBuckets(output);
+    expect(result.staged).toContain('src/both.ts');
+    expect(result.unstaged).toContain('src/both.ts');
+    expect(result.untracked).not.toContain('src/both.ts');
+  });
+
+  it('parses full porcelain output correctly', () => {
+    const output = 'M  src/staged.ts\n M src/unstaged.ts\n?? src/new.ts\n';
+    expect(parseStatusBuckets(output)).toEqual({
+      staged: ['src/staged.ts'],
+      unstaged: ['src/unstaged.ts'],
+      untracked: ['src/new.ts'],
+    });
+  });
+});

--- a/packages/core/src/git/git-parse.ts
+++ b/packages/core/src/git/git-parse.ts
@@ -1,0 +1,91 @@
+/** Shared git output parsers used by route handlers. */
+
+export interface DiffEntry {
+  status: string;
+  path: string;
+  oldPath?: string;
+}
+
+export interface StatusBuckets {
+  staged: string[];
+  unstaged: string[];
+  untracked: string[];
+}
+
+/**
+ * Returns true when an error originates from running git in a non-repo directory.
+ * Used to suppress noisy warnings for expected "not a git repository" failures.
+ */
+export function isNotGitRepo(err: unknown): boolean {
+  return (
+    typeof (err as { message?: unknown }).message === 'string' &&
+    (err as { message: string }).message.includes('not a git repository')
+  );
+}
+
+/**
+ * Parses `git diff --name-status` output (tab-separated) into structured entries.
+ * Renamed (R) and copied (C) entries carry an `oldPath`.
+ */
+export function parseDiffNameStatus(output: string): DiffEntry[] {
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('\t');
+      const status = parts[0] ?? '';
+      if (status.startsWith('R') || status.startsWith('C')) {
+        return { status: status[0]!, path: parts[2] ?? '', oldPath: parts[1] };
+      }
+      return { status, path: parts[1] ?? '' };
+    })
+    .filter((f) => f.path.length > 0);
+}
+
+/**
+ * Parses `git status --porcelain` output into structured file entries.
+ * Each line's first two characters are the XY status code; the rest (after 3 chars) is the path.
+ * Renamed (R) and copied (C) entries use " -> " to separate old and new paths.
+ * Directory entries (trailing slash) are filtered out.
+ */
+export function parseStatusLines(output: string): DiffEntry[] {
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((line: string) => {
+      const code = line.slice(0, 2).trim();
+      const rest = line.slice(3);
+      if (code.startsWith('R') || code.startsWith('C')) {
+        const arrow = rest.indexOf(' -> ');
+        if (arrow !== -1) return { status: code, path: rest.slice(arrow + 4), oldPath: rest.slice(0, arrow) };
+      }
+      return { status: code, path: rest };
+    })
+    .filter((f) => !f.path.endsWith('/'));
+}
+
+/**
+ * Parses `git status --porcelain` output into staged/unstaged/untracked buckets.
+ * Uses the two-character XY format: X = index status, Y = working-tree status.
+ * Renamed from the original `parsePortcelainStatus` (fixing the typo).
+ */
+export function parseStatusBuckets(output: string): StatusBuckets {
+  const staged: string[] = [];
+  const unstaged: string[] = [];
+  const untracked: string[] = [];
+
+  for (const line of output.split('\n').filter(Boolean)) {
+    const indexStatus = line[0] ?? ' ';
+    const workingStatus = line[1] ?? ' ';
+    const filename = line.slice(3);
+
+    if (indexStatus === '?' && workingStatus === '?') {
+      untracked.push(filename);
+      continue;
+    }
+    if (indexStatus !== ' ') staged.push(filename);
+    if (workingStatus !== ' ') unstaged.push(filename);
+  }
+
+  return { staged, unstaged, untracked };
+}

--- a/packages/core/src/git/git-service.ts
+++ b/packages/core/src/git/git-service.ts
@@ -176,6 +176,18 @@ export class GitService {
     }
   }
 
+  /**
+   * Tries 'main' then 'master' to find a common merge-base with HEAD.
+   * Returns the first match or null when neither resolves.
+   */
+  async detectBaseBranch(): Promise<{ baseBranch: string; mergeBase: string } | null> {
+    for (const base of ['main', 'master']) {
+      const sha = await this.mergeBase(base, 'HEAD');
+      if (sha) return { baseBranch: base, mergeBase: sha };
+    }
+    return null;
+  }
+
   async checkout(branch: string): Promise<void> {
     return this.withLock(async () => {
       // If it looks like a remote ref (e.g. "origin/feat/foo"), strip the

--- a/packages/core/src/messages/__tests__/apply-tool-grouping-characterization.test.ts
+++ b/packages/core/src/messages/__tests__/apply-tool-grouping-characterization.test.ts
@@ -1,0 +1,645 @@
+/**
+ * CHARACTERIZATION TESTS for applyToolGrouping (WS14b safety net).
+ *
+ * These tests pin the CURRENT behavior of applyToolGrouping so that the
+ * upcoming refactor (dropping the internal NG_SENTINEL round-trip) cannot
+ * silently reorder, drop, or mis-wrap content.
+ *
+ * Rules:
+ * - DO NOT change production code to make these pass.
+ * - If you find an expectation is wrong, fix the test to match reality, not
+ *   the other way around.
+ * - Every test has a "CHARACTERIZATION" comment on the assertion that pins
+ *   specific current behavior the refactor must preserve.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyToolGrouping } from '../display-helpers.js';
+import type { DisplayContent, ToolCategories } from '@qlan-ro/mainframe-types';
+
+// ---------------------------------------------------------------------------
+// Shared fixture categories (mirrors a realistic Claude adapter declaration)
+// ---------------------------------------------------------------------------
+const CAT: ToolCategories = {
+  explore: new Set(['Read', 'Grep', 'Glob', 'LS']),
+  hidden: new Set(['HiddenTool']),
+  progress: new Set(['TodoWrite']),
+  subagent: new Set(['Task', 'Agent']),
+};
+
+// ---------------------------------------------------------------------------
+// 1. POSITIONAL INTERLEAVING — highest priority
+//    Tests that non-groupable content (thinking, image) preserves its exact
+//    position between surrounding explore tools and text blocks.
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — positional interleaving', () => {
+  it('text → explore → thinking → explore → text: each element stays in its original slot', () => {
+    // CHARACTERIZATION: the thinking breaks both explore runs (each is alone →
+    // no tool_group wrapping). All five items appear in original order.
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'First text' },
+      { type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'thinking', thinking: 'some thought' },
+      { type: 'tool_call', id: 'tc2', name: 'Grep', input: { pattern: 'foo' }, category: 'explore' },
+      { type: 'text', text: 'Last text' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: pins exact output order and shapes
+    expect(out).toHaveLength(5);
+    expect(out[0]).toEqual({ type: 'text', text: 'First text' });
+    expect(out[1]).toEqual({ type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' });
+    expect(out[2]).toEqual({ type: 'thinking', thinking: 'some thought' });
+    expect(out[3]).toEqual({
+      type: 'tool_call',
+      id: 'tc2',
+      name: 'Grep',
+      input: { pattern: 'foo' },
+      category: 'explore',
+    });
+    expect(out[4]).toEqual({ type: 'text', text: 'Last text' });
+  });
+
+  it('explore → image → explore → text: image stays between the two solo explores, not hoisted', () => {
+    // CHARACTERIZATION: image is non-groupable. It breaks both explore runs so
+    // neither is in a group. The image appears in slot [1] — between the two
+    // explore tool_calls — not reordered to the front or back.
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'image', mediaType: 'image/png', data: 'base64data' },
+      { type: 'tool_call', id: 'tc2', name: 'Grep', input: { pattern: 'foo' }, category: 'explore' },
+      { type: 'text', text: 'End' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: 4 items, original order preserved
+    expect(out).toHaveLength(4);
+    expect(out[0]).toEqual({
+      type: 'tool_call',
+      id: 'tc1',
+      name: 'Read',
+      input: { path: '/a' },
+      category: 'explore',
+    });
+    expect(out[1]).toEqual({ type: 'image', mediaType: 'image/png', data: 'base64data' });
+    expect(out[2]).toEqual({
+      type: 'tool_call',
+      id: 'tc2',
+      name: 'Grep',
+      input: { pattern: 'foo' },
+      category: 'explore',
+    });
+    expect(out[3]).toEqual({ type: 'text', text: 'End' });
+  });
+
+  it('explore → explore → thinking → explore: first pair groups, thinking stays in slot, last is solo', () => {
+    // CHARACTERIZATION: Read+Grep are consecutive → form a tool_group.
+    // The thinking in the middle position stays between the tool_group and the
+    // solo LS that follows — i.e., [tool_group, thinking, solo-explore].
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'x' }, category: 'explore' },
+      { type: 'thinking', thinking: 'mid-thought' },
+      { type: 'tool_call', id: 'e3', name: 'LS', input: { path: '/' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: 3 output items: tool_group | thinking | solo-explore
+    expect(out).toHaveLength(3);
+
+    // slot 0 — grouped first pair
+    expect(out[0]!.type).toBe('tool_group');
+    const grp = out[0] as DisplayContent & { type: 'tool_group' };
+    expect(grp.calls).toHaveLength(2);
+    expect((grp.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+
+    // slot 1 — thinking NOT hoisted to the front
+    expect(out[1]).toEqual({ type: 'thinking', thinking: 'mid-thought' });
+
+    // slot 2 — solo explore (not in a group)
+    expect(out[2]).toEqual({ type: 'tool_call', id: 'e3', name: 'LS', input: { path: '/' }, category: 'explore' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. NON-GROUPABLE SANDWICHED INSIDE AN EXPLORE RUN
+//    Pin the exact split behavior when a non-groupable item interrupts what
+//    would otherwise be a run of ≥2 explore tools.
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — non-groupable sandwiched inside explore run', () => {
+  it('explore → thinking → explore → explore: thinking breaks the first tool into solo; remainder groups', () => {
+    // CHARACTERIZATION: groupToolCallParts looks ahead only over consecutive
+    // tool-call entries. The sentinel text for "thinking" is a non-tool-call
+    // entry that stops the look-ahead for tc1 immediately, so tc1 is alone.
+    // tc2 and tc3 then form their own consecutive run of 2 → tool_group.
+    // The thinking sentinel is decoded back at its original position between
+    // the solo tc1 and the tool_group.
+    //
+    // Output: [solo-Read, thinking, tool_group(Grep, LS)]
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'thinking', thinking: 'interruption' },
+      { type: 'tool_call', id: 'tc2', name: 'Grep', input: { pattern: 'foo' }, category: 'explore' },
+      { type: 'tool_call', id: 'tc3', name: 'LS', input: { path: '/' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: tc1 is NOT grouped with tc2/tc3
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({
+      type: 'tool_call',
+      id: 'tc1',
+      name: 'Read',
+      input: { path: '/a' },
+      category: 'explore',
+    });
+    expect(out[1]).toEqual({ type: 'thinking', thinking: 'interruption' });
+    expect(out[2]!.type).toBe('tool_group');
+    const grp = out[2] as DisplayContent & { type: 'tool_group' };
+    expect(grp.calls).toHaveLength(2);
+    expect((grp.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('tc2');
+    expect((grp.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('tc3');
+  });
+
+  it('explore → explore → thinking → explore → explore: two groups separated by thinking', () => {
+    // CHARACTERIZATION: e1+e2 form group1. thinking stays in slot [1].
+    // e3+e4 form group2. Order: [group1, thinking, group2].
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'x' }, category: 'explore' },
+      { type: 'thinking', thinking: 'between groups' },
+      { type: 'tool_call', id: 'e3', name: 'Glob', input: { pattern: '*.ts' }, category: 'explore' },
+      { type: 'tool_call', id: 'e4', name: 'LS', input: { path: '/' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(3);
+    expect(out[0]!.type).toBe('tool_group');
+    expect(out[1]).toEqual({ type: 'thinking', thinking: 'between groups' });
+    expect(out[2]!.type).toBe('tool_group');
+
+    const grp1 = out[0] as DisplayContent & { type: 'tool_group' };
+    const grp2 = out[2] as DisplayContent & { type: 'tool_group' };
+    expect((grp1.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp1.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+    expect((grp2.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e3');
+    expect((grp2.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. SINGLE LONE EXPLORE TOOL — wrapping behavior
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — lone explore tool', () => {
+  it('a single explore tool is NOT wrapped in a tool_group', () => {
+    // CHARACTERIZATION: tool_group is only emitted when group.length >= 2
+    // (see tool-grouping.ts line 111). A single explore tool passes through
+    // as a bare tool_call.
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(1);
+    // CHARACTERIZATION: type is 'tool_call', NOT 'tool_group'
+    expect(out[0]!.type).toBe('tool_call');
+    expect(out[0]).toEqual({ type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' });
+  });
+
+  it('exactly two consecutive explore tools ARE wrapped in a tool_group', () => {
+    // CHARACTERIZATION: the minimum group size is 2.
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'x' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe('tool_group');
+    const grp = out[0] as DisplayContent & { type: 'tool_group' };
+    expect(grp.calls).toHaveLength(2);
+    expect((grp.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+  });
+
+  it('two explore runs separated by a default (non-explore) tool each form their own group', () => {
+    // CHARACTERIZATION: a non-explore tool_call (Write) is NOT hidden and NOT
+    // explore, so it breaks the first group. Each pair forms a separate group.
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'x' }, category: 'explore' },
+      { type: 'tool_call', id: 'w1', name: 'Write', input: { path: '/b', content: 'x' }, category: 'default' },
+      { type: 'tool_call', id: 'e3', name: 'Read', input: { path: '/c' }, category: 'explore' },
+      { type: 'tool_call', id: 'e4', name: 'LS', input: { path: '/' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(3);
+    expect(out[0]!.type).toBe('tool_group');
+    expect(out[1]).toEqual({
+      type: 'tool_call',
+      id: 'w1',
+      name: 'Write',
+      input: { path: '/b', content: 'x' },
+      category: 'default',
+    });
+    expect(out[2]!.type).toBe('tool_group');
+
+    const grp1 = out[0] as DisplayContent & { type: 'tool_group' };
+    const grp2 = out[2] as DisplayContent & { type: 'tool_group' };
+    expect(grp1.calls).toHaveLength(2);
+    expect(grp2.calls).toHaveLength(2);
+    expect((grp1.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp1.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+    expect((grp2.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e3');
+    expect((grp2.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. _TaskProgress ACCUMULATION + INSERTION POSITION
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — _TaskProgress accumulation and position', () => {
+  it('consecutive progress tools: both accumulated into one _TaskProgress at first-seen position', () => {
+    // CHARACTERIZATION: taskInsertIndex captures the position of the FIRST
+    // progress tool (slot 1, after "Before"). Both tp1 and tp2 appear in the
+    // accumulated items array. The single _TaskProgress is spliced in at
+    // slot 1 (after "Before"), before "After".
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'Before' },
+      { type: 'tool_call', id: 'tp1', name: 'TodoWrite', input: { task: 'a' }, category: 'progress' },
+      { type: 'tool_call', id: 'tp2', name: 'TodoWrite', input: { task: 'b' }, category: 'progress' },
+      { type: 'text', text: 'After' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: [text, _TaskProgress(tp1,tp2), text]
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ type: 'text', text: 'Before' });
+    expect(out[1]!.type).toBe('tool_call');
+    const prog = out[1] as DisplayContent & { type: 'tool_call' };
+    expect(prog.name).toBe('_TaskProgress');
+    expect(prog.category).toBe('progress');
+    // CHARACTERIZATION: both items appear in the accumulated list
+    const items = (prog.input as { items: Array<{ toolCallId: string; toolName: string }> }).items;
+    expect(items).toHaveLength(2);
+    expect(items[0]!.toolCallId).toBe('tp1');
+    expect(items[1]!.toolCallId).toBe('tp2');
+    expect(out[2]).toEqual({ type: 'text', text: 'After' });
+  });
+
+  it('scattered progress tools (non-progress between them): only the FIRST progress is in items; second is DROPPED', () => {
+    // CHARACTERIZATION: this is a known limitation of the current implementation.
+    // groupToolCallParts walks parts linearly and collects progress tools it
+    // encounters. When tc1 (Read) is encountered, the look-ahead for the
+    // explore group starts — it scans forward and skips hidden+progress tools
+    // inside the explore run. BUT tp2 comes AFTER tc1's explore group ends
+    // (position 3), so tp2 falls outside the scope of the explore group loop.
+    // However, tp2 IS still a progress tool so it should be collected…
+    //
+    // Actually: tc1 is explore, so it enters the explore group loop starting
+    // from i=2 (after tp1 at i=1). j starts at i+1 = 3, which is tp2. tp2 is
+    // a progress tool, so it is skipped inside the explore look-ahead (j++).
+    // But tp2 is also added to taskItems inside the main loop? No — once we
+    // enter the explore branch at i=2, j advances over tp2 as a progress/hidden
+    // skipped entry, then i = j = 4. tp2 was consumed by the explore look-ahead
+    // without being added to taskItems. Result: tp2 is silently DROPPED.
+    //
+    // This is a CHARACTERIZATION — pin it as-is, do NOT fix it here.
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'Before' },
+      { type: 'tool_call', id: 'tp1', name: 'TodoWrite', input: { task: 'a' }, category: 'progress' },
+      { type: 'tool_call', id: 'tc1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'tp2', name: 'TodoWrite', input: { task: 'b' }, category: 'progress' },
+      { type: 'text', text: 'After' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: tp2 is dropped; only tp1 is in items; tc1 (Read) solo
+    expect(out).toHaveLength(4);
+    expect(out[0]).toEqual({ type: 'text', text: 'Before' });
+
+    // _TaskProgress at slot 1 — inserted at taskInsertIndex (= 1, where tp1 was)
+    expect(out[1]!.type).toBe('tool_call');
+    const prog = out[1] as DisplayContent & { type: 'tool_call' };
+    expect(prog.name).toBe('_TaskProgress');
+    const items = (prog.input as { items: Array<{ toolCallId: string }> }).items;
+    // CHARACTERIZATION: only tp1 — tp2 is DROPPED by explore look-ahead
+    expect(items).toHaveLength(1);
+    expect(items[0]!.toolCallId).toBe('tp1');
+
+    // tc1 (Read) is still present as a solo explore (not wrapped in tool_group)
+    expect(out[2]).toEqual({
+      type: 'tool_call',
+      id: 'tc1',
+      name: 'Read',
+      input: { path: '/a' },
+      category: 'explore',
+    });
+
+    expect(out[3]).toEqual({ type: 'text', text: 'After' });
+  });
+
+  it('progress insert position: _TaskProgress goes at the slot of the first progress tool', () => {
+    // CHARACTERIZATION: taskInsertIndex = result.length at the time the first
+    // progress tool is encountered. Here the progress tool is after two text
+    // blocks — taskInsertIndex = 2 (after the two text entries).
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'A' },
+      { type: 'text', text: 'B' },
+      { type: 'tool_call', id: 'tp1', name: 'TodoWrite', input: { task: 'x' }, category: 'progress' },
+      { type: 'tool_call', id: 'tp2', name: 'TodoWrite', input: { task: 'y' }, category: 'progress' },
+      { type: 'text', text: 'C' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(4);
+    expect(out[0]).toEqual({ type: 'text', text: 'A' });
+    expect(out[1]).toEqual({ type: 'text', text: 'B' });
+    // CHARACTERIZATION: _TaskProgress inserted at slot 2 (where first progress was)
+    expect(out[2]!.type).toBe('tool_call');
+    expect((out[2] as DisplayContent & { type: 'tool_call' }).name).toBe('_TaskProgress');
+    expect(out[3]).toEqual({ type: 'text', text: 'C' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. task_group NESTING — children order, explore grouping inside, thinking
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — task_group nesting', () => {
+  it('task_group children: explore pair grouped as _ToolGroup tool_call (not tool_group), thinking after stays in position', () => {
+    // CHARACTERIZATION: Inside task_group.calls, the inner explore groups are
+    // NOT converted to type:'tool_group'. They appear as type:'tool_call' with
+    // name:'_ToolGroup'. This is because the _TaskGroup branch in
+    // convertGroupedPartsToDisplay maps children through the raw else-branch
+    // (tool_call mapping) which doesn't special-case _ToolGroup.
+    //
+    // Order in task_group.calls: [_ToolGroup(Read,Grep), thinking, solo-LS]
+    const input: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'agent1',
+        name: 'Task',
+        input: { description: 'do work' },
+        category: 'subagent',
+      },
+      {
+        type: 'tool_call',
+        id: 'c1',
+        name: 'Read',
+        input: { path: '/a' },
+        category: 'explore',
+        parentToolUseId: 'agent1',
+      },
+      {
+        type: 'tool_call',
+        id: 'c2',
+        name: 'Grep',
+        input: { pattern: 'x' },
+        category: 'explore',
+        parentToolUseId: 'agent1',
+      },
+      { type: 'thinking', thinking: 'child thought', parentToolUseId: 'agent1' },
+      {
+        type: 'tool_call',
+        id: 'c3',
+        name: 'LS',
+        input: { path: '/' },
+        category: 'explore',
+        parentToolUseId: 'agent1',
+      },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe('task_group');
+    const tg = out[0] as DisplayContent & { type: 'task_group' };
+    expect(tg.agentId).toBe('agent1');
+    expect(tg.taskArgs).toEqual({ description: 'do work' });
+    expect(tg.calls).toHaveLength(3);
+
+    // CHARACTERIZATION: slot 0 — inner explore group rendered as tool_call with name='_ToolGroup'
+    const innerGroup = tg.calls[0] as DisplayContent & { type: 'tool_call' };
+    expect(innerGroup.type).toBe('tool_call');
+    expect(innerGroup.name).toBe('_ToolGroup');
+    // The _ToolGroup args.items lists Read and Grep
+    const items = (innerGroup.input as { items: Array<{ toolName: string; toolCallId: string }> }).items;
+    expect(items).toHaveLength(2);
+    expect(items[0]!.toolCallId).toBe('c1');
+    expect(items[0]!.toolName).toBe('Read');
+    expect(items[1]!.toolCallId).toBe('c2');
+    expect(items[1]!.toolName).toBe('Grep');
+
+    // CHARACTERIZATION: slot 1 — thinking in correct position (not hoisted)
+    expect(tg.calls[1]).toEqual({ type: 'thinking', thinking: 'child thought', parentToolUseId: 'agent1' });
+
+    // CHARACTERIZATION: slot 2 — solo LS (alone, not grouped)
+    expect(tg.calls[2]).toEqual({
+      type: 'tool_call',
+      id: 'c3',
+      name: 'LS',
+      input: { path: '/' },
+      category: 'explore',
+      parentToolUseId: 'agent1',
+    });
+  });
+
+  it('task_group children: thinking BEFORE explore pair stays at position [0]', () => {
+    // CHARACTERIZATION: thinking at start of children, then explore group.
+    // Order: [thinking, _ToolGroup(Read,Grep)]
+    const input: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'agent1',
+        name: 'Task',
+        input: { description: 'work' },
+        category: 'subagent',
+      },
+      { type: 'thinking', thinking: 'before explore', parentToolUseId: 'agent1' },
+      {
+        type: 'tool_call',
+        id: 'c1',
+        name: 'Read',
+        input: { path: '/a' },
+        category: 'explore',
+        parentToolUseId: 'agent1',
+      },
+      {
+        type: 'tool_call',
+        id: 'c2',
+        name: 'Grep',
+        input: { pattern: 'x' },
+        category: 'explore',
+        parentToolUseId: 'agent1',
+      },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe('task_group');
+    const tg = out[0] as DisplayContent & { type: 'task_group' };
+    expect(tg.calls).toHaveLength(2);
+
+    // CHARACTERIZATION: thinking is at index 0, NOT after the explore group
+    expect(tg.calls[0]).toEqual({ type: 'thinking', thinking: 'before explore', parentToolUseId: 'agent1' });
+
+    // CHARACTERIZATION: _ToolGroup at index 1
+    const innerGrp = tg.calls[1] as DisplayContent & { type: 'tool_call' };
+    expect(innerGrp.type).toBe('tool_call');
+    expect(innerGrp.name).toBe('_ToolGroup');
+    const items = (innerGrp.input as { items: Array<{ toolCallId: string }> }).items;
+    expect(items[0]!.toolCallId).toBe('c1');
+    expect(items[1]!.toolCallId).toBe('c2');
+  });
+
+  it('subagent without children: stays as bare tool_call, no task_group wrapper', () => {
+    // CHARACTERIZATION: groupTaskChildren only creates a _TaskGroup when children.length > 0.
+    // A subagent with no parentToolUseId-tagged children passes through as-is.
+    const input: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'agent1',
+        name: 'Task',
+        input: { description: 'solo agent' },
+        category: 'subagent',
+      },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    expect(out).toHaveLength(1);
+    // CHARACTERIZATION: no task_group — bare tool_call
+    expect(out[0]!.type).toBe('tool_call');
+    expect((out[0] as DisplayContent & { type: 'tool_call' }).id).toBe('agent1');
+    expect((out[0] as DisplayContent & { type: 'tool_call' }).name).toBe('Task');
+  });
+
+  it('task_group agentId comes from tool_use id, not taskArgs.description', () => {
+    // CHARACTERIZATION: regression guard for #184. agentId must equal the
+    // tool_use id so React keys stay unique when two agents share a description.
+    const input: DisplayContent[] = [
+      {
+        type: 'tool_call',
+        id: 'toolu_unique_001',
+        name: 'Task',
+        input: { description: 'same label', prompt: 'p1' },
+        category: 'subagent',
+      },
+      {
+        type: 'tool_call',
+        id: 'child_001',
+        name: 'Bash',
+        input: { command: 'echo a' },
+        category: 'default',
+        parentToolUseId: 'toolu_unique_001',
+      },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    const tg = out[0] as DisplayContent & { type: 'task_group' };
+    // CHARACTERIZATION: agentId is the tool_use id, not the description string
+    expect(tg.agentId).toBe('toolu_unique_001');
+    expect(tg.agentId).not.toBe('same label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. HIDDEN TOOL SUPPRESSION
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — hidden tool suppression', () => {
+  it('a hidden tool between two explore tools is suppressed; explore tools are NOT grouped', () => {
+    // CHARACTERIZATION: isHiddenToolPart returns true for HiddenTool.
+    // The hidden tool is skipped during the explore look-ahead (j++ without
+    // pushing to group), so the explore run continues PAST the hidden tool.
+    // BUT the hidden tool is at the tool-call level (type='tool-call'), not
+    // a text sentinel, so it doesn't break the contiguous run from the
+    // look-ahead loop's perspective.
+    //
+    // Result: Read and Grep ARE grouped together (hidden tool is invisible).
+    const input: DisplayContent[] = [
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a' }, category: 'explore' },
+      { type: 'tool_call', id: 'h1', name: 'HiddenTool', input: {}, category: 'hidden' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'x' }, category: 'explore' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: Read + Grep are grouped (hidden tool skipped)
+    expect(out).toHaveLength(1);
+    expect(out[0]!.type).toBe('tool_group');
+    const grp = out[0] as DisplayContent & { type: 'tool_group' };
+    expect(grp.calls).toHaveLength(2);
+    expect((grp.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. MIXED CONTENT — full realistic sequence
+// ---------------------------------------------------------------------------
+describe('applyToolGrouping — realistic mixed sequence', () => {
+  it('text → thinking → explore×3 → default → text: output order matches input order', () => {
+    // CHARACTERIZATION: thinking at the front, then three consecutive explores
+    // (group), then default tool, then text. The thinking must NOT be moved
+    // after the explore group.
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'I will analyze the codebase.' },
+      { type: 'thinking', thinking: 'plan: read 3 files' },
+      { type: 'tool_call', id: 'e1', name: 'Read', input: { path: '/a.ts' }, category: 'explore' },
+      { type: 'tool_call', id: 'e2', name: 'Grep', input: { pattern: 'import' }, category: 'explore' },
+      { type: 'tool_call', id: 'e3', name: 'LS', input: { path: '/src' }, category: 'explore' },
+      { type: 'tool_call', id: 'd1', name: 'Bash', input: { command: 'pwd' }, category: 'default' },
+      { type: 'text', text: 'Done.' },
+    ];
+
+    const out = applyToolGrouping(input, CAT);
+
+    // CHARACTERIZATION: [text, thinking, tool_group(3), default, text]
+    expect(out).toHaveLength(5);
+    expect(out[0]).toEqual({ type: 'text', text: 'I will analyze the codebase.' });
+    expect(out[1]).toEqual({ type: 'thinking', thinking: 'plan: read 3 files' });
+    expect(out[2]!.type).toBe('tool_group');
+    const grp = out[2] as DisplayContent & { type: 'tool_group' };
+    expect(grp.calls).toHaveLength(3);
+    expect((grp.calls[0] as DisplayContent & { type: 'tool_call' }).id).toBe('e1');
+    expect((grp.calls[1] as DisplayContent & { type: 'tool_call' }).id).toBe('e2');
+    expect((grp.calls[2] as DisplayContent & { type: 'tool_call' }).id).toBe('e3');
+    expect(out[3]).toEqual({
+      type: 'tool_call',
+      id: 'd1',
+      name: 'Bash',
+      input: { command: 'pwd' },
+      category: 'default',
+    });
+    expect(out[4]).toEqual({ type: 'text', text: 'Done.' });
+  });
+
+  it('empty input returns empty output', () => {
+    expect(applyToolGrouping([], CAT)).toEqual([]);
+  });
+
+  it('input with no tool calls passes through unchanged', () => {
+    const input: DisplayContent[] = [
+      { type: 'text', text: 'Hello' },
+      { type: 'thinking', thinking: 'think' },
+      { type: 'text', text: 'World' },
+    ];
+    const out = applyToolGrouping(input, CAT);
+    expect(out).toEqual(input);
+  });
+});

--- a/packages/core/src/messages/display-helpers.ts
+++ b/packages/core/src/messages/display-helpers.ts
@@ -174,11 +174,6 @@ export function convertUserContent(content: MessageContent[]): {
 
 /** Apply tool grouping (explore groups, task groups, progress accumulation). */
 export function applyToolGrouping(content: DisplayContent[], categories: ToolCategories): DisplayContent[] {
-  // The grouping functions only understand text and tool-call PartEntry values.
-  // Non-groupable content (thinking, image, etc.) is encoded as sentinel text
-  // entries (`\0ng:N`) so they pass through grouping untouched, then decoded back.
-  const nonGroupable: DisplayContent[] = [];
-
   const parts: PartEntry[] = content.map((c) => {
     if (c.type === 'tool_call') {
       return {
@@ -193,13 +188,13 @@ export function applyToolGrouping(content: DisplayContent[], categories: ToolCat
       };
     }
     if (c.type === 'text') return { type: 'text' as const, text: c.text, ...withParentId(c.parentToolUseId) };
-    // Encode non-groupable content as sentinel text so it survives grouping in-place.
-    // Carry parentToolUseId so groupTaskChildren can include sentinels belonging to a subagent.
-    const idx = nonGroupable.length;
-    nonGroupable.push(c);
+    // Non-groupable content (thinking, image, etc.) is carried as a first-class
+    // passthrough entry so it flows through grouping in-place without encoding.
+    // parentToolUseId is preserved so groupTaskChildren can include passthrough
+    // entries belonging to a subagent's children.
     return {
-      type: 'text' as const,
-      text: `\0ng:${idx}`,
+      type: 'passthrough' as const,
+      content: c,
       ...withParentId('parentToolUseId' in c ? c.parentToolUseId : undefined),
     };
   });
@@ -207,28 +202,27 @@ export function applyToolGrouping(content: DisplayContent[], categories: ToolCat
   let grouped = groupToolCallParts(parts, categories);
   grouped = groupTaskChildren(grouped, categories);
 
-  return convertGroupedPartsToDisplay(grouped, content, categories, nonGroupable);
+  return convertGroupedPartsToDisplay(grouped, content, categories);
 }
-
-const NG_SENTINEL_RE = /^\0ng:(\d+)$/;
 
 /** Convert PartEntry[] back to DisplayContent[], handling virtual group entries. */
 function convertGroupedPartsToDisplay(
   parts: PartEntry[],
   originalContent: DisplayContent[],
   categories: ToolCategories,
-  nonGroupable: DisplayContent[] = [],
 ): DisplayContent[] {
   const result: DisplayContent[] = [];
 
   for (const part of parts) {
+    if (part.type === 'passthrough') {
+      // Non-groupable content flows through directly; the original DisplayContent
+      // already carries parentToolUseId from the mapping step.
+      result.push(part.content);
+      continue;
+    }
+
     if (part.type === 'text') {
-      // Decode sentinel markers back to original non-groupable content
-      const match = NG_SENTINEL_RE.exec(part.text);
-      if (match) {
-        const item = nonGroupable[Number(match[1])];
-        if (item) result.push(item);
-      } else if (part.text) {
+      if (part.text) {
         result.push({
           type: 'text',
           text: part.text,
@@ -273,15 +267,12 @@ function convertGroupedPartsToDisplay(
         agentId,
         taskArgs: taskArgs ?? {},
         calls: children.map((child) => {
+          if (child.type === 'passthrough') {
+            // The original DisplayContent already carries parentToolUseId;
+            // pass it through unchanged.
+            return child.content;
+          }
           if (child.type === 'text') {
-            const m = NG_SENTINEL_RE.exec(child.text);
-            if (m) {
-              const original = nonGroupable[Number(m[1])];
-              // The original DisplayContent already carries parentToolUseId from
-              // applyToolGrouping's encoding step; pass it through unchanged.
-              if (original) return original;
-              return { type: 'text' as const, text: '', ...withParentId(child.parentToolUseId) };
-            }
             return { type: 'text' as const, text: child.text, ...withParentId(child.parentToolUseId) };
           }
           return {

--- a/packages/core/src/messages/tool-grouping.ts
+++ b/packages/core/src/messages/tool-grouping.ts
@@ -46,7 +46,8 @@ export type PartEntry =
       category?: string;
       parentToolUseId?: string;
     }
-  | { type: 'text'; text: string; parentToolUseId?: string };
+  | { type: 'text'; text: string; parentToolUseId?: string }
+  | { type: 'passthrough'; content: import('@qlan-ro/mainframe-types').DisplayContent; parentToolUseId?: string };
 
 /**
  * Post-processes parts to group consecutive explore tools, suppress hidden tools,

--- a/packages/core/src/server/routes/exec-git.ts
+++ b/packages/core/src/server/routes/exec-git.ts
@@ -4,10 +4,22 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-export async function execGit(args: string[], cwd: string): Promise<string> {
+/**
+ * Runs a git command and returns stdout.
+ *
+ * `timeout` defaults to 30s, which suits the fast read/parse commands most
+ * callers issue. Pass `timeout: 0` for genuinely long-running operations
+ * (e.g. `worktree add`, which may clone/checkout and run hooks) so they are
+ * not capped — `execFile` treats 0 as no timeout.
+ */
+export async function execGit(args: string[], cwd: string, opts?: { timeout?: number }): Promise<string> {
   await access(cwd).catch(() => {
     throw Object.assign(new Error(`Directory not accessible: ${cwd}`), { code: 128 });
   });
-  const { stdout } = await execFileAsync('git', args, { cwd, encoding: 'utf-8', timeout: 30_000 });
+  const { stdout } = await execFileAsync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: opts?.timeout ?? 30_000,
+  });
   return stdout;
 }

--- a/packages/core/src/server/routes/git-chat.ts
+++ b/packages/core/src/server/routes/git-chat.ts
@@ -7,51 +7,9 @@ import { resolveAndValidatePath } from './path-utils.js';
 import { asyncHandler } from './async-handler.js';
 import { GitService } from '../../git/git-service.js';
 import { createChildLogger } from '../../logger.js';
+import { isNotGitRepo, parseDiffNameStatus, parseStatusBuckets } from '../../git/git-parse.js';
 
 const logger = createChildLogger('routes:git-chat');
-
-function isNotGitRepo(err: unknown): boolean {
-  return (
-    typeof (err as { message?: unknown }).message === 'string' &&
-    (err as { message: string }).message.includes('not a git repository')
-  );
-}
-
-function parseDiffNameStatus(output: string): { status: string; path: string; oldPath?: string }[] {
-  return output
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => {
-      const parts = line.split('\t');
-      const status = parts[0] ?? '';
-      if (status.startsWith('R') || status.startsWith('C')) {
-        return { status: status[0]!, path: parts[2] ?? '', oldPath: parts[1] };
-      }
-      return { status, path: parts[1] ?? '' };
-    })
-    .filter((f) => f.path.length > 0);
-}
-
-function parsePortcelainStatus(output: string): { staged: string[]; unstaged: string[]; untracked: string[] } {
-  const staged: string[] = [];
-  const unstaged: string[] = [];
-  const untracked: string[] = [];
-
-  for (const line of output.split('\n').filter(Boolean)) {
-    const indexStatus = line[0] ?? ' ';
-    const workingStatus = line[1] ?? ' ';
-    const filename = line.slice(3);
-
-    if (indexStatus === '?' && workingStatus === '?') {
-      untracked.push(filename);
-      continue;
-    }
-    if (indexStatus !== ' ') staged.push(filename);
-    if (workingStatus !== ' ') unstaged.push(filename);
-  }
-
-  return { staged, unstaged, untracked };
-}
 
 const StatusBody = z.object({ chatId: z.string() });
 const PushBody = z.object({ chatId: z.string() });
@@ -129,20 +87,12 @@ async function handleDiffSinceMain(ctx: RouteContext, req: Request, res: Respons
 
   try {
     const svc = GitService.forProject(basePath);
-    let baseBranch: string | null = null;
-    let mergeBase: string | null = null;
-    for (const base of ['main', 'master']) {
-      const sha = await svc.mergeBase(base, 'HEAD');
-      if (sha) {
-        baseBranch = base;
-        mergeBase = sha;
-        break;
-      }
-    }
-    if (!mergeBase) {
+    const baseInfo = await svc.detectBaseBranch();
+    if (!baseInfo) {
       res.json({ diffs: {}, baseBranch: null, mergeBase: null });
       return;
     }
+    const { baseBranch, mergeBase } = baseInfo;
 
     const nameStatusArgs = ['--name-status', mergeBase, ...(files ? ['--', ...files] : [])];
     const nameStatusOutput = await svc.diff(nameStatusArgs);
@@ -187,7 +137,7 @@ export function gitChatRoutes(ctx: RouteContext): Router {
   router.post(
     '/api/git/status',
     chatRoute(ctx, StatusBody, 'status', async (svc) => {
-      return parsePortcelainStatus(await svc.statusRaw());
+      return parseStatusBuckets(await svc.statusRaw());
     }),
   );
 

--- a/packages/core/src/server/routes/git.ts
+++ b/packages/core/src/server/routes/git.ts
@@ -10,6 +10,7 @@ import { GitService } from '../../git/git-service.js';
 import { createChildLogger } from '../../logger.js';
 import { gitWriteRoutes } from './git-write.js';
 import { gitChatRoutes } from './git-chat.js';
+import { isNotGitRepo, parseDiffNameStatus, parseStatusLines } from '../../git/git-parse.js';
 
 const GitDiffQuery = z.object({
   chatId: z.string().optional(),
@@ -22,52 +23,6 @@ const GitDiffQuery = z.object({
 });
 
 const logger = createChildLogger('routes:git');
-
-function isNotGitRepo(err: unknown): boolean {
-  return (
-    typeof (err as { message?: unknown }).message === 'string' &&
-    (err as { message: string }).message.includes('not a git repository')
-  );
-}
-
-function parseStatusLines(output: string): { status: string; path: string; oldPath?: string }[] {
-  return output
-    .split('\n')
-    .filter(Boolean)
-    .map((line: string) => {
-      const code = line.slice(0, 2).trim();
-      const rest = line.slice(3);
-      if (code.startsWith('R') || code.startsWith('C')) {
-        const arrow = rest.indexOf(' -> ');
-        if (arrow !== -1) return { status: code, path: rest.slice(arrow + 4), oldPath: rest.slice(0, arrow) };
-      }
-      return { status: code, path: rest };
-    })
-    .filter((f) => !f.path.endsWith('/'));
-}
-
-function parseDiffNameStatus(output: string): { status: string; path: string; oldPath?: string }[] {
-  return output
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => {
-      const parts = line.split('\t');
-      const status = parts[0] ?? '';
-      if (status.startsWith('R') || status.startsWith('C')) {
-        return { status: status[0]!, path: parts[2] ?? '', oldPath: parts[1] };
-      }
-      return { status, path: parts[1] ?? '' };
-    })
-    .filter((f) => f.path.length > 0);
-}
-
-async function detectMergeBase(svc: GitService): Promise<{ baseBranch: string; mergeBase: string } | null> {
-  for (const base of ['main', 'master']) {
-    const sha = await svc.mergeBase(base, 'HEAD');
-    if (sha) return { baseBranch: base, mergeBase: sha };
-  }
-  return null;
-}
 
 /** GET /api/projects/:id/git/status?chatId=X */
 async function handleGitStatus(ctx: RouteContext, req: Request, res: Response): Promise<void> {
@@ -121,7 +76,7 @@ async function handleBranchDiffs(ctx: RouteContext, req: Request, res: Response)
   try {
     const svc = GitService.forProject(basePath);
     const branch = await svc.currentBranch();
-    const baseInfo = await detectMergeBase(svc);
+    const baseInfo = await svc.detectBaseBranch();
 
     if (!baseInfo || branch === baseInfo.baseBranch) {
       res.json({ branch, baseBranch: null, mergeBase: null, files: [] });

--- a/packages/core/src/workspace/worktree.ts
+++ b/packages/core/src/workspace/worktree.ts
@@ -72,7 +72,10 @@ export async function createWorktree(
   const worktreePath = path.join(worktreeDir, sanitizedBranch);
 
   await mkdir(worktreeDir, { recursive: true });
-  await execGit(['worktree', 'add', '-b', branchName, worktreePath, baseBranch], projectPath);
+  // No timeout: `worktree add` can clone/checkout a large tree and run hooks,
+  // which legitimately exceeds the default 30s cap (the previous sync impl had
+  // no timeout either).
+  await execGit(['worktree', 'add', '-b', branchName, worktreePath, baseBranch], projectPath, { timeout: 0 });
   return { worktreePath, branchName };
 }
 

--- a/packages/core/src/workspace/worktree.ts
+++ b/packages/core/src/workspace/worktree.ts
@@ -1,15 +1,10 @@
-import { execFile, execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { promisify } from 'node:util';
 import type { ProjectsRepository } from '../db/projects.js';
 import { createChildLogger } from '../logger.js';
 import { execGit } from '../server/routes/exec-git.js';
 
 const log = createChildLogger('worktree-backfill');
-
-const execFileAsync = promisify(execFile);
 
 export interface WorktreeEntry {
   path: string;
@@ -42,9 +37,7 @@ export function parseWorktreeList(output: string): WorktreeEntry[] {
 
 export async function getWorktrees(projectPath: string): Promise<WorktreeEntry[]> {
   try {
-    const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
-      cwd: projectPath,
-    });
+    const stdout = await execGit(['worktree', 'list', '--porcelain'], projectPath);
     return parseWorktreeList(stdout);
   } catch {
     /* best-effort: not a git repo / no worktrees */
@@ -57,33 +50,29 @@ export interface WorktreeInfo {
   branchName: string;
 }
 
-export function isGitRepo(projectPath: string): boolean {
+export async function isGitRepo(projectPath: string): Promise<boolean> {
   try {
-    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], { cwd: projectPath, encoding: 'utf-8', stdio: 'pipe' });
+    await execGit(['rev-parse', '--is-inside-work-tree'], projectPath);
     return true;
   } catch {
-    /* best-effort: not a git repo / no worktrees */
+    /* best-effort: not a git repo */
     return false;
   }
 }
 
-export function createWorktree(
+export async function createWorktree(
   projectPath: string,
   chatId: string,
   dirName: string,
   baseBranch: string,
   branchName: string,
-): WorktreeInfo {
+): Promise<WorktreeInfo> {
   const sanitizedBranch = branchName.replace(/\//g, '-');
   const worktreeDir = path.join(projectPath, dirName);
   const worktreePath = path.join(worktreeDir, sanitizedBranch);
 
-  mkdirSync(worktreeDir, { recursive: true });
-  execFileSync('git', ['worktree', 'add', '-b', branchName, worktreePath, baseBranch], {
-    cwd: projectPath,
-    encoding: 'utf-8',
-    stdio: 'pipe',
-  });
+  await mkdir(worktreeDir, { recursive: true });
+  await execGit(['worktree', 'add', '-b', branchName, worktreePath, baseBranch], projectPath);
   return { worktreePath, branchName };
 }
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { convertMessage, ERROR_PLACEHOLDER, PERMISSION_PLACEHOLDER } from './convert-message';
+import { convertMessage, PERMISSION_PLACEHOLDER } from './convert-message';
 import type { DisplayMessage, DisplayContent } from '@qlan-ro/mainframe-types';
 
 /* ── helpers ─────────────────────────────────────────────────────── */
@@ -22,18 +22,12 @@ function display(
 /* ── sentinel placeholders ───────────────────────────────────────── */
 
 describe('sentinel placeholders', () => {
-  it('ERROR_PLACEHOLDER has null-byte prefix', () => {
-    expect(ERROR_PLACEHOLDER.text).toBe('\0__MF_ERROR__');
-    expect(ERROR_PLACEHOLDER.type).toBe('text');
-  });
-
   it('PERMISSION_PLACEHOLDER has null-byte prefix', () => {
     expect(PERMISSION_PLACEHOLDER.text).toBe('\0__MF_PERMISSION__');
     expect(PERMISSION_PLACEHOLDER.type).toBe('text');
   });
 
-  it('placeholders are frozen', () => {
-    expect(Object.isFrozen(ERROR_PLACEHOLDER)).toBe(true);
+  it('PERMISSION_PLACEHOLDER is frozen', () => {
     expect(Object.isFrozen(PERMISSION_PLACEHOLDER)).toBe(true);
   });
 });
@@ -207,11 +201,13 @@ describe('convertMessage', () => {
       });
     });
 
-    it('converts error blocks to ERROR_PLACEHOLDER', () => {
+    it('carries error block message text directly in the text part (no sentinel)', () => {
       const msg = display('assistant', [{ type: 'error', message: 'something went wrong' }]);
       const result = convertMessage(msg);
       expect(result.content).toHaveLength(1);
-      expect((result.content as unknown as Array<Record<string, unknown>>)[0]).toBe(ERROR_PLACEHOLDER);
+      const part = (result.content as unknown as Array<Record<string, unknown>>)[0]!;
+      expect(part.type).toBe('text');
+      expect(part.text).toBe('something went wrong');
     });
 
     it('converts permission_request blocks to PERMISSION_PLACEHOLDER', () => {
@@ -350,19 +346,33 @@ describe('convertMessage', () => {
       const types = (result.content as unknown as Array<Record<string, unknown>>).map((p) => p.type);
       expect(types).toEqual(['reasoning', 'text', 'tool-call', 'text']);
 
-      // The last one should be the error placeholder
+      // The last part carries the actual error message text (no sentinel)
       const last = (result.content as unknown as Array<Record<string, unknown>>)[3]!;
-      expect(last).toBe(ERROR_PLACEHOLDER);
+      expect(last.type).toBe('text');
+      expect(last.text).toBe('oops');
     });
   });
 
   describe('error messages', () => {
-    it('converts error type messages to assistant role with ERROR_PLACEHOLDER', () => {
+    it('converts error type messages to assistant role carrying the error message text', () => {
       const msg = display('error', [{ type: 'error', message: 'crash' }]);
       const result = convertMessage(msg);
 
       expect(result.role).toBe('assistant');
-      expect(result.content).toEqual([ERROR_PLACEHOLDER]);
+      const parts = result.content as unknown as Array<Record<string, unknown>>;
+      expect(parts).toHaveLength(1);
+      expect(parts[0]!.type).toBe('text');
+      expect(parts[0]!.text).toBe('crash');
+    });
+
+    it('falls back to default message when error block is missing', () => {
+      // error type message with no error block in content
+      const msg = display('error', []);
+      const result = convertMessage(msg);
+
+      expect(result.role).toBe('assistant');
+      const parts = result.content as unknown as Array<Record<string, unknown>>;
+      expect(parts[0]!.text).toBe('An error occurred');
     });
   });
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -375,15 +375,15 @@ describe('convertMessage', () => {
       expect(parts[0]!.text).toBe('An error occurred');
     });
 
-    it('falls back to default message when the error block message is empty', () => {
-      // An empty error string must not collapse to an empty text part —
-      // MainframeText drops empty text before its error check, which would
-      // hide the error bubble entirely.
-      const msg = display('error', [{ type: 'error', message: '' }]);
-      const result = convertMessage(msg);
-
-      const parts = result.content as unknown as Array<Record<string, unknown>>;
-      expect(parts[0]!.text).toBe('An error occurred');
+    it('falls back to default message when the error block message is empty or whitespace-only', () => {
+      // An empty or whitespace-only error string must not collapse to a blank
+      // text part — MainframeText drops blank-after-trim text before its error
+      // check, which would hide the error bubble entirely.
+      for (const blank of ['', '   ', '\n\t']) {
+        const msg = display('error', [{ type: 'error', message: blank }]);
+        const parts = convertMessage(msg).content as unknown as Array<Record<string, unknown>>;
+        expect(parts[0]!.text).toBe('An error occurred');
+      }
     });
   });
 

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.test.ts
@@ -374,6 +374,17 @@ describe('convertMessage', () => {
       const parts = result.content as unknown as Array<Record<string, unknown>>;
       expect(parts[0]!.text).toBe('An error occurred');
     });
+
+    it('falls back to default message when the error block message is empty', () => {
+      // An empty error string must not collapse to an empty text part —
+      // MainframeText drops empty text before its error check, which would
+      // hide the error bubble entirely.
+      const msg = display('error', [{ type: 'error', message: '' }]);
+      const result = convertMessage(msg);
+
+      const parts = result.content as unknown as Array<Record<string, unknown>>;
+      expect(parts[0]!.text).toBe('An error occurred');
+    });
   });
 
   describe('permission messages', () => {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -208,10 +208,10 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
 
     case 'error': {
       const errorBlock = message.content.find((c): c is DisplayContent & { type: 'error' } => c.type === 'error');
-      // `||` (not `??`) so an empty-string message also falls back — an error
-      // bubble must always render visible text, and MainframeText drops empty
-      // text parts before its error check.
-      const errorText = errorBlock?.message || 'An error occurred';
+      // Fall back when the message is missing, empty, OR whitespace-only — an
+      // error bubble must always render visible text, and MainframeText drops
+      // blank-after-trim text parts before its error check.
+      const errorText = errorBlock?.message?.trim() ? errorBlock.message : 'An error occurred';
       return {
         role: 'assistant',
         content: [{ type: 'text', text: errorText }],

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -7,8 +7,8 @@ type ContentPart = Exclude<ThreadMessageLike['content'], string>[number];
 // Re-export for consumers that import from this module
 export type { ToolGroupItem, TaskProgressItem, PartEntry } from '@qlan-ro/mainframe-core/messages';
 
-// Sentinel placeholders — null-byte prefix prevents collision with user content
-export const ERROR_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_ERROR__' });
+// Sentinel placeholder for permission_request — rendered as null (no visible UI needed here).
+// A null-byte prefix prevents collision with user content.
 export const PERMISSION_PLACEHOLDER = Object.freeze({ type: 'text' as const, text: '\0__MF_PERMISSION__' });
 
 function mapDisplayContentToToolCall(block: DisplayContent & { type: 'tool_call' }): ContentPart {
@@ -186,7 +186,11 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
             break;
           }
           case 'error':
-            parts.push(ERROR_PLACEHOLDER);
+            // Carry the message text directly so the renderer can display it without
+            // a sentinel round-trip or cross-message scan. The renderer identifies error
+            // parts by looking up the original DisplayMessage (via getExternalStoreMessages)
+            // and matching the text to the error block's message field.
+            parts.push({ type: 'text', text: block.message });
             break;
           case 'permission_request':
             parts.push(PERMISSION_PLACEHOLDER);
@@ -202,13 +206,16 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
       };
     }
 
-    case 'error':
+    case 'error': {
+      const errorBlock = message.content.find((c): c is DisplayContent & { type: 'error' } => c.type === 'error');
+      const errorText = errorBlock?.message ?? 'An error occurred';
       return {
         role: 'assistant',
-        content: [ERROR_PLACEHOLDER],
+        content: [{ type: 'text', text: errorText }],
         id: message.id,
         createdAt: new Date(message.timestamp),
       };
+    }
 
     case 'permission':
       return {

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/convert-message.ts
@@ -208,7 +208,10 @@ export function convertMessage(message: DisplayMessage): ThreadMessageLike {
 
     case 'error': {
       const errorBlock = message.content.find((c): c is DisplayContent & { type: 'error' } => c.type === 'error');
-      const errorText = errorBlock?.message ?? 'An error occurred';
+      // `||` (not `??`) so an empty-string message also falls back — an error
+      // bubble must always render visible text, and MainframeText drops empty
+      // text parts before its error check.
+      const errorText = errorBlock?.message || 'An error occurred';
       return {
         role: 'assistant',
         content: [{ type: 'text', text: errorText }],

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
@@ -1,23 +1,42 @@
-import React from 'react';
 import type { TextMessagePartComponent } from '@assistant-ui/react';
-import { getExternalStoreMessages } from '@assistant-ui/react';
-import { useMessage } from '@assistant-ui/react';
+import { getExternalStoreMessages, useMessage } from '@assistant-ui/react';
 import type { DisplayMessage } from '@qlan-ro/mainframe-types';
-import { ERROR_PLACEHOLDER, PERMISSION_PLACEHOLDER } from '../convert-message';
+import { PERMISSION_PLACEHOLDER } from '../convert-message';
 import { ErrorPart } from './ErrorPart';
 import { MarkdownText } from './markdown-text';
 
 export const MainframeText: TextMessagePartComponent = (props) => {
   const { text } = props;
-  if (text === ERROR_PLACEHOLDER.text) {
-    return <ErrorPartFromMessage />;
-  }
 
   if (text === PERMISSION_PLACEHOLDER.text) {
     return null;
   }
 
   if (!text || text.trim() === '') return null;
+
+  return <MainframeTextInner {...props} />;
+};
+
+/**
+ * Renders a text part. If the original DisplayMessage has an error block whose
+ * message matches this text part, renders an ErrorPart instead of markdown.
+ * This avoids the sentinel round-trip: error message text is now carried directly
+ * in the text part, and the renderer identifies it by checking the source blocks
+ * within the current message only (no cross-message scan).
+ */
+const MainframeTextInner: TextMessagePartComponent = (props) => {
+  const { text } = props;
+  const originalMessages = useMessage((m) => getExternalStoreMessages<DisplayMessage>(m));
+
+  // Check if this text part corresponds to an error block in the current message.
+  // The outer message always maps to a single DisplayMessage at index 0.
+  const original = originalMessages[0];
+  const isError =
+    original !== undefined && original.content.some((block) => block.type === 'error' && block.message === text);
+
+  if (isError) {
+    return <ErrorPart message={text} />;
+  }
 
   // data-text-part marks this subtree as searchable by the chat-local FindBar.
   return (
@@ -26,18 +45,3 @@ export const MainframeText: TextMessagePartComponent = (props) => {
     </div>
   );
 };
-
-function ErrorPartFromMessage() {
-  const originalMessages = useMessage((m) => getExternalStoreMessages<DisplayMessage>(m));
-  const errorMessage = findErrorMessage(originalMessages);
-  return <ErrorPart message={errorMessage} />;
-}
-
-function findErrorMessage(messages: DisplayMessage[]): string {
-  for (const msg of messages) {
-    for (const block of msg.content) {
-      if (block.type === 'error') return block.message;
-    }
-  }
-  return 'An error occurred';
-}

--- a/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
+++ b/packages/desktop/src/renderer/components/chat/assistant-ui/parts/MainframeText.tsx
@@ -28,11 +28,16 @@ const MainframeTextInner: TextMessagePartComponent = (props) => {
   const { text } = props;
   const originalMessages = useMessage((m) => getExternalStoreMessages<DisplayMessage>(m));
 
-  // Check if this text part corresponds to an error block in the current message.
+  // Error parts live only in error-type DisplayMessages, whose single rendered
+  // text part IS the error. Key off the message type rather than matching the
+  // message string (which could collide with ordinary text). The block-message
+  // match is kept as a defensive fallback for any future path that embeds an
+  // error block inside a non-error message.
   // The outer message always maps to a single DisplayMessage at index 0.
   const original = originalMessages[0];
   const isError =
-    original !== undefined && original.content.some((block) => block.type === 'error' && block.message === text);
+    original !== undefined &&
+    (original.type === 'error' || original.content.some((block) => block.type === 'error' && block.message === text));
 
   if (isError) {
     return <ErrorPart message={text} />;


### PR DESCRIPTION
## Tech-debt remediation — batch 2 (3 workstreams)

Stacked on #359 (base: `feat/code-tech-debt`). Will retarget to `main` once #359 merges. Continues the audit-driven remediation; each workstream is a behavior-preserving refactor landed as its own commit with green build + tests.

### WS5 — Git layer consolidation (`71eb584a`)
- Extracted the byte-identical route parsers (`isNotGitRepo`, `parseDiffNameStatus`, `parseStatusLines`, and the porcelain bucket parser — typo `parsePortcelainStatus` → `parseStatusBuckets`) into one shared `git/git-parse.ts` with direct unit tests.
- Replaced three copies of the `['main','master']` merge-base loop with a single `GitService.detectBaseBranch()`. Route response shapes unchanged.
- Migrated `workspace/worktree.ts` off `execFileSync`/`mkdirSync` and a private `promisify(execFile)` onto the canonical async `execGit` + `fs/promises` — `createWorktree`/`getWorktrees` no longer block the daemon event loop; `config-manager` callers await accordingly.
- Removed the dead, unexported `isGitRepo` helper.

### WS14a — Error-message sentinel removal (`439a5895`)
- The desktop renderer destroyed an `error` block's message into a frozen `\0__MF_ERROR__` text sentinel, then string-compared it and re-scanned every message to recover the text it had discarded. Now `convert-message` carries `block.message` directly and `MainframeText` identifies the error part from the current message's own blocks. Removes `ERROR_PLACEHOLDER` and `findErrorMessage`.

### WS14b — Grouping sentinel round-trip removal (`236fe854`, tests `5e4beed4`)
- `applyToolGrouping` flattened `DisplayContent` into a parallel `PartEntry` model, smuggling non-groupable content (thinking/image/skill_loaded/…) through grouping as a magic `\0ng:N` string indexed into a side array, then decoding it in two places via regex.
- Replaced with a first-class `{ type: 'passthrough'; content }` `PartEntry` variant — content rides through grouping carrying its own data + `parentToolUseId`, decoding by returning `part.content`. Removes the `nonGroupable` array, the `\0ng:` encoding, and `NG_SENTINEL_RE`.
- Guarded by 19 new characterization tests pinning positional interleaving, run-breaking, `_TaskProgress` splice position, task_group nesting, and the #184 agentId invariant.

### Verification
- `pnpm build` green (types + core + desktop, 0 TS errors).
- Core suite **1627 passing**; desktop `convert-message`/`MainframeText` green.
- WS5 + WS14b are byte-identical refactors (pinned by tests). WS14a preserves rendering.

### Follow-ups (not in this PR)
- **WS14c** — remove the desktop `_ToolGroup`/`_TaskGroup` re-encode + untyped `args` blob; needs the running app to verify rendering.
- **Scattered-progress data loss** — `groupToolCallParts` silently drops a second progress tool caught in an explore look-ahead (pinned as characterization, not fixed).
- **WS14a string-equality** — `MainframeText` matches error parts by `message === text`; robust index-based match grouped with WS14c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
