### PR TITLE
chore: graduate to 1.0.0 (first stable release)

### DIFF
--- a/.changeset/release-v1-0-0.md
+++ b/.changeset/release-v1-0-0.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': major
+---
+
+First stable release: graduate the desktop app, core, and types from 0.x to 1.0.0. This marks the Electron desktop line as stable ahead of the 2.0 Tauri major.


### PR DESCRIPTION
Adds a **major** changeset to graduate `@qlan-ro/mainframe-types`, `@qlan-ro/mainframe-core`, and `@qlan-ro/mainframe-desktop` (the `fixed` group) from `0.22.x` to **`1.0.0`**.

## Why now
Marks the Electron desktop line as a stable **1.x** release **before** the Tauri rewrite lands as **2.0**. This gives a real 1.x line for 2.0 to supersede (coherent semver) and a tagged, signed fallback build.

## What happens on merge
1. `version.yml` opens/updates the **"chore: version packages"** PR computing `1.0.0` for the fixed group (consumes this changeset + any other pending ones).
2. Merging that PR → `prepare-release.yml` tags **`v1.0.0`** → `release.yml` builds + signs the desktop artifacts.

## Reviewer checklist before merging the follow-up version PR
- Confirm all three fixed-group packages show `1.0.0`.
- Confirm the consolidated CHANGELOG reads right.
- Post-tag: smoke-test the **signed** `.dmg`/`.exe`/`.AppImage` (watch the known `better-sqlite3` native-ABI rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)