### PR TITLE
fix(core): codex non-fast turns sent unsupported service_tier: flex

### DIFF
--- a/.changeset/codex-service-tier-flex.md
+++ b/.changeset/codex-service-tier-flex.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix Codex sessions failing immediately with "Session ended unexpectedly". Non-fast turns were sending `serviceTier: 'flex'`, which models like gpt-5.5 reject with `400 Unsupported service_tier: flex`. The fast toggle now sends `serviceTier: 'fast'` only when on, and omits the field otherwise so Codex uses the account default tier. The failure reason from a failed Codex turn is now logged and surfaced in the error card instead of the generic message.

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -365,8 +365,13 @@ function buildSessionSink(
       const notifyConfig = readNotificationConfig(db);
       if (isError) {
         if (!wasInterrupted) {
+          const detail = typeof data.result === 'string' ? data.result.trim() : '';
+          log.warn(
+            { chatId, subtype: data.subtype, reason: detail || null },
+            'session ended unexpectedly — emitting error message',
+          );
           const message = messages.createTransientMessage(chatId, 'error', [
-            { type: 'error', message: 'Session ended unexpectedly' },
+            { type: 'error', message: detail || 'Session ended unexpectedly' },
           ]);
           messages.append(chatId, message);
           emitEvent({ type: 'message.added', chatId, message });

--- a/packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts
@@ -16,16 +16,27 @@ describe('buildTurnConfig', () => {
     expect(cfg.summary).toBe('concise');
   });
 
-  // Trusts already-resolved inputs — it does NOT re-gate on model caps (the resolver
-  // already clamped tuning.fast; the settings UI already gated personality). The
-  // session only knows the model id, so re-checking caps here would be inert.
-  it('serviceTier follows resolved tuning.fast, not a model-cap re-check', () => {
-    expect(buildTurnConfig({ effort: 'high', fast: false, ultracode: false, adaptiveThinking: false }, {}, 'm', 'default').serviceTier).toBe('flex');
-    expect(buildTurnConfig({ effort: 'high', fast: true, ultracode: false, adaptiveThinking: false }, {}, 'm', 'default').serviceTier).toBe('fast');
+  // serviceTier is 'fast' only when tuning.fast is true; it is undefined otherwise so
+  // the caller omits service_tier entirely and the account default tier is used.
+  // The string 'flex' is never produced — sending it caused OpenAI 400 errors on gpt-5.5.
+  it('serviceTier is fast when tuning.fast is true and undefined when tuning.fast is false', () => {
+    expect(
+      buildTurnConfig({ effort: 'high', fast: false, ultracode: false, adaptiveThinking: false }, {}, 'm', 'default')
+        .serviceTier,
+    ).toBeUndefined();
+    expect(
+      buildTurnConfig({ effort: 'high', fast: true, ultracode: false, adaptiveThinking: false }, {}, 'm', 'default')
+        .serviceTier,
+    ).toBe('fast');
   });
 
   it('omits personality/summary when not provided', () => {
-    const cfg = buildTurnConfig({ effort: null, fast: false, ultracode: false, adaptiveThinking: false }, {}, 'm', 'default');
+    const cfg = buildTurnConfig(
+      { effort: null, fast: false, ultracode: false, adaptiveThinking: false },
+      {},
+      'm',
+      'default',
+    );
     expect(cfg.personality).toBeUndefined();
     expect(cfg.summary).toBeUndefined();
   });

--- a/packages/core/src/plugins/builtin/codex/event-mapper.ts
+++ b/packages/core/src/plugins/builtin/codex/event-mapper.ts
@@ -308,11 +308,19 @@ function handleTurnCompleted(params: TurnCompletedParams, sink: SessionSink, sta
   const { turn } = params;
   const isError = turn.status === 'failed' || turn.status === 'interrupted';
 
+  if (isError) {
+    log.warn(
+      { turnId: turn.id, status: turn.status, reason: turn.error?.message ?? null },
+      'codex: turn ended in error',
+    );
+  }
+
   sink.onResult({
     total_cost_usd: 0,
     usage: state.lastUsage,
     subtype: isError ? 'error_during_execution' : undefined,
     is_error: isError,
+    result: turn.error?.message,
   });
   state.lastUsage = undefined;
 }

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -245,7 +245,7 @@ export class CodexSession implements AdapterSession {
       sandboxPolicy: this.mapSandboxPolicy(sandbox),
       collaborationMode: turnCfg.collaborationMode,
       model: this.pendingModel,
-      serviceTier: turnCfg.serviceTier,
+      ...(turnCfg.serviceTier ? { serviceTier: turnCfg.serviceTier } : {}),
       ...(turnCfg.personality ? { personality: turnCfg.personality } : {}),
       ...(turnCfg.summary ? { summary: turnCfg.summary } : {}),
     });
@@ -442,5 +442,4 @@ export class CodexSession implements AdapterSession {
         return { type: 'workspaceWrite' };
     }
   }
-
 }

--- a/packages/core/src/plugins/builtin/codex/turn-config.ts
+++ b/packages/core/src/plugins/builtin/codex/turn-config.ts
@@ -9,7 +9,13 @@ export interface CodexProviderTuning {
 
 export interface CodexTurnConfig {
   collaborationMode: CollaborationMode;
-  serviceTier: 'fast' | 'flex';
+  /**
+   * Only set to 'fast' when the (model-clamped) fast toggle is on. Left undefined
+   * otherwise so turn/start omits service_tier and Codex uses the account default.
+   * We never send 'flex': it's rejected by models that don't support it (e.g.
+   * gpt-5.5 → 400 Unsupported service_tier: flex).
+   */
+  serviceTier?: 'fast';
   personality?: string;
   summary?: string;
 }
@@ -36,8 +42,8 @@ export function buildTurnConfig(
         developer_instructions: null,
       },
     },
-    serviceTier: tuning.fast ? 'fast' : 'flex',
   };
+  if (tuning.fast) cfg.serviceTier = 'fast';
   if (codex.personality) cfg.personality = codex.personality;
   if (codex.reasoningSummary) cfg.summary = codex.reasoningSummary;
   return cfg;


### PR DESCRIPTION
## Problem

New Codex sessions failed immediately with a bare **"Session ended unexpectedly"** card. The daemon logged nothing, so there were no clues in `~/.mainframe/logs`.

Root cause, recovered from the Codex rollout:
```json
{"type":"error","status":400,"error":{"type":"invalid_request_error",
 "message":"Unsupported service_tier: flex"}}
```

`buildTurnConfig` (PR #378) sets `serviceTier: tuning.fast ? 'fast' : 'flex'`, so **every non-fast turn** sends `service_tier: flex`. Models such as `gpt-5.5` reject that tier with a 400 → the turn completes as `failed` → `error_during_execution` → the generic error card.

## Fix

- Send `serviceTier: 'fast'` **only** when the (already model-clamped) fast toggle is on; otherwise omit the field entirely so Codex uses the account default tier. `'flex'` is never sent. "Fast off" now means "normal tier", not "force the slow/cheap flex tier".
- `turn/start` omits `serviceTier` when unset.

## Diagnostics (so this never hides again)

- A failed Codex turn now `log.warn`s `turn.error.message` and threads it into `SessionResult.result`.
- The shared result handler `log.warn`s `{ chatId, subtype, reason }` before emitting, and shows the **real** reason in the error card instead of the generic string. This also covers the Claude adapter, which shares the same path.

## Verification

- `vitest run src/plugins/builtin/codex` → **38 passed** (turn-config test updated: fast off ⇒ `serviceTier` undefined, fast on ⇒ `'fast'`).
- `pnpm --filter @qlan-ro/mainframe-core build` → clean.
- Pre-existing unrelated typecheck error in `mid-session-worktree.test.ts` (`applyTuning`) is on `main` already and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)