### PR TITLE
Fix daemon startup blocked by task reconciliation

### DIFF
--- a/.changeset/async-background-task-reconcile.md
+++ b/.changeset/async-background-task-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+Start the daemon before reconciling recovered Claude background tasks, and broadcast recovered tasks to connected clients once reconciliation completes.

--- a/packages/core/src/background-tasks/__tests__/reconcile.test.ts
+++ b/packages/core/src/background-tasks/__tests__/reconcile.test.ts
@@ -76,6 +76,26 @@ describe('reconcileBackgroundTasks', () => {
     expect(t.summary).toBe('recovered after daemon restart');
   });
 
+  it('emits events for recovered tasks so live clients update after async reconciliation', async () => {
+    const db = makeDb([makeChat('sess-running'), makeChat('sess-stopped')], { p1: '/Users/x/proj' });
+    (readdir as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(['-Users-x-proj'])
+      .mockResolvedValueOnce(['sess-running', 'sess-stopped'])
+      .mockResolvedValueOnce(['run001.output'])
+      .mockResolvedValueOnce(['stop01.output']);
+    vi.spyOn(lsofMod, 'lsofWriters').mockResolvedValueOnce([777]).mockResolvedValueOnce([]);
+    const events: Array<{ kind: string; chatId: string; taskId: string }> = [];
+    tracker.on('background_task.started', (chatId, task) => events.push({ kind: 'started', chatId, taskId: task.id }));
+    tracker.on('background_task.ended', (chatId, task) => events.push({ kind: 'ended', chatId, taskId: task.id }));
+
+    await reconcileBackgroundTasks({ tracker, db, spoolRoot: '/tmp/claude-501', validator: ALWAYS_VALID });
+
+    expect(events).toEqual([
+      { kind: 'started', chatId: 'chat-sess-running', taskId: 'run001' },
+      { kind: 'ended', chatId: 'chat-sess-stopped', taskId: 'stop01' },
+    ]);
+  });
+
   it('skips unknown claudeSessionId', async () => {
     const db = makeDb([makeChat('sess-known')], { p1: '/Users/x/proj' });
     (readdir as ReturnType<typeof vi.fn>)

--- a/packages/core/src/background-tasks/reconcile.ts
+++ b/packages/core/src/background-tasks/reconcile.ts
@@ -95,7 +95,7 @@ async function reconcileInner(deps: ReconcileDeps, spoolRoot: string): Promise<v
       }
 
       const writers = await lsofWriters(fp);
-      deps.tracker.adopt(chat.id, buildRecoveredSnapshot(taskId, fp, st, writers));
+      deps.tracker.adopt(chat.id, buildRecoveredSnapshot(taskId, fp, st, writers), { emit: true });
       if (writers.length > 0) deps.tracker.setPid(chat.id, taskId, writers[0]!);
     },
   });

--- a/packages/core/src/background-tasks/tracker.ts
+++ b/packages/core/src/background-tasks/tracker.ts
@@ -10,6 +10,10 @@ type TerminalUpdate = {
 
 const TERMINAL = new Set<BackgroundTaskStatus>(['completed', 'failed', 'stopped']);
 
+interface AdoptOptions {
+  emit?: boolean;
+}
+
 export class BackgroundTaskTracker {
   private readonly emitter = new EventEmitter();
   private readonly byChat = new Map<string, Map<string, BackgroundTask>>();
@@ -58,14 +62,17 @@ export class BackgroundTaskTracker {
   }
 
   /**
-   * Insert a fully-formed task from reconciliation. Bypasses event emission;
-   * caller is responsible for any UI notification. Replaces any existing entry
+   * Insert a fully-formed task from reconciliation. Replaces any existing entry
    * with the same id.
    */
-  adopt(chatId: string, task: BackgroundTask): void {
+  adopt(chatId: string, task: BackgroundTask, options: AdoptOptions = {}): void {
     const chat = this.byChat.get(chatId) ?? new Map<string, BackgroundTask>();
     chat.set(task.id, task);
     this.byChat.set(chatId, chat);
+    if (options.emit === true) {
+      const event = task.status === 'running' ? 'background_task.started' : 'background_task.ended';
+      this.emitter.emit(event, chatId, task);
+    }
   }
 
   get(chatId: string, taskId: string): BackgroundTask | null {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -134,11 +134,14 @@ async function main(): Promise<void> {
     backgroundTasks,
   });
 
-  await reconcileBackgroundTasks({ tracker: backgroundTasks, db });
   const livenessScheduler = startLivenessScheduler({ tracker: backgroundTasks });
 
   await server.start(config.port);
   broadcastEvent = (event) => server.broadcastEvent(event);
+
+  reconcileBackgroundTasks({ tracker: backgroundTasks, db }).catch((err) => {
+    logger.warn({ err }, 'Background task reconciliation failed');
+  });
 
   // Probe adapters for dynamic model lists (non-blocking)
   adapters


### PR DESCRIPTION
## Summary
- start the daemon before reconciling recovered Claude background tasks
- emit existing background task events for recovered tasks so connected clients update
- add a focused reconciliation regression test and changeset

## Verification
- pnpm --filter @qlan-ro/mainframe-core exec vitest run src/background-tasks/__tests__/reconcile.test.ts src/background-tasks/__tests__/tracker.test.ts --pool=forks
- pnpm --filter @qlan-ro/mainframe-core build