### PR TITLE
WS4: API response envelope consistency

### DIFF
--- a/.changeset/ws4-response-envelope.md
+++ b/.changeset/ws4-response-envelope.md
@@ -1,0 +1,7 @@
+---
+"@qlan-ro/mainframe-core": patch
+"@qlan-ro/mainframe-types": patch
+"@qlan-ro/mainframe-desktop": patch
+---
+
+Normalize the daemon HTTP API to a single response envelope. Every route now returns `{ success: true, data }` (or `{ success: true }` for state-only mutations) and `{ success: false, error }` on failure, replacing the previous mix of bare objects, bare arrays, and ad-hoc `{ tasks }` / `{ ok: true }` / `{ reason }` shapes. Git read endpoints keep their not-a-git-repo "soft errors" as successful empty payloads so the existing empty-state UX is unchanged. Desktop API consumers unwrap the envelope; the mobile client already tolerates both shapes. Internal-only change with no user-facing behavior difference.

--- a/packages/core/src/__tests__/lsp/lsp-routes.test.ts
+++ b/packages/core/src/__tests__/lsp/lsp-routes.test.ts
@@ -28,12 +28,13 @@ describe('GET /api/lsp/languages', () => {
       .query({ projectId: '550e8400-e29b-41d4-a716-446655440000' });
 
     expect(res.status).toBe(200);
-    expect(res.body.languages).toHaveLength(3);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.languages).toHaveLength(3);
 
-    const ts = res.body.languages.find((l: any) => l.id === 'typescript');
+    const ts = res.body.data.languages.find((l: any) => l.id === 'typescript');
     expect(ts).toEqual({ id: 'typescript', installed: true, active: false });
 
-    const java = res.body.languages.find((l: any) => l.id === 'java');
+    const java = res.body.data.languages.find((l: any) => l.id === 'java');
     expect(java).toEqual({ id: 'java', installed: false, active: false });
   });
 

--- a/packages/core/src/__tests__/routes/attachments.test.ts
+++ b/packages/core/src/__tests__/routes/attachments.test.ts
@@ -186,7 +186,7 @@ describe('attachmentRoutes', () => {
       await handler({ params: { chatId: 'c1', attachmentId: 'att1' }, query: {} }, res, vi.fn());
 
       expect(ctx.attachmentStore!.get).toHaveBeenCalledWith('c1', 'att1');
-      expect(res.json).toHaveBeenCalledWith(attachment);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: attachment });
     });
 
     it('returns 404 when attachment not found', async () => {

--- a/packages/core/src/__tests__/routes/chats.test.ts
+++ b/packages/core/src/__tests__/routes/chats.test.ts
@@ -354,7 +354,7 @@ describe('chatRoutes', () => {
       await flushPromises();
 
       expect(ctx.chats.getMessagesFromDisk).toHaveBeenCalledWith('c1');
-      expect(res.json).toHaveBeenCalledWith({ files: ['src/index.ts'] });
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { files: ['src/index.ts'] } });
     });
   });
 });

--- a/packages/core/src/__tests__/routes/files.test.ts
+++ b/packages/core/src/__tests__/routes/files.test.ts
@@ -64,10 +64,13 @@ describe('GET /api/projects/:id/tree', () => {
     await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
     expect(res.json).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'src', type: 'directory' }),
-        expect.objectContaining({ name: 'README.md', type: 'file' }),
-      ]),
+      expect.objectContaining({
+        success: true,
+        data: expect.arrayContaining([
+          expect.objectContaining({ name: 'src', type: 'directory' }),
+          expect.objectContaining({ name: 'README.md', type: 'file' }),
+        ]),
+      }),
     );
   });
 
@@ -94,7 +97,7 @@ describe('GET /api/projects/:id/tree', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
-    const entries = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+    const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> }).data;
     const link = entries.find((e) => e.name === 'link-to-dir');
     expect(link).toBeDefined();
     expect(link?.type).toBe('directory');
@@ -111,7 +114,7 @@ describe('GET /api/projects/:id/tree', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
-    const entries = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+    const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> }).data;
     const link = entries.find((e) => e.name === 'link-to-file');
     expect(link).toBeDefined();
     expect(link?.type).toBe('file');
@@ -128,7 +131,7 @@ describe('GET /api/projects/:id/tree', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
-    const entries = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+    const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> }).data;
     expect(entries.find((e) => e.name === 'broken-link')).toBeUndefined();
     expect(entries.find((e) => e.name === 'visible.txt')).toBeDefined();
   });
@@ -145,7 +148,8 @@ describe('GET /api/projects/:id/tree', () => {
 
       await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
-      const entries = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+      const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> })
+        .data;
       const link = entries.find((e) => e.name === 'outside-dir-link');
       expect(link).toBeDefined();
       expect(link?.type).toBe('directory');
@@ -166,7 +170,7 @@ describe('GET /api/projects/:id/tree', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: '.' } }, res, vi.fn());
 
-    const entries = res.json.mock.calls[0][0] as Array<{ name: string }>;
+    const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string }> }).data;
     expect(entries.find((e) => e.name === '.claude')).toBeDefined();
     expect(entries.find((e) => e.name === '.env')).toBeDefined();
     expect(entries.find((e) => e.name === 'src')).toBeDefined();
@@ -184,7 +188,7 @@ describe('GET /api/projects/:id/tree', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: '.claude' } }, res, vi.fn());
 
-    const entries = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+    const entries = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> }).data;
     const wt = entries.find((e) => e.name === 'worktrees');
     expect(wt).toBeDefined();
     expect(wt?.type).toBe('directory');
@@ -200,7 +204,7 @@ describe('GET /api/projects/:id/search/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { q: '' } }, res, vi.fn());
 
-    expect(res.json).toHaveBeenCalledWith([]);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: [] });
   });
 
   it('finds files by name', async () => {
@@ -214,7 +218,7 @@ describe('GET /api/projects/:id/search/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { q: 'main' } }, res, vi.fn());
 
-    const results = res.json.mock.calls[0][0] as Array<{ name: string }>;
+    const results = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string }> }).data;
     expect(results.some((r) => r.name === 'main.ts')).toBe(true);
   });
 
@@ -235,7 +239,7 @@ describe('GET /api/projects/:id/search/files', () => {
     // query 'app' matches app.ts; query 'env' matches .env.local
     await handler({ params: { id: 'proj-1' }, query: { q: 'env' } }, res, vi.fn());
 
-    const results = res.json.mock.calls[0][0];
+    const results = (res.json.mock.calls[0][0] as { success: true; data: any[] }).data;
     const names = results.map((r: any) => r.name);
     // gitignored config file should now surface
     expect(names).toContain('.env.local');
@@ -259,7 +263,7 @@ describe('GET /api/projects/:id/search/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { q: 'icon' } }, res, vi.fn());
 
-    const results = res.json.mock.calls[0][0];
+    const results = (res.json.mock.calls[0][0] as { success: true; data: any[] }).data;
     const names = results.map((r: any) => r.name);
 
     // Editable source file should surface
@@ -283,7 +287,7 @@ describe('GET /api/projects/:id/search/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { q: 'legacy_lumen' } }, res, vi.fn());
 
-    const results = res.json.mock.calls[0][0];
+    const results = (res.json.mock.calls[0][0] as { success: true; data: any[] }).data;
     const names = results.map((r: any) => r.name);
     expect(names).toContain('legacy_lumen.log');
   });
@@ -299,7 +303,7 @@ describe('GET /api/projects/:id/search/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { q: 'button' } }, res, vi.fn());
 
-    const results = res.json.mock.calls[0][0] as Array<{ name: string; type: string }>;
+    const results = (res.json.mock.calls[0][0] as { success: true; data: Array<{ name: string; type: string }> }).data;
     // Every result must be a file — no directories
     for (const r of results) {
       expect(r.type).toBe('file');
@@ -334,11 +338,14 @@ describe('GET /api/filesystem/browse', () => {
     await handler({ query: { path: projectDir } } as any, res, vi.fn());
 
     expect(res.json).toHaveBeenCalledWith({
-      path: realProjectDir,
-      entries: [
-        { name: 'alpha', path: expect.stringContaining('alpha'), type: 'directory' },
-        { name: 'beta', path: expect.stringContaining('beta'), type: 'directory' },
-      ],
+      success: true,
+      data: {
+        path: realProjectDir,
+        entries: [
+          { name: 'alpha', path: expect.stringContaining('alpha'), type: 'directory' },
+          { name: 'beta', path: expect.stringContaining('beta'), type: 'directory' },
+        ],
+      },
     });
   });
 
@@ -356,7 +363,7 @@ describe('GET /api/filesystem/browse', () => {
 
     await handler({ query: { path: projectDir } } as any, res, vi.fn());
 
-    const result = res.json.mock.calls[0][0];
+    const result = (res.json.mock.calls[0][0] as { success: true; data: { entries: { name: string }[] } }).data;
     expect(result.entries).toHaveLength(1);
     expect(result.entries[0].name).toBe('visible');
   });
@@ -391,7 +398,7 @@ describe('GET /api/filesystem/browse', () => {
       await handler({ query: { path: outsideDir } } as any, res, vi.fn());
 
       expect(res.status).not.toHaveBeenCalledWith(403);
-      const result = res.json.mock.calls[0][0];
+      const result = (res.json.mock.calls[0][0] as { success: true; data: { entries: { name: string }[] } }).data;
       expect(result.entries.some((e: { name: string }) => e.name === 'subdir')).toBe(true);
     } finally {
       await rm(outsideDir, { recursive: true, force: true });
@@ -410,7 +417,7 @@ describe('GET /api/filesystem/browse', () => {
     await handler({ query: { path: '~/sub' } } as any, res, vi.fn());
 
     expect(res.status).not.toHaveBeenCalledWith(404);
-    const result = res.json.mock.calls[0][0];
+    const result = (res.json.mock.calls[0][0] as { success: true; data: { path: string } }).data;
     expect(result.path).toContain('sub');
   });
 
@@ -428,7 +435,8 @@ describe('GET /api/filesystem/browse', () => {
     const resDirs = mockRes();
     await handler({ query: { path: projectDir } } as any, resDirs, vi.fn());
 
-    const defaultResult = resDirs.json.mock.calls[0][0];
+    type BrowseResult = { success: true; data: { entries: { name: string }[] } };
+    const defaultResult = (resDirs.json.mock.calls[0][0] as BrowseResult).data;
     expect(defaultResult.entries.some((e: { name: string }) => e.name === 'myfile.txt')).toBe(false);
     expect(defaultResult.entries.some((e: { name: string }) => e.name === 'mydir')).toBe(true);
 
@@ -436,7 +444,7 @@ describe('GET /api/filesystem/browse', () => {
     const resBoth = mockRes();
     await handler({ query: { path: projectDir, includeFiles: 'true' } } as any, resBoth, vi.fn());
 
-    const filesResult = resBoth.json.mock.calls[0][0];
+    const filesResult = (resBoth.json.mock.calls[0][0] as BrowseResult).data;
     expect(filesResult.entries.some((e: { name: string }) => e.name === 'myfile.txt')).toBe(true);
     expect(filesResult.entries.some((e: { name: string }) => e.name === 'mydir')).toBe(true);
   });
@@ -455,7 +463,8 @@ describe('GET /api/filesystem/browse', () => {
     const resDefault = mockRes();
     await handler({ query: { path: projectDir } } as any, resDefault, vi.fn());
 
-    const defaultResult = resDefault.json.mock.calls[0][0];
+    type BrowseResult = { success: true; data: { entries: { name: string }[] } };
+    const defaultResult = (resDefault.json.mock.calls[0][0] as BrowseResult).data;
     expect(defaultResult.entries.some((e: { name: string }) => e.name === '.hidden')).toBe(false);
     expect(defaultResult.entries.some((e: { name: string }) => e.name === 'visible.txt')).toBe(false);
 
@@ -463,7 +472,7 @@ describe('GET /api/filesystem/browse', () => {
     const resFiles = mockRes();
     await handler({ query: { path: projectDir, includeFiles: 'true' } } as any, resFiles, vi.fn());
 
-    const filesResult = resFiles.json.mock.calls[0][0];
+    const filesResult = (resFiles.json.mock.calls[0][0] as BrowseResult).data;
     expect(filesResult.entries.some((e: { name: string }) => e.name === 'visible.txt')).toBe(true);
     expect(filesResult.entries.some((e: { name: string }) => e.name === '.hidden')).toBe(false);
 
@@ -475,7 +484,7 @@ describe('GET /api/filesystem/browse', () => {
       vi.fn(),
     );
 
-    const bothResult = resBoth.json.mock.calls[0][0];
+    const bothResult = (resBoth.json.mock.calls[0][0] as BrowseResult).data;
     expect(bothResult.entries.some((e: { name: string }) => e.name === 'visible.txt')).toBe(true);
     expect(bothResult.entries.some((e: { name: string }) => e.name === '.hidden')).toBe(true);
   });
@@ -493,7 +502,7 @@ describe('GET /api/filesystem/browse', () => {
 
     await handler({ query: { path: projectDir, includeHidden: 'true' } } as any, res, vi.fn());
 
-    const result = res.json.mock.calls[0][0];
+    const result = (res.json.mock.calls[0][0] as { success: true; data: { entries: { name: string }[] } }).data;
     expect(result.entries.some((e: { name: string }) => e.name === 'node_modules')).toBe(false);
     expect(result.entries.some((e: { name: string }) => e.name === 'src')).toBe(true);
   });
@@ -511,7 +520,8 @@ describe('GET /api/filesystem/browse', () => {
 
     await handler({ query: { path: projectDir, includeFiles: 'true' } } as any, res, vi.fn());
 
-    const result = res.json.mock.calls[0][0];
+    const result = (res.json.mock.calls[0][0] as { success: true; data: { entries: { name: string; type: string }[] } })
+      .data;
     const dirEntry = result.entries.find((e: { name: string }) => e.name === 'adir');
     const fileEntry = result.entries.find((e: { name: string }) => e.name === 'afile.ts');
     expect(dirEntry?.type).toBe('directory');
@@ -530,7 +540,9 @@ describe('GET /api/projects/:id/files', () => {
 
     await handler({ params: { id: 'proj-1' }, query: { path: 'hello.txt' } }, res, vi.fn());
 
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ content: 'world' }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, data: expect.objectContaining({ content: 'world' }) }),
+    );
   });
 
   it('rejects path traversal with 403', async () => {
@@ -557,7 +569,9 @@ describe('GET /api/files/external', () => {
 
     await handler({ query: { path: extFile } } as any, res, vi.fn());
 
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ content: '# External' }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, data: expect.objectContaining({ content: '# External' }) }),
+    );
   });
 
   it('returns 404 for a non-existent file', async () => {

--- a/packages/core/src/__tests__/routes/files.test.ts
+++ b/packages/core/src/__tests__/routes/files.test.ts
@@ -636,7 +636,7 @@ describe('PUT /api/projects/:id/files', () => {
       vi.fn(),
     );
 
-    expect(res.json).toHaveBeenCalledWith({ path: 'hello.txt', success: true });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { path: 'hello.txt' } });
   });
 
   it('returns 400 when path is missing', async () => {

--- a/packages/core/src/__tests__/routes/git-diff.test.ts
+++ b/packages/core/src/__tests__/routes/git-diff.test.ts
@@ -127,11 +127,14 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
 
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        baseBranch: 'main',
-        mergeBase: 'abc123',
-        diffs: {
-          'src/foo.ts': { main: 'original content', worktree: 'modified content' },
-        },
+        success: true,
+        data: expect.objectContaining({
+          baseBranch: 'main',
+          mergeBase: 'abc123',
+          diffs: {
+            'src/foo.ts': { main: 'original content', worktree: 'modified content' },
+          },
+        }),
       }),
     );
   });
@@ -152,7 +155,10 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
 
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        diffs: { 'src/new.ts': { main: '', worktree: 'new file content' } },
+        success: true,
+        data: expect.objectContaining({
+          diffs: { 'src/new.ts': { main: '', worktree: 'new file content' } },
+        }),
       }),
     );
     expect(mockSvc.show).not.toHaveBeenCalled();
