### PR TITLE
Fix Codex JSON-RPC parsing with trailing output

### DIFF
--- a/.changeset/fix-codex-jsonrpc-framing.md
+++ b/.changeset/fix-codex-jsonrpc-framing.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+Handle Codex app-server JSON-RPC messages that include trailing stdout bytes on the same line instead of dropping the notification as malformed.

--- a/packages/core/src/__tests__/codex-jsonrpc.test.ts
+++ b/packages/core/src/__tests__/codex-jsonrpc.test.ts
@@ -176,6 +176,22 @@ describe('JsonRpcClient', () => {
     expect(onNotification).toHaveBeenCalledOnce();
   });
 
+  it('dispatches a valid JSON-RPC object before trailing stdout noise on the same line', () => {
+    const onNotification = vi.fn();
+    const proc = createMockProcess();
+    createClient(proc, { onNotification });
+
+    const notification = JSON.stringify({
+      method: 'thread/tokenUsage/updated',
+      params: { tokenUsage: { total: { totalTokens: 20805, inputTokens: 20000, outputTokens: 805 } } },
+    });
+    proc.stdout!.emit('data', Buffer.from(`${notification}progress: still running\n`));
+
+    expect(onNotification).toHaveBeenCalledWith('thread/tokenUsage/updated', {
+      tokenUsage: { total: { totalTokens: 20805, inputTokens: 20000, outputTokens: 805 } },
+    });
+  });
+
   it('calls onExit when process closes', () => {
     const onExit = vi.fn();
     const proc = createMockProcess();

--- a/packages/core/src/plugins/builtin/codex/jsonrpc.ts
+++ b/packages/core/src/plugins/builtin/codex/jsonrpc.ts
@@ -14,6 +14,53 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+function findJsonObjectEnd(input: string): number | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return i + 1;
+    } else if (depth === 0 && !/\s/.test(ch)) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function parseJsonRpcMessages(line: string): Record<string, unknown>[] {
+  const messages: Record<string, unknown>[] = [];
+  let rest = line.trim();
+
+  while (rest) {
+    try {
+      messages.push(JSON.parse(rest) as Record<string, unknown>);
+      return messages;
+    } catch {
+      const end = findJsonObjectEnd(rest);
+      if (end === null) throw new Error('No complete JSON object found');
+      messages.push(JSON.parse(rest.slice(0, end)) as Record<string, unknown>);
+      rest = rest.slice(end).trim();
+      if (!rest.startsWith('{')) return messages;
+    }
+  }
+
+  return messages;
+}
+
 export interface JsonRpcHandlers {
   onNotification: (method: string, params: unknown) => void;
   onRequest: (method: string, params: unknown, id: RequestId) => void;
@@ -110,8 +157,9 @@ export class JsonRpcClient {
       if (!line.trim()) continue;
       log.trace({ line }, 'jsonrpc recv');
       try {
-        const msg = JSON.parse(line.trim()) as Record<string, unknown>;
-        this.dispatch(msg);
+        for (const msg of parseJsonRpcMessages(line)) {
+          this.dispatch(msg);
+        }
       } catch {
         log.warn({ line: line.slice(0, 200) }, 'jsonrpc: malformed JSON line');
       }


### PR DESCRIPTION
## Summary
- parse the first balanced JSON-RPC object from Codex stdout lines
- dispatch valid notifications even when Codex appends trailing stdout bytes
- add a regression test for token usage notifications with trailing output and a changeset

## Verification
- pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/codex-jsonrpc.test.ts --pool=forks
- pnpm --filter @qlan-ro/mainframe-core build