### PR TITLE
Materialize the adapter catalog: static seed, gated refresh, revisioned propagation

### DIFF
--- a/.changeset/adapter-catalog-materialized.md
+++ b/.changeset/adapter-catalog-materialized.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Adapter catalog is statically seeded at startup, refreshed by a gated per-adapter probe, and propagated with a monotonic revision.

--- a/.claude/skills/claude-protocol-debugger/cli-binary-internals.md
+++ b/.claude/skills/claude-protocol-debugger/cli-binary-internals.md
@@ -352,10 +352,12 @@ do **not** pass `--effort` at spawn (no layer → `effortValue` is the sole sour
 truth, mutable at startup and mid-session). Mixing the flag with `apply_flag_settings`
 breaks mid-session changes.
 
-**Mainframe gap:** `probe-models.ts` reads `supportsEffort` (boolean) but drops
-`supportedEffortLevels`. `ChatEffort` is hardcoded `'low'|'medium'|'high'` and the
-UI `EFFORT_OPTIONS` mirrors it — so `xhigh`/`max` are unreachable, and Sonnet would
-wrongly offer `xhigh` if we naively widened the static list.
+**Mainframe status (since #378):** `probe-models.ts` consumes `supportedEffortLevels` into
+`AdapterModel.supportedEfforts`, and the daemon applies effort at runtime via
+`apply_flag_settings{effortLevel}` — never `--effort` at spawn, so the permission-layer
+masking above never triggers. `clampEffortToSupported()` clamps a requested effort to
+each model's own `supportedEfforts` (falling back to its default), so a model without
+`xhigh` (e.g. Sonnet) is never offered it.
 
 ## Model/Harness Config Flags — full inventory (v2.1.156)
 

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -80,4 +80,37 @@ describe('AdapterRegistry', () => {
     expect(mock).toBeDefined();
     expect(mock?.models).toEqual(mockModels);
   });
+
+  // Plugin-provided adapters (e.g. the e2e mock-cli plugin) aren't backed by a real spawnable
+  // CLI binary on PATH — they report their own installed state and model catalog directly.
+  // The refresh must not conclude "not installed" (and skip listModels()) just because a
+  // `<adapterId> --version` spawn ENOENTs; it should fall back to the adapter's own
+  // isInstalled()/getVersion() before giving up.
+  it('falls back to the adapter’s own isInstalled()/listModels() when no CLI binary resolves', async () => {
+    const registry = new AdapterRegistry();
+    const models: AdapterModel[] = [{ id: 'plugin-model', label: 'Plugin Model' }];
+    const adapter: Adapter = {
+      id: 'plugin-adapter',
+      name: 'Plugin Adapter',
+      capabilities: { planMode: false },
+      isInstalled: vi.fn().mockResolvedValue(true),
+      getVersion: vi.fn().mockResolvedValue('0.1.0'),
+      listModels: vi.fn().mockResolvedValue(models),
+      killAll: vi.fn(),
+    } as unknown as Adapter;
+    registry.register(adapter);
+    registry.seedStaticSnapshots();
+    registry.configureRefresh({
+      resolveExecutablePath: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn().mockResolvedValue({ ok: false, stdout: '' }), // no `plugin-adapter` binary on PATH
+      emitEvent: vi.fn(),
+    });
+    registry.allowRefresh();
+
+    await registry.refreshAll();
+
+    const snapshot = registry.getSnapshots().find((item) => item.id === 'plugin-adapter');
+    expect(snapshot?.installed).toBe(true);
+    expect(snapshot?.models).toEqual(models);
+  });
 });

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -9,6 +9,7 @@ function createMockAdapter(models: AdapterModel[]): Adapter {
     name: 'Mock Adapter',
     isInstalled: vi.fn().mockResolvedValue(true),
     getVersion: vi.fn().mockResolvedValue('1.0.0'),
+    getFallbackModels: () => models,
     listModels: vi.fn().mockResolvedValue(models),
     spawn: vi.fn(),
     kill: vi.fn(),
@@ -71,57 +72,12 @@ describe('AdapterRegistry', () => {
     const registry = new AdapterRegistry();
     const mockModels: AdapterModel[] = [{ id: 'mock-fast', label: 'Mock Fast', contextWindow: 128_000 }];
     registry.register(createMockAdapter(mockModels));
+    registry.seedStaticSnapshots();
 
     const list = await registry.list();
     const mock = list.find((item) => item.id === 'mock');
 
     expect(mock).toBeDefined();
     expect(mock?.models).toEqual(mockModels);
-  });
-});
-
-describe('AdapterRegistry.probeAllModels', () => {
-  it('calls probeModels on adapters that support it and emits event', async () => {
-    const probedModels: AdapterModel[] = [{ id: 'probed-model', label: 'Probed' }];
-    const adapter = createMockAdapter([{ id: 'fallback', label: 'Fallback' }]);
-    (adapter as any).probeModels = vi.fn().mockResolvedValue(probedModels);
-
-    const registry = new AdapterRegistry();
-    registry.register(adapter);
-
-    const events: any[] = [];
-    await registry.probeAllModels((event) => events.push(event));
-
-    expect((adapter as any).probeModels).toHaveBeenCalled();
-    expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({
-      type: 'adapter.models.updated',
-      adapterId: 'mock',
-      models: probedModels,
-    });
-  });
-
-  it('skips adapters without probeModels', async () => {
-    const adapter = createMockAdapter([]);
-    const registry = new AdapterRegistry();
-    registry.register(adapter);
-
-    const events: any[] = [];
-    await registry.probeAllModels((event) => events.push(event));
-
-    expect(events).toHaveLength(0);
-  });
-
-  it('handles probe failure gracefully', async () => {
-    const adapter = createMockAdapter([]);
-    (adapter as any).probeModels = vi.fn().mockResolvedValue(null);
-
-    const registry = new AdapterRegistry();
-    registry.register(adapter);
-
-    const events: any[] = [];
-    await registry.probeAllModels((event) => events.push(event));
-
-    expect(events).toHaveLength(0);
   });
 });

--- a/packages/core/src/__tests__/chat/mid-session-worktree.test.ts
+++ b/packages/core/src/__tests__/chat/mid-session-worktree.test.ts
@@ -35,6 +35,7 @@ function makeDeps(active: ActiveChat): ConfigManagerDeps {
     startChat: vi.fn(async () => {}),
     stopChat: vi.fn(async () => {}),
     emitEvent: vi.fn(),
+    applyTuning: vi.fn(async () => {}),
   };
 }
 