@@ -173,7 +179,10 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
 
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        diffs: { 'src/gone.ts': { main: 'old content', worktree: '' } },
+        success: true,
+        data: expect.objectContaining({
+          diffs: { 'src/gone.ts': { main: 'old content', worktree: '' } },
+        }),
       }),
     );
   });
@@ -191,7 +200,10 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
     await waitForResponse(res);
 
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ diffs: expect.any(Object), baseBranch: 'main', mergeBase: 'abc123' }),
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ diffs: expect.any(Object), baseBranch: 'main', mergeBase: 'abc123' }),
+      }),
     );
   });
 
@@ -222,7 +234,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Project not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Project not found' });
   });
 
   it('returns empty diffs when no merge base is found', async () => {
@@ -236,7 +248,7 @@ describe('POST /api/projects/:id/git/diff-since-main', () => {
     handler({ params: { id: 'proj-1' }, query: {}, body: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith({ diffs: {}, baseBranch: null, mergeBase: null });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { diffs: {}, baseBranch: null, mergeBase: null } });
   });
 
   it('returns 400 when git diff fails', async () => {
@@ -296,7 +308,7 @@ describe('POST /api/git/stage', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Chat not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Chat not found' });
   });
 
   it('returns 400 for git error', async () => {
@@ -344,7 +356,7 @@ describe('POST /api/git/commit', () => {
     );
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith({ hash: 'abc1234' });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { hash: 'abc1234' } });
     expect(mockSvc.stage).toHaveBeenCalledWith(['src/button.tsx']);
     expect(mockSvc.commit).toHaveBeenCalledWith('feat: add button');
   });
@@ -381,7 +393,7 @@ describe('POST /api/git/commit', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Chat not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Chat not found' });
   });
 
   it('skips staging when files array is empty', async () => {
@@ -396,7 +408,7 @@ describe('POST /api/git/commit', () => {
     await waitForResponse(res);
 
     expect(mockSvc.stage).not.toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith({ hash: 'def5678' });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { hash: 'def5678' } });
   });
 
   it('returns 400 when git commit fails', async () => {
@@ -448,7 +460,7 @@ describe('POST /api/git/push', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Chat not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Chat not found' });
   });
 
   it('returns 400 on push rejection (non-fast-forward)', async () => {
@@ -509,9 +521,12 @@ describe('POST /api/git/status', () => {
     expect(res.status).not.toHaveBeenCalledWith(expect.any(Number));
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        staged: expect.any(Array),
-        unstaged: expect.any(Array),
-        untracked: expect.any(Array),
+        success: true,
+        data: expect.objectContaining({
+          staged: expect.any(Array),
+          unstaged: expect.any(Array),
+          untracked: expect.any(Array),
+        }),
       }),
     );
   });
@@ -531,9 +546,12 @@ describe('POST /api/git/status', () => {
     await waitForResponse(res);
 
     expect(res.json).toHaveBeenCalledWith({
-      staged: ['src/staged.ts'],
-      unstaged: ['src/unstaged.ts'],
-      untracked: ['src/new.ts'],
+      success: true,
+      data: {
+        staged: ['src/staged.ts'],
+        unstaged: ['src/unstaged.ts'],
+        untracked: ['src/new.ts'],
+      },
     });
   });
 
@@ -549,7 +567,7 @@ describe('POST /api/git/status', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Chat not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Chat not found' });
   });
 
   it('returns 400 when chatId is missing', async () => {

--- a/packages/core/src/__tests__/routes/git-diff.test.ts
+++ b/packages/core/src/__tests__/routes/git-diff.test.ts
@@ -92,7 +92,10 @@ describe('GET /api/projects/:id/git/diff', () => {
     handler({ params: { id: 'proj-1' }, query: { source: 'git', file: 'src/foo.ts' } }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ diff: 'diff output', source: 'git' }));
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: expect.objectContaining({ diff: 'diff output', source: 'git' }),
+    });
   });
 
   it('returns 400 when source is not "git"', async () => {

--- a/packages/core/src/__tests__/routes/git-write.test.ts
+++ b/packages/core/src/__tests__/routes/git-write.test.ts
@@ -87,7 +87,7 @@ describe('GET /api/projects/:id/git/branches', () => {
     await waitForResponse(res);
 
     expect(mockSvc.branches).toHaveBeenCalledOnce();
-    expect(res.json).toHaveBeenCalledWith(branchResult);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: branchResult });
   });
 
   it('returns 404 when project not found', async () => {
@@ -101,7 +101,7 @@ describe('GET /api/projects/:id/git/branches', () => {
     await waitForResponse(res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Project not found' });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Project not found' });
   });
 });
 
@@ -118,7 +118,7 @@ describe('POST /api/projects/:id/git/checkout', () => {
     await waitForResponse(res);
 
     expect(mockSvc.checkout).toHaveBeenCalledWith('feature/foo');
-    expect(res.json).toHaveBeenCalledWith({ ok: true });
+    expect(res.json).toHaveBeenCalledWith({ success: true });
   });
 
   it('returns 400 when branch is missing', async () => {
@@ -149,7 +149,7 @@ describe('POST /api/projects/:id/git/merge', () => {
     await waitForResponse(res);
 
     expect(mockSvc.merge).toHaveBeenCalledWith('feature/foo');
-    expect(res.json).toHaveBeenCalledWith(mergeResult);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: mergeResult });
   });
 
   it('returns conflict result', async () => {
@@ -164,7 +164,7 @@ describe('POST /api/projects/:id/git/merge', () => {
     handler({ params: { id: 'proj-1' }, query: {}, body: { branch: 'feature/conflicting' } }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith(conflictResult);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: conflictResult });
   });
 });
 
@@ -182,7 +182,7 @@ describe('POST /api/projects/:id/git/delete-branch', () => {
     await waitForResponse(res);
 
     expect(mockSvc.deleteBranch).toHaveBeenCalledWith('feature/unmerged', undefined, undefined);
-    expect(res.json).toHaveBeenCalledWith(notMergedResult);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: notMergedResult });
   });
 
   it('calls deleteBranch with force=true when specified', async () => {
@@ -197,7 +197,7 @@ describe('POST /api/projects/:id/git/delete-branch', () => {
     await waitForResponse(res);
 
     expect(mockSvc.deleteBranch).toHaveBeenCalledWith('feature/old', true, undefined);
-    expect(res.json).toHaveBeenCalledWith({ status: 'success' });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { status: 'success' } });
   });
 
   it('passes remote=true for remote branch deletion', async () => {
@@ -212,6 +212,6 @@ describe('POST /api/projects/:id/git/delete-branch', () => {
     await waitForResponse(res);
 
     expect(mockSvc.deleteBranch).toHaveBeenCalledWith('origin/feature/old', undefined, true);
-    expect(res.json).toHaveBeenCalledWith({ status: 'success' });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { status: 'success' } });
   });
 });

--- a/packages/core/src/__tests__/routes/git.test.ts
+++ b/packages/core/src/__tests__/routes/git.test.ts
@@ -29,6 +29,23 @@ function createCtx(projectPath: string): RouteContext {
   };
 }
 
+function createCtxNotFound(): RouteContext {
+  return {
+    db: {
+      projects: {
+        get: vi.fn().mockReturnValue(null),
+      },
+      chats: {
+        list: vi.fn().mockReturnValue([]),
+        get: vi.fn().mockReturnValue(null),
+      },
+      settings: { get: vi.fn().mockReturnValue(null) },
+    } as any,
+    chats: { getChat: vi.fn().mockReturnValue(null), on: vi.fn() } as any,
+    adapters: { get: vi.fn(), list: vi.fn() } as any,
+  };
+}
+
 function extractHandler(router: any, method: string, routePath: string) {
   const layer = router.stack.find((l: any) => l.route?.path === routePath && l.route?.methods[method]);
   if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${routePath}`);
@@ -36,7 +53,7 @@ function extractHandler(router: any, method: string, routePath: string) {
 }
 
 describe('GET /api/projects/:id/git/branch', () => {
-  it('returns a branch name for a real git repo', async () => {
+  it('returns enveloped branch name for a real git repo', async () => {
     const ctx = createCtx(REAL_GIT_PATH);
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/branch');
@@ -45,12 +62,13 @@ describe('GET /api/projects/:id/git/branch', () => {
     handler({ params: { id: 'proj-1' }, query: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    const result = res.json.mock.calls[0][0] as { branch: string | null };
-    expect(typeof result.branch).toBe('string');
-    expect(result.branch!.length).toBeGreaterThan(0);
+    const result = res.json.mock.calls[0][0] as { success: boolean; data: { branch: string | null } };
+    expect(result.success).toBe(true);
+    expect(typeof result.data.branch).toBe('string');
+    expect(result.data.branch!.length).toBeGreaterThan(0);
   });
 
-  it('returns { branch: null } for non-git directory', async () => {
+  it('returns success:true with branch:null for non-git directory', async () => {
     const ctx = createCtx('/tmp');
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/branch');
@@ -59,12 +77,24 @@ describe('GET /api/projects/:id/git/branch', () => {
     handler({ params: { id: 'proj-1' }, query: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith({ branch: null });
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: { branch: null } });
+  });
+
+  it('returns success:false with 404 when project not found', async () => {
+    const ctx = createCtxNotFound();
+    const router = gitRoutes(ctx);
+    const handler = extractHandler(router, 'get', '/api/projects/:id/git/branch');
+    const res = mockRes();
+
+    handler({ params: { id: 'proj-missing' }, query: {} }, res, vi.fn());
+    // status is called synchronously for 404
+    await vi.waitFor(() => expect(res.status).toHaveBeenCalledWith(404), { timeout: 2000 });
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Project not found' });
   });
 });
 
 describe('GET /api/projects/:id/git/status', () => {
-  it('returns files array for a real git repo', async () => {
+  it('returns enveloped files array for a real git repo', async () => {
     const ctx = createCtx(REAL_GIT_PATH);
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/status');
@@ -73,11 +103,12 @@ describe('GET /api/projects/:id/git/status', () => {
     handler({ params: { id: 'proj-1' }, query: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    const result = res.json.mock.calls[0][0] as { files: unknown[] };
-    expect(Array.isArray(result.files)).toBe(true);
+    const result = res.json.mock.calls[0][0] as { success: boolean; data: { files: unknown[] } };
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.data.files)).toBe(true);
   });
 
-  it('returns { files: [], error } for non-git directory', async () => {
+  it('returns success:true with empty files for non-git directory', async () => {
     const ctx = createCtx('/tmp');
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/status');
@@ -86,12 +117,15 @@ describe('GET /api/projects/:id/git/status', () => {
     handler({ params: { id: 'proj-1' }, query: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ files: [], error: expect.any(String) }));
+    const result = res.json.mock.calls[0][0] as { success: boolean; data: { files: unknown[]; error: string } };
+    expect(result.success).toBe(true);
+    expect(result.data.files).toEqual([]);
+    expect(typeof result.data.error).toBe('string');
   });
 });
 
 describe('GET /api/projects/:id/git/branch-diffs', () => {
-  it('returns branch diff info for a real git repo', async () => {
+  it('returns enveloped branch diff info for a real git repo', async () => {
     const ctx = createCtx(REAL_GIT_PATH);
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/branch-diffs');
@@ -101,16 +135,20 @@ describe('GET /api/projects/:id/git/branch-diffs', () => {
     await waitForResponse(res);
 
     const result = res.json.mock.calls[0][0] as {
-      branch: string | null;
-      baseBranch: string | null;
-      mergeBase: string | null;
-      files: unknown[];
+      success: boolean;
+      data: {
+        branch: string | null;
+        baseBranch: string | null;
+        mergeBase: string | null;
+        files: unknown[];
+      };
     };
-    expect(Array.isArray(result.files)).toBe(true);
-    expect(typeof result.branch === 'string' || result.branch === null).toBe(true);
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.data.files)).toBe(true);
+    expect(typeof result.data.branch === 'string' || result.data.branch === null).toBe(true);
   });
 
-  it('returns empty result for non-git directory', async () => {
+  it('returns success:true with empty result for non-git directory', async () => {
     const ctx = createCtx('/tmp');
     const router = gitRoutes(ctx);
     const handler = extractHandler(router, 'get', '/api/projects/:id/git/branch-diffs');
@@ -119,8 +157,8 @@ describe('GET /api/projects/:id/git/branch-diffs', () => {
     handler({ params: { id: 'proj-1' }, query: {} }, res, vi.fn());
     await waitForResponse(res);
 
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ branch: null, baseBranch: null, mergeBase: null, files: [] }),
-    );
+    const result = res.json.mock.calls[0][0] as { success: boolean; data: object };
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ branch: null, baseBranch: null, mergeBase: null, files: [] });
   });
 });

--- a/packages/core/src/__tests__/routes/search.test.ts
+++ b/packages/core/src/__tests__/routes/search.test.ts
@@ -61,17 +61,20 @@ describe('GET /api/projects/:id/search/content', () => {
 
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        results: expect.arrayContaining([
-          expect.objectContaining({
-            file: 'notes.txt',
-            line: 2,
-            column: 1,
-            text: 'find me here',
-          }),
-        ]),
+        success: true,
+        data: expect.objectContaining({
+          results: expect.arrayContaining([
+            expect.objectContaining({
+              file: 'notes.txt',
+              line: 2,
+              column: 1,
+              text: 'find me here',
+            }),
+          ]),
+        }),
       }),
     );
-    const { results } = res.json.mock.calls[0][0];
+    const { results } = res.json.mock.calls[0][0].data;
     expect(results).toHaveLength(1);
   });
 
@@ -88,7 +91,7 @@ describe('GET /api/projects/:id/search/content', () => {
     handler({ params: { id: 'proj-1' }, query: { q: 'foo', path: 'src' } }, res, vi.fn());
     await flushPromises();
 
-    const { results } = res.json.mock.calls[0][0];
+    const { results } = res.json.mock.calls[0][0].data;
     const files = results.map((r: any) => r.file);
     expect(files).toContain('src/alpha.ts');
     expect(files).toContain('src/beta.ts');
@@ -104,7 +107,7 @@ describe('GET /api/projects/:id/search/content', () => {
     await flushPromises();
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(String) }));
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false, error: expect.any(String) }));
   });
 
   it('returns 400 for too-short query', async () => {
@@ -131,7 +134,7 @@ describe('GET /api/projects/:id/search/content', () => {
     handler({ params: { id: 'proj-1' }, query: { q: 'findme', path: '.', includeIgnored: 'true' } }, res, vi.fn());
     await flushPromises();
 
-    const { results } = res.json.mock.calls[0][0];
+    const { results } = res.json.mock.calls[0][0].data;
     const files = results.map((r: any) => r.file);
     expect(files).toContain('app.ts');
     expect(files).not.toContain('app.class');
@@ -148,7 +151,7 @@ describe('GET /api/projects/:id/search/content', () => {
     handler({ params: { id: 'proj-1' }, query: { q: 'hello', path: 'readme.txt' } }, res, vi.fn());
     await flushPromises();
 
-    const { results } = res.json.mock.calls[0][0];
+    const { results } = res.json.mock.calls[0][0].data;
     expect(results).toHaveLength(1);
     expect(results[0].column).toBe(1);
     expect(results[0].text).toBe('Hello World');
@@ -167,7 +170,7 @@ describe('GET /api/projects/:id/search/content', () => {
     handler({ params: { id: 'proj-1' }, query: { q: 'target', path: '.' } }, res, vi.fn());
     await flushPromises();
 
-    const { results } = res.json.mock.calls[0][0];
+    const { results } = res.json.mock.calls[0][0].data;
     expect(results).toHaveLength(1);
     expect(results[0].file).toContain('core.ts');
     expect(results[0].text).toContain('target');

--- a/packages/core/src/__tests__/routes/search.test.ts
+++ b/packages/core/src/__tests__/routes/search.test.ts
@@ -56,7 +56,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'find me', path: 'notes.txt' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'find me', path: 'notes.txt' } }, res, vi.fn());
     await flushPromises();
 
     expect(res.json).toHaveBeenCalledWith(
@@ -88,7 +88,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'foo', path: 'src' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'foo', path: 'src' } }, res, vi.fn());
     await flushPromises();
 
     const { results } = res.json.mock.calls[0][0].data;
@@ -103,7 +103,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'test', path: '../../etc' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'test', path: '../../etc' } }, res, vi.fn());
     await flushPromises();
 
     expect(res.status).toHaveBeenCalledWith(403);
@@ -116,7 +116,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'a', path: '.' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'a', path: '.' } }, res, vi.fn());
     await flushPromises();
 
     expect(res.status).toHaveBeenCalledWith(400);
@@ -131,7 +131,11 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'findme', path: '.', includeIgnored: 'true' } }, res, vi.fn());
+    await handler(
+      { params: { id: 'proj-1' }, query: { q: 'findme', path: '.', includeIgnored: 'true' } },
+      res,
+      vi.fn(),
+    );
     await flushPromises();
 
     const { results } = res.json.mock.calls[0][0].data;
@@ -148,7 +152,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'hello', path: 'readme.txt' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'hello', path: 'readme.txt' } }, res, vi.fn());
     await flushPromises();
 
     const { results } = res.json.mock.calls[0][0].data;
@@ -167,7 +171,7 @@ describe('GET /api/projects/:id/search/content', () => {
     const handler = extractHandler(router, 'get', '/api/projects/:id/search/content');
     const res = mockRes();
 
-    handler({ params: { id: 'proj-1' }, query: { q: 'target', path: '.' } }, res, vi.fn());
+    await handler({ params: { id: 'proj-1' }, query: { q: 'target', path: '.' } }, res, vi.fn());
     await flushPromises();
 
     const { results } = res.json.mock.calls[0][0].data;

--- a/packages/core/src/__tests__/routes/worktree.test.ts
+++ b/packages/core/src/__tests__/routes/worktree.test.ts
@@ -118,7 +118,7 @@ describe('worktreeRoutes', () => {
       );
 
       expect(ctx.chats.forkToWorktree).toHaveBeenCalledWith('chat-1', 'main', 'session/abc123');
-      expect(res.json).toHaveBeenCalledWith({ success: true, chatId: 'new-chat-42' });
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { chatId: 'new-chat-42' } });
     });
 
     it('returns 409 when repo is dirty', async () => {
@@ -136,7 +136,7 @@ describe('worktreeRoutes', () => {
       );
 
       expect(res.status).toHaveBeenCalledWith(409);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Working tree has uncommitted changes' });
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Working tree has uncommitted changes' });
     });
   });
 });

--- a/packages/core/src/server/routes/__tests__/background-tasks.test.ts
+++ b/packages/core/src/server/routes/__tests__/background-tasks.test.ts
@@ -35,8 +35,9 @@ describe('background-tasks routes', () => {
     );
     const res = await request(makeApp({ tracker })).get('/api/chats/c1/background-tasks');
     expect(res.status).toBe(200);
-    expect(res.body.tasks).toHaveLength(1);
-    expect(res.body.tasks[0].id).toBe('t1');
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.tasks).toHaveLength(1);
+    expect(res.body.data.tasks[0].id).toBe('t1');
   });
 
   it('GET /output → 409 no_output when outputPath is null (adopted task without path)', async () => {
@@ -58,7 +59,7 @@ describe('background-tasks routes', () => {
     });
     const res = await request(makeApp({ tracker })).get('/api/chats/c1/background-tasks/t1/output');
     expect(res.status).toBe(409);
-    expect(res.body).toEqual({ reason: 'no_output' });
+    expect(res.body).toEqual({ success: false, error: 'no_output' });
   });
 
   it('GET /output → 404 when task missing', async () => {
@@ -75,7 +76,7 @@ describe('background-tasks routes', () => {
       '/api/chats/c1/background-tasks/t1/output',
     );
     expect(res.status).toBe(409);
-    expect(res.body).toEqual({ reason: 'invalid_path' });
+    expect(res.body).toEqual({ success: false, error: 'invalid_path' });
   });
 
   it('GET /output → 200 + bounded tail when validator accepts', async () => {
@@ -100,7 +101,7 @@ describe('background-tasks routes', () => {
     expect(res.status).toBe(404);
   });
 
-  it('POST /kill → 204 on success', async () => {
+  it('POST /kill → 200 on success', async () => {
     const tracker = new BackgroundTaskTracker();
     tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
     const session = { stopBackgroundTask: vi.fn().mockResolvedValue({ ok: true }) };
@@ -108,7 +109,8 @@ describe('background-tasks routes', () => {
     const res = await request(makeApp({ tracker, sessionForChat: () => session, killImpl })).post(
       '/api/chats/c1/background-tasks/t1/kill',
     );
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
   });
 
   it('POST /kill → 502 + error body when kill fails', async () => {
@@ -186,7 +188,8 @@ describe('background-tasks routes', () => {
         }),
       );
     const res = await request(app).post('/api/chats/chat-a/background-tasks/rec-1/kill');
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
     expect(killImpl).toHaveBeenCalledWith(expect.objectContaining({ session: null }));
   });
 });

--- a/packages/core/src/server/routes/__tests__/files.test.ts
+++ b/packages/core/src/server/routes/__tests__/files.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { fileRoutes } from '../files.js';
+import type { RouteContext } from '../types.js';
+
+function makeApp(projectPath: string | null = null) {
+  const app = express();
+  app.use(express.json());
+  const ctx = {
+    db: {
+      projects: {
+        get: (_id: string) => (projectPath !== null ? { path: projectPath } : null),
+      },
+    },
+    chats: {
+      getChat: (_chatId: string) => null,
+    },
+  } as unknown as RouteContext;
+  app.use(fileRoutes(ctx));
+  return app;
+}
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'mf-files-envelope-'));
+  await writeFile(join(projectDir, 'hello.txt'), 'hello world\n');
+  await mkdir(join(projectDir, 'subdir'));
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe('handleTree', () => {
+  it('returns 404 envelope when project is not found', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get('/api/projects/missing/tree?path=.');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ success: false, error: 'Project not found' });
+  });
+
+  it('returns array wrapped in envelope on success', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/tree?path=.');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, data: expect.any(Array) });
+    const names = (res.body.data as { name: string }[]).map((e) => e.name);
+    expect(names).toContain('hello.txt');
+    expect(names).toContain('subdir');
+  });
+
+  it('returns 403 envelope when path is outside project', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/tree?path=../../etc');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ success: false, error: 'Path outside project' });
+  });
+});
+
+describe('handleFileContent', () => {
+  it('returns file content wrapped in envelope on success', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/files?path=hello.txt');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      data: { path: 'hello.txt', content: 'hello world\n' },
+    });
+  });
+
+  it('returns 403 envelope when file path is outside project', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/files?path=../../etc/passwd');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ success: false, error: 'Path outside project' });
+  });
+
+  it('returns 404 envelope when project is not found', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get('/api/projects/missing/files?path=hello.txt');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ success: false, error: 'Project not found' });
+  });
+});
+
+describe('handleSearchFiles', () => {
+  it('returns empty array in envelope for empty query', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/search/files?q=');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, data: [] });
+  });
+
+  it('returns matching files in envelope', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/search/files?q=hello');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, data: expect.any(Array) });
+  });
+});

--- a/packages/core/src/server/routes/__tests__/respond.test.ts
+++ b/packages/core/src/server/routes/__tests__/respond.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Response } from 'express';
+import { ok, okEmpty, fail } from '../respond.js';
+
+function mockRes(): Response & { body?: unknown; statusCode: number } {
+  const res = { statusCode: 200 } as unknown as Response & { body?: unknown; statusCode: number };
+  res.status = vi.fn((n: number) => {
+    res.statusCode = n;
+    return res;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+describe('respond helpers', () => {
+  it('ok wraps payload in { success: true, data }', () => {
+    const res = mockRes();
+    ok(res, { a: 1 });
+    expect(res.body).toEqual({ success: true, data: { a: 1 } });
+  });
+
+  it('okEmpty emits { success: true }', () => {
+    const res = mockRes();
+    okEmpty(res);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('fail sets status and emits { success: false, error }', () => {
+    const res = mockRes();
+    fail(res, 404, 'Not found');
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ success: false, error: 'Not found' });
+  });
+});

--- a/packages/core/src/server/routes/__tests__/search.test.ts
+++ b/packages/core/src/server/routes/__tests__/search.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { contentSearchRoutes } from '../search.js';
+import type { RouteContext } from '../types.js';
+
+/**
+ * Minimal RouteContext stub. handleContentSearch only uses:
+ *   ctx.db.projects.get(id)   — via getEffectivePath
+ *   ctx.chats.getChat(chatId) — via getEffectivePath (chatId path, not exercised here)
+ */
+function makeApp(projectPath: string | null = null) {
+  const app = express();
+  app.use(express.json());
+  const ctx = {
+    db: {
+      projects: {
+        get: (_id: string) => (projectPath !== null ? { path: projectPath } : null),
+      },
+    },
+    chats: {
+      getChat: (_chatId: string) => null,
+    },
+  } as unknown as RouteContext;
+  app.use(contentSearchRoutes(ctx));
+  return app;
+}
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'mf-search-envelope-'));
+  await writeFile(join(projectDir, 'sample.txt'), 'hello world\n');
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe('content search routes', () => {
+  it('returns 404 with canonical envelope when project is not found', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get('/api/projects/missing/search/content?q=hello&path=.');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ success: false, error: 'Project not found' });
+  });
+
+  it('returns 200 with canonical envelope for a valid search', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get(
+      `/api/projects/p1/search/content?q=hello&path=${encodeURIComponent('sample.txt')}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, data: { results: expect.any(Array) } });
+  });
+
+  it('returns 403 with canonical envelope when path is outside project', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get(`/api/projects/p1/search/content?q=hello&path=${encodeURIComponent('../etc')}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ success: false, error: 'Path outside project' });
+  });
+
+  it('returns 400 with canonical envelope when query is too short', async () => {
+    const app = makeApp(projectDir);
+    const res = await request(app).get('/api/projects/p1/search/content?q=a&path=.');
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ success: false, error: expect.any(String) });
+  });
+});

--- a/packages/core/src/server/routes/attachments.ts
+++ b/packages/core/src/server/routes/attachments.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import type { RouteContext } from './types.js';
 import { param } from './types.js';
 import { validate, UploadAttachmentsBody } from './schemas.js';
+import { ok } from './respond.js';
 
 const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -57,7 +58,7 @@ export function attachmentRoutes(ctx: RouteContext): Router {
       res.status(404).json({ success: false, error: 'Attachment not found' });
       return;
     }
-    res.json(attachment);
+    ok(res, attachment);
   });
 
   return router;

--- a/packages/core/src/server/routes/background-tasks.ts
+++ b/packages/core/src/server/routes/background-tasks.ts
@@ -5,6 +5,7 @@ import { BackgroundTaskTracker } from '../../background-tasks/tracker.js';
 import { killBackgroundTask, type SessionLike } from '../../background-tasks/kill.js';
 import { makeSpoolValidator, type SpoolValidator } from '../../background-tasks/spool-validator.js';
 import { createChildLogger } from '../../logger.js';
+import { ok, okEmpty, fail } from './respond.js';
 
 const log = createChildLogger('routes:background-tasks');
 
@@ -44,10 +45,10 @@ function makeListHandler(tracker: BackgroundTaskTracker) {
   return (req: Request, res: Response): void => {
     const parsed = Params.safeParse(req.params);
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.message });
+      fail(res, 400, parsed.error.message);
       return;
     }
-    res.json({ tasks: tracker.list(parsed.data.chatId) });
+    ok(res, { tasks: tracker.list(parsed.data.chatId) });
   };
 }
 
@@ -70,16 +71,16 @@ function makeOutputHandler(tracker: BackgroundTaskTracker, validator: SpoolValid
     const p = Params.safeParse(req.params);
     const q = OutputQuery.safeParse(req.query);
     if (!p.success || !q.success || !p.data.taskId) {
-      res.status(400).json({ error: 'bad request' });
+      fail(res, 400, 'bad request');
       return;
     }
     const task = tracker.get(p.data.chatId, p.data.taskId);
     if (!task) {
-      res.status(404).json({ error: 'task not found' });
+      fail(res, 404, 'task not found');
       return;
     }
     if (task.outputPath === null) {
-      res.status(409).json({ reason: 'no_output' });
+      fail(res, 409, 'no_output');
       return;
     }
     const valid = await validator(task.outputPath, task.id);
@@ -88,7 +89,7 @@ function makeOutputHandler(tracker: BackgroundTaskTracker, validator: SpoolValid
         { chatId: p.data.chatId, taskId: p.data.taskId, outputPath: task.outputPath },
         'spool-root validation failed',
       );
-      res.status(409).json({ reason: 'invalid_path' });
+      fail(res, 409, 'invalid_path');
       return;
     }
     const maxBytes = Math.min(q.data.bytes ?? DEFAULT_READ_BYTES, MAX_READ_BYTES);
@@ -98,7 +99,7 @@ function makeOutputHandler(tracker: BackgroundTaskTracker, validator: SpoolValid
       res.send(buf.toString('utf-8'));
     } catch (err) {
       log.warn({ err, outputPath: task.outputPath }, 'failed to read spool file');
-      res.status(500).json({ error: 'read failed' });
+      fail(res, 500, 'read failed');
     }
   };
 }
@@ -111,18 +112,18 @@ function makeKillHandler(
   return async (req: Request, res: Response): Promise<void> => {
     const p = Params.safeParse(req.params);
     if (!p.success || !p.data.taskId) {
-      res.status(400).json({ error: 'bad request' });
+      fail(res, 400, 'bad request');
       return;
     }
     const task = tracker.get(p.data.chatId, p.data.taskId);
     if (!task) {
-      res.status(404).json({ error: 'task not found' });
+      fail(res, 404, 'task not found');
       return;
     }
     const session = sessionForChat(p.data.chatId); // may be null for recovered tasks
     const result = await killImpl({ chatId: p.data.chatId, taskId: p.data.taskId, session, tracker });
-    if (result.ok) res.status(204).end();
-    else res.status(502).json({ error: result.error });
+    if (result.ok) okEmpty(res);
+    else fail(res, 502, result.error);
   };
 }
 

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -4,6 +4,7 @@ import type { Chat } from '@qlan-ro/mainframe-types';
 import type { RouteContext } from './types.js';
 import { param } from './types.js';
 import { asyncHandler } from './async-handler.js';
+import { ok } from './respond.js';
 import { createChildLogger } from '../../logger.js';
 import { extractSessionFilePaths } from '../../messages/session-files.js';
 import { readToolResultFromJsonl } from '../../messages/read-tool-result-from-jsonl.js';
@@ -202,7 +203,7 @@ export function chatRoutes(ctx: RouteContext): Router {
       // in-memory cache during an active session.
       const messages = await ctx.chats.getMessagesFromDisk(chatId);
       const files = extractSessionFilePaths(messages);
-      res.json({ files });
+      ok(res, { files });
     }),
   );
 

--- a/packages/core/src/server/routes/context.ts
+++ b/packages/core/src/server/routes/context.ts
@@ -6,6 +6,7 @@ import { param } from './types.js';
 import { resolveReadablePath } from './path-utils.js';
 import { validate, AddMentionBody } from './schemas.js';
 import { asyncHandler } from './async-handler.js';
+import { ok, fail } from './respond.js';
 import { createChildLogger } from '../../logger.js';
 
 const logger = createChildLogger('routes:context');
@@ -60,10 +61,10 @@ export function contextRoutes(ctx: RouteContext): Router {
         }
 
         const content = await readFile(fullPath, 'utf-8');
-        res.json({ path: filePath, content });
+        ok(res, { path: filePath, content });
       } catch (err) {
         logger.warn({ err, path: filePath }, 'Failed to read session file');
-        res.status(404).json({ success: false, error: 'File not found' });
+        fail(res, 404, 'File not found');
       }
     }),
   );

--- a/packages/core/src/server/routes/files.ts
+++ b/packages/core/src/server/routes/files.ts
@@ -12,6 +12,7 @@ import { createChildLogger } from '../../logger.js';
 import { BrowseFilesystemQuery, validate } from './schemas.js';
 import { IGNORED_DIRS, hasBinaryExtension } from '../fs-utils.js';
 import { listFilesWithRipgrep } from '../ripgrep.js';
+import { ok, fail } from './respond.js';
 
 const logger = createChildLogger('routes:files');
 
@@ -21,7 +22,7 @@ const TREE_HIDDEN_NAMES = new Set(['.git']);
 async function handleTree(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -29,7 +30,7 @@ async function handleTree(ctx: RouteContext, req: Request, res: Response): Promi
   try {
     const fullPath = resolveAndValidatePath(basePath, dirPath);
     if (!fullPath) {
-      res.status(403).json({ error: 'Path outside project' });
+      fail(res, 403, 'Path outside project');
       return;
     }
 
@@ -64,10 +65,10 @@ async function handleTree(ctx: RouteContext, req: Request, res: Response): Promi
         if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
         return a.name.localeCompare(b.name);
       });
-    res.json(entries);
+    ok(res, entries);
   } catch (err) {
     logger.warn({ err, path: dirPath }, 'Failed to read directory tree');
-    res.status(404).json({ error: 'Directory not found' });
+    fail(res, 404, 'Directory not found');
   }
 }
 
@@ -75,13 +76,13 @@ async function handleTree(ctx: RouteContext, req: Request, res: Response): Promi
 async function handleSearchFiles(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
   const q = ((req.query.q as string) || '').toLowerCase();
   if (q.length < 1) {
-    res.json([]);
+    ok(res, []);
     return;
   }
 
@@ -89,7 +90,7 @@ async function handleSearchFiles(ctx: RouteContext, req: Request, res: Response)
     await realpath(basePath);
   } catch (err) {
     logger.warn({ err, basePath }, 'Project path not found for file search');
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -155,14 +156,17 @@ async function handleSearchFiles(ctx: RouteContext, req: Request, res: Response)
   }
 
   const combined = [...substringHits, ...fuzzyHits].slice(0, limit);
-  res.json(combined.map(({ exact: _, ...r }) => r));
+  ok(
+    res,
+    combined.map(({ exact: _, ...r }) => r),
+  );
 }
 
 /** GET /api/projects/:id/files-list?limit=5000&chatId=X */
 async function handleFilesList(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -172,7 +176,7 @@ async function handleFilesList(ctx: RouteContext, req: Request, res: Response): 
     await realpath(basePath);
   } catch (err) {
     logger.warn({ err, basePath }, 'Project path not found for file listing');
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -199,20 +203,20 @@ async function handleFilesList(ctx: RouteContext, req: Request, res: Response): 
     }
   };
   await walk(basePath);
-  res.json(files);
+  ok(res, files);
 }
 
 /** GET /api/projects/:id/files?path=relative/path&chatId=X */
 async function handleFileContent(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
   const filePath = req.query.path as string;
   if (!filePath) {
-    res.status(400).json({ error: 'path query required' });
+    fail(res, 400, 'path query required');
     return;
   }
 
@@ -221,27 +225,27 @@ async function handleFileContent(ctx: RouteContext, req: Request, res: Response)
   try {
     const fullPath = resolveReadablePath(basePath, filePath);
     if (!fullPath) {
-      res.status(403).json({ error: 'Path outside project' });
+      fail(res, 403, 'Path outside project');
       return;
     }
 
     const stats = await stat(fullPath);
     const maxSize = encoding === 'base64' ? 10 * 1024 * 1024 : 2 * 1024 * 1024;
     if (stats.size > maxSize) {
-      res.status(413).json({ error: `File too large (max ${maxSize / 1024 / 1024}MB)` });
+      fail(res, 413, `File too large (max ${maxSize / 1024 / 1024}MB)`);
       return;
     }
 
     if (encoding === 'base64') {
       const buffer = await readFile(fullPath);
-      res.json({ path: filePath, content: buffer.toString('base64'), encoding: 'base64' });
+      ok(res, { path: filePath, content: buffer.toString('base64'), encoding: 'base64' });
     } else {
       const content = await readFile(fullPath, 'utf-8');
-      res.json({ path: filePath, content });
+      ok(res, { path: filePath, content });
     }
   } catch (err) {
     logger.warn({ err, path: filePath }, 'Failed to read file content');
-    res.status(404).json({ error: 'File not found' });
+    fail(res, 404, 'File not found');
   }
 }
 
@@ -249,13 +253,13 @@ async function handleFileContent(ctx: RouteContext, req: Request, res: Response)
 async function handleWriteFile(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(WriteFileBody, req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    fail(res, 400, parsed.error);
     return;
   }
 
   const basePath = getEffectivePath(ctx, param(req, 'id'), parsed.data.chatId);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -265,15 +269,15 @@ async function handleWriteFile(ctx: RouteContext, req: Request, res: Response): 
   try {
     const fullPath = resolveAndValidatePath(basePath, filePath);
     if (!fullPath) {
-      res.status(403).json({ error: 'Path outside project' });
+      fail(res, 403, 'Path outside project');
       return;
     }
 
     await writeFile(fullPath, content, 'utf-8');
-    res.json({ path: filePath, success: true });
+    ok(res, { path: filePath });
   } catch (err) {
     logger.warn({ err, path: filePath }, 'Failed to write file');
-    res.status(500).json({ error: 'Failed to write file' });
+    fail(res, 500, 'Failed to write file');
   }
 }
 
@@ -311,7 +315,7 @@ function isBlockedExternalPath(resolved: string): boolean {
 async function handleExternalFileContent(_ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(ExternalFileQuery, req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    fail(res, 400, parsed.error);
     return;
   }
 
@@ -320,7 +324,7 @@ async function handleExternalFileContent(_ctx: RouteContext, req: Request, res: 
   // Check blocklist against the raw requested path first (before realpath) so that
   // attempts to access sensitive paths are rejected even when the file doesn't exist.
   if (isBlockedExternalPath(requestedPath)) {
-    res.status(403).json({ error: 'Access to this path is not allowed' });
+    fail(res, 403, 'Access to this path is not allowed');
     return;
   }
 
@@ -328,13 +332,13 @@ async function handleExternalFileContent(_ctx: RouteContext, req: Request, res: 
   try {
     resolved = await realpath(requestedPath);
   } catch {
-    res.status(404).json({ error: 'File not found' });
+    fail(res, 404, 'File not found');
     return;
   }
 
   // Check again after realpath in case a symlink resolves to a blocked path.
   if (isBlockedExternalPath(resolved)) {
-    res.status(403).json({ error: 'Access to this path is not allowed' });
+    fail(res, 403, 'Access to this path is not allowed');
     return;
   }
 
@@ -343,27 +347,27 @@ async function handleExternalFileContent(_ctx: RouteContext, req: Request, res: 
     fileStat = await stat(resolved);
   } catch (err) {
     logger.warn({ err, path: resolved }, 'Failed to stat external file');
-    res.status(404).json({ error: 'File not found' });
+    fail(res, 404, 'File not found');
     return;
   }
 
   if (!fileStat.isFile()) {
-    res.status(400).json({ error: 'Path is not a file' });
+    fail(res, 400, 'Path is not a file');
     return;
   }
 
   const MAX_SIZE = 2 * 1024 * 1024;
   if (fileStat.size > MAX_SIZE) {
-    res.status(413).json({ error: 'File too large (max 2MB)' });
+    fail(res, 413, 'File too large (max 2MB)');
     return;
   }
 
   try {
     const content = await readFile(resolved, 'utf-8');
-    res.json({ path: resolved, content });
+    ok(res, { path: resolved, content });
   } catch (err) {
     logger.warn({ err, path: resolved }, 'Failed to read external file');
-    res.status(500).json({ error: 'Failed to read file' });
+    fail(res, 500, 'Failed to read file');
   }
 }
 
@@ -371,7 +375,7 @@ async function handleExternalFileContent(_ctx: RouteContext, req: Request, res: 
 async function handleBrowseFilesystem(_ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(BrowseFilesystemQuery, req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    fail(res, 400, parsed.error);
     return;
   }
 
@@ -390,7 +394,7 @@ async function handleBrowseFilesystem(_ctx: RouteContext, req: Request, res: Res
   try {
     real = await realpath(normalized);
   } catch {
-    res.status(404).json({ error: 'Directory not found' });
+    fail(res, 404, 'Directory not found');
     return;
   }
 
@@ -430,10 +434,10 @@ async function handleBrowseFilesystem(_ctx: RouteContext, req: Request, res: Res
       return a.name.localeCompare(b.name);
     });
 
-    res.json({ path: real, entries: resolved });
+    ok(res, { path: real, entries: resolved });
   } catch (err) {
     logger.warn({ err, path: requestedPath }, 'Failed to browse directory');
-    res.status(404).json({ error: 'Directory not found' });
+    fail(res, 404, 'Directory not found');
   }
 }
 

--- a/packages/core/src/server/routes/git-chat.ts
+++ b/packages/core/src/server/routes/git-chat.ts
@@ -8,6 +8,7 @@ import { asyncHandler } from './async-handler.js';
 import { GitService } from '../../git/git-service.js';
 import { createChildLogger } from '../../logger.js';
 import { isNotGitRepo, parseDiffNameStatus, parseStatusBuckets } from '../../git/git-parse.js';
+import { ok, okEmpty, fail } from './respond.js';
 
 const logger = createChildLogger('routes:git-chat');
 
@@ -36,29 +37,32 @@ function chatRoute<T extends { chatId: string; files?: string[] }>(
     const parsed = schema.safeParse(req.body);
     if (!parsed.success) {
       const firstIssue = parsed.error.issues[0];
-      res.status(400).json({ error: firstIssue?.message ?? String(parsed.error) });
+      fail(res, 400, firstIssue?.message ?? String(parsed.error));
       return;
     }
     const data = parsed.data;
     const workDir = ctx.chats.getEffectivePath(data.chatId);
     if (!workDir) {
-      res.status(404).json({ error: 'Chat not found' });
+      fail(res, 404, 'Chat not found');
       return;
     }
     if (opts?.validatePaths && data.files) {
       for (const file of data.files) {
         if (!resolveAndValidatePath(workDir, file)) {
-          res.status(400).json({ error: `Path outside project: ${file}` });
+          fail(res, 400, `Path outside project: ${file}`);
           return;
         }
       }
     }
     try {
       const result = await handler(GitService.forProject(workDir), workDir, data, res);
-      if (!res.headersSent) res.json(result ?? { success: true });
+      if (!res.headersSent) {
+        if (result === undefined) okEmpty(res);
+        else ok(res, result);
+      }
     } catch (err) {
       if (!isNotGitRepo(err)) logger.error({ err, workDir, chatId: data.chatId }, `${label} failed`);
-      res.status(400).json({ error: (err as Error).message ?? 'Unknown error' });
+      fail(res, 400, (err as Error).message ?? 'Unknown error');
     }
   });
 }
@@ -75,13 +79,13 @@ function chatRoute<T extends { chatId: string; files?: string[] }>(
 async function handleDiffSinceMain(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = DiffSinceMainBody.safeParse(req.body);
   if (!parsed.success) {
-    res.status(400).json({ error: String(parsed.error) });
+    fail(res, 400, String(parsed.error));
     return;
   }
   const { chatId, files } = parsed.data;
   const basePath = getEffectivePath(ctx, param(req, 'id'), chatId);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -89,7 +93,7 @@ async function handleDiffSinceMain(ctx: RouteContext, req: Request, res: Respons
     const svc = GitService.forProject(basePath);
     const baseInfo = await svc.detectBaseBranch();
     if (!baseInfo) {
-      res.json({ diffs: {}, baseBranch: null, mergeBase: null });
+      ok(res, { diffs: {}, baseBranch: null, mergeBase: null });
       return;
     }
     const { baseBranch, mergeBase } = baseInfo;
@@ -124,10 +128,10 @@ async function handleDiffSinceMain(ctx: RouteContext, req: Request, res: Respons
       }),
     );
 
-    res.json({ diffs, baseBranch, mergeBase });
+    ok(res, { diffs, baseBranch, mergeBase });
   } catch (err) {
     logger.error({ err, basePath, chatId }, 'Failed to get diff since main');
-    res.status(400).json({ error: (err as Error).message ?? 'Unknown error' });
+    fail(res, 400, (err as Error).message ?? 'Unknown error');
   }
 }
 
@@ -149,7 +153,7 @@ export function gitChatRoutes(ctx: RouteContext): Router {
       'stage',
       async (svc, _wd, { files }) => {
         if (files.length > 0) await svc.stage(files);
-        return { success: true };
+        return;
       },
       { validatePaths: true },
     ),
@@ -163,7 +167,7 @@ export function gitChatRoutes(ctx: RouteContext): Router {
       'unstage',
       async (svc, _wd, { files }) => {
         if (files.length > 0) await svc.unstage(files);
-        return { success: true };
+        return;
       },
       { validatePaths: true },
     ),
@@ -188,10 +192,10 @@ export function gitChatRoutes(ctx: RouteContext): Router {
     chatRoute(ctx, PushBody, 'push', async (svc, _wd, _data, res) => {
       const result = await svc.push();
       if (result.status === 'rejected') {
-        res.status(400).json({ error: result.message ?? 'Push rejected' });
+        fail(res, 400, result.message ?? 'Push rejected');
         return;
       }
-      return { success: true };
+      return;
     }),
   );
 

--- a/packages/core/src/server/routes/git-write.ts
+++ b/packages/core/src/server/routes/git-write.ts
@@ -5,6 +5,7 @@ import { getEffectivePath, param } from './types.js';
 import { asyncHandler } from './async-handler.js';
 import { GitService } from '../../git/git-service.js';
 import { createChildLogger } from '../../logger.js';
+import { ok, okEmpty, fail } from './respond.js';
 import {
   GitCheckoutBody,
   GitCreateBranchBody,
@@ -22,7 +23,7 @@ const logger = createChildLogger('routes:git-write');
 function resolveProject(ctx: RouteContext, req: Request, res: Response): string | null {
   const chatId = (req.query.chatId as string | undefined) ?? (req.body?.chatId as string | undefined);
   const projectPath = getEffectivePath(ctx, param(req, 'id'), chatId);
-  if (!projectPath) res.status(404).json({ error: 'Project not found' });
+  if (!projectPath) fail(res, 404, 'Project not found');
   return projectPath;
 }
 
@@ -37,15 +38,16 @@ function gitRoute<T>(
     if (!projectPath) return;
     const parsed = schema.safeParse(req.body);
     if (!parsed.success) {
-      res.status(400).json({ error: String(parsed.error) });
+      fail(res, 400, String(parsed.error));
       return;
     }
     try {
       const result = await handler(GitService.forProject(projectPath), parsed.data);
-      res.json(result ?? { ok: true });
+      if (result === undefined) okEmpty(res);
+      else ok(res, result);
     } catch (err) {
       logger.warn({ err }, `${label} failed`);
-      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+      fail(res, 500, err instanceof Error ? err.message : String(err));
     }
   });
 }
@@ -56,10 +58,11 @@ function gitRouteNoBody(ctx: RouteContext, handler: (svc: GitService) => Promise
     if (!projectPath) return;
     try {
       const result = await handler(GitService.forProject(projectPath));
-      res.json(result ?? { ok: true });
+      if (result === undefined) okEmpty(res);
+      else ok(res, result);
     } catch (err) {
       logger.warn({ err }, `${label} failed`);
-      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+      fail(res, 500, err instanceof Error ? err.message : String(err));
     }
   });
 }

--- a/packages/core/src/server/routes/git.ts
+++ b/packages/core/src/server/routes/git.ts
@@ -11,6 +11,7 @@ import { createChildLogger } from '../../logger.js';
 import { gitWriteRoutes } from './git-write.js';
 import { gitChatRoutes } from './git-chat.js';
 import { isNotGitRepo, parseDiffNameStatus, parseStatusLines } from '../../git/git-parse.js';
+import { ok, fail } from './respond.js';
 
 const GitDiffQuery = z.object({
   chatId: z.string().optional(),
@@ -28,7 +29,7 @@ const logger = createChildLogger('routes:git');
 async function handleGitStatus(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -36,12 +37,12 @@ async function handleGitStatus(ctx: RouteContext, req: Request, res: Response): 
     const svc = GitService.forProject(basePath);
     const status = await svc.statusRaw();
     const files = parseStatusLines(status);
-    res.json({ files });
+    ok(res, { files });
   } catch (err) {
     if (!isNotGitRepo(err)) {
       logger.warn({ err, basePath }, 'Failed to get git status');
     }
-    res.json({ files: [], error: 'Not a git repository' });
+    ok(res, { files: [], error: 'Not a git repository' });
   }
 }
 
@@ -49,19 +50,19 @@ async function handleGitStatus(ctx: RouteContext, req: Request, res: Response): 
 async function handleGitBranch(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
   try {
     const svc = GitService.forProject(basePath);
     const branch = await svc.currentBranch();
-    res.json({ branch });
+    ok(res, { branch });
   } catch (err) {
     if (!isNotGitRepo(err)) {
       logger.warn({ err, basePath }, 'Failed to get git branch');
     }
-    res.json({ branch: null });
+    ok(res, { branch: null });
   }
 }
 
@@ -69,7 +70,7 @@ async function handleGitBranch(ctx: RouteContext, req: Request, res: Response): 
 async function handleBranchDiffs(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const basePath = getEffectivePath(ctx, param(req, 'id'), req.query.chatId as string | undefined);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -79,7 +80,7 @@ async function handleBranchDiffs(ctx: RouteContext, req: Request, res: Response)
     const baseInfo = await svc.detectBaseBranch();
 
     if (!baseInfo || branch === baseInfo.baseBranch) {
-      res.json({ branch, baseBranch: null, mergeBase: null, files: [] });
+      ok(res, { branch, baseBranch: null, mergeBase: null, files: [] });
       return;
     }
 
@@ -87,12 +88,12 @@ async function handleBranchDiffs(ctx: RouteContext, req: Request, res: Response)
     const committedOutput = await svc.diff(['--name-status', `${mergeBase}..HEAD`]);
     const files = parseDiffNameStatus(committedOutput);
 
-    res.json({ branch, baseBranch, mergeBase, files });
+    ok(res, { branch, baseBranch, mergeBase, files });
   } catch (err) {
     if (!isNotGitRepo(err)) {
       logger.warn({ err, basePath }, 'Failed to compute branch diffs');
     }
-    res.json({ branch: null, baseBranch: null, mergeBase: null, files: [] });
+    ok(res, { branch: null, baseBranch: null, mergeBase: null, files: [] });
   }
 }
 
@@ -100,14 +101,14 @@ async function handleBranchDiffs(ctx: RouteContext, req: Request, res: Response)
 async function handleDiff(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(GitDiffQuery, req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    fail(res, 400, parsed.error);
     return;
   }
 
   const { chatId, file, oldPath, base } = parsed.data;
   const basePath = getEffectivePath(ctx, param(req, 'id'), chatId);
   if (!basePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -129,7 +130,7 @@ async function handleDiff(ctx: RouteContext, req: Request, res: Response): Promi
     if (file) {
       const resolvedFile = resolveAndValidatePath(basePath, file);
       if (!resolvedFile) {
-        res.status(403).json({ error: 'Path outside project' });
+        fail(res, 403, 'Path outside project');
         return;
       }
       try {
@@ -138,12 +139,12 @@ async function handleDiff(ctx: RouteContext, req: Request, res: Response): Promi
         /* deleted file */
       }
     }
-    res.json({ diff, original, modified, source: 'git' });
+    ok(res, { diff, original, modified, source: 'git' });
   } catch (err) {
     if (!isNotGitRepo(err)) {
       logger.warn({ err, basePath, file }, 'Failed to compute git diff');
     }
-    res.json({ diff: '', original: '', modified: '', source: 'git' });
+    ok(res, { diff: '', original: '', modified: '', source: 'git' });
   }
 }
 

--- a/packages/core/src/server/routes/lsp-routes.ts
+++ b/packages/core/src/server/routes/lsp-routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { LspManager } from '../../lsp/lsp-manager.js';
 import type { LspLanguageStatus } from '@qlan-ro/mainframe-types';
 import { asyncHandler } from './async-handler.js';
+import { ok, fail } from './respond.js';
 
 const LspLanguagesQuerySchema = z.object({
   projectId: z.string().min(1),
@@ -16,7 +17,7 @@ export function lspRoutes(manager: LspManager): Router {
     asyncHandler(async (req: Request, res: Response) => {
       const parsed = LspLanguagesQuerySchema.safeParse(req.query);
       if (!parsed.success) {
-        res.status(400).json({ success: false, error: parsed.error.issues });
+        fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
         return;
       }
 
@@ -35,7 +36,7 @@ export function lspRoutes(manager: LspManager): Router {
         }),
       );
 
-      res.json({ languages });
+      ok(res, { languages });
     }),
   );
 

--- a/packages/core/src/server/routes/respond.ts
+++ b/packages/core/src/server/routes/respond.ts
@@ -1,0 +1,16 @@
+import type { Response } from 'express';
+
+/** Send a successful response wrapping `data` in the canonical envelope. */
+export function ok<T>(res: Response, data: T): void {
+  res.json({ success: true, data });
+}
+
+/** Send a successful response with no payload (state-only mutations). */
+export function okEmpty(res: Response): void {
+  res.json({ success: true });
+}
+
+/** Send a failed response with the given HTTP status and error message. */
+export function fail(res: Response, status: number, error: string): void {
+  res.status(status).json({ success: false, error });
+}

--- a/packages/core/src/server/routes/search.ts
+++ b/packages/core/src/server/routes/search.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import type { RouteContext } from './types.js';
 import { getEffectivePath, param } from './types.js';
+import { ok, fail } from './respond.js';
 import type { SearchContentResult } from '@qlan-ro/mainframe-types';
 import { asyncHandler } from './async-handler.js';
 import { isWithinBase } from './path-utils.js';
@@ -87,7 +88,7 @@ async function searchFile(
 async function handleContentSearch(ctx: RouteContext, req: Request, res: Response): Promise<void> {
   const parsed = validate(ContentSearchQuery, req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    fail(res, 400, parsed.error);
     return;
   }
 
@@ -96,7 +97,7 @@ async function handleContentSearch(ctx: RouteContext, req: Request, res: Respons
 
   const rawBasePath = getEffectivePath(ctx, param(req, 'id'), chatId);
   if (!rawBasePath) {
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
@@ -106,13 +107,13 @@ async function handleContentSearch(ctx: RouteContext, req: Request, res: Respons
     basePath = await realpath(rawBasePath);
   } catch (err) {
     logger.warn({ err, rawBasePath }, 'Project base path not resolvable');
-    res.status(404).json({ error: 'Project not found' });
+    fail(res, 404, 'Project not found');
     return;
   }
 
   const resolvedScope = await resolveWithinBase(basePath, scopePath);
   if (!resolvedScope) {
-    res.status(403).json({ error: 'Path outside project' });
+    fail(res, 403, 'Path outside project');
     return;
   }
 
@@ -121,7 +122,7 @@ async function handleContentSearch(ctx: RouteContext, req: Request, res: Respons
     scopeStat = await stat(resolvedScope);
   } catch (err) {
     logger.warn({ err, resolvedScope }, 'Scope path not found during content search');
-    res.status(404).json({ error: 'Path not found' });
+    fail(res, 404, 'Path not found');
     return;
   }
 
@@ -160,7 +161,7 @@ async function handleContentSearch(ctx: RouteContext, req: Request, res: Respons
         allFiles = await listProjectFiles(basePath, { includeIgnored: includeIgnoredFlag });
       } catch (err) {
         logger.warn({ err, basePath }, 'Failed to list project files for content search');
-        res.status(500).json({ error: 'Failed to list project files' });
+        fail(res, 500, 'Failed to list project files');
         return;
       }
 
@@ -197,7 +198,7 @@ async function handleContentSearch(ctx: RouteContext, req: Request, res: Respons
     }
   }
 
-  res.json({ results });
+  ok(res, { results });
 }
 
 export function contentSearchRoutes(ctx: RouteContext): Router {

--- a/packages/core/src/server/routes/worktree.ts
+++ b/packages/core/src/server/routes/worktree.ts
@@ -8,6 +8,7 @@ import { createChildLogger } from '../../logger.js';
 import { getWorktrees, removeWorktree } from '../../workspace/index.js';
 import { GitDeleteWorktreeBody } from './schemas.js';
 import { killTasksForChat } from '../../background-tasks/kill.js';
+import { ok, okEmpty, fail } from './respond.js';
 
 const log = createChildLogger('routes:worktree');
 
@@ -109,16 +110,16 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       const chatId = param(req, 'id');
       const parsed = EnableWorktreeBody.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' });
+        fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
         return;
       }
       try {
         await ctx.chats.enableWorktree(chatId, parsed.data.baseBranch, parsed.data.branchName);
-        res.json({ success: true });
+        okEmpty(res);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to enable worktree';
         log.warn({ err, chatId }, 'enable-worktree failed');
-        res.status(400).json({ error: message });
+        fail(res, 400, message);
       }
     }),
   );
@@ -129,11 +130,11 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       const chatId = param(req, 'id');
       try {
         await ctx.chats.disableWorktree(chatId);
-        res.json({ success: true });
+        okEmpty(res);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to disable worktree';
         log.warn({ err, chatId }, 'disable-worktree failed');
-        res.status(400).json({ error: message });
+        fail(res, 400, message);
       }
     }),
   );
@@ -144,17 +145,17 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       const chatId = param(req, 'id');
       const parsed = ForkWorktreeBody.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' });
+        fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
         return;
       }
       try {
         const result = await ctx.chats.forkToWorktree(chatId, parsed.data.baseBranch, parsed.data.branchName);
-        res.json({ success: true, chatId: result.chatId });
+        ok(res, { chatId: result.chatId });
       } catch (err) {
         const statusCode = (err as Error & { statusCode?: number }).statusCode ?? 500;
         const message = err instanceof Error ? err.message : 'Failed to fork to worktree';
         log.warn({ err, chatId }, 'fork-worktree failed');
-        res.status(statusCode).json({ error: message });
+        fail(res, statusCode, message);
       }
     }),
   );
@@ -164,12 +165,12 @@ export function worktreeRoutes(ctx: RouteContext): Router {
     asyncHandler(async (req, res) => {
       const projectPath = getProjectPath(ctx, param(req, 'id'));
       if (!projectPath) {
-        res.status(404).json({ error: 'Project not found' });
+        fail(res, 404, 'Project not found');
         return;
       }
       const worktrees = await getWorktrees(projectPath);
       const filtered = worktrees.filter((wt) => wt.path !== projectPath);
-      res.json({ worktrees: filtered });
+      ok(res, { worktrees: filtered });
     }),
   );
 
@@ -179,16 +180,16 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       const chatId = param(req, 'id');
       const parsed = AttachWorktreeBody.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' });
+        fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
         return;
       }
       try {
         await ctx.chats.attachWorktree(chatId, parsed.data.worktreePath, parsed.data.branchName);
-        res.json({ success: true });
+        okEmpty(res);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to attach worktree';
         log.warn({ err, chatId }, 'attach-worktree failed');
-        res.status(400).json({ error: message });
+        fail(res, 400, message);
       }
     }),
   );
@@ -199,22 +200,22 @@ export function worktreeRoutes(ctx: RouteContext): Router {
       const projectId = param(req, 'id');
       const projectPath = getProjectPath(ctx, projectId);
       if (!projectPath) {
-        res.status(404).json({ error: 'Project not found' });
+        fail(res, 404, 'Project not found');
         return;
       }
       const parsed = GitDeleteWorktreeBody.safeParse(req.body);
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' });
+        fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
         return;
       }
       const { worktreePath, branchName } = parsed.data;
       try {
         await validateAndDeleteWorktree(ctx, projectId, projectPath, worktreePath, branchName);
-        res.json({ success: true });
+        okEmpty(res);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to delete worktree';
         log.warn({ err, projectId, worktreePath }, 'delete-worktree failed');
-        res.status(400).json({ error: message });
+        fail(res, 400, message);
       }
     }),
   );

--- a/packages/desktop/src/renderer/lib/api/attachments-api.ts
+++ b/packages/desktop/src/renderer/lib/api/attachments-api.ts
@@ -1,3 +1,4 @@
+import type { ApiResponse } from '@qlan-ro/mainframe-types';
 import { fetchJson, API_BASE } from './http';
 import { createLogger } from '../logger';
 
@@ -14,7 +15,18 @@ export async function getAttachment(
   data: string;
   originalPath?: string;
 }> {
-  return fetchJson(`${API_BASE}/api/chats/${chatId}/attachments/${attachmentId}`);
+  const json = await fetchJson<
+    ApiResponse<{
+      name: string;
+      mediaType: string;
+      sizeBytes: number;
+      kind: 'image' | 'file';
+      data: string;
+      originalPath?: string;
+    }>
+  >(`${API_BASE}/api/chats/${chatId}/attachments/${attachmentId}`);
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function uploadAttachments(

--- a/packages/desktop/src/renderer/lib/api/background-tasks-api.ts
+++ b/packages/desktop/src/renderer/lib/api/background-tasks-api.ts
@@ -1,10 +1,12 @@
-import type { BackgroundTask } from '@qlan-ro/mainframe-types';
+import type { BackgroundTask, ApiResponse } from '@qlan-ro/mainframe-types';
 import { API_BASE } from './http.js';
 
 export async function listBackgroundTasks(chatId: string): Promise<{ tasks: BackgroundTask[] }> {
   const res = await fetch(`${API_BASE}/api/chats/${encodeURIComponent(chatId)}/background-tasks`);
   if (!res.ok) throw new Error(`listBackgroundTasks ${res.status}`);
-  return res.json();
+  const json = (await res.json()) as ApiResponse<{ tasks: BackgroundTask[] }>;
+  if (!json.success) throw new Error(`listBackgroundTasks: ${json.error}`);
+  return json.data;
 }
 
 export async function getBackgroundTaskOutput(chatId: string, taskId: string, bytes?: number): Promise<string> {
@@ -14,8 +16,8 @@ export async function getBackgroundTaskOutput(chatId: string, taskId: string, by
   if (bytes !== undefined) url.searchParams.set('bytes', String(bytes));
   const res = await fetch(url);
   if (res.status === 409) {
-    const body = (await res.json().catch(() => ({}))) as { reason?: string };
-    throw new Error(`no_output: ${body.reason ?? 'unknown'}`);
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(`no_output: ${body.error ?? 'unknown'}`);
   }
   if (!res.ok) throw new Error(`getBackgroundTaskOutput ${res.status}`);
   return res.text();

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -82,7 +82,11 @@ export async function getSessionContext(chatId: string): Promise<SessionContext>
 }
 
 export async function getSessionFile(chatId: string, filePath: string): Promise<{ path: string; content: string }> {
-  return fetchJson(`${API_BASE}/api/chats/${chatId}/session-file?path=${encodeURIComponent(filePath)}`);
+  const json = await fetchJson<ApiResponse<{ path: string; content: string }>>(
+    `${API_BASE}/api/chats/${chatId}/session-file?path=${encodeURIComponent(filePath)}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function addMention(

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -1,4 +1,4 @@
-import type { ControlRequest, SessionContext, SearchContentResult } from '@qlan-ro/mainframe-types';
+import type { ApiResponse, ControlRequest, SessionContext, SearchContentResult } from '@qlan-ro/mainframe-types';
 import { fetchJson, postJson, putJson, API_BASE } from './http';
 
 export async function getFileTree(
@@ -123,6 +123,7 @@ export async function searchContent(
   if (chatId) params.set('chatId', chatId);
   const res = await fetch(`${API_BASE}/api/projects/${projectId}/search/content?${params}`, { signal });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const json = await res.json();
-  return json.results;
+  const json = (await res.json()) as ApiResponse<{ results: SearchContentResult[] }>;
+  if (!json.success) throw new Error(json.error);
+  return json.data.results;
 }

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -100,7 +100,9 @@ export async function getPendingPermission(chatId: string): Promise<ControlReque
 }
 
 export async function getSessionFiles(chatId: string): Promise<{ files: string[] }> {
-  return fetchJson(`${API_BASE}/api/chats/${chatId}/session-files`);
+  const json = await fetchJson<ApiResponse<{ files: string[] }>>(`${API_BASE}/api/chats/${chatId}/session-files`);
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getSessionContext(chatId: string): Promise<SessionContext> {

--- a/packages/desktop/src/renderer/lib/api/files-api.ts
+++ b/packages/desktop/src/renderer/lib/api/files-api.ts
@@ -8,12 +8,18 @@ export async function getFileTree(
 ): Promise<{ name: string; type: 'file' | 'directory'; path: string }[]> {
   const params = new URLSearchParams({ path: dirPath });
   if (chatId) params.set('chatId', chatId);
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/tree?${params}`);
+  const json = await fetchJson<ApiResponse<{ name: string; type: 'file' | 'directory'; path: string }[]>>(
+    `${API_BASE}/api/projects/${projectId}/tree?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getFilesList(projectId: string, chatId?: string): Promise<string[]> {
   const params = chatId ? `?chatId=${chatId}` : '';
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/files-list${params}`);
+  const json = await fetchJson<ApiResponse<string[]>>(`${API_BASE}/api/projects/${projectId}/files-list${params}`);
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function searchFiles(
@@ -24,7 +30,11 @@ export async function searchFiles(
 ): Promise<{ name: string; path: string; type: string }[]> {
   const params = new URLSearchParams({ q: query, limit: String(limit) });
   if (chatId) params.set('chatId', chatId);
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/search/files?${params}`);
+  const json = await fetchJson<ApiResponse<{ name: string; path: string; type: string }[]>>(
+    `${API_BASE}/api/projects/${projectId}/search/files?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getFileContent(
@@ -34,7 +44,11 @@ export async function getFileContent(
 ): Promise<{ path: string; content: string }> {
   const params = new URLSearchParams({ path: filePath });
   if (chatId) params.set('chatId', chatId);
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/files?${params}`);
+  const json = await fetchJson<ApiResponse<{ path: string; content: string }>>(
+    `${API_BASE}/api/projects/${projectId}/files?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function saveFileContent(
@@ -43,7 +57,12 @@ export async function saveFileContent(
   content: string,
   chatId?: string,
 ): Promise<void> {
-  await putJson(`${API_BASE}/api/projects/${projectId}/files`, { path: filePath, content, chatId });
+  const json = await putJson<ApiResponse<{ path: string }>>(`${API_BASE}/api/projects/${projectId}/files`, {
+    path: filePath,
+    content,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
 }
 
 /**
@@ -52,7 +71,11 @@ export async function saveFileContent(
  */
 export async function getExternalFileContent(absolutePath: string): Promise<{ path: string; content: string }> {
   const params = new URLSearchParams({ path: absolutePath });
-  return fetchJson(`${API_BASE}/api/files/external?${params}`);
+  const json = await fetchJson<ApiResponse<{ path: string; content: string }>>(
+    `${API_BASE}/api/files/external?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getFileBinary(
@@ -62,7 +85,11 @@ export async function getFileBinary(
 ): Promise<{ path: string; content: string; encoding: 'base64' }> {
   const params = new URLSearchParams({ path: filePath, encoding: 'base64' });
   if (chatId) params.set('chatId', chatId);
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/files?${params}`);
+  const json = await fetchJson<ApiResponse<{ path: string; content: string; encoding: 'base64' }>>(
+    `${API_BASE}/api/projects/${projectId}/files?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getPendingPermission(chatId: string): Promise<ControlRequest | null> {
@@ -111,7 +138,11 @@ export async function browseFilesystem(
   if (opts?.includeFiles) params.set('includeFiles', 'true');
   if (opts?.includeHidden) params.set('includeHidden', 'true');
   const qs = params.toString();
-  return fetchJson(`${API_BASE}/api/filesystem/browse${qs ? `?${qs}` : ''}`);
+  const json = await fetchJson<ApiResponse<{ path: string; entries: BrowseEntry[] }>>(
+    `${API_BASE}/api/filesystem/browse${qs ? `?${qs}` : ''}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function searchContent(

--- a/packages/desktop/src/renderer/lib/api/git-api.ts
+++ b/packages/desktop/src/renderer/lib/api/git-api.ts
@@ -7,6 +7,7 @@ import type {
   RebaseResult,
   DeleteBranchResult,
   UpdateAllResult,
+  ApiResponse,
 } from '@qlan-ro/mainframe-types';
 import { fetchJson, postJson, API_BASE } from './http';
 
@@ -25,11 +26,19 @@ export async function getGitStatus(
 
 export async function getGitBranches(projectId: string, chatId?: string): Promise<BranchListResult> {
   const params = chatId ? `?chatId=${chatId}` : '';
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/branches${params}`);
+  const json = await fetchJson<ApiResponse<BranchListResult>>(
+    `${API_BASE}/api/projects/${projectId}/git/branches${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitCheckout(projectId: string, branch: string, chatId?: string): Promise<void> {
-  await postJson(`${API_BASE}/api/projects/${projectId}/git/checkout`, { branch, chatId });
+  const json = await postJson<ApiResponse<unknown>>(`${API_BASE}/api/projects/${projectId}/git/checkout`, {
+    branch,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
 }
 
 export async function gitCreateBranch(
@@ -38,11 +47,21 @@ export async function gitCreateBranch(
   startPoint?: string,
   chatId?: string,
 ): Promise<void> {
-  await postJson(`${API_BASE}/api/projects/${projectId}/git/branch`, { name, startPoint, chatId });
+  const json = await postJson<ApiResponse<unknown>>(`${API_BASE}/api/projects/${projectId}/git/branch`, {
+    name,
+    startPoint,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
 }
 
 export async function gitFetch(projectId: string, remote?: string, chatId?: string): Promise<FetchResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/fetch`, { remote, chatId });
+  const json = await postJson<ApiResponse<FetchResult>>(`${API_BASE}/api/projects/${projectId}/git/fetch`, {
+    remote,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitPull(
@@ -52,7 +71,14 @@ export async function gitPull(
   localBranch?: string,
   chatId?: string,
 ): Promise<PullResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/pull`, { remote, branch, localBranch, chatId });
+  const json = await postJson<ApiResponse<PullResult>>(`${API_BASE}/api/projects/${projectId}/git/pull`, {
+    remote,
+    branch,
+    localBranch,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitPush(
@@ -61,19 +87,39 @@ export async function gitPush(
   remote?: string,
   chatId?: string,
 ): Promise<PushResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/push`, { branch, remote, chatId });
+  const json = await postJson<ApiResponse<PushResult>>(`${API_BASE}/api/projects/${projectId}/git/push`, {
+    branch,
+    remote,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitMerge(projectId: string, branch: string, chatId?: string): Promise<MergeResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/merge`, { branch, chatId });
+  const json = await postJson<ApiResponse<MergeResult>>(`${API_BASE}/api/projects/${projectId}/git/merge`, {
+    branch,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitRebase(projectId: string, branch: string, chatId?: string): Promise<RebaseResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/rebase`, { branch, chatId });
+  const json = await postJson<ApiResponse<RebaseResult>>(`${API_BASE}/api/projects/${projectId}/git/rebase`, {
+    branch,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitAbort(projectId: string, chatId?: string): Promise<{ aborted: boolean }> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/abort`, { chatId });
+  const json = await postJson<ApiResponse<{ aborted: boolean }>>(`${API_BASE}/api/projects/${projectId}/git/abort`, {
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitRenameBranch(
@@ -82,7 +128,12 @@ export async function gitRenameBranch(
   newName: string,
   chatId?: string,
 ): Promise<void> {
-  await postJson(`${API_BASE}/api/projects/${projectId}/git/rename-branch`, { oldName, newName, chatId });
+  const json = await postJson<ApiResponse<unknown>>(`${API_BASE}/api/projects/${projectId}/git/rename-branch`, {
+    oldName,
+    newName,
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
 }
 
 export async function gitDeleteBranch(
@@ -92,11 +143,20 @@ export async function gitDeleteBranch(
   remote?: boolean,
   chatId?: string,
 ): Promise<DeleteBranchResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/delete-branch`, { name, force, remote, chatId });
+  const json = await postJson<ApiResponse<DeleteBranchResult>>(
+    `${API_BASE}/api/projects/${projectId}/git/delete-branch`,
+    { name, force, remote, chatId },
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function gitUpdateAll(projectId: string, chatId?: string): Promise<UpdateAllResult> {
-  return postJson(`${API_BASE}/api/projects/${projectId}/git/update-all`, { chatId });
+  const json = await postJson<ApiResponse<UpdateAllResult>>(`${API_BASE}/api/projects/${projectId}/git/update-all`, {
+    chatId,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getDiff(

--- a/packages/desktop/src/renderer/lib/api/git-api.ts
+++ b/packages/desktop/src/renderer/lib/api/git-api.ts
@@ -13,7 +13,11 @@ import { fetchJson, postJson, API_BASE } from './http';
 
 export async function getGitBranch(projectId: string, chatId?: string): Promise<{ branch: string | null }> {
   const params = chatId ? `?chatId=${chatId}` : '';
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/branch${params}`);
+  const json = await fetchJson<ApiResponse<{ branch: string | null }>>(
+    `${API_BASE}/api/projects/${projectId}/git/branch${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getGitStatus(
@@ -21,7 +25,11 @@ export async function getGitStatus(
   chatId?: string,
 ): Promise<{ files: { status: string; path: string }[] }> {
   const params = chatId ? `?chatId=${chatId}` : '';
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/status${params}`);
+  const json = await fetchJson<ApiResponse<{ files: { status: string; path: string }[] }>>(
+    `${API_BASE}/api/projects/${projectId}/git/status${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getGitBranches(projectId: string, chatId?: string): Promise<BranchListResult> {
@@ -171,7 +179,11 @@ export async function getDiff(
   if (chatId) params.set('chatId', chatId);
   if (oldPath) params.set('oldPath', oldPath);
   if (base) params.set('base', base);
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/diff?${params}`);
+  const json = await fetchJson<ApiResponse<{ original: string; modified: string; diff?: string; source: string }>>(
+    `${API_BASE}/api/projects/${projectId}/git/diff?${params}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export interface BranchDiffResponse {
@@ -185,5 +197,9 @@ export async function getBranchDiffs(projectId: string, chatId?: string): Promis
   const params = new URLSearchParams();
   if (chatId) params.set('chatId', chatId);
   const qs = params.toString();
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/branch-diffs${qs ? `?${qs}` : ''}`);
+  const json = await fetchJson<ApiResponse<BranchDiffResponse>>(
+    `${API_BASE}/api/projects/${projectId}/git/branch-diffs${qs ? `?${qs}` : ''}`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }

--- a/packages/desktop/src/renderer/lib/api/git.ts
+++ b/packages/desktop/src/renderer/lib/api/git.ts
@@ -1,4 +1,5 @@
 import { postJson, API_BASE } from './http';
+import type { ApiResponse } from '@qlan-ro/mainframe-types';
 
 export interface GitDiffResponse {
   diffs: Record<string, { main: string; worktree: string }>;
@@ -14,26 +15,42 @@ export interface GitStatusResponse {
 
 export const gitApi = {
   async getDiff(projectId: string, chatId: string, files?: string[]): Promise<GitDiffResponse> {
-    return postJson(`${API_BASE}/api/projects/${projectId}/git/diff-since-main`, { chatId, files });
+    const json = await postJson<ApiResponse<GitDiffResponse>>(
+      `${API_BASE}/api/projects/${projectId}/git/diff-since-main`,
+      { chatId, files },
+    );
+    if (!json.success) throw new Error(json.error);
+    return json.data;
   },
 
   async getStatus(chatId: string): Promise<GitStatusResponse> {
-    return postJson(`${API_BASE}/api/git/status`, { chatId });
+    const json = await postJson<ApiResponse<GitStatusResponse>>(`${API_BASE}/api/git/status`, { chatId });
+    if (!json.success) throw new Error(json.error);
+    return json.data;
   },
 
-  async stageFiles(chatId: string, files: string[]): Promise<{ success: boolean }> {
-    return postJson(`${API_BASE}/api/git/stage`, { chatId, files });
+  async stageFiles(chatId: string, files: string[]): Promise<void> {
+    const json = await postJson<ApiResponse<never>>(`${API_BASE}/api/git/stage`, { chatId, files });
+    if (!json.success) throw new Error(json.error);
   },
 
-  async unstageFiles(chatId: string, files: string[]): Promise<{ success: boolean }> {
-    return postJson(`${API_BASE}/api/git/unstage`, { chatId, files });
+  async unstageFiles(chatId: string, files: string[]): Promise<void> {
+    const json = await postJson<ApiResponse<never>>(`${API_BASE}/api/git/unstage`, { chatId, files });
+    if (!json.success) throw new Error(json.error);
   },
 
   async commit(chatId: string, message: string, files: string[]): Promise<{ hash: string }> {
-    return postJson(`${API_BASE}/api/git/commit`, { chatId, message, files });
+    const json = await postJson<ApiResponse<{ hash: string }>>(`${API_BASE}/api/git/commit`, {
+      chatId,
+      message,
+      files,
+    });
+    if (!json.success) throw new Error(json.error);
+    return json.data;
   },
 
-  async push(chatId: string): Promise<{ success: boolean }> {
-    return postJson(`${API_BASE}/api/git/push`, { chatId });
+  async push(chatId: string): Promise<void> {
+    const json = await postJson<ApiResponse<never>>(`${API_BASE}/api/git/push`, { chatId });
+    if (!json.success) throw new Error(json.error);
   },
 };

--- a/packages/desktop/src/renderer/lib/api/worktree-api.ts
+++ b/packages/desktop/src/renderer/lib/api/worktree-api.ts
@@ -1,3 +1,4 @@
+import type { ApiResponse } from '@qlan-ro/mainframe-types';
 import { API_BASE, fetchJson, postJson } from './http';
 
 export async function enableWorktree(chatId: string, baseBranch: string, branchName: string): Promise<void> {
@@ -13,13 +14,22 @@ export async function forkToWorktree(
   baseBranch: string,
   branchName: string,
 ): Promise<{ chatId: string }> {
-  return postJson<{ chatId: string }>(`${API_BASE}/api/chats/${chatId}/fork-worktree`, { baseBranch, branchName });
+  const json = await postJson<ApiResponse<{ chatId: string }>>(`${API_BASE}/api/chats/${chatId}/fork-worktree`, {
+    baseBranch,
+    branchName,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function getWorktrees(
   projectId: string,
 ): Promise<{ worktrees: { path: string; branch: string | null }[] }> {
-  return fetchJson(`${API_BASE}/api/projects/${projectId}/git/worktrees`);
+  const json = await fetchJson<ApiResponse<{ worktrees: { path: string; branch: string | null }[] }>>(
+    `${API_BASE}/api/projects/${projectId}/git/worktrees`,
+  );
+  if (!json.success) throw new Error(json.error);
+  return json.data;
 }
 
 export async function attachWorktree(chatId: string, worktreePath: string, branchName: string): Promise<void> {

--- a/packages/desktop/src/renderer/lib/lsp/lsp-client.ts
+++ b/packages/desktop/src/renderer/lib/lsp/lsp-client.ts
@@ -34,7 +34,12 @@ async function discoverWorkspaceFolders(
   const base = getDaemonHttpUrl();
   try {
     const res = await fetch(`${base}/api/projects/${projectId}/search/files?q=tsconfig.json&limit=20`);
-    const files: { path: string; type: string }[] = await res.json();
+    const envelope = (await res.json()) as {
+      success: boolean;
+      data?: { path: string; type: string }[];
+      error?: string;
+    };
+    const files: { path: string; type: string }[] = envelope.success && envelope.data ? envelope.data : [];
     const dirs = new Set<string>();
     for (const f of files) {
       if (f.type !== 'file' || !f.path.endsWith('tsconfig.json')) continue;
@@ -284,9 +289,11 @@ export class LspClientManager {
     const base = getDaemonHttpUrl();
     fetch(`${base}/api/projects/${projectId}/files?path=${encodeURIComponent(filePath)}`)
       .then((r) => r.json())
-      .then((data: { content: string }) => {
+      .then((envelope: { success: boolean; data?: { content: string } }) => {
+        const content = envelope.success && envelope.data ? envelope.data.content : undefined;
+        if (content === undefined) return;
         this.sendNotification(entry, 'textDocument/didOpen', {
-          textDocument: { uri, languageId: language, version: 1, text: data.content },
+          textDocument: { uri, languageId: language, version: 1, text: content },
         });
       })
       .catch((err) => console.warn('[lsp] preloadDocument didOpen failed', err));

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,0 +1,11 @@
+/** Successful response carrying a payload. */
+export type ApiOk<T> = { success: true; data: T };
+
+/** Successful response with no payload (state-only mutations). */
+export type ApiOkEmpty = { success: true };
+
+/** Failed response. `error` is a human-readable message. */
+export type ApiErr = { success: false; error: string };
+
+/** Canonical daemon HTTP response envelope. */
+export type ApiResponse<T> = ApiOk<T> | ApiErr;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,6 +15,7 @@ export * from './lsp.js';
 export * from './git.js';
 export * from './__fixtures__/ask-user-question.js';
 export * from './background-task.js';
+export * from './api.js';
 export type {
   PluginCapability,
   PluginManifest,


### PR DESCRIPTION
## Summary

Normalizes the entire daemon HTTP API to **one response envelope**, replacing the previous mix of bare objects, bare arrays, `{ tasks }`, `{ ok: true }`, `{ reason }`, and `{ success, data }`.

Canonical shape:
- Success with payload: `{ success: true, data: T }`
- State-only mutation: `{ success: true }`
- Failure: `{ success: false, error: string }` (HTTP status preserved)

Internal, same-version API (daemon ships with desktop/mobile). No user-facing behavior change.

## What changed

**Foundation:** `ApiResponse<T>` type in `@qlan-ro/mainframe-types` + `ok`/`okEmpty`/`fail` server helpers.

**Routes migrated** (each with desktop consumer + tests, per-family commits): search · background-tasks (outlier) · lsp · context session-file · git-write (12 endpoints) · git reads · git-chat · files · worktree · attachments-serve · chats session-files.

## Decisions (Opus review of the initial draft)

1. **Errors stay `error: string`** (not structured `{ code, message, details }`) — no consumer branches on a code; would churn every error test for zero benefit. Optional `code?` can be added later, non-breaking.
2. **`{ success: true }` (no `data`) is valid** for state-only mutations — no fabricated echo payloads.
3. **Git read soft-errors stay `success: true`** — not-a-git-repo returns `{ success: true, data: { branch: null } }`, preserving the empty-state UX (a `fail` would make the client throw).
4. **Per-family coordinated commits**, green at every step — no big-bang, no risky central `fetchJson` unwrap flip.

## Clients
- **Desktop** consumers read `json.data` / check `json.success`.
- **Mobile** needs no change — its `fetchJson` already unwraps (`'data' in body ? body.data : body`), tolerating both shapes.

## Verification
- `pnpm build` — clean, **0 type errors**.
- `pnpm test` — green: types 3, mobile 8, core 1570, desktop 746.
- Also fixed a pre-existing `search.test.ts` timing flake (await the handler vs 50ms `flushPromises`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)