### PR TITLE
fix(core): realign test fixtures with current types (35 tsc errors)

### DIFF
--- a/.changeset/orange-days-move.md
+++ b/.changeset/orange-days-move.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: realign `@qlan-ro/mainframe-core` test fixtures with current types (no runtime/API change, so no changelog entry).

--- a/packages/core/src/__tests__/adapter-events-flow.test.ts
+++ b/packages/core/src/__tests__/adapter-events-flow.test.ts
@@ -173,7 +173,7 @@ describe('adapter events flow', () => {
     const events = await setup(adapter);
 
     adapter.currentSession!.simulateToolResult([
-      { type: 'tool_result', toolUseId: 'tu-1', content: 'wrote file successfully' },
+      { type: 'tool_result', toolUseId: 'tu-1', content: 'wrote file successfully', isError: false },
     ]);
     await sleep(50);
 

--- a/packages/core/src/__tests__/chat-resume.test.ts
+++ b/packages/core/src/__tests__/chat-resume.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { describe, it, expect, afterEach, vi, type Mock } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { WebSocket } from 'ws';
 import { WebSocketManager } from '../server/websocket.js';
@@ -30,6 +30,7 @@ function createMockChatManager(chatOverride?: Partial<Chat>): MockChatManager {
         totalCost: 0,
         totalTokensInput: 0,
         totalTokensOutput: 0,
+        lastContextTokensInput: 0,
         ...chatOverride,
       }
     : null;
@@ -123,7 +124,7 @@ describe('chat.resume auto-start', () => {
 
   it('auto-starts Plan sessions with processState=working and no pending permission', async () => {
     const chats = createMockChatManager({
-      permissionMode: 'plan',
+      planMode: true,
       processState: 'working',
     });
     chats.hasPendingPermission.mockReturnValue(false);
@@ -155,7 +156,7 @@ describe('chat.resume auto-start', () => {
 
   it('does NOT auto-start non-YOLO sessions with pending permission', async () => {
     const chats = createMockChatManager({
-      permissionMode: 'plan',
+      planMode: true,
       processState: 'working',
     });
     chats.hasPendingPermission.mockReturnValue(true);

--- a/packages/core/src/__tests__/claude-external-sessions.test.ts
+++ b/packages/core/src/__tests__/claude-external-sessions.test.ts
@@ -77,7 +77,7 @@ describe('listExternalSessions', () => {
         if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
         return [] as unknown as never;
       });
-      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
 
       const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
@@ -107,7 +107,7 @@ describe('listExternalSessions', () => {
         if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
         return [] as unknown as never;
       });
-      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
 
       const result = await listExternalSessions('/test/project', ['exclude-me']);
       expect(result).toHaveLength(1);
@@ -139,7 +139,7 @@ describe('listExternalSessions', () => {
         if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
         return [] as unknown as never;
       });
-      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
 
       const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
@@ -171,7 +171,7 @@ describe('listExternalSessions', () => {
         if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
         return [] as unknown as never;
       });
-      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
 
       const result = await listExternalSessions('/test/project', []);
       expect(result[0]!.sessionId).toBe('newer');
@@ -196,7 +196,7 @@ describe('listExternalSessions', () => {
         if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
         return [] as unknown as never;
       });
-      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+      mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
 
       const result = await listExternalSessions('/test/project', []);
       expect(result).toHaveLength(1);
@@ -252,8 +252,8 @@ describe('listExternalSessions', () => {
         return [] as unknown as never;
       });
       mockReadFile
-        .mockResolvedValueOnce(JSON.stringify(indexMain) as unknown as ArrayBuffer)
-        .mockResolvedValueOnce(JSON.stringify(indexWorktree) as unknown as ArrayBuffer);
+        .mockResolvedValueOnce(JSON.stringify(indexMain) as unknown as string)
+        .mockResolvedValueOnce(JSON.stringify(indexWorktree) as unknown as string);
 
       const result = await listExternalSessions('/test/project', []);
       const ids = result.map((s) => s.sessionId).sort();
@@ -458,7 +458,7 @@ describe('listExternalSessions', () => {
       if (s.endsWith(path.join('.claude', 'projects'))) return ['-test-project'] as unknown as never;
       return [] as unknown as never;
     });
-    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as ArrayBuffer);
+    mockReadFile.mockResolvedValue(JSON.stringify(index) as unknown as string);
     mockStat.mockResolvedValue({ mtime: new Date('2025-12-31T00:00:00Z') } as never);
 
     const result = await listExternalSessions('/test/project', []);

--- a/packages/core/src/__tests__/codex-jsonrpc.test.ts
+++ b/packages/core/src/__tests__/codex-jsonrpc.test.ts
@@ -42,7 +42,7 @@ describe('JsonRpcClient', () => {
       written.push(data);
       if (typeof cb === 'function') cb();
       return true;
-    }) as unknown as typeof proc.stdin.write;
+    }) as unknown as NonNullable<typeof proc.stdin>['write'];
 
     const client = createClient(proc);
     const promise = client.request<{ thread: { id: string } }>('thread/start', { cwd: '/tmp' });
@@ -68,7 +68,7 @@ describe('JsonRpcClient', () => {
       written.push(data);
       if (typeof cb === 'function') cb();
       return true;
-    }) as unknown as typeof proc.stdin.write;
+    }) as unknown as NonNullable<typeof proc.stdin>['write'];
 
     const client = createClient(proc);
     const promise = client.request('model/list');
@@ -125,7 +125,7 @@ describe('JsonRpcClient', () => {
       written.push(data);
       if (typeof cb === 'function') cb();
       return true;
-    }) as unknown as typeof proc.stdin.write;
+    }) as unknown as NonNullable<typeof proc.stdin>['write'];
 
     const client = createClient(proc);
     client.respond(99, { decision: 'accept' });
@@ -154,7 +154,7 @@ describe('JsonRpcClient', () => {
       written.push(data);
       if (typeof cb === 'function') cb();
       return true;
-    }) as unknown as typeof proc.stdin.write;
+    }) as unknown as NonNullable<typeof proc.stdin>['write'];
 
     const client = createClient(proc);
     const promise = client.request('thread/start');

--- a/packages/core/src/__tests__/codex-session.test.ts
+++ b/packages/core/src/__tests__/codex-session.test.ts
@@ -66,7 +66,7 @@ describe('CodexSession', () => {
   });
 
   it('spawns codex app-server with correct args', async () => {
-    const session = new CodexSession({ projectPath: '/tmp/project' });
+    const session = new CodexSession({ projectPath: '/tmp/project', mainframeChatId: 'test-chat' });
     const sink = createSink();
 
     // Spawn will start the handshake which will hang, so we simulate the response
@@ -92,17 +92,17 @@ describe('CodexSession', () => {
   });
 
   it('sets adapterId to codex', () => {
-    const session = new CodexSession({ projectPath: '/tmp' });
+    const session = new CodexSession({ projectPath: '/tmp', mainframeChatId: 'test-chat' });
     expect(session.adapterId).toBe('codex');
   });
 
   it('isSpawned returns false before spawn', () => {
-    const session = new CodexSession({ projectPath: '/tmp' });
+    const session = new CodexSession({ projectPath: '/tmp', mainframeChatId: 'test-chat' });
     expect(session.isSpawned).toBe(false);
   });
 
   it('maps yolo permission mode to never approval + danger-full-access sandbox', async () => {
-    const session = new CodexSession({ projectPath: '/tmp/project' });
+    const session = new CodexSession({ projectPath: '/tmp/project', mainframeChatId: 'test-chat' });
     const sink = createSink();
 
     const spawnPromise = session.spawn({ permissionMode: 'yolo' }, sink);
@@ -146,7 +146,7 @@ describe('CodexSession', () => {
   });
 
   it('kill calls close on client', async () => {
-    const session = new CodexSession({ projectPath: '/tmp' });
+    const session = new CodexSession({ projectPath: '/tmp', mainframeChatId: 'test-chat' });
     const sink = createSink();
 
     const spawnPromise = session.spawn({}, sink);

--- a/packages/core/src/__tests__/control-requests.test.ts
+++ b/packages/core/src/__tests__/control-requests.test.ts
@@ -148,6 +148,7 @@ function createMockDb(chat?: Partial<Chat>) {
     totalCost: 0,
     totalTokensInput: 0,
     totalTokensOutput: 0,
+    lastContextTokensInput: 0,
     processState: 'idle',
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -242,7 +243,7 @@ describe('ChatManager.updateChatConfig — in-flight control requests', () => {
   let registry: AdapterRegistry;
   let claude: ClaudeAdapter;
   let db: ReturnType<typeof createMockDb>;
-  let killSpy: ReturnType<typeof vi.fn>;
+  let killSpy: ReturnType<typeof vi.fn<() => void>>;
   let spawnCount: number;
   let currentMockSession: MockClaudeSession | null;
   let capturedEvents: any[];
@@ -256,7 +257,7 @@ describe('ChatManager.updateChatConfig — in-flight control requests', () => {
     registry.register(new ClaudeAdapter());
     claude = registry.get('claude') as ClaudeAdapter;
 
-    killSpy = vi.fn();
+    killSpy = vi.fn<() => void>();
     spawnCount = 0;
     currentMockSession = null;
     capturedEvents = [];
@@ -326,12 +327,12 @@ describe('ChatManager.updateChatConfig — in-flight control requests', () => {
   });
 
   it('emits chat.updated event on in-flight config change', async () => {
-    await manager.updateChatConfig(chatId, undefined, 'claude-sonnet-4-5-20250929', 'plan');
+    await manager.updateChatConfig(chatId, undefined, 'claude-sonnet-4-5-20250929', undefined, true);
 
     const chatUpdated = capturedEvents.find((e) => e.type === 'chat.updated');
     expect(chatUpdated).toBeTruthy();
     expect(chatUpdated.chat.model).toBe('claude-sonnet-4-5-20250929');
-    expect(chatUpdated.chat.permissionMode).toBe('plan');
+    expect(chatUpdated.chat.planMode).toBe(true);
   });
 
   it('no-op when nothing changed', async () => {

--- a/packages/core/src/__tests__/external-session-service.test.ts
+++ b/packages/core/src/__tests__/external-session-service.test.ts
@@ -11,6 +11,7 @@ function createMockAdapter(sessions: ExternalSession[] = []): Adapter {
   return {
     id: 'claude',
     name: 'Claude',
+    capabilities: { planMode: false },
     isInstalled: async () => true,
     getVersion: async () => '1.0',
     listModels: async () => [],
@@ -96,6 +97,7 @@ describe('ExternalSessionService', () => {
       const adapterWithoutList: Adapter = {
         id: 'other',
         name: 'Other',
+        capabilities: { planMode: false },
         isInstalled: async () => true,
         getVersion: async () => '1.0',
         listModels: async () => [],

--- a/packages/core/src/__tests__/file-watcher.test.ts
+++ b/packages/core/src/__tests__/file-watcher.test.ts
@@ -35,7 +35,7 @@ describe('FileWatcherService', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     broadcast = vi.fn();
-    service = new FileWatcherService(broadcast);
+    service = new FileWatcherService(broadcast as unknown as (event: DaemonEvent) => void);
     vi.mocked(watch).mockClear();
     mockWatcher.close.mockClear();
     mockWatcher.on.mockClear();

--- a/packages/core/src/__tests__/plan-mode-handler.test.ts
+++ b/packages/core/src/__tests__/plan-mode-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PlanModeHandler, type PlanModeContext } from '../chat/plan-mode-handler.js';
-import type { Chat, ControlResponse } from '@qlan-ro/mainframe-types';
+import type { Chat, ControlResponse, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { ActiveChat } from '../chat/types.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { PlanModeActionHandler } from '../chat/plan-mode-actions.js';
@@ -92,7 +92,7 @@ function makeContext(
     } as any,
     adapters: makeAdapters(actionHandler),
     getActiveChat: vi.fn().mockReturnValue(activeChat),
-    emitEvent: vi.fn(),
+    emitEvent: vi.fn<(event: DaemonEvent) => void>(),
     clearDisplayCache: vi.fn(),
     startChat: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/__tests__/queued-message-lifecycle.test.ts
+++ b/packages/core/src/__tests__/queued-message-lifecycle.test.ts
@@ -76,6 +76,8 @@ describe('Queued message cleanup — onQueuedProcessed via isReplay', () => {
   function makeSessionState(): ClaudeSessionState {
     return {
       chatId,
+      mainframeChatId: chatId,
+      realProjectPath: '/tmp',
       buffer: '',
       child: null,
       status: 'ready',
@@ -83,7 +85,14 @@ describe('Queued message cleanup — onQueuedProcessed via isReplay', () => {
       activeTasks: new Map(),
       interruptTimer: null,
       pendingCancelCallbacks: new Map(),
+      pendingStopTaskCallbacks: new Map(),
       pendingPrCreates: new Set(),
+      pendingPrMutations: new Map(),
+      toolUseRegistry: new Map(),
+      skillPathCache: new Map(),
+      taskV2Events: [],
+      lastActivityAt: 0,
+      taskEvents: null as unknown as ClaudeSessionState['taskEvents'],
     };
   }
 

--- a/packages/core/src/__tests__/restore-permission.test.ts
+++ b/packages/core/src/__tests__/restore-permission.test.ts
@@ -6,7 +6,6 @@ import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
 import { ClaudePlanModeHandler } from '../plugins/builtin/claude/plan-mode-handler.js';
 import type {
-  Chat,
   ChatMessage,
   ControlResponse,
   AdapterSession,
@@ -305,14 +304,14 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
     registry.register(adapter);
   });
 
-  function setupWithPendingPermission(permissionMode: Chat['permissionMode']) {
+  function setupWithPendingPermission() {
     const testChat = {
       id: chatId,
       adapterId: 'mock',
       projectId: 'proj-1',
       claudeSessionId: 'session-1',
       status: 'active',
-      permissionMode,
+      planMode: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       totalCost: 0,
@@ -331,7 +330,7 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
   }
 
   it('escalates permission mode before spawning CLI when approving ExitPlanMode', async () => {
-    setupWithPendingPermission('plan');
+    setupWithPendingPermission();
 
     // Load chat so activeChats is populated
     await manager.loadChat(chatId);
@@ -360,7 +359,7 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
   });
 
   it('escalates to default when no executionMode specified', async () => {
-    setupWithPendingPermission('plan');
+    setupWithPendingPermission();
     await manager.loadChat(chatId);
 
     await manager.respondToPermission(chatId, {
@@ -376,7 +375,7 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
   });
 
   it('does NOT escalate when denying ExitPlanMode', async () => {
-    setupWithPendingPermission('plan');
+    setupWithPendingPermission();
     await manager.loadChat(chatId);
 
     await manager.respondToPermission(chatId, {
@@ -386,9 +385,9 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
       behavior: 'deny',
     });
 
-    // Mode should stay as 'plan'
+    // Mode should stay in plan mode (denying ExitPlanMode does not escalate)
     expect(adapter.lastSpawnOptions).not.toBeNull();
-    expect(adapter.lastSpawnOptions!.permissionMode).toBe('plan');
+    expect(adapter.lastSpawnOptions!.planMode).toBe(true);
   });
 
   it('does NOT escalate for non-ExitPlanMode approvals', async () => {
@@ -430,7 +429,7 @@ describe('respondToPermission with no process (daemon restart scenario)', () => 
   });
 
   it('clears pending permission after responding', async () => {
-    setupWithPendingPermission('plan');
+    setupWithPendingPermission();
     await manager.loadChat(chatId);
 
     expect(manager.hasPendingPermission(chatId)).toBe(true);

--- a/packages/core/src/__tests__/title-generation.test.ts
+++ b/packages/core/src/__tests__/title-generation.test.ts
@@ -70,8 +70,8 @@ function createMockDb(settingsGetFn?: (...args: unknown[]) => unknown) {
 
 function titleUpdates(db: ReturnType<typeof createMockDb>): string[] {
   return db.chats.update.mock.calls
-    .filter(([_id, data]: [string, Record<string, unknown>]) => 'title' in data)
-    .map(([_id, data]: [string, { title: string }]) => data.title);
+    .filter((call) => 'title' in (call[1] as Record<string, unknown>))
+    .map((call) => (call[1] as { title: string }).title);
 }
 
 function makeEventCollector(): { events: DaemonEvent[]; onEvent: (e: DaemonEvent) => void } {


### PR DESCRIPTION
## What

`tsc --noEmit` on `@qlan-ro/mainframe-core` reported **35 errors across 12 test files** — test fixtures/mocks that drifted from the current types. This realigns them. **No production code changed.**

## Why these weren't caught by CI

CI's build runs `tsc -p tsconfig.build.json`, which **excludes `src/__tests__/**`**, so test-only type drift accumulates silently. A bare `tsc --noEmit` (includes tests) surfaces it. (Also confirmed the recently-merged work was *not* the cause — `git checkout`'d a clean `origin/main` and reproduced all 35 there.)

> Note: a separate red herring — running `tsc` on core *without building `@qlan-ro/mainframe-types` first* produces ~31 phantom `websocket.ts` "never" errors (stale types `dist`). Building types first clears them; production code is clean.

## Fixes (by pattern)

- **plan mode** is now a separate `planMode: boolean`, not `permissionMode: 'plan'` — updated Chat fixtures, the `restore-permission` helper, and `updateChatConfig` calls + the matching runtime assertions to the new model
- `Chat` fixtures missing required `lastContextTokensInput`
- `SessionOptions` now requires `mainframeChatId` (codex-session)
- `Adapter` now requires `capabilities` (external-session-service mocks)
- `tool_result` `MessageContent` now requires `isError` (adapter-events-flow)
- `ClaudeSessionState` gained required fields (queued-message-lifecycle)
- `@types/node` v25: `ArrayBuffer`→`string` on readFile mocks (claude-external-sessions)
- `vi.fn()` typed to the expected signature where assigned to a specific fn type (control-requests, plan-mode-handler, file-watcher)
- non-null assertions (codex-jsonrpc); de-tupled `.map/.filter` callbacks (title-generation)
- removed now-unused imports (`Chat`, `beforeEach`)

No `as any` / `@ts-ignore` used.

## Verification

- `tsc --noEmit` → **0 errors**
- `pnpm --filter @qlan-ro/mainframe-core build` → **exit 0**
- 12 affected test files → **113 tests pass**

## Follow-up (not in this PR)

These drift silently because no CI gate typechecks tests. Consider adding a `typecheck` step (`tsc --noEmit`) to CI so this can't regress — happy to do that separately (it may surface similar drift in other packages' tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)