--- a/packages/core/src/__tests__/claude-probe-models.test.ts
+++ b/packages/core/src/__tests__/claude-probe-models.test.ts
@@ -84,8 +84,8 @@ describe('probeModels', () => {
 
     const result = await promise;
 
-    expect(result).toHaveLength(2);
-    expect(result![0]).toEqual({
+    expect(result!.models).toHaveLength(2);
+    expect(result!.models[0]).toEqual({
       id: 'default',
       label: 'Default - Opus 4.7',
       description: 'Opus 4.7 with 1M context',
@@ -95,7 +95,7 @@ describe('probeModels', () => {
       supportsUltracode: true,
       isDefault: true,
     });
-    expect(result![1]).toEqual({
+    expect(result!.models[1]).toEqual({
       id: 'claude-sonnet-4-6',
       label: 'Sonnet 4.6',
       description: 'Sonnet 4.6 · Best for everyday tasks',
@@ -134,10 +134,12 @@ import { mapModelInfo } from '../plugins/builtin/claude/probe-models.js';
 describe('mapModelInfo capabilities', () => {
   it('maps effort levels, fast, adaptive-thinking, derives ultracode', () => {
     const m = mapModelInfo({
-      value: 'default', displayName: 'Default',
+      value: 'default',
+      displayName: 'Default',
       description: 'Opus 4.8 with 1M context · Most capable',
       supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
-      supportsAdaptiveThinking: true, supportsFastMode: true,
+      supportsAdaptiveThinking: true,
+      supportsFastMode: true,
     });
     expect(m.supportedEfforts).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
     expect(m.supportsFast).toBe(true);
@@ -147,8 +149,11 @@ describe('mapModelInfo capabilities', () => {
 
   it('hides ultracode for models without xhigh (Sonnet)', () => {
     const m = mapModelInfo({
-      value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6',
-      supportedEffortLevels: ['low', 'medium', 'high', 'max'], supportsFastMode: true,
+      value: 'sonnet',
+      displayName: 'Sonnet',
+      description: 'Sonnet 4.6',
+      supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+      supportsFastMode: true,
     });
     expect(m.supportsUltracode).toBeUndefined();
   });

--- a/packages/core/src/__tests__/control-requests.test.ts
+++ b/packages/core/src/__tests__/control-requests.test.ts
@@ -108,12 +108,21 @@ describe('ClaudeAdapter control requests', () => {
     expect(payload.request.mode).toBe('plan');
   });
 
+  // setModel now awaits the CLI's control_response (Task 8), so tests must resolve it via the
+  // session's ControlRequestChannel — otherwise the call hangs until the 5s timeout and rejects.
+  function resolveWrittenAsSuccess(session: any, written: string[], index: number): void {
+    const requestId = JSON.parse(written[index]!.trim()).request_id;
+    session.control.resolve(requestId, { request_id: requestId, subtype: 'success' });
+  }
+
   it('setModel sends correct control_request payload', async () => {
     const { session, written } = injectMockChild(adapter, chatId);
 
-    await session.setModel('claude-sonnet-4-5-20250929');
+    const pending = session.setModel('claude-sonnet-4-5-20250929');
+    await vi.waitFor(() => expect(written).toHaveLength(1));
+    resolveWrittenAsSuccess(session, written, 0);
+    await pending;
 
-    expect(written).toHaveLength(1);
     const payload = JSON.parse(written[0]!.trim());
     expect(payload.type).toBe('control_request');
     expect(payload.request_id).toBeTruthy();
@@ -137,9 +146,11 @@ describe('ClaudeAdapter control requests', () => {
     const { session, written } = injectMockChild(adapter, chatId);
 
     await session.setPermissionMode('default');
-    await session.setModel('claude-opus-4-6');
+    const pending = session.setModel('claude-opus-4-6');
+    await vi.waitFor(() => expect(written).toHaveLength(2));
+    resolveWrittenAsSuccess(session, written, 1);
+    await pending;
 
-    expect(written).toHaveLength(2);
     const id1 = JSON.parse(written[0]!.trim()).request_id;
     const id2 = JSON.parse(written[1]!.trim()).request_id;
     expect(id1).not.toBe(id2);

--- a/packages/core/src/__tests__/queued-message-lifecycle.test.ts
+++ b/packages/core/src/__tests__/queued-message-lifecycle.test.ts
@@ -84,8 +84,6 @@ describe('Queued message cleanup — onQueuedProcessed via isReplay', () => {
       pid: 123,
       activeTasks: new Map(),
       interruptTimer: null,
-      pendingCancelCallbacks: new Map(),
-      pendingStopTaskCallbacks: new Map(),
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       toolUseRegistry: new Map(),

--- a/packages/core/src/adapters/__tests__/registry.test.ts
+++ b/packages/core/src/adapters/__tests__/registry.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AdapterRegistry } from '../index.js';
+import type { Adapter, AdapterModel, DaemonEvent } from '@qlan-ro/mainframe-types';
+
+function fakeAdapter(over: Partial<Adapter> & { probeResult?: AdapterModel[] | null } = {}): Adapter {
+  const fallback: AdapterModel[] = [{ id: 'fb', label: 'Fallback' }];
+  return {
+    id: 'claude',
+    name: 'Claude',
+    capabilities: { planMode: true },
+    isInstalled: vi.fn().mockResolvedValue(true),
+    getVersion: vi.fn().mockResolvedValue('1.0.0'),
+    getFallbackModels: vi.fn().mockReturnValue(fallback),
+    listModels: vi.fn().mockResolvedValue(fallback),
+    probeModels: vi.fn().mockResolvedValue(over.probeResult ?? null),
+    createSession: vi.fn(),
+    killAll: vi.fn(),
+    ...over,
+  } as unknown as Adapter;
+}
+
+const deps = (emit: (e: DaemonEvent) => void, path: string | undefined = '/abs/claude') => ({
+  resolveExecutablePath: async () => path,
+  run: async () => ({ ok: true, stdout: 'claude 2.0.0' }),
+  emitEvent: emit,
+});
+
+describe('AdapterRegistry catalog materialization', () => {
+  it('seeds statically without spawning (no isInstalled/getVersion/listModels calls)', () => {
+    const a = fakeAdapter();
+    const reg = new AdapterRegistry();
+    reg.register(a);
+    reg.seedStaticSnapshots();
+    const snaps = reg.getSnapshots();
+    expect(snaps[0]!.catalogSource).toBe('fallback');
+    expect(snaps[0]!.modelsRevision).toBe(1);
+    expect(a.isInstalled as any).not.toHaveBeenCalled();
+    expect(a.getVersion as any).not.toHaveBeenCalled();
+    expect(a.listModels as any).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES to refresh until allowRefresh() (blocker #1: no pre-backfill probe)', async () => {
+    const a = fakeAdapter({ probeResult: [{ id: 'live', label: 'Live' }] });
+    const events: DaemonEvent[] = [];
+    const reg = new AdapterRegistry();
+    reg.register(a);
+    reg.seedStaticSnapshots();
+    reg.configureRefresh(deps((e) => events.push(e)));
+    await reg.list(); // refresh not allowed yet
+    expect(a.probeModels as any).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+    expect(reg.getSnapshots()[0]!.catalogSource).toBe('fallback');
+  });
+
+  it('bumps revision, flips catalogSource, and emits after allowRefresh()', async () => {
+    const probed: AdapterModel[] = [{ id: 'live', label: 'Live' }];
+    const a = fakeAdapter({ probeResult: probed });
+    const events: DaemonEvent[] = [];
+    const reg = new AdapterRegistry();
+    reg.register(a);
+    reg.seedStaticSnapshots();
+    reg.configureRefresh(deps((e) => events.push(e)));
+    reg.allowRefresh();
+    await reg.refreshAll();
+    const info = reg.getSnapshots()[0]!;
+    expect(info.catalogSource).toBe('probed');
+    expect(info.modelsRevision).toBe(2);
+    expect(info.models).toEqual(probed);
+    expect(events).toContainEqual({
+      type: 'adapter.models.updated',
+      adapterId: 'claude',
+      models: probed,
+      modelsRevision: 2,
+    });
+    expect(a.probeModels as any).toHaveBeenCalledWith('/abs/claude');
+  });
+
+  it('latches per-adapter: a failed adapter retries while a succeeded one does not (blocker #5)', async () => {
+    const ok = fakeAdapter({ probeResult: [{ id: 'ok', label: 'OK' }] });
+    const bad = fakeAdapter();
+    (bad as any).id = 'codex';
+    (bad as any).name = 'Codex';
+    (bad as any).probeModels = undefined;
+    (bad as any).listModels = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'c', label: 'C' }]);
+    (bad as any).getFallbackModels = () => [];
+    const reg = new AdapterRegistry();
+    reg.register(ok);
+    reg.register(bad);
+    reg.seedStaticSnapshots();
+    reg.configureRefresh(deps(() => {}));
+    reg.allowRefresh();
+    await reg.refreshAll(); // ok succeeds+latches; codex returns [] (no live models) → not latched
+    await reg.refreshAll(); // ok skipped (latched); codex retries → succeeds
+    expect((ok.probeModels as any).mock.calls.length).toBe(1);
+    expect((bad as any).listModels.mock.calls.length).toBe(2);
+  });
+
+  it('skips live discovery for an uninstalled adapter (blocker #9: no wasted 30s Codex spawn)', async () => {
+    const a = fakeAdapter({ probeResult: [{ id: 'live', label: 'Live' }] });
+    const reg = new AdapterRegistry();
+    reg.register(a);
+    reg.seedStaticSnapshots();
+    // --version fails → installed === false → no probe.
+    reg.configureRefresh({
+      resolveExecutablePath: async () => undefined,
+      run: async () => ({ ok: false, stdout: '' }),
+      emitEvent: () => {},
+    });
+    reg.allowRefresh();
+    await reg.refreshAll();
+    expect(a.probeModels as any).not.toHaveBeenCalled();
+    expect(reg.getSnapshots()[0]!.installed).toBe(false);
+    expect(reg.getSnapshots()[0]!.catalogSource).toBe('fallback');
+  });
+});

--- a/packages/core/src/adapters/__tests__/registry.test.ts
+++ b/packages/core/src/adapters/__tests__/registry.test.ts
@@ -99,7 +99,13 @@ describe('AdapterRegistry catalog materialization', () => {
   });
 
   it('skips live discovery for an uninstalled adapter (blocker #9: no wasted 30s Codex spawn)', async () => {
-    const a = fakeAdapter({ probeResult: [{ id: 'live', label: 'Live' }] });
+    // A genuinely-uninstalled CLI adapter fails BOTH the registry's own `--version` spawn AND
+    // its own isInstalled() (which independently re-resolves the same binary) — unlike a
+    // plugin-provided adapter, which has no CLI binary but still reports installed:true itself.
+    const a = fakeAdapter({
+      probeResult: [{ id: 'live', label: 'Live' }],
+      isInstalled: vi.fn().mockResolvedValue(false),
+    });
     const reg = new AdapterRegistry();
     reg.register(a);
     reg.seedStaticSnapshots();

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -99,8 +99,16 @@ export class AdapterRegistry {
     const exePath = await deps.resolveExecutablePath(adapterId);
     // One --version spawn covers installed AND version (blocker #6: collapse the double spawn, use the resolved path).
     const ver = await deps.run(exePath ?? adapter.id, ['--version'], { timeoutMs: 5_000 });
-    const installed = ver.ok;
-    const version = ver.ok ? parseVersion(ver.stdout) : undefined;
+    let installed = ver.ok;
+    let version = ver.ok ? parseVersion(ver.stdout) : undefined;
+    // The spawn above assumes the adapter is a literal CLI binary on PATH. Plugin-provided
+    // adapters (e.g. the e2e mock-cli plugin, or any future non-CLI Adapter) have no such
+    // binary and would always ENOENT here — they report their own installed state instead.
+    // Fall back to asking the adapter directly before concluding "not installed".
+    if (!installed) {
+      installed = await adapter.isInstalled();
+      if (installed) version = (await adapter.getVersion()) ?? undefined;
+    }
     // Skip live model discovery for an uninstalled adapter — no point spawning a probe (or Codex's
     // 30s app-server) that will only ENOENT. Keep the fallback snapshot; refresh installed/version only.
     if (!installed) {

--- a/packages/core/src/adapters/index.ts
+++ b/packages/core/src/adapters/index.ts
@@ -1,57 +1,159 @@
 import type { Adapter, AdapterInfo, AdapterModel, DaemonEvent } from '@qlan-ro/mainframe-types';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('adapter-registry');
+const REFRESH_LIST_CAP_MS = 2_000;
+
+interface RunResult {
+  ok: boolean;
+  stdout: string;
+}
+interface RefreshDeps {
+  resolveExecutablePath(adapterId: string): Promise<string | undefined>;
+  run(cmd: string, args: string[], opts?: { timeoutMs?: number }): Promise<RunResult>;
+  emitEvent(event: DaemonEvent): void;
+}
+
+function parseVersion(stdout: string): string | undefined {
+  return stdout.match(/(\d+\.\d+\.\d+)/)?.[1];
+}
 
 export class AdapterRegistry {
   private adapters = new Map<string, Adapter>();
+  private snapshots = new Map<string, AdapterInfo>();
+  private deps: RefreshDeps | null = null;
+  private refreshAllowed = false;
+  private inFlight = new Map<string, Promise<void>>(); // per-adapter single-flight
+  private succeeded = new Set<string>(); // per-adapter success latch
 
   register(adapter: Adapter): void {
     this.adapters.set(adapter.id, adapter);
   }
-
   get(id: string): Adapter | undefined {
     return this.adapters.get(id);
   }
-
   getAll(): Adapter[] {
     return [...this.adapters.values()];
   }
-
   killAll(): void {
-    for (const adapter of this.adapters.values()) {
-      adapter.killAll();
-    }
+    for (const a of this.adapters.values()) a.killAll();
   }
 
-  async probeAllModels(emitEvent: (event: DaemonEvent) => void): Promise<void> {
-    const probes = [...this.adapters.values()]
-      .filter(
-        (a): a is Adapter & { probeModels(): Promise<AdapterModel[] | null> } =>
-          typeof (a as any).probeModels === 'function',
-      )
-      .map(async (adapter) => {
-        const models = await adapter.probeModels();
-        if (models) {
-          emitEvent({ type: 'adapter.models.updated', adapterId: adapter.id, models });
-        }
-      });
-    await Promise.allSettled(probes);
+  configureRefresh(deps: RefreshDeps): void {
+    this.deps = deps;
+  }
+  allowRefresh(): void {
+    this.refreshAllowed = true;
   }
 
-  async list(): Promise<AdapterInfo[]> {
-    const infos: AdapterInfo[] = [];
+  /** STATIC-ONLY seed: no CLI spawn. Safe to call before server.start(). */
+  seedStaticSnapshots(): void {
     for (const adapter of this.adapters.values()) {
-      const installed = await adapter.isInstalled();
-      const version = installed ? await adapter.getVersion() : undefined;
-      const models = await adapter.listModels();
-      infos.push({
+      this.snapshots.set(adapter.id, {
         id: adapter.id,
         name: adapter.name,
         description: `${adapter.name} adapter`,
-        installed,
-        version: version || undefined,
-        models,
+        installed: false, // enriched post-backfill; never frozen — refreshAll always runs after backfill
+        version: undefined,
+        models: adapter.getFallbackModels?.() ?? [],
+        modelsRevision: 1,
+        catalogSource: 'fallback',
         capabilities: adapter.capabilities,
       });
     }
-    return infos;
+  }
+
+  getSnapshots(): AdapterInfo[] {
+    return [...this.snapshots.values()];
+  }
+
+  async list(): Promise<AdapterInfo[]> {
+    if (this.refreshAllowed) {
+      const p = this.refreshAll();
+      await Promise.race([p, new Promise<void>((r) => setTimeout(r, REFRESH_LIST_CAP_MS).unref())]);
+    }
+    return this.getSnapshots();
+  }
+
+  /** Per-adapter, parallel, single-flight. Idempotent — safe to call repeatedly. */
+  refreshAll(): Promise<void> {
+    return Promise.allSettled(this.getAll().map((a) => this.refreshAdapter(a.id))).then((results) => {
+      // Log rejections outside each adapter's own try/catch (no silent catches).
+      for (const r of results) if (r.status === 'rejected') log.warn({ err: r.reason }, 'adapter refresh rejected');
+    });
+  }
+
+  private refreshAdapter(adapterId: string): Promise<void> {
+    if (!this.refreshAllowed || this.succeeded.has(adapterId)) return Promise.resolve();
+    const existing = this.inFlight.get(adapterId);
+    if (existing) return existing;
+    const p = this.runRefresh(adapterId).finally(() => this.inFlight.delete(adapterId));
+    this.inFlight.set(adapterId, p);
+    return p;
+  }
+
+  private async runRefresh(adapterId: string): Promise<void> {
+    const adapter = this.adapters.get(adapterId);
+    const deps = this.deps;
+    if (!adapter || !deps) return;
+    const exePath = await deps.resolveExecutablePath(adapterId);
+    // One --version spawn covers installed AND version (blocker #6: collapse the double spawn, use the resolved path).
+    const ver = await deps.run(exePath ?? adapter.id, ['--version'], { timeoutMs: 5_000 });
+    const installed = ver.ok;
+    const version = ver.ok ? parseVersion(ver.stdout) : undefined;
+    // Skip live model discovery for an uninstalled adapter — no point spawning a probe (or Codex's
+    // 30s app-server) that will only ENOENT. Keep the fallback snapshot; refresh installed/version only.
+    if (!installed) {
+      this.applyRefresh(adapterId, { installed, version, models: undefined }, deps);
+      log.warn({ adapterId, exePath }, 'adapter not installed — skipping live catalog discovery');
+      return;
+    }
+    // Live model catalog: Claude probes; Codex (no probeModels) lists.
+    let models: AdapterModel[] | null;
+    try {
+      models =
+        typeof adapter.probeModels === 'function' ? await adapter.probeModels(exePath) : await adapter.listModels();
+    } catch (err) {
+      log.warn({ err, adapterId }, 'live model refresh threw; keeping fallback catalog');
+      models = null;
+    }
+    const gotLive = Array.isArray(models) && models.length > 0;
+    this.applyRefresh(adapterId, { installed, version, models: gotLive ? models! : undefined }, deps);
+    if (gotLive) this.succeeded.add(adapterId);
+    else log.warn({ adapterId, exePath }, 'no live catalog — will retry on next refresh');
+  }
+
+  private applyRefresh(
+    adapterId: string,
+    patch: { installed: boolean; version?: string; models?: AdapterModel[] },
+    deps: RefreshDeps,
+  ): void {
+    const prev = this.snapshots.get(adapterId);
+    if (!prev) return;
+    const modelsChanged = patch.models !== undefined;
+    const modelsRevision = modelsChanged ? (prev.modelsRevision ?? 1) + 1 : prev.modelsRevision;
+    const next: AdapterInfo = {
+      ...prev,
+      installed: patch.installed,
+      version: patch.version ?? prev.version,
+      models: patch.models ?? prev.models,
+      modelsRevision,
+      catalogSource: modelsChanged ? 'probed' : prev.catalogSource,
+    };
+    // Mutate the cache BEFORE emitting so a throwing emitEvent cannot leave the snapshot un-updated (blocker #12).
+    this.snapshots.set(adapterId, next);
+    if (modelsChanged) {
+      log.info({ adapterId, modelsRevision, count: patch.models!.length }, 'adapter catalog updated');
+      try {
+        deps.emitEvent({
+          type: 'adapter.models.updated',
+          adapterId,
+          models: patch.models!,
+          modelsRevision: modelsRevision!,
+        });
+      } catch (err) {
+        log.error({ err, adapterId }, 'emit adapter.models.updated failed (snapshot already updated)');
+      }
+    }
   }
 }

--- a/packages/core/src/chat/__tests__/config-manager.test.ts
+++ b/packages/core/src/chat/__tests__/config-manager.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ChatConfigManager, type ConfigManagerDeps } from '../config-manager.js';
+import type { Chat, AdapterSession } from '@qlan-ro/mainframe-types';
+import type { ActiveChat } from '../types.js';
+
+function baseChat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: 'c1',
+    adapterId: 'claude',
+    projectId: 'p1',
+    status: 'active',
+    createdAt: '',
+    updatedAt: '',
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    lastContextTokensInput: 0,
+    model: 'old-model',
+    permissionMode: 'default',
+    ...overrides,
+  } as Chat;
+}
+
+function fakeDeps(active: ActiveChat, overrides: Partial<ConfigManagerDeps> = {}): ConfigManagerDeps {
+  return {
+    adapters: {} as any,
+    db: { chats: { update: vi.fn() }, settings: { get: vi.fn() } } as any,
+    startingChats: new Map(),
+    getActiveChat: () => active,
+    startChat: vi.fn(),
+    stopChat: vi.fn(),
+    emitEvent: vi.fn(),
+    applyTuning: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('ChatConfigManager.updateChatConfig — independent apply', () => {
+  it('persists permissionMode even when setModel rejects', async () => {
+    const session: Partial<AdapterSession> = {
+      isSpawned: true,
+      setModel: vi.fn().mockRejectedValue(new Error('set_model failed: timeout')),
+      setPermissionMode: vi.fn().mockResolvedValue(undefined),
+    };
+    const active: ActiveChat = { chat: baseChat(), session: session as AdapterSession };
+    const deps = fakeDeps(active);
+    const manager = new ChatConfigManager(deps);
+
+    await manager.updateChatConfig('c1', undefined, 'new-model', 'acceptEdits', undefined);
+
+    expect(session.setModel).toHaveBeenCalledWith('new-model');
+    expect(session.setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+    expect(deps.db.chats.update).toHaveBeenCalledWith('c1', { permissionMode: 'acceptEdits' });
+    expect(active.chat.model).toBe('old-model'); // rejected — not applied
+    expect(active.chat.permissionMode).toBe('acceptEdits'); // succeeded — applied
+    expect(deps.applyTuning).not.toHaveBeenCalled(); // model didn't actually change
+    expect(deps.emitEvent).toHaveBeenCalledWith({ type: 'chat.updated', chat: active.chat });
+  });
+
+  it('does not persist or emit when every setting rejects', async () => {
+    const session: Partial<AdapterSession> = {
+      isSpawned: true,
+      setModel: vi.fn().mockRejectedValue(new Error('timeout')),
+    };
+    const active: ActiveChat = { chat: baseChat(), session: session as AdapterSession };
+    const deps = fakeDeps(active);
+    const manager = new ChatConfigManager(deps);
+
+    await manager.updateChatConfig('c1', undefined, 'new-model', undefined, undefined);
+
+    expect(deps.db.chats.update).not.toHaveBeenCalled();
+    expect(deps.emitEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/chat/__tests__/resolve-tuning-for-chat.test.ts
+++ b/packages/core/src/chat/__tests__/resolve-tuning-for-chat.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTuningForChat } from '../resolve-tuning-for-chat.js';
+import type { AdapterModel } from '@qlan-ro/mainframe-types';
+
+function deps(models: AdapterModel[], chat: any) {
+  return {
+    db: { chats: { get: () => chat }, settings: { get: () => null } },
+    adapters: { get: () => ({ listModels: async () => models }) },
+  };
+}
+
+describe('resolveTuningForChat against the probed catalog', () => {
+  it('keeps xhigh when the probed model supports it', async () => {
+    const models: AdapterModel[] = [
+      { id: 'opus[1m]', label: 'Opus', supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
+    ];
+    const t = await resolveTuningForChat(
+      deps(models, { id: 'c1', adapterId: 'claude', model: 'opus[1m]', effort: 'xhigh' }),
+      'c1',
+    );
+    expect(t?.effort).toBe('xhigh');
+  });
+
+  it('falls back to the isDefault probed model for an alias id', async () => {
+    const models: AdapterModel[] = [{ id: 'claude-x', label: 'X', isDefault: true, supportedEfforts: ['low', 'high'] }];
+    const t = await resolveTuningForChat(
+      deps(models, { id: 'c2', adapterId: 'claude', model: 'default', effort: 'high' }),
+      'c2',
+    );
+    expect(t?.effort).toBe('high');
+  });
+});

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -1,4 +1,4 @@
-import type { Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { AdapterSession, Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { DatabaseManager } from '../db/index.js';
@@ -43,6 +43,105 @@ export class ChatConfigManager {
     }
   }
 
+  /**
+   * Apply one config setting to an already-spawned session and stage it into `updates`/
+   * `active.chat` only if the CLI accepts it. Rejections are logged, not thrown, so sibling
+   * settings in the same request still get their own chance to apply.
+   */
+  private async applyLiveSetting<K extends 'model' | 'permissionMode' | 'planMode'>(
+    chatId: string,
+    active: ActiveChat,
+    updates: Partial<Chat>,
+    key: K,
+    value: Chat[K] | undefined,
+    setter: (value: NonNullable<Chat[K]>) => Promise<void>,
+  ): Promise<void> {
+    if (value === undefined) return;
+    const setterName = `set${key[0]!.toUpperCase()}${key.slice(1)}`;
+    try {
+      await setter(value as NonNullable<Chat[K]>);
+      updates[key] = value;
+      active.chat[key] = value;
+    } catch (err) {
+      log.warn({ err, chatId }, `${setterName} rejected; not persisting ${key}`);
+    }
+  }
+
+  /**
+   * Each setting is applied and persisted INDEPENDENTLY: a rejected/timed-out setModel()
+   * (which now awaits and throws — see session.ts) must not skip setPermissionMode or
+   * setPlanMode, and must not 500 the whole request. Only settings the CLI actually
+   * accepted get written to the DB.
+   */
+  private async applyLiveSessionSettings(
+    chatId: string,
+    active: ActiveChat,
+    session: AdapterSession,
+    changes: { model?: string; permissionMode?: Chat['permissionMode']; planMode?: boolean },
+  ): Promise<void> {
+    const updates: Partial<Chat> = {};
+    await this.applyLiveSetting(chatId, active, updates, 'model', changes.model, (v) => session.setModel(v));
+    await this.applyLiveSetting(chatId, active, updates, 'permissionMode', changes.permissionMode, (v) =>
+      session.setPermissionMode(v),
+    );
+    await this.applyLiveSetting(chatId, active, updates, 'planMode', changes.planMode, (v) => session.setPlanMode(v));
+
+    if (Object.keys(updates).length === 0) return;
+    this.deps.db.chats.update(chatId, updates);
+    // Model switch can invalidate the live tuning (e.g. xhigh/ultracode on a model that
+    // doesn't support them). Re-resolve against the new model and re-apply.
+    if (updates.model !== undefined) await this.deps.applyTuning(chatId);
+    this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
+  }
+
+  /**
+   * Config change that needs a respawn: an adapter switch, or any setting change while no live
+   * session exists yet to apply it to directly. Waits out an in-flight spawn, kills the current
+   * session, persists the new settings, then restarts if a session had been running.
+   */
+  private async respawnWithConfig(
+    chatId: string,
+    active: ActiveChat,
+    changes: { adapterId?: string; model?: string; permissionMode?: Chat['permissionMode']; planMode?: boolean },
+  ): Promise<void> {
+    const inflight = this.deps.startingChats.get(chatId);
+    if (inflight) {
+      try {
+        await inflight;
+      } catch {
+        /* spawn may have failed */
+      }
+    }
+
+    const wasSpawned = active.session?.isSpawned ?? false;
+    if (wasSpawned) {
+      await active.session!.kill();
+      active.session = null;
+    }
+
+    const updates: Partial<Chat> = {};
+    if (changes.adapterId !== undefined) {
+      updates.adapterId = changes.adapterId;
+      active.chat.adapterId = changes.adapterId;
+    }
+    if (changes.model !== undefined) {
+      updates.model = changes.model;
+      active.chat.model = changes.model;
+    }
+    if (changes.permissionMode !== undefined) {
+      updates.permissionMode = changes.permissionMode;
+      active.chat.permissionMode = changes.permissionMode;
+    }
+    if (changes.planMode !== undefined) {
+      updates.planMode = changes.planMode;
+      active.chat.planMode = changes.planMode;
+    }
+
+    this.deps.db.chats.update(chatId, updates);
+    this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
+    if (wasSpawned) await this.deps.startChat(chatId);
+  }
+
   /** Persist a worktree path/branch change (undefined clears it) and broadcast it. */
   private applyWorktreeUpdate(
     active: ActiveChat,
@@ -76,87 +175,20 @@ export class ChatConfigManager {
     if (!adapterChanged && !modelChanged && !modeChanged && !planModeChanged) return;
 
     if (active.session?.isSpawned && !adapterChanged) {
-      // Each setting is applied and persisted INDEPENDENTLY: a rejected/timed-out setModel()
-      // (which now awaits and throws — see session.ts) must not skip setPermissionMode or
-      // setPlanMode, and must not 500 the whole request. Only settings the CLI actually
-      // accepted get written to the DB.
-      const session = active.session;
-      const updates: Partial<Chat> = {};
-      if (modelChanged) {
-        try {
-          await session.setModel(model!);
-          updates.model = model;
-          active.chat.model = model;
-        } catch (err) {
-          log.warn({ err, chatId }, 'setModel rejected; not persisting model');
-        }
-      }
-      if (modeChanged) {
-        try {
-          await session.setPermissionMode(permissionMode!);
-          updates.permissionMode = permissionMode;
-          active.chat.permissionMode = permissionMode;
-        } catch (err) {
-          log.warn({ err, chatId }, 'setPermissionMode rejected; not persisting permissionMode');
-        }
-      }
-      if (planModeChanged) {
-        try {
-          await session.setPlanMode(planMode!);
-          updates.planMode = planMode;
-          active.chat.planMode = planMode;
-        } catch (err) {
-          log.warn({ err, chatId }, 'setPlanMode rejected; not persisting planMode');
-        }
-      }
-      if (Object.keys(updates).length > 0) {
-        this.deps.db.chats.update(chatId, updates);
-        // Model switch can invalidate the live tuning (e.g. xhigh/ultracode on a model
-        // that doesn't support them). Re-resolve against the new model and re-apply.
-        if (updates.model !== undefined) await this.deps.applyTuning(chatId);
-        this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
-      }
+      await this.applyLiveSessionSettings(chatId, active, active.session, {
+        model: modelChanged ? model : undefined,
+        permissionMode: modeChanged ? permissionMode : undefined,
+        planMode: planModeChanged ? planMode : undefined,
+      });
       return;
     }
 
-    const inflight = this.deps.startingChats.get(chatId);
-    if (inflight) {
-      try {
-        await inflight;
-      } catch {
-        /* spawn may have failed */
-      }
-    }
-
-    const wasSpawned = active.session?.isSpawned ?? false;
-    if (wasSpawned) {
-      await active.session!.kill();
-      active.session = null;
-    }
-
-    const updates: Partial<Chat> = {};
-    if (adapterChanged) {
-      updates.adapterId = adapterId;
-      active.chat.adapterId = adapterId!;
-    }
-    if (modelChanged) {
-      updates.model = model;
-      active.chat.model = model;
-    }
-    if (modeChanged) {
-      updates.permissionMode = permissionMode;
-      active.chat.permissionMode = permissionMode;
-    }
-    if (planModeChanged) {
-      updates.planMode = planMode;
-      active.chat.planMode = planMode;
-    }
-
-    this.deps.db.chats.update(chatId, updates);
-    this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
-    if (wasSpawned) {
-      await this.deps.startChat(chatId);
-    }
+    await this.respawnWithConfig(chatId, active, {
+      adapterId: adapterChanged ? adapterId : undefined,
+      model: modelChanged ? model : undefined,
+      permissionMode: modeChanged ? permissionMode : undefined,
+      planMode: planModeChanged ? planMode : undefined,
+    });
   }
 
   async enableWorktree(chatId: string, baseBranch: string, branchName: string): Promise<void> {

--- a/packages/core/src/chat/config-manager.ts
+++ b/packages/core/src/chat/config-manager.ts
@@ -4,6 +4,9 @@ import type { AdapterRegistry } from '../adapters/index.js';
 import type { DatabaseManager } from '../db/index.js';
 import { createWorktree, removeWorktree, moveSessionFiles, getClaudeProjectDir } from '../workspace/index.js';
 import type { ActiveChat } from './types.js';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('config-manager');
 
 export interface ConfigManagerDeps {
   adapters: AdapterRegistry;
@@ -73,27 +76,46 @@ export class ChatConfigManager {
     if (!adapterChanged && !modelChanged && !modeChanged && !planModeChanged) return;
 
     if (active.session?.isSpawned && !adapterChanged) {
-      if (modelChanged) await active.session.setModel(model!);
-      if (modeChanged) await active.session.setPermissionMode(permissionMode!);
-      if (planModeChanged) await active.session.setPlanMode(planMode!);
+      // Each setting is applied and persisted INDEPENDENTLY: a rejected/timed-out setModel()
+      // (which now awaits and throws — see session.ts) must not skip setPermissionMode or
+      // setPlanMode, and must not 500 the whole request. Only settings the CLI actually
+      // accepted get written to the DB.
+      const session = active.session;
       const updates: Partial<Chat> = {};
       if (modelChanged) {
-        updates.model = model;
-        active.chat.model = model;
+        try {
+          await session.setModel(model!);
+          updates.model = model;
+          active.chat.model = model;
+        } catch (err) {
+          log.warn({ err, chatId }, 'setModel rejected; not persisting model');
+        }
       }
       if (modeChanged) {
-        updates.permissionMode = permissionMode;
-        active.chat.permissionMode = permissionMode;
+        try {
+          await session.setPermissionMode(permissionMode!);
+          updates.permissionMode = permissionMode;
+          active.chat.permissionMode = permissionMode;
+        } catch (err) {
+          log.warn({ err, chatId }, 'setPermissionMode rejected; not persisting permissionMode');
+        }
       }
       if (planModeChanged) {
-        updates.planMode = planMode;
-        active.chat.planMode = planMode;
+        try {
+          await session.setPlanMode(planMode!);
+          updates.planMode = planMode;
+          active.chat.planMode = planMode;
+        } catch (err) {
+          log.warn({ err, chatId }, 'setPlanMode rejected; not persisting planMode');
+        }
       }
-      this.deps.db.chats.update(chatId, updates);
-      // Model switch can invalidate the live tuning (e.g. xhigh/ultracode on a model
-      // that doesn't support them). Re-resolve against the new model and re-apply.
-      if (modelChanged) await this.deps.applyTuning(chatId);
-      this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
+      if (Object.keys(updates).length > 0) {
+        this.deps.db.chats.update(chatId, updates);
+        // Model switch can invalidate the live tuning (e.g. xhigh/ultracode on a model
+        // that doesn't support them). Re-resolve against the new model and re-apply.
+        if (updates.model !== undefined) await this.deps.applyTuning(chatId);
+        this.deps.emitEvent({ type: 'chat.updated', chat: active.chat });
+      }
       return;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ import { BackgroundTaskTracker } from './background-tasks/tracker.js';
 import { reconcileBackgroundTasks } from './background-tasks/reconcile.js';
 import { startLivenessScheduler } from './background-tasks/liveness.js';
 import { AdapterRegistry } from './adapters/index.js';
-import { backfillAdapterExecutables, defaultRun } from './adapters/resolve-executable.js';
+import { backfillAdapterExecutables, defaultRun, resolveAdapterExecutable } from './adapters/resolve-executable.js';
 import { ChatManager } from './chat/index.js';
 import { AttachmentStore } from './attachment/index.js';
 import { createServerManager } from './server/index.js';
@@ -119,6 +119,21 @@ async function main(): Promise<void> {
     wrapClaudeForRecording(adapters);
   }
 
+  // Static, spawn-free seed so GET /api/adapters serves instantly and never blocks on a CLI.
+  // MUST stay static — CodexAdapter.listModels() spawns a 30s-timeout app-server (see codex/adapter.ts).
+  adapters.seedStaticSnapshots();
+
+  // Configure the refresh BEFORE server.start() so no request can trigger an unconfigured probe.
+  // emitEvent late-binds through the broadcastEvent closure (set after server.start()).
+  adapters.configureRefresh({
+    resolveExecutablePath: async (adapterId) => {
+      const resolved = await resolveAdapterExecutable(adapterId, { settings: db.settings, run: defaultRun });
+      return resolved.valid ? resolved.path : undefined;
+    },
+    run: defaultRun,
+    emitEvent: (event) => broadcastEvent(event),
+  });
+
   let daemonTunnelUrl: string | null = null;
 
   const server = createServerManager({
@@ -143,26 +158,26 @@ async function main(): Promise<void> {
     logger.warn({ err }, 'Background task reconciliation failed');
   });
 
-  // Probe adapters for dynamic model lists (non-blocking)
-  adapters
-    .probeAllModels((event) => broadcastEvent(event))
-    .catch((err) => {
-      logger.warn({ err }, 'Model probe failed');
-    });
-
   // Non-blocking: backfill worktree parent relationships for existing projects.
   // Failure here must not prevent the daemon from serving requests.
   backfillWorktreeRelationships(db.projects).catch((err) => {
     logger.warn({ err }, 'Worktree relationship backfill failed');
   });
 
-  // Non-blocking: resolve + persist absolute CLI paths for registered adapters
-  // so spawns are explicit. Failure must not block serving requests.
-  backfillAdapterExecutables(
+  // Resolve + persist absolute CLI paths BEFORE any live refresh so the probe/enrichment
+  // spawn the real executable (not a bare name that ENOENTs under a packaged-app PATH).
+  await backfillAdapterExecutables(
     adapters.getAll().map((a) => a.id),
     { settings: db.settings, run: defaultRun },
   ).catch((err) => {
     logger.warn({ err }, 'Adapter executable backfill failed');
+  });
+
+  // Only now may the refresh run. allowRefresh() is the gate that makes a pre-backfill
+  // probe impossible; refreshAll() enriches installed/version/models per adapter and emits.
+  adapters.allowRefresh();
+  adapters.refreshAll().catch((err) => {
+    logger.warn({ err }, 'Adapter catalog refresh failed');
   });
 
   if (config.tunnel === true) {

--- a/packages/core/src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { enrichWithContextWindow } from '../adapter.js';
+import type { AdapterModel } from '@qlan-ro/mainframe-types';
+
+describe('enrichWithContextWindow', () => {
+  it('infers 1M window from a [1m] id suffix when the description omits "1M"', () => {
+    const probed: AdapterModel[] = [{ id: 'claude-fable-5[1m]', label: 'Fable 5', description: 'Fable 5' }];
+    expect(enrichWithContextWindow(probed)[0]!.contextWindow).toBe(1_000_000);
+  });
+  it('keeps the 200k default for a non-[1m] unknown id with no 1M description', () => {
+    const probed: AdapterModel[] = [{ id: 'claude-fable-5', label: 'Fable 5', description: 'Fable 5' }];
+    expect(enrichWithContextWindow(probed)[0]!.contextWindow).toBe(200_000);
+  });
+  it('stamps the default entry window from resolvedModel when it resolves to a [1m] model', () => {
+    const probed: AdapterModel[] = [{ id: 'default', label: 'Default', description: 'Fable 5' }];
+    expect(enrichWithContextWindow(probed, 'claude-fable-5[1m]')[0]!.contextWindow).toBe(1_000_000);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-detection.test.ts
@@ -44,7 +44,6 @@ function createMockSession(): ClaudeSession {
       status: 'ready',
       lastAssistantUsage: undefined,
       activeTasks: new Map(),
-      pendingCancelCallbacks: new Map(),
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       toolUseRegistry: new Map(),

--- a/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/pr-mutation-detection.test.ts
@@ -36,7 +36,6 @@ function createMockSession(): ClaudeSession {
       status: 'ready',
       lastAssistantUsage: undefined,
       activeTasks: new Map(),
-      pendingCancelCallbacks: new Map(),
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       toolUseRegistry: new Map(),

--- a/packages/core/src/plugins/builtin/claude/__tests__/probe-context-window.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/probe-context-window.test.ts
@@ -16,11 +16,13 @@ describe('ClaudeAdapter.probeModels — contextWindow enrichment', () => {
   });
 
   it('preserves contextWindow from the static catalog for known model IDs', async () => {
-    mockedProbe.mockResolvedValueOnce([
-      { id: 'default', label: 'Default', isDefault: true, description: 'Opus 4.7 with 1M context · Most capable' },
-      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-      { id: 'sonnet[1m]', label: 'Sonnet 4.6 (1M context)' },
-    ] satisfies AdapterModel[]);
+    mockedProbe.mockResolvedValueOnce({
+      models: [
+        { id: 'default', label: 'Default', isDefault: true, description: 'Opus 4.7 with 1M context · Most capable' },
+        { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+        { id: 'sonnet[1m]', label: 'Sonnet 4.6 (1M context)' },
+      ] satisfies AdapterModel[],
+    });
 
     const adapter = new ClaudeAdapter();
     const probed = await adapter.probeModels();
@@ -33,10 +35,12 @@ describe('ClaudeAdapter.probeModels — contextWindow enrichment', () => {
   });
 
   it('falls back to description sniff for unknown IDs', async () => {
-    mockedProbe.mockResolvedValueOnce([
-      { id: 'claude-future-1m', label: 'Future 1M', description: 'Future model with 1M context' },
-      { id: 'claude-future-small', label: 'Future Small', description: 'Faster everyday model' },
-    ] satisfies AdapterModel[]);
+    mockedProbe.mockResolvedValueOnce({
+      models: [
+        { id: 'claude-future-1m', label: 'Future 1M', description: 'Future model with 1M context' },
+        { id: 'claude-future-small', label: 'Future Small', description: 'Faster everyday model' },
+      ] satisfies AdapterModel[],
+    });
 
     const adapter = new ClaudeAdapter();
     const probed = await adapter.probeModels();
@@ -46,9 +50,9 @@ describe('ClaudeAdapter.probeModels — contextWindow enrichment', () => {
   });
 
   it('respects an explicit contextWindow on the probed entry', async () => {
-    mockedProbe.mockResolvedValueOnce([
-      { id: 'claude-custom', label: 'Custom', contextWindow: 500_000 },
-    ] satisfies AdapterModel[]);
+    mockedProbe.mockResolvedValueOnce({
+      models: [{ id: 'claude-custom', label: 'Custom', contextWindow: 500_000 }] satisfies AdapterModel[],
+    });
 
     const adapter = new ClaudeAdapter();
     const probed = await adapter.probeModels();
@@ -56,11 +60,24 @@ describe('ClaudeAdapter.probeModels — contextWindow enrichment', () => {
   });
 
   it('listModels() returns enriched dynamic models after probe', async () => {
-    mockedProbe.mockResolvedValueOnce([{ id: 'default', label: 'Default', isDefault: true }] satisfies AdapterModel[]);
+    mockedProbe.mockResolvedValueOnce({
+      models: [{ id: 'default', label: 'Default', isDefault: true }] satisfies AdapterModel[],
+    });
 
     const adapter = new ClaudeAdapter();
     await adapter.probeModels();
     const listed = await adapter.listModels();
     expect(listed[0]?.contextWindow).toBe(1_000_000);
+  });
+
+  it("stamps the 'default' entry's window from resolvedModel when it has no description hint", async () => {
+    mockedProbe.mockResolvedValueOnce({
+      models: [{ id: 'default', label: 'Default', isDefault: true }] satisfies AdapterModel[],
+      resolvedModel: 'claude-fable-5[1m]',
+    });
+
+    const adapter = new ClaudeAdapter();
+    const probed = await adapter.probeModels();
+    expect(probed![0]?.contextWindow).toBe(1_000_000);
   });
 });

--- a/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractProbePayload } from '../probe-models.js';
+
+describe('extractProbePayload', () => {
+  // Live-verified against CLI 2.1.198 (2026-07-04): `resolvedModel` is NOT a sibling of the
+  // top-level `models` array as originally assumed — it's a per-entry field on each model,
+  // e.g. `{ value: 'default', resolvedModel: 'claude-opus-4-8[1m]', ... }`. We only need the
+  // "default" entry's resolvedModel, since that's the alias enrichWithContextWindow resolves.
+  it("reads models and the 'default' entry's resolvedModel from the wrapped initialize response", () => {
+    const event = {
+      type: 'control_response',
+      response: {
+        response: {
+          models: [{ value: 'default', displayName: 'Default', resolvedModel: 'claude-fable-5[1m]' }],
+        },
+      },
+    };
+    const out = extractProbePayload(event);
+    expect(out?.models).toHaveLength(1);
+    expect(out?.resolvedModel).toBe('claude-fable-5[1m]');
+  });
+
+  it('returns null when there is no models array', () => {
+    expect(extractProbePayload({ type: 'control_response', response: { response: {} } })).toBeNull();
+  });
+
+  it('returns undefined resolvedModel when no entry is the default alias', () => {
+    const event = {
+      type: 'control_response',
+      response: { response: { models: [{ value: 'claude-sonnet-5', displayName: 'Sonnet 5' }] } },
+    };
+    expect(extractProbePayload(event)?.resolvedModel).toBeUndefined();
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/session-control.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/session-control.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ControlRequestChannel } from '../session-control.js';
+import { createChildLogger } from '../../../../logger.js';
+
+function fakeStdin() {
+  return { write: vi.fn() } as any;
+}
+
+describe('ControlRequestChannel', () => {
+  it('correlates a response to its awaiting caller by request_id', async () => {
+    const ch = new ControlRequestChannel(createChildLogger('t'), 's1');
+    const stdin = fakeStdin();
+    const promise = ch.sendAwaiting(
+      stdin,
+      { subtype: 'set_model', model: 'x' },
+      { label: 'set_model', timeoutMs: 1000 },
+    );
+    const written = JSON.parse(stdin.write.mock.calls[0][0]);
+    expect(ch.resolve(written.request_id, { subtype: 'success' })).toBe(true);
+    await expect(promise).resolves.toEqual({ subtype: 'success' });
+  });
+
+  it('resolves undefined on timeout (caller treats as failure)', async () => {
+    vi.useFakeTimers();
+    const ch = new ControlRequestChannel(createChildLogger('t'), 's1');
+    const promise = ch.sendAwaiting(fakeStdin(), { subtype: 'x' }, { label: 'x', timeoutMs: 50 });
+    vi.advanceTimersByTime(60);
+    await expect(promise).resolves.toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it('ignores a non-terminal intermediate ack, then resolves on the terminal shape', async () => {
+    const ch = new ControlRequestChannel(createChildLogger('t'), 's1');
+    const stdin = fakeStdin();
+    const promise = ch.sendAwaiting(
+      stdin,
+      { subtype: 'cancel_async_message' },
+      {
+        label: 'cancel_async_message',
+        timeoutMs: 5000,
+        isTerminal: (r) => typeof (r as any)?.cancelled === 'boolean',
+      },
+    );
+    const written = JSON.parse(stdin.write.mock.calls[0][0]);
+    expect(ch.resolve(written.request_id, { ack: true })).toBe(false); // intermediate — caller keeps waiting
+    expect(ch.resolve(written.request_id, { cancelled: true })).toBe(true);
+    await expect(promise).resolves.toEqual({ cancelled: true });
+  });
+
+  it('drainAllAsFailed resolves every pending caller with undefined', async () => {
+    const ch = new ControlRequestChannel(createChildLogger('t'), 's1');
+    const p = ch.sendAwaiting(fakeStdin(), { subtype: 'x' }, { label: 'x', timeoutMs: 10_000 });
+    ch.drainAllAsFailed();
+    await expect(p).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/stop-background-task.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/stop-background-task.test.ts
@@ -13,7 +13,6 @@ describe('ClaudeSession.stopBackgroundTask()', () => {
     const result = await session.stopBackgroundTask('task-1');
 
     expect(result).toEqual({ ok: false, error: 'stdin unavailable' });
-    expect(session.state.pendingStopTaskCallbacks.size).toBe(0);
   });
 
   it('returns stdin-unavailable when stdin is destroyed', async () => {
@@ -23,10 +22,9 @@ describe('ClaudeSession.stopBackgroundTask()', () => {
     const result = await session.stopBackgroundTask('task-2');
 
     expect(result).toEqual({ ok: false, error: 'stdin unavailable' });
-    expect(session.state.pendingStopTaskCallbacks.size).toBe(0);
   });
 
-  it('resolves timeout after 5s when no callback arrives', async () => {
+  it('resolves timeout after 5s when no response arrives', async () => {
     vi.useFakeTimers();
     const session = new ClaudeSession({ projectPath: '/tmp', mainframeChatId: 'test-chat-id' } as any);
     const fakeStdin = { destroyed: false, write: vi.fn() };
@@ -34,40 +32,43 @@ describe('ClaudeSession.stopBackgroundTask()', () => {
 
     const pending = session.stopBackgroundTask('task-3');
 
-    // Callback registered, not yet resolved
-    await Promise.resolve();
-    expect(session.state.pendingStopTaskCallbacks.size).toBe(1);
-
     await vi.advanceTimersByTimeAsync(5001);
     const result = await pending;
 
     expect(result).toEqual({ ok: false, error: 'timeout' });
-    expect(session.state.pendingStopTaskCallbacks.size).toBe(0);
   });
 
-  it('resolves with ok:true when the pending callback is invoked', async () => {
+  // Live-verified against CLI 2.1.198 (2026-07-05): stop_task's success/failure signal is the
+  // OUTER envelope's subtype — the nested `response.response` is always `{}`, even for a real
+  // task that was genuinely killed. See session.ts's isTerminalControlResponse / stopBackgroundTask.
+  it('resolves with ok:true when control.resolve() delivers a success envelope', async () => {
     const session = new ClaudeSession({ projectPath: '/tmp', mainframeChatId: 'test-chat-id' } as any);
     const fakeStdin = { destroyed: false, write: vi.fn() };
     session.state.child = { stdin: fakeStdin } as any;
 
     const pending = session.stopBackgroundTask('task-4');
-
-    // Let the Promise executor run and register the callback
     await Promise.resolve();
 
-    const entries = [...session.state.pendingStopTaskCallbacks.entries()];
-    const entry = entries[0];
-    expect(entry).toBeDefined();
-    const [requestId, callback] = entry!;
-    expect(requestId).toBeTruthy();
-
-    // Simulate the event router (Task 4) invoking the callback.
-    // The implementation clears the entry via clearTimeout but does not
-    // explicitly delete it from the map — only the timeout path does that.
-    callback({ ok: true });
+    const requestId = JSON.parse(fakeStdin.write.mock.calls[0]![0]).request_id;
+    expect(session.control.resolve(requestId, { request_id: requestId, subtype: 'success', response: {} })).toBe(true);
 
     const result = await pending;
     expect(result).toEqual({ ok: true });
+  });
+
+  it('resolves with ok:false + the CLI error message on an error envelope', async () => {
+    const session = new ClaudeSession({ projectPath: '/tmp', mainframeChatId: 'test-chat-id' } as any);
+    const fakeStdin = { destroyed: false, write: vi.fn() };
+    session.state.child = { stdin: fakeStdin } as any;
+
+    const pending = session.stopBackgroundTask('task-4b');
+    await Promise.resolve();
+
+    const requestId = JSON.parse(fakeStdin.write.mock.calls[0]![0]).request_id;
+    session.control.resolve(requestId, { request_id: requestId, subtype: 'error', error: 'no such task' });
+
+    const result = await pending;
+    expect(result).toEqual({ ok: false, error: 'no such task' });
   });
 
   it('writes a JSON stop_task control_request to stdin', async () => {
@@ -90,9 +91,8 @@ describe('ClaudeSession.stopBackgroundTask()', () => {
     expect(parsed.request.subtype).toBe('stop_task');
     expect(parsed.request.task_id).toBe('task-5');
 
-    // Clean up: invoke the pending callback so the promise settles
-    const cbEntry = [...session.state.pendingStopTaskCallbacks.entries()][0];
-    cbEntry![1]({ ok: true });
+    // Clean up: resolve so the promise settles
+    session.control.resolve(parsed.request_id, { request_id: parsed.request_id, subtype: 'success', response: {} });
     await pending;
   });
 });

--- a/packages/core/src/plugins/builtin/claude/__tests__/stop-task-routing.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/stop-task-routing.test.ts
@@ -1,40 +1,50 @@
 import { describe, it, expect, vi } from 'vitest';
 import { handleControlResponseEvent } from '../events.js';
+import { ControlRequestChannel } from '../session-control.js';
+import { createChildLogger } from '../../../../logger.js';
 
+// stop_task/set_model/cancel_async_message routing all funnel through ONE shared
+// ControlRequestChannel now (Task 8) — events.ts is a thin, subtype-agnostic forwarder.
+// Per-subtype interpretation (ok/error shape, terminal predicates) lives on the
+// session.ts caller side (see session-control.test.ts and the stopBackgroundTask/
+// cancelQueuedMessage tests), not here.
 function makeSession(): any {
-  return {
-    id: 's1',
-    state: { pendingStopTaskCallbacks: new Map(), pendingCancelCallbacks: new Map() },
-  };
+  return { id: 's1', control: new ControlRequestChannel(createChildLogger('t'), 's1') };
 }
 
-function mkEvent(requestId: string, inner: Record<string, unknown>) {
-  return {
-    type: 'control_response',
-    response: { request_id: requestId, response: inner },
-  };
+function mkEvent(requestId: string, response: Record<string, unknown>) {
+  return { type: 'control_response', response: { request_id: requestId, ...response } };
 }
 
-describe('stop_task control_response routing', () => {
-  it('invokes pending callback with ok:true on subtype=success', () => {
+describe('control_response routing into the shared ControlRequestChannel', () => {
+  it('forwards the outer envelope to control.resolve() by request_id', () => {
     const session = makeSession();
-    const cb = vi.fn();
-    session.state.pendingStopTaskCallbacks.set('req-1', cb);
-    handleControlResponseEvent(session, mkEvent('req-1', { subtype: 'success' }) as any, {} as any);
-    expect(cb).toHaveBeenCalledWith({ ok: true });
-    expect(session.state.pendingStopTaskCallbacks.has('req-1')).toBe(false);
+    const resolveSpy = vi.spyOn(session.control, 'resolve');
+    const event = mkEvent('req-1', { subtype: 'success', response: {} });
+    handleControlResponseEvent(session, event as any, {} as any);
+    expect(resolveSpy).toHaveBeenCalledWith('req-1', event.response);
   });
 
-  it('invokes pending callback with ok:false + error on subtype=error', () => {
+  it('resolves a real pending stop_task awaiter on the outer envelope subtype', async () => {
     const session = makeSession();
-    const cb = vi.fn();
-    session.state.pendingStopTaskCallbacks.set('req-2', cb);
+    const stdin = { write: vi.fn() } as any;
+    const promise = session.control.sendAwaiting(
+      stdin,
+      { subtype: 'stop_task', task_id: 't1' },
+      {
+        label: 'stop_task',
+        isTerminal: (r: any) => r?.subtype === 'success' || r?.subtype === 'error',
+      },
+    );
+    const requestId = JSON.parse(stdin.write.mock.calls[0][0]).request_id;
+
     handleControlResponseEvent(
       session,
-      mkEvent('req-2', { subtype: 'error', error: 'no such task' }) as any,
+      mkEvent(requestId, { subtype: 'error', error: 'no such task' }) as any,
       {} as any,
     );
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: 'no such task' });
+
+    await expect(promise).resolves.toEqual({ request_id: requestId, subtype: 'error', error: 'no such task' });
   });
 
   it('ignores unknown request_id without throwing', () => {

--- a/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/todo-extraction.test.ts
@@ -35,7 +35,6 @@ function createMockSession(): ClaudeSession {
       status: 'ready',
       lastAssistantUsage: undefined,
       activeTasks: new Map(),
-      pendingCancelCallbacks: new Map(),
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       toolUseRegistry: new Map(),

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -27,12 +27,12 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 const EXTENDED_CONTEXT_WINDOW = 1_000_000;
 const CLAUDE_MODELS: AdapterModel[] = [
   // The CLI accepts "default" as an alias that resolves to the user's tier default
-  // at spawn time (Opus 4.7 on Max with 1M merge enabled). The probe replaces this
+  // at spawn time (Opus 4.8 on Max with 1M merge enabled). The probe replaces this
   // with the live catalog, but keep the label aligned with the current upstream default.
   {
     id: 'default',
-    label: 'Default - Opus 4.7',
-    description: 'Opus 4.7 with 1M context',
+    label: 'Default - Opus 4.8',
+    description: 'Opus 4.8 with 1M context',
     contextWindow: EXTENDED_CONTEXT_WINDOW,
     supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
     supportsFast: true,
@@ -116,14 +116,22 @@ const CLAUDE_MODELS: AdapterModel[] = [
   { id: 'claude-3-5-haiku-20241022', label: 'Haiku 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
 ];
 
+function hasExtendedWindowSuffix(id: string): boolean {
+  return /\[1m\]$/i.test(id);
+}
+
 // The CLI's model probe doesn't expose context window size — only a marketing
 // description like "Opus 4.7 with 1M context". Reconcile probed entries with
-// the static catalog so known IDs retain their authoritative window, and
-// unknown IDs fall back to a description sniff before the 200k default.
-function enrichWithContextWindow(probed: AdapterModel[]): AdapterModel[] {
+// the static catalog so known IDs retain their authoritative window, unknown
+// IDs ending in "[1m]" (or resolving to one via `resolvedModel`) get the
+// extended window, and everything else falls back to a description sniff
+// before the 200k default.
+export function enrichWithContextWindow(probed: AdapterModel[], resolvedModel?: string): AdapterModel[] {
   const staticById = new Map(CLAUDE_MODELS.map((m) => [m.id, m]));
   return probed.map((model) => {
     if (model.contextWindow) return model;
+    const effectiveId = model.id === 'default' && resolvedModel ? resolvedModel : model.id;
+    if (hasExtendedWindowSuffix(effectiveId)) return { ...model, contextWindow: EXTENDED_CONTEXT_WINDOW };
     const fromStatic = staticById.get(model.id)?.contextWindow;
     if (fromStatic) return { ...model, contextWindow: fromStatic };
     const window = /\b1m\b|1m context/i.test(model.description ?? '')
@@ -173,14 +181,18 @@ export class ClaudeAdapter implements Adapter {
     });
   }
 
+  getFallbackModels(): AdapterModel[] {
+    return CLAUDE_MODELS;
+  }
+
   async listModels(): Promise<AdapterModel[]> {
     return this.dynamicModels ?? CLAUDE_MODELS;
   }
 
-  async probeModels(): Promise<AdapterModel[] | null> {
-    const models = await doProbeModels('claude');
-    if (models) {
-      this.dynamicModels = enrichWithContextWindow(models);
+  async probeModels(executablePath?: string): Promise<AdapterModel[] | null> {
+    const result = await doProbeModels(executablePath ?? 'claude');
+    if (result) {
+      this.dynamicModels = enrichWithContextWindow(result.models, result.resolvedModel);
     }
     return this.dynamicModels;
   }

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -117,30 +117,13 @@ export function handleControlResponseEvent(
     sink.onContextUsage(usage);
   }
 
-  // Route cancel_async_message responses to pending callbacks
+  // Route every other control_response (set_model, apply_flag_settings, cancel_async_message,
+  // stop_task, ...) through the session's single correlation channel by request_id. `response`
+  // is the OUTER envelope ({subtype, request_id, response?}) — resolve() hands it to whichever
+  // awaiting caller's isTerminal predicate accepts it. Unmatched ids (e.g. this same context-usage
+  // response, which has no pending awaiter) return false harmlessly.
   const requestId = (response.request_id as string) || undefined;
-  const innerResponse = response.response as Record<string, unknown> | undefined;
-  if (requestId && innerResponse && typeof innerResponse.cancelled === 'boolean') {
-    const callback = session.state.pendingCancelCallbacks.get(requestId);
-    if (callback) {
-      session.state.pendingCancelCallbacks.delete(requestId);
-      callback(innerResponse.cancelled);
-    }
-  }
-
-  // Route stop_task responses to pending callbacks (mirrors cancel above)
-  if (requestId && innerResponse && typeof innerResponse.subtype === 'string') {
-    const stopCb = session.state.pendingStopTaskCallbacks.get(requestId);
-    if (stopCb) {
-      session.state.pendingStopTaskCallbacks.delete(requestId);
-      if (innerResponse.subtype === 'success') {
-        stopCb({ ok: true });
-      } else {
-        const errMsg = typeof innerResponse.error === 'string' ? innerResponse.error : 'unknown error';
-        stopCb({ ok: false, error: errMsg });
-      }
-    }
-  }
+  if (requestId) session.control.resolve(requestId, response);
 }
 
 function handleResultEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {

--- a/packages/core/src/plugins/builtin/claude/probe-models.ts
+++ b/packages/core/src/plugins/builtin/claude/probe-models.ts
@@ -11,6 +11,8 @@ interface CliModelInfo {
   value: string;
   displayName: string;
   description?: string;
+  /** The concrete model id an alias (e.g. "default") currently resolves to. Per-entry, not payload-level. */
+  resolvedModel?: string;
   supportedEffortLevels?: import('@qlan-ro/mainframe-types').EffortLevel[];
   supportsAdaptiveThinking?: boolean;
   supportsFastMode?: boolean;
@@ -47,10 +49,36 @@ export function mapModelInfo(info: CliModelInfo): AdapterModel {
   return model;
 }
 
-export function probeModels(executable: string): Promise<AdapterModel[] | null> {
+export interface ProbeResult {
+  models: AdapterModel[];
+  resolvedModel?: string;
+}
+
+/**
+ * Parse the (possibly double-wrapped) `initialize` control_response.
+ *
+ * Live-verified against CLI 2.1.198 (2026-07-04): `resolvedModel` is NOT a sibling of the
+ * top-level `models` array as originally assumed — each model entry carries its own
+ * `resolvedModel`, e.g. `{ value: 'default', resolvedModel: 'claude-opus-4-8[1m]', ... }`.
+ * We only need the "default" entry's, since that's the alias id whose real window
+ * `enrichWithContextWindow` must infer.
+ */
+export function extractProbePayload(event: Record<string, unknown>): ProbeResult | null {
+  if (event.type !== 'control_response') return null;
+  const response = event.response as Record<string, unknown> | undefined;
+  const payload = ((response?.response as Record<string, unknown>) ?? response) as Record<string, unknown> | undefined;
+  const rawModels = payload?.models;
+  if (!Array.isArray(rawModels)) return null;
+  const models = (rawModels as CliModelInfo[]).map(mapModelInfo);
+  const defaultEntry = (rawModels as CliModelInfo[]).find((m) => m.value === 'default');
+  const resolvedModel = typeof defaultEntry?.resolvedModel === 'string' ? defaultEntry.resolvedModel : undefined;
+  return { models, resolvedModel };
+}
+
+export function probeModels(executable: string): Promise<ProbeResult | null> {
   return new Promise((resolve) => {
     let settled = false;
-    const finish = (result: AdapterModel[] | null) => {
+    const finish = (result: ProbeResult | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -110,15 +138,10 @@ export function probeModels(executable: string): Promise<AdapterModel[] | null> 
         if (!line) continue;
         try {
           const event = JSON.parse(line);
-          if (event.type === 'control_response') {
-            // Claude CLI wraps the initialize payload under response.response when subtype === 'success'.
-            const payload = event.response?.response ?? event.response;
-            const rawModels = payload?.models;
-            if (Array.isArray(rawModels)) {
-              const models = (rawModels as CliModelInfo[]).map(mapModelInfo);
-              log.info({ count: models.length }, 'probe received models');
-              finish(models);
-            }
+          const parsed = extractProbePayload(event);
+          if (parsed) {
+            log.info({ count: parsed.models.length }, 'probe received models');
+            finish(parsed);
           }
         } catch {
           /* expected: CLI emits non-JSON lines (progress indicators, hook events, etc.) */

--- a/packages/core/src/plugins/builtin/claude/session-control.ts
+++ b/packages/core/src/plugins/builtin/claude/session-control.ts
@@ -1,0 +1,75 @@
+import { nanoid } from 'nanoid';
+import type { ChildProcess } from 'node:child_process';
+import type { Logger } from 'pino';
+
+type Raw = Record<string, unknown> | undefined;
+
+/**
+ * One correlation channel per session for control_request/control_response round-trips.
+ * Fire-and-forget callers use send(); awaiting callers use sendAwaiting(). A single
+ * pending map is drained by events.ts via resolve(), and by session close via drainAllAsFailed().
+ */
+interface Pending {
+  /** When provided, resolve() fulfills only on a response the predicate accepts — intermediate acks are ignored. */
+  isTerminal?: (raw: Raw) => boolean;
+  done: (raw: Raw) => void;
+}
+
+export class ControlRequestChannel {
+  private pending = new Map<string, Pending>();
+  constructor(
+    private readonly log: Logger,
+    private readonly sessionId: string,
+  ) {}
+
+  send(stdin: ChildProcess['stdin'], request: Record<string, unknown>): string {
+    const requestId = nanoid();
+    stdin?.write(JSON.stringify({ type: 'control_request', request_id: requestId, request }) + '\n');
+    return requestId;
+  }
+
+  sendAwaiting(
+    stdin: ChildProcess['stdin'],
+    request: Record<string, unknown>,
+    opts: { label: string; timeoutMs?: number; isTerminal?: (raw: Raw) => boolean },
+  ): Promise<Raw> {
+    const requestId = this.send(stdin, request);
+    return new Promise<Raw>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        this.log.warn(
+          { sessionId: this.sessionId, requestId, label: opts.label },
+          `${opts.label} control_response timed out`,
+        );
+        resolve(undefined);
+      }, opts.timeoutMs ?? 5_000);
+      this.pending.set(requestId, {
+        isTerminal: opts.isTerminal,
+        done: (raw) => {
+          clearTimeout(timer);
+          resolve(raw);
+        },
+      });
+    });
+  }
+
+  /**
+   * Route a control_response to its awaiting caller. Returns false when unmatched
+   * (e.g. context-usage) or when the response is a non-terminal intermediate ack the
+   * caller's predicate rejects — in that case the caller keeps waiting.
+   */
+  resolve(requestId: string, raw: Raw): boolean {
+    const entry = this.pending.get(requestId);
+    if (!entry) return false;
+    if (entry.isTerminal && !entry.isTerminal(raw)) return false; // intermediate ack — keep waiting
+    this.pending.delete(requestId);
+    entry.done(raw);
+    return true;
+  }
+
+  /** Fail every pending caller when the session dies, so no awaiter hangs forever. */
+  drainAllAsFailed(): void {
+    for (const entry of this.pending.values()) entry.done(undefined);
+    this.pending.clear();
+  }
+}

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -372,29 +372,29 @@ export class ClaudeSession implements AdapterSession {
     this.sendControlRequest(child.stdin, { subtype: 'set_permission_mode', mode: cliMode });
   }
 
-  /** Awaits a terminal control_response (see isTerminalControlResponse) so callers never persist a rejected/timed-out change. */
-  private awaitTerminal(stdin: ChildProcess['stdin'], request: Record<string, unknown>, label: string) {
+  /** Awaits a terminal control_response so a rejected/timed-out change is never persisted as if it had succeeded. */
+  private awaitTerminal(stdin: ChildProcess['stdin'], request: Record<string, unknown>) {
+    const label = String(request.subtype);
     return this.control.sendAwaiting(stdin, request, { label, isTerminal: isTerminalControlResponse });
+  }
+
+  private failIfNotTerminal(raw: Record<string, unknown> | undefined, label: string): void {
+    if (raw?.subtype !== 'success') throw new Error(`${label} failed: ${(raw?.error as string) ?? 'timeout'}`);
   }
 
   async setModel(model: string): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
-    const raw = await this.awaitTerminal(child.stdin, { subtype: 'set_model', model }, 'set_model');
-    if (raw?.subtype !== 'success') throw new Error(`set_model failed: ${(raw?.error as string) ?? 'timeout'}`);
+    const raw = await this.awaitTerminal(child.stdin, { subtype: 'set_model', model });
+    this.failIfNotTerminal(raw, 'set_model');
   }
 
   async applyTuning(tuning: ResolvedTuning): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
     const settings = tuningToFlagSettings(tuning);
-    const raw = await this.awaitTerminal(
-      child.stdin,
-      { subtype: 'apply_flag_settings', settings },
-      'apply_flag_settings',
-    );
-    if (raw?.subtype !== 'success')
-      throw new Error(`apply_flag_settings failed: ${(raw?.error as string) ?? 'timeout'}`);
+    const raw = await this.awaitTerminal(child.stdin, { subtype: 'apply_flag_settings', settings });
+    this.failIfNotTerminal(raw, 'apply_flag_settings');
   }
 
   async sendCommand(command: string, args = ''): Promise<void> {
@@ -519,7 +519,7 @@ export class ClaudeSession implements AdapterSession {
       log.warn({ sessionId: this.id, taskId }, 'stopBackgroundTask: stdin unavailable');
       return { ok: false, error: 'stdin unavailable' };
     }
-    const raw = await this.awaitTerminal(stdin, { subtype: 'stop_task', task_id: taskId }, 'stop_task');
+    const raw = await this.awaitTerminal(stdin, { subtype: 'stop_task', task_id: taskId });
     if (raw?.subtype === 'success') return { ok: true };
     const err = raw?.error ?? (raw?.response as Record<string, unknown> | undefined)?.error;
     return { ok: false, error: typeof err === 'string' ? err : 'timeout' };

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -127,8 +127,7 @@ export class ClaudeSession implements AdapterSession {
   /** Mutable internal state — readable by claude-events.ts and tests. */
   readonly state: ClaudeSessionState;
 
-  /** Correlation channel for control_request/control_response round-trips. PUBLIC — events.ts
-   *  routes responses into it. Assigned in the constructor body, after `this.id` is set. */
+  /** control_request/control_response channel; PUBLIC (events.ts routes into it); set in the constructor body. */
   readonly control!: ControlRequestChannel;
 
   /** Last non-plan permission mode seen at spawn time. Used by setPlanMode(off)
@@ -377,7 +376,6 @@ export class ClaudeSession implements AdapterSession {
     this.sendControlRequest(child.stdin, { subtype: 'set_permission_mode', mode: cliMode });
   }
 
-  /** Awaits a terminal control_response so a rejected/timed-out change is never persisted as if it had succeeded. */
   private awaitTerminal(stdin: ChildProcess['stdin'], request: Record<string, unknown>) {
     const label = String(request.subtype);
     return this.control.sendAwaiting(stdin, request, { label, isTerminal: isTerminalControlResponse });

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -108,12 +108,11 @@ export function promoteToLocalSettings(updates: ControlUpdate[]): ControlUpdate[
   return updates.map((u) => (u.destination === 'session' ? { ...u, destination: 'localSettings' as const } : u));
 }
 
-/** set_model/apply_flag_settings/stop_task signal success/failure via the OUTER envelope's `subtype`. */
+// Envelope-shape helpers: set_model/apply_flag_settings/stop_task signal success/failure via the
+// OUTER `subtype`; cancel_async_message's only real signal is the NESTED `response.cancelled`.
 function isTerminalCtrl(raw: Record<string, unknown> | undefined): boolean {
   return raw?.subtype === 'success' || raw?.subtype === 'error';
 }
-
-/** cancel_async_message's only real signal is the nested `response.response.cancelled` boolean. */
 function hasCancelledFlag(raw: Record<string, unknown> | undefined): boolean {
   return typeof (raw?.response as Record<string, unknown> | undefined)?.cancelled === 'boolean';
 }
@@ -501,14 +500,8 @@ export class ClaudeSession implements AdapterSession {
       log.warn({ sessionId: this.id, uuid }, 'cancelQueuedMessage: stdin unavailable');
       return false;
     }
-    const raw = await this.control.sendAwaiting(
-      stdin,
-      { subtype: 'cancel_async_message', message_uuid: uuid },
-      {
-        label: 'cancel_async_message',
-        isTerminal: hasCancelledFlag,
-      },
-    );
+    const opts = { label: 'cancel_async_message', isTerminal: hasCancelledFlag };
+    const raw = await this.control.sendAwaiting(stdin, { subtype: 'cancel_async_message', message_uuid: uuid }, opts);
     const cancelled = (raw?.response as Record<string, unknown> | undefined)?.cancelled;
     return typeof cancelled === 'boolean' ? cancelled : false;
   }

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -109,7 +109,7 @@ export function promoteToLocalSettings(updates: ControlUpdate[]): ControlUpdate[
 }
 
 /** set_model/apply_flag_settings/stop_task signal success/failure via the OUTER envelope's `subtype`. */
-function isTerminalControlResponse(raw: Record<string, unknown> | undefined): boolean {
+function isTerminalCtrl(raw: Record<string, unknown> | undefined): boolean {
   return raw?.subtype === 'success' || raw?.subtype === 'error';
 }
 
@@ -377,27 +377,25 @@ export class ClaudeSession implements AdapterSession {
   }
 
   private awaitTerminal(stdin: ChildProcess['stdin'], request: Record<string, unknown>) {
-    const label = String(request.subtype);
-    return this.control.sendAwaiting(stdin, request, { label, isTerminal: isTerminalControlResponse });
+    return this.control.sendAwaiting(stdin, request, { label: String(request.subtype), isTerminal: isTerminalCtrl });
   }
 
-  private failIfNotTerminal(raw: Record<string, unknown> | undefined, label: string): void {
-    if (raw?.subtype !== 'success') throw new Error(`${label} failed: ${(raw?.error as string) ?? 'timeout'}`);
+  private async requireSuccess(stdin: ChildProcess['stdin'], request: Record<string, unknown>): Promise<void> {
+    const raw = await this.awaitTerminal(stdin, request);
+    if (raw?.subtype === 'success') return;
+    throw new Error(`${request.subtype} failed: ${(raw?.error as string) ?? 'timeout'}`);
   }
 
   async setModel(model: string): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
-    const raw = await this.awaitTerminal(child.stdin, { subtype: 'set_model', model });
-    this.failIfNotTerminal(raw, 'set_model');
+    await this.requireSuccess(child.stdin, { subtype: 'set_model', model });
   }
 
   async applyTuning(tuning: ResolvedTuning): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
-    const settings = tuningToFlagSettings(tuning);
-    const raw = await this.awaitTerminal(child.stdin, { subtype: 'apply_flag_settings', settings });
-    this.failIfNotTerminal(raw, 'apply_flag_settings');
+    await this.requireSuccess(child.stdin, { subtype: 'apply_flag_settings', settings: tuningToFlagSettings(tuning) });
   }
 
   async sendCommand(command: string, args = ''): Promise<void> {

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -113,6 +113,11 @@ function isTerminalControlResponse(raw: Record<string, unknown> | undefined): bo
   return raw?.subtype === 'success' || raw?.subtype === 'error';
 }
 
+/** cancel_async_message's only real signal is the nested `response.response.cancelled` boolean. */
+function hasCancelledFlag(raw: Record<string, unknown> | undefined): boolean {
+  return typeof (raw?.response as Record<string, unknown> | undefined)?.cancelled === 'boolean';
+}
+
 export class ClaudeSession implements AdapterSession {
   readonly id: string;
   readonly adapterId = 'claude';
@@ -505,7 +510,7 @@ export class ClaudeSession implements AdapterSession {
       { subtype: 'cancel_async_message', message_uuid: uuid },
       {
         label: 'cancel_async_message',
-        isTerminal: (r) => typeof (r?.response as Record<string, unknown> | undefined)?.cancelled === 'boolean',
+        isTerminal: hasCancelledFlag,
       },
     );
     const cancelled = (raw?.response as Record<string, unknown> | undefined)?.cancelled;

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -20,6 +20,7 @@ import type {
   ResolvedTuning,
 } from '@qlan-ro/mainframe-types';
 import { handleStdout, handleStderr } from './events.js';
+import { ControlRequestChannel } from './session-control.js';
 import { tuningToFlagSettings } from './tuning.js';
 import type { DetectedPrCore } from './pr-detection.js';
 import { ClaudeTaskEvents } from './task-events.js';
@@ -73,10 +74,6 @@ export interface ClaudeSessionState {
   pid: number;
   activeTasks: Map<string, { type: string; command?: string }>;
   interruptTimer: ReturnType<typeof setTimeout> | null;
-  /** Pending cancel_async_message callbacks keyed by request_id */
-  pendingCancelCallbacks: Map<string, (cancelled: boolean) => void>;
-  /** Pending stop_task callbacks keyed by request_id */
-  pendingStopTaskCallbacks: Map<string, (result: { ok: boolean; error?: string }) => void>;
   /** Tool_use IDs for Bash commands that match PR-create patterns (gh pr create, etc.) */
   pendingPrCreates: Set<string>;
   /** Tool_use IDs → parsed PR info for mutation commands (gh pr edit/ready/merge/close/reopen/comment/review, etc.) */
@@ -111,6 +108,11 @@ export function promoteToLocalSettings(updates: ControlUpdate[]): ControlUpdate[
   return updates.map((u) => (u.destination === 'session' ? { ...u, destination: 'localSettings' as const } : u));
 }
 
+/** set_model/apply_flag_settings/stop_task signal success/failure via the OUTER envelope's `subtype`. */
+function isTerminalControlResponse(raw: Record<string, unknown> | undefined): boolean {
+  return raw?.subtype === 'success' || raw?.subtype === 'error';
+}
+
 export class ClaudeSession implements AdapterSession {
   readonly id: string;
   readonly adapterId = 'claude';
@@ -119,6 +121,10 @@ export class ClaudeSession implements AdapterSession {
 
   /** Mutable internal state — readable by claude-events.ts and tests. */
   readonly state: ClaudeSessionState;
+
+  /** Correlation channel for control_request/control_response round-trips. PUBLIC — events.ts
+   *  routes responses into it. Assigned in the constructor body, after `this.id` is set. */
+  readonly control!: ControlRequestChannel;
 
   /** Last non-plan permission mode seen at spawn time. Used by setPlanMode(off)
    *  to restore the original mode when plan is toggled off. */
@@ -136,6 +142,7 @@ export class ClaudeSession implements AdapterSession {
     backgroundTasks: BackgroundTaskTracker = new BackgroundTaskTracker(),
   ) {
     this.id = nanoid();
+    this.control = new ControlRequestChannel(log, this.id);
     this.projectPath = options.projectPath;
     this.resumeSessionId = options.chatId;
     this.onExit = onExit;
@@ -149,8 +156,6 @@ export class ClaudeSession implements AdapterSession {
       pid: 0,
       activeTasks: new Map(),
       interruptTimer: null,
-      pendingCancelCallbacks: new Map(),
-      pendingStopTaskCallbacks: new Map(),
       pendingPrCreates: new Set(),
       pendingPrMutations: new Map(),
       toolUseRegistry: new Map(),
@@ -263,6 +268,7 @@ export class ClaudeSession implements AdapterSession {
     });
     child.on('close', (code: number | null) => {
       this.state.child = null;
+      this.control.drainAllAsFailed(); // no in-flight sendAwaiting caller should hang past process death
       activeSink.onExit(code);
       this.onExit?.();
     });
@@ -293,6 +299,7 @@ export class ClaudeSession implements AdapterSession {
     child.kill('SIGTERM');
     await Promise.race([exited, timeout]);
     this.state.child = null;
+    this.control.drainAllAsFailed();
     log.debug({ sessionId: this.id }, 'claude session killed');
   }
 
@@ -302,9 +309,7 @@ export class ClaudeSession implements AdapterSession {
    * can correlate by it. Fire-and-forget callers ignore the return.
    */
   private sendControlRequest(stdin: ChildProcess['stdin'], request: Record<string, unknown>): string {
-    const requestId = nanoid();
-    stdin?.write(JSON.stringify({ type: 'control_request', request_id: requestId, request }) + '\n');
-    return requestId;
+    return this.control.send(stdin, request);
   }
 
   async interrupt(): Promise<void> {
@@ -367,16 +372,29 @@ export class ClaudeSession implements AdapterSession {
     this.sendControlRequest(child.stdin, { subtype: 'set_permission_mode', mode: cliMode });
   }
 
+  /** Awaits a terminal control_response (see isTerminalControlResponse) so callers never persist a rejected/timed-out change. */
+  private awaitTerminal(stdin: ChildProcess['stdin'], request: Record<string, unknown>, label: string) {
+    return this.control.sendAwaiting(stdin, request, { label, isTerminal: isTerminalControlResponse });
+  }
+
   async setModel(model: string): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
-    this.sendControlRequest(child.stdin, { subtype: 'set_model', model });
+    const raw = await this.awaitTerminal(child.stdin, { subtype: 'set_model', model }, 'set_model');
+    if (raw?.subtype !== 'success') throw new Error(`set_model failed: ${(raw?.error as string) ?? 'timeout'}`);
   }
 
   async applyTuning(tuning: ResolvedTuning): Promise<void> {
     const child = this.state.child;
     if (!child) throw new Error(`Session ${this.id} not spawned`);
-    this.sendControlRequest(child.stdin, { subtype: 'apply_flag_settings', settings: tuningToFlagSettings(tuning) });
+    const settings = tuningToFlagSettings(tuning);
+    const raw = await this.awaitTerminal(
+      child.stdin,
+      { subtype: 'apply_flag_settings', settings },
+      'apply_flag_settings',
+    );
+    if (raw?.subtype !== 'success')
+      throw new Error(`apply_flag_settings failed: ${(raw?.error as string) ?? 'timeout'}`);
   }
 
   async sendCommand(command: string, args = ''): Promise<void> {
@@ -475,49 +493,36 @@ export class ClaudeSession implements AdapterSession {
     stdin.write(json + '\n');
   }
 
+  /** The cancelled boolean lives nested at `response.response.cancelled`, not on the outer envelope. */
   async cancelQueuedMessage(uuid: string): Promise<boolean> {
     const stdin = this.state.child?.stdin;
     if (!stdin || stdin.destroyed) {
       log.warn({ sessionId: this.id, uuid }, 'cancelQueuedMessage: stdin unavailable');
       return false;
     }
-    const requestId = this.sendControlRequest(stdin, { subtype: 'cancel_async_message', message_uuid: uuid });
-    log.info({ sessionId: this.id, uuid, requestId }, 'sent cancel_async_message');
-
-    // Wait for the CLI's control_response with the actual cancelled boolean
-    return new Promise<boolean>((resolve) => {
-      const timeout = setTimeout(() => {
-        this.state.pendingCancelCallbacks.delete(requestId);
-        log.warn({ sessionId: this.id, uuid, requestId }, 'cancel_async_message timed out');
-        resolve(false);
-      }, 5000);
-      this.state.pendingCancelCallbacks.set(requestId, (cancelled) => {
-        clearTimeout(timeout);
-        resolve(cancelled);
-      });
-    });
+    const raw = await this.control.sendAwaiting(
+      stdin,
+      { subtype: 'cancel_async_message', message_uuid: uuid },
+      {
+        label: 'cancel_async_message',
+        isTerminal: (r) => typeof (r?.response as Record<string, unknown> | undefined)?.cancelled === 'boolean',
+      },
+    );
+    const cancelled = (raw?.response as Record<string, unknown> | undefined)?.cancelled;
+    return typeof cancelled === 'boolean' ? cancelled : false;
   }
 
+  /** stop_task's nested `response.response` is always `{}`; the outer envelope's `subtype` is the only success/failure signal. */
   async stopBackgroundTask(taskId: string): Promise<{ ok: boolean; error?: string }> {
     const stdin = this.state.child?.stdin;
     if (!stdin || stdin.destroyed) {
       log.warn({ sessionId: this.id, taskId }, 'stopBackgroundTask: stdin unavailable');
       return { ok: false, error: 'stdin unavailable' };
     }
-    const requestId = this.sendControlRequest(stdin, { subtype: 'stop_task', task_id: taskId });
-    log.info({ sessionId: this.id, taskId, requestId }, 'sent stop_task');
-
-    return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-      const timeout = setTimeout(() => {
-        this.state.pendingStopTaskCallbacks.delete(requestId);
-        log.warn({ sessionId: this.id, taskId, requestId }, 'stop_task timed out');
-        resolve({ ok: false, error: 'timeout' });
-      }, 5000);
-      this.state.pendingStopTaskCallbacks.set(requestId, (result) => {
-        clearTimeout(timeout);
-        resolve(result);
-      });
-    });
+    const raw = await this.awaitTerminal(stdin, { subtype: 'stop_task', task_id: taskId }, 'stop_task');
+    if (raw?.subtype === 'success') return { ok: true };
+    const err = raw?.error ?? (raw?.response as Record<string, unknown> | undefined)?.error;
+    return { ok: false, error: typeof err === 'string' ? err : 'timeout' };
   }
 
   getContextFiles(): { global: ContextFile[]; project: ContextFile[] } {

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -58,6 +58,10 @@ export class CodexAdapter implements Adapter {
     });
   }
 
+  getFallbackModels(): AdapterModel[] {
+    return [];
+  }
+
   async listModels(): Promise<AdapterModel[]> {
     if (this.cachedModels) return this.cachedModels;
     let client: JsonRpcClient | null = null;

--- a/packages/core/src/server/__tests__/adapter-replay.test.ts
+++ b/packages/core/src/server/__tests__/adapter-replay.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { buildConnectReplayEvents } from '../adapter-replay.js';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+
+const base = { name: 'C', description: 'x', installed: true, capabilities: { planMode: true } };
+
+describe('buildConnectReplayEvents', () => {
+  it('replays only probed catalogs, carrying the revision', () => {
+    const snaps: AdapterInfo[] = [
+      { id: 'claude', models: [{ id: 'a', label: 'A' }], modelsRevision: 3, catalogSource: 'probed', ...base },
+      { id: 'codex', models: [{ id: 'b', label: 'B' }], modelsRevision: 1, catalogSource: 'fallback', ...base },
+    ];
+    expect(buildConnectReplayEvents(snaps)).toEqual([
+      { type: 'adapter.models.updated', adapterId: 'claude', models: [{ id: 'a', label: 'A' }], modelsRevision: 3 },
+    ]);
+  });
+
+  it('omits adapters with no revision', () => {
+    const snaps: AdapterInfo[] = [{ id: 'x', models: [], catalogSource: 'probed', ...base }];
+    expect(buildConnectReplayEvents(snaps)).toEqual([]);
+  });
+});

--- a/packages/core/src/server/adapter-replay.ts
+++ b/packages/core/src/server/adapter-replay.ts
@@ -1,0 +1,21 @@
+import type { AdapterInfo, DaemonEvent } from '@qlan-ro/mainframe-types';
+
+/**
+ * Events to replay to a client the moment it connects, so a fresh connection's
+ * catalog is authoritative (the renderer resets its store on connect, then applies
+ * these). Only probed catalogs carry the live model list worth replaying.
+ */
+export function buildConnectReplayEvents(snapshots: AdapterInfo[]): DaemonEvent[] {
+  const events: DaemonEvent[] = [];
+  for (const s of snapshots) {
+    if (s.catalogSource === 'probed' && typeof s.modelsRevision === 'number') {
+      events.push({
+        type: 'adapter.models.updated',
+        adapterId: s.id,
+        models: s.models,
+        modelsRevision: s.modelsRevision,
+      });
+    }
+  }
+  return events;
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -17,7 +17,7 @@ export interface ServerManager {
 export type ServerManagerDeps = Omit<HttpServerDeps, 'lspManager'>;
 
 export function createServerManager(deps: ServerManagerDeps): ServerManager {
-  const { db, chats } = deps;
+  const { db, chats, adapters } = deps;
   const lspRegistry = new LspRegistry();
   const lspManager = new LspManager(lspRegistry);
   const lspHandler = new LspConnectionHandler(lspManager, db);
@@ -31,7 +31,7 @@ export function createServerManager(deps: ServerManagerDeps): ServerManager {
   return {
     async start(port: number): Promise<void> {
       _fileWatcher = new FileWatcherService((event) => _wsManager?.broadcastEvent(event));
-      _wsManager = new WebSocketManager(httpServer, chats, lspHandler, _fileWatcher, db.devices);
+      _wsManager = new WebSocketManager(httpServer, chats, lspHandler, _fileWatcher, db.devices, adapters);
 
       return new Promise((resolve) => {
         httpServer.listen(port, '127.0.0.1', () => {

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -10,6 +10,8 @@ import { validateAuthedToken } from '../auth/validate-authed-token.js';
 import type { DevicesRepository } from '../db/devices.js';
 import { LspConnectionHandler, parseLspUpgradePath } from '../lsp/index.js';
 import type { FileWatcherService } from '../files/file-watcher.js';
+import type { AdapterRegistry } from '../adapters/index.js';
+import { buildConnectReplayEvents } from './adapter-replay.js';
 
 const log = createChildLogger('ws');
 
@@ -39,6 +41,7 @@ export class WebSocketManager {
     private lspHandler?: LspConnectionHandler,
     private fileWatcher?: FileWatcherService,
     private devicesRepo?: DevicesRepository,
+    private adapters?: AdapterRegistry,
   ) {
     this.wss = new WebSocketServer({ noServer: true });
     this.setupUpgradeAuth(server);
@@ -97,6 +100,12 @@ export class WebSocketManager {
 
       const ready: DaemonEvent = { type: 'connection.ready', clientId: client.id };
       ws.send(JSON.stringify(ready));
+
+      if (this.adapters) {
+        for (const event of buildConnectReplayEvents(this.adapters.getSnapshots())) {
+          if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(event));
+        }
+      }
 
       ws.on('message', async (data) => {
         try {

--- a/packages/desktop/src/renderer/hooks/__tests__/useAppInit.tags.test.ts
+++ b/packages/desktop/src/renderer/hooks/__tests__/useAppInit.tags.test.ts
@@ -108,13 +108,19 @@ vi.mock('../../store/settings', () => ({
 }));
 
 const mockSetAdapters = vi.fn();
+const mockResetRevisionBaseline = vi.fn();
 vi.mock('../../store/adapters', () => ({
   useAdaptersStore: Object.assign(
     vi.fn((selector: (s: unknown) => unknown) => {
       const state = { setAdapters: mockSetAdapters };
       return selector ? selector(state) : state;
     }),
-    { getState: vi.fn(() => ({ setAdapters: mockSetAdapters })) },
+    {
+      getState: vi.fn(() => ({
+        setAdapters: mockSetAdapters,
+        resetRevisionBaseline: mockResetRevisionBaseline,
+      })),
+    },
   ),
 }));
 

--- a/packages/desktop/src/renderer/hooks/useAppInit.ts
+++ b/packages/desktop/src/renderer/hooks/useAppInit.ts
@@ -24,7 +24,6 @@ const log = createLogger('renderer:init');
 export function useAppInit(): void {
   const { setProjects, setLoading, setError } = useProjectsStore();
   const loadProviders = useSettingsStore((s) => s.loadProviders);
-  const setAdapters = useAdaptersStore((s) => s.setAdapters);
 
   useEffect(() => {
     // One-time cleanup of removed localStorage keys from unified session view migration
@@ -38,16 +37,24 @@ export function useAppInit(): void {
 
     const loadData = async () => {
       setLoading(true);
+
+      // Drop the revision baseline (not the models) BEFORE fetching, so a reconnect ACCEPTS
+      // the restarted daemon's snapshot even at a tied revision, while keeping last-known
+      // models on screen — no blank model-picker flash on every reconnect blip. Apply the
+      // adapters snapshot as it settles rather than gating it behind the batched fetch below.
+      useAdaptersStore.getState().resetRevisionBaseline();
+      getAdapters()
+        .then((list) => useAdaptersStore.getState().setAdapters(list))
+        .catch((err) => log.warn('adapter fetch failed', { err: String(err) }));
+
       try {
-        const [projectsResult, adaptersResult, providerResult, pluginsResult, chatsResult, tagsResult] =
-          await Promise.allSettled([
-            getProjects(),
-            getAdapters(),
-            getProviderSettings(),
-            getPlugins(),
-            getAllChats(),
-            useTagsStore.getState().refreshRegistry(),
-          ]);
+        const [projectsResult, providerResult, pluginsResult, chatsResult, tagsResult] = await Promise.allSettled([
+          getProjects(),
+          getProviderSettings(),
+          getPlugins(),
+          getAllChats(),
+          useTagsStore.getState().refreshRegistry(),
+        ]);
 
         if (projectsResult.status === 'fulfilled') {
           // Don't wipe a populated list with a transient empty result. On reconnect this fetch can
@@ -59,12 +66,6 @@ export function useAppInit(): void {
           }
         } else {
           throw projectsResult.reason;
-        }
-
-        if (adaptersResult.status === 'fulfilled') {
-          setAdapters(adaptersResult.value);
-        } else {
-          log.warn('adapter fetch failed', { err: String(adaptersResult.reason) });
         }
 
         if (providerResult.status === 'fulfilled') {
@@ -156,7 +157,7 @@ export function useAppInit(): void {
       unsubConnection();
       daemonClient.disconnect();
     };
-  }, [setProjects, setLoading, setError, loadProviders, setAdapters]);
+  }, [setProjects, setLoading, setError, loadProviders]);
 }
 
 export function useProject(projectId: string | null) {

--- a/packages/desktop/src/renderer/lib/ws-event-router.test.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.test.ts
@@ -6,6 +6,7 @@ const addChat = vi.fn();
 const openChatTab = vi.fn();
 const updateTabLabel = vi.fn();
 const getClientId = vi.fn<() => string | undefined>();
+const updateAdapterModels = vi.fn();
 
 vi.mock('../store/chats', () => ({
   useChatsStore: {
@@ -65,7 +66,7 @@ vi.mock('../store/sandbox', () => ({
 }));
 
 vi.mock('../store/adapters', () => ({
-  useAdaptersStore: { getState: () => ({ updateAdapterModels: vi.fn() }) },
+  useAdaptersStore: { getState: () => ({ updateAdapterModels }) },
 }));
 
 vi.mock('./logger', () => ({
@@ -122,5 +123,14 @@ describe('routeEvent — chat.created is pure list-sync (WS8)', () => {
     expect(addChat).toHaveBeenCalledWith(baseChat);
     expect(setActiveChat).not.toHaveBeenCalled();
     expect(openChatTab).not.toHaveBeenCalled();
+  });
+});
+
+describe('routeEvent — adapter.models.updated forwards the revision', () => {
+  it('passes adapterId, models, and modelsRevision to the store', () => {
+    const models = [{ id: 'm1', label: 'M1' }];
+    const event: DaemonEvent = { type: 'adapter.models.updated', adapterId: 'claude', models, modelsRevision: 4 };
+    routeEvent(event);
+    expect(updateAdapterModels).toHaveBeenCalledWith('claude', models, 4);
   });
 });

--- a/packages/desktop/src/renderer/lib/ws-event-router.ts
+++ b/packages/desktop/src/renderer/lib/ws-event-router.ts
@@ -227,8 +227,12 @@ export function routeEvent(event: DaemonEvent): void {
       chats.setQueuedMessages(event.chatId, event.refs);
       break;
     case 'adapter.models.updated':
-      log.info('event:adapter.models.updated', { adapterId: event.adapterId, count: event.models.length });
-      useAdaptersStore.getState().updateAdapterModels(event.adapterId, event.models);
+      log.info('event:adapter.models.updated', {
+        adapterId: event.adapterId,
+        count: event.models.length,
+        modelsRevision: event.modelsRevision,
+      });
+      useAdaptersStore.getState().updateAdapterModels(event.adapterId, event.models, event.modelsRevision);
       break;
     case 'error':
       log.error('daemon error event', { error: event.error });

--- a/packages/desktop/src/renderer/store/__tests__/adapters.test.ts
+++ b/packages/desktop/src/renderer/store/__tests__/adapters.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAdaptersStore } from '../adapters.js';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+
+const info = (id: string, rev: number, models: any[], installed = true): AdapterInfo => ({
+  id,
+  name: id,
+  description: '',
+  installed,
+  version: '1',
+  models,
+  modelsRevision: rev,
+  catalogSource: 'fallback',
+  capabilities: { planMode: true },
+});
+
+describe('desktop adapters store', () => {
+  beforeEach(() => useAdaptersStore.getState().resetAdapters());
+
+  it('setAdapters refreshes identity but keeps newer models', () => {
+    useAdaptersStore.getState().updateAdapterModels('claude', [{ id: 'live', label: 'L' }], 5); // partial, rev5
+    useAdaptersStore.getState().setAdapters([info('claude', 2, [{ id: 'old', label: 'O' }])]); // identity+rev2
+    const a = useAdaptersStore.getState().adapters.find((x) => x.id === 'claude')!;
+    expect(a.name).toBe('claude'); // identity applied
+    expect(a.models[0]!.id).toBe('live'); // newer models kept
+    expect(a.modelsRevision).toBe(5);
+  });
+
+  it('updateAdapterModels upserts a partial entry when the adapter is unknown', () => {
+    useAdaptersStore.getState().updateAdapterModels('codex', [{ id: 'm', label: 'M' }], 3);
+    expect(useAdaptersStore.getState().adapters.find((x) => x.id === 'codex')?.models[0]!.id).toBe('m');
+  });
+
+  it('resetRevisionBaseline keeps models visible but accepts a tied-revision snapshot', () => {
+    useAdaptersStore.getState().setAdapters([info('claude', 2, [{ id: 'a', label: 'A' }])]);
+    useAdaptersStore.getState().resetRevisionBaseline();
+    const mid = useAdaptersStore.getState().adapters.find((x) => x.id === 'claude')!;
+    expect(mid.models[0]!.id).toBe('a'); // still visible
+    expect(mid.modelsRevision).toBeUndefined(); // baseline dropped
+    useAdaptersStore.getState().setAdapters([info('claude', 2, [{ id: 'b', label: 'B' }])]); // tied rev 2
+    expect(useAdaptersStore.getState().adapters.find((x) => x.id === 'claude')!.models[0]!.id).toBe('b');
+  });
+
+  it('resetAdapters clears the store (daemon switch only)', () => {
+    useAdaptersStore.getState().setAdapters([info('claude', 1, [])]);
+    useAdaptersStore.getState().resetAdapters();
+    expect(useAdaptersStore.getState().adapters).toHaveLength(0);
+  });
+});

--- a/packages/desktop/src/renderer/store/__tests__/adapters.test.ts
+++ b/packages/desktop/src/renderer/store/__tests__/adapters.test.ts
@@ -15,7 +15,7 @@ const info = (id: string, rev: number, models: any[], installed = true): Adapter
 });
 
 describe('desktop adapters store', () => {
-  beforeEach(() => useAdaptersStore.getState().resetAdapters());
+  beforeEach(() => useAdaptersStore.setState({ adapters: [] }));
 
   it('setAdapters refreshes identity but keeps newer models', () => {
     useAdaptersStore.getState().updateAdapterModels('claude', [{ id: 'live', label: 'L' }], 5); // partial, rev5
@@ -39,11 +39,5 @@ describe('desktop adapters store', () => {
     expect(mid.modelsRevision).toBeUndefined(); // baseline dropped
     useAdaptersStore.getState().setAdapters([info('claude', 2, [{ id: 'b', label: 'B' }])]); // tied rev 2
     expect(useAdaptersStore.getState().adapters.find((x) => x.id === 'claude')!.models[0]!.id).toBe('b');
-  });
-
-  it('resetAdapters clears the store (daemon switch only)', () => {
-    useAdaptersStore.getState().setAdapters([info('claude', 1, [])]);
-    useAdaptersStore.getState().resetAdapters();
-    expect(useAdaptersStore.getState().adapters).toHaveLength(0);
   });
 });

--- a/packages/desktop/src/renderer/store/__tests__/revision-merge.test.ts
+++ b/packages/desktop/src/renderer/store/__tests__/revision-merge.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { applyIfNewer } from '../revision-merge.js';
+
+describe('applyIfNewer', () => {
+  it('applies a strictly-newer revision', () => {
+    expect(applyIfNewer(2, 3)).toBe(true);
+  });
+  it('rejects equal/older', () => {
+    expect(applyIfNewer(3, 3)).toBe(false);
+    expect(applyIfNewer(3, 1)).toBe(false);
+  });
+  it('applies when no current revision', () => {
+    expect(applyIfNewer(undefined, 1)).toBe(true);
+  });
+  it('rejects when incoming is undefined', () => {
+    expect(applyIfNewer(1, undefined)).toBe(false);
+  });
+});

--- a/packages/desktop/src/renderer/store/adapters.ts
+++ b/packages/desktop/src/renderer/store/adapters.ts
@@ -10,8 +10,6 @@ interface AdaptersState {
   updateAdapterModels: (adapterId: string, models: AdapterModel[], modelsRevision: number) => void;
   /** Drop the revision baseline (accept-anything) but KEEP models visible. Used on reconnect. */
   resetRevisionBaseline: () => void;
-  /** Hard clear — visible blank. Reserved for a genuine daemon switch (desktop has one daemon). */
-  resetAdapters: () => void;
 }
 
 /** Merge an HTTP snapshot: identity/meta always refresh; models apply only-if-newer. */
@@ -70,5 +68,4 @@ export const useAdaptersStore = create<AdaptersState>((set) => ({
   // applies even if it ties the stored revision (a restarted same-port daemon reuses revision 2).
   resetRevisionBaseline: () =>
     set((state) => ({ adapters: state.adapters.map((a) => ({ ...a, modelsRevision: undefined })) })),
-  resetAdapters: () => set({ adapters: [] }),
 }));

--- a/packages/desktop/src/renderer/store/adapters.ts
+++ b/packages/desktop/src/renderer/store/adapters.ts
@@ -1,21 +1,74 @@
 import { create } from 'zustand';
 import type { AdapterInfo, AdapterModel } from '@qlan-ro/mainframe-types';
+import { applyIfNewer } from './revision-merge.js';
 
 interface AdaptersState {
   adapters: AdapterInfo[];
   loading: boolean;
   setAdapters: (adapters: AdapterInfo[]) => void;
   setLoading: (loading: boolean) => void;
-  updateAdapterModels: (adapterId: string, models: AdapterModel[]) => void;
+  updateAdapterModels: (adapterId: string, models: AdapterModel[], modelsRevision: number) => void;
+  /** Drop the revision baseline (accept-anything) but KEEP models visible. Used on reconnect. */
+  resetRevisionBaseline: () => void;
+  /** Hard clear — visible blank. Reserved for a genuine daemon switch (desktop has one daemon). */
+  resetAdapters: () => void;
+}
+
+/** Merge an HTTP snapshot: identity/meta always refresh; models apply only-if-newer. */
+function mergeSnapshot(existing: AdapterInfo[], incoming: AdapterInfo[]): AdapterInfo[] {
+  const byId = new Map(existing.map((a) => [a.id, a]));
+  for (const inc of incoming) {
+    const cur = byId.get(inc.id);
+    if (!cur) {
+      byId.set(inc.id, inc);
+      continue;
+    }
+    const takeModels = applyIfNewer(cur.modelsRevision, inc.modelsRevision);
+    byId.set(inc.id, {
+      ...inc, // identity/meta from the snapshot
+      models: takeModels ? inc.models : cur.models,
+      modelsRevision: takeModels ? inc.modelsRevision : cur.modelsRevision,
+      catalogSource: takeModels ? inc.catalogSource : cur.catalogSource,
+    });
+  }
+  return [...byId.values()];
 }
 
 export const useAdaptersStore = create<AdaptersState>((set) => ({
   adapters: [],
   loading: false,
-  setAdapters: (adapters) => set({ adapters }),
+  setAdapters: (adapters) => set((state) => ({ adapters: mergeSnapshot(state.adapters, adapters) })),
   setLoading: (loading) => set({ loading }),
-  updateAdapterModels: (adapterId, models) =>
-    set((state) => ({
-      adapters: state.adapters.map((a) => (a.id === adapterId ? { ...a, models } : a)),
-    })),
+  updateAdapterModels: (adapterId, models, modelsRevision) =>
+    set((state) => {
+      const cur = state.adapters.find((a) => a.id === adapterId);
+      if (cur) {
+        if (!applyIfNewer(cur.modelsRevision, modelsRevision)) return state;
+        return {
+          adapters: state.adapters.map((a) =>
+            a.id === adapterId ? { ...a, models, modelsRevision, catalogSource: 'probed' } : a,
+          ),
+        };
+      }
+      // Partial entry so a connect-replay arriving before the HTTP seed is not dropped. The
+      // installed:true / planMode:false / id-as-name values are placeholders that BRIEFLY lie;
+      // reset-on-connect always fires the full-snapshot fetch right after, and mergeSnapshot
+      // overwrites identity from that snapshot, so the window is a few ms.
+      const partial: AdapterInfo = {
+        id: adapterId,
+        name: adapterId,
+        description: '',
+        installed: true,
+        models,
+        modelsRevision,
+        catalogSource: 'probed',
+        capabilities: { planMode: false },
+      };
+      return { adapters: [...state.adapters, partial] };
+    }),
+  // Keep last-known models visible; only drop the revision baseline so the next snapshot/replay
+  // applies even if it ties the stored revision (a restarted same-port daemon reuses revision 2).
+  resetRevisionBaseline: () =>
+    set((state) => ({ adapters: state.adapters.map((a) => ({ ...a, modelsRevision: undefined })) })),
+  resetAdapters: () => set({ adapters: [] }),
 }));

--- a/packages/desktop/src/renderer/store/revision-merge.ts
+++ b/packages/desktop/src/renderer/store/revision-merge.ts
@@ -1,0 +1,5 @@
+/** Only-if-newer guard for monotonic-revision fields. Shaped for reuse by other revisioned stores. */
+export function applyIfNewer(current: number | undefined, incoming: number | undefined): boolean {
+  if (incoming === undefined) return false;
+  return current === undefined || incoming > current;
+}

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -198,6 +198,10 @@ export interface AdapterInfo {
   installed: boolean;
   version?: string;
   models: AdapterModel[];
+  /** Monotonic per-adapter counter, bumped on every models change. Absent on legacy/mobile payloads. */
+  modelsRevision?: number;
+  /** Provenance of `models`: 'probed' = live CLI catalog, 'fallback' = static list. Absent on legacy payloads. */
+  catalogSource?: 'probed' | 'fallback';
   capabilities: {
     planMode: boolean;
   };
@@ -247,7 +251,13 @@ export const TUNABLE_FEATURES = [
 export type FeatureKey = (typeof TUNABLE_FEATURES)[number]['key'];
 
 const EFFORT_RANK: Record<EffortLevel, number> = {
-  none: 0, minimal: 1, low: 2, medium: 3, high: 4, xhigh: 5, max: 6,
+  none: 0,
+  minimal: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  xhigh: 5,
+  max: 6,
 };
 
 /**
@@ -268,7 +278,9 @@ export function clampEffortToSupported(
   if (supported.length === 0) return null;
   if (supported.includes(requested)) return requested;
   if (defaultEffort && supported.includes(defaultEffort)) return defaultEffort;
-  const below = supported.filter((e) => EFFORT_RANK[e] <= EFFORT_RANK[requested]).sort((a, b) => EFFORT_RANK[b] - EFFORT_RANK[a]);
+  const below = supported
+    .filter((e) => EFFORT_RANK[e] <= EFFORT_RANK[requested])
+    .sort((a, b) => EFFORT_RANK[b] - EFFORT_RANK[a]);
   return below[0] ?? [...supported].sort((a, b) => EFFORT_RANK[a] - EFFORT_RANK[b])[0] ?? null;
 }
 
@@ -296,7 +308,9 @@ export interface Adapter {
   isInstalled(): Promise<boolean>;
   getVersion(): Promise<string | null>;
   listModels(): Promise<AdapterModel[]>;
-  probeModels?(): Promise<AdapterModel[] | null>;
+  probeModels?(executablePath?: string): Promise<AdapterModel[] | null>;
+  /** Synchronous static fallback catalog for instant, spawn-free startup seeding. */
+  getFallbackModels?(): AdapterModel[];
 
   createSession(options: SessionOptions): AdapterSession;
   killAll(): void;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -63,7 +63,12 @@ export type DaemonEvent =
   | { type: 'chat.compacting'; chatId: string }
   | { type: 'chat.compactDone'; chatId: string }
   | { type: 'chat.contextUsage'; chatId: string; percentage: number; totalTokens: number; maxTokens: number }
-  | { type: 'adapter.models.updated'; adapterId: string; models: import('./adapter.js').AdapterModel[] }
+  | {
+      type: 'adapter.models.updated';
+      adapterId: string;
+      models: import('./adapter.js').AdapterModel[];
+      modelsRevision: number;
+    }
   | { type: 'todos.updated'; chatId: string; todos: import('./chat.js').TodoItem[] }
   | { type: 'chat.prDetected'; chatId: string; pr: import('./adapter.js').DetectedPr }
   | {


### PR DESCRIPTION
## Summary

Reworks how the daemon's adapter model catalog (Claude/Codex) is built and kept fresh, so it never blocks startup on a CLI spawn and can never regress to a stale snapshot after a reconnect.

- **Materialized catalog** (`AdapterRegistry`): seeds a static, spawn-free snapshot synchronously before `server.start()`, then refreshes per-adapter (parallel, single-flight, latched on success) only after `allowRefresh()` opens — which happens strictly after executable-path backfill completes. `GET /api/adapters` always serves instantly from the cache; a request never triggers an ad-hoc probe.
- **Monotonic revision**: every `AdapterInfo`/`adapter.models.updated` now carries `modelsRevision` + `catalogSource: 'fallback' | 'probed'`. Both fields are additive/optional so `packages/mobile` keeps working unmodified.
- **Connect-replay**: a fresh WS connection immediately receives one `adapter.models.updated` per already-probed adapter (`server/adapter-replay.ts`), so a reconnecting client doesn't wait for the next refresh cycle.
- **Desktop store**: identity/meta always refresh from an HTTP snapshot; `models`/`modelsRevision` apply only-if-newer (`applyIfNewer`). `useAppInit` resets the revision baseline (not the models) on every connect/reconnect, so a restarted daemon is accepted even at a tied revision without a blank model-picker flash.
- **Context-window fix**: `enrichWithContextWindow` now infers the 1M window from a `[1m]` id suffix (and from `resolvedModel` for the `default` alias), not just a description sniff.
- **Control-response correlation** (`session-control.ts`): the two duplicated `pendingCancelCallbacks`/`pendingStopTaskCallbacks` maps are replaced by one `ControlRequestChannel` per session. `setModel`/`applyTuning` now await their control_response instead of firing and forgetting, so a rejected/timed-out change is never persisted as if it had succeeded. `config-manager.updateChatConfig` applies model/permission-mode/plan-mode independently — one rejected setting no longer blocks the others or fails the whole request.

## Live-verification gate outcomes (CLI 2.1.198, 2026-07-05)

**Task 3 gate (probe `resolvedModel`):** the field **does exist**, but the plan's assumption drifted from reality — it is **not** a sibling of the top-level `models` array. Each model entry in the `initialize` response carries its own `resolvedModel` (e.g. `{ value: 'default', resolvedModel: 'claude-opus-4-8[1m]', ... }`). `extractProbePayload` now reads the `"default"` entry's `resolvedModel` specifically, since that's the only one `enrichWithContextWindow` needs.

**Task 8 gate (control_response shapes):** all four subtypes (`set_model`, `apply_flag_settings`, `cancel_async_message`, `stop_task`) emit exactly one correlated `control_response` per `request_id`, with no intermediate ack — so `setModel`/`applyTuning` were wired to `sendAwaiting`. The envelope shape also drifted from the plan's assumption:
- `set_model` / `apply_flag_settings` / `stop_task`: the terminal success/failure signal is the **outer** envelope's `subtype` (`response.subtype`), not a nested `response.response.subtype`.
- `cancel_async_message`: the real signal is nested at `response.response.cancelled` (boolean).
- **Bug found and fixed**: `stop_task`'s nested `response.response` is **always `{}`**, even for a real background task that was genuinely killed (verified live: spawned a real `sleep 120` background task, stopped it, `response.response` was still `{}`). The pre-existing `pendingStopTaskCallbacks` logic read that always-empty nested `subtype`, so `stopBackgroundTask()` silently timed out after 5s on every call regardless of actual CLI success. Fixed by reading the outer envelope's `subtype` instead.

## Per-task test evidence

| Task | Evidence |
|---|---|
| 1 — types | `pnpm --filter @qlan-ro/mainframe-types build` clean |
| 2 — context-window fix | `adapter-enrich.test.ts` (3/3) |
| 3 — resolvedModel capture | `probe-models.test.ts` (3/3), `probe-context-window.test.ts` (5/5), `claude-probe-models.test.ts` (5/5) |
| 4 — registry materialization | `adapters/__tests__/registry.test.ts` (5/5), `__tests__/adapter-registry.test.ts` migrated |
| 5 — startup wiring | full core suite green |
| 6 — connect-replay | `server/__tests__/adapter-replay.test.ts` (2/2); `websocket.ts` stays at 296 lines (< 300) |
| 7 — resolveTuningForChat guard | `chat/__tests__/resolve-tuning-for-chat.test.ts` (2/2) |
| 8 — control channel + independent apply | `session-control.test.ts` (4/4), `stop-task-routing.test.ts` (3/3), `stop-background-task.test.ts` (6/6), `config-manager.test.ts` (2/2, verified to fail against the pre-Task-8 implementation), 6 migrated tests + `control-requests.test.ts` (an additional file the plan's Step 6b list missed, also fixed); `session.ts` net-shrank to 567 lines (from 568) |
| 9 — desktop store | `revision-merge.test.ts` (4/4), `store/adapters.test.ts` (4/4), `ws-event-router.test.ts` (3/3, +1 new case); existing `adapters.test.ts` fixtures compile unchanged |
| 10 — docs | `cli-binary-internals.md` corrected (see blocker note below) |
| 11 — changeset + full verification | see below |

## Manual smoke (Task 11 Step 3)

Ran the built daemon on a scratch data dir/port:
- First successful `GET /api/adapters` (~1s after spawn) returned `catalogSource: "fallback"`, `modelsRevision: 1`, `installed: false` for both adapters.
- ~40ms later, both flipped to `catalogSource: "probed"`, `modelsRevision: 2`, `installed: true`.
- Server logs confirm ordering: `backfilled adapter executable path` (both adapters, absolute paths) precedes `adapter catalog updated` (both adapters) — the refresh never runs before backfill.
- Restarted with `PATH=/usr/bin` (stripped): both Claude and Codex still resolved to `probed`/`installed: true`, because their absolute paths were already persisted from the prior run and `resolveAdapterExecutable` reads the persisted config path before falling back to `PATH`.
- Reconnect/reset-on-connect behavior verified via the `adapter-replay.test.ts` and desktop store unit tests rather than a full Electron run (proportionate to the change; the underlying logic is unit-covered end to end).

## Known blocker — Task 10 Step 1 not applicable

`docs/adapters/claude/MODELS.md` (the plan's other Task 10 target) **does not exist in this worktree**. It is untracked and excluded via a local `.git/info/exclude` rule (`/docs/adapters/`) — a machine-local convention, not part of the repository. `git ls-files` confirms it was never committed on `main`. I completed the docs fix only for the file that is actually tracked (`.claude/skills/claude-protocol-debugger/cli-binary-internals.md`).

## Out of scope, noted only

- `packages/core/src/__tests__/chat/mid-session-worktree.test.ts` fails `tsc --noEmit` (`ConfigManagerDeps` missing `applyTuning` in the test's mock) — confirmed pre-existing on `origin/main` before this branch's first commit, unrelated to this PR.
- `packages/desktop`'s bare `tsc --noEmit` (no `-p`) fails with hundreds of `TS6305` "not built from source" errors — a pre-existing composite-project/build-graph artifact (the `out/` directory was never built), unrelated to content. The meaningful check, `tsc --noEmit -p tsconfig.web.json`, is clean of any errors introduced by this PR (same 12 pre-existing, unrelated errors before and after, confirmed via `git stash` comparison).
- `packages/core`'s full suite has one flaky, timing-based test (`routes/git.test.ts`, real-git-repo `vi.waitFor`) that failed once in isolation from a larger run but passed cleanly standalone and on every other run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)