### PR TITLE
chore(release): 2.0 pre-release mode + tag-derived pre-release flag

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@qlan-ro/mainframe-app-electron": "1.0.0",
+    "@qlan-ro/mainframe-app-tauri": "1.0.0",
+    "@qlan-ro/mainframe-core": "1.0.0",
+    "@qlan-ro/mainframe-e2e": "0.1.0",
+    "@qlan-ro/mainframe-types": "1.0.0",
+    "@qlan-ro/mainframe-ui": "1.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/release-prerelease-mode.md
+++ b/.changeset/release-prerelease-mode.md
@@ -1,0 +1,5 @@
+---
+---
+
+Release tooling only: enter changesets pre mode (`rc`) for the 2.0 line and
+mark pre-release-suffixed tags as GitHub pre-releases. No package changelog.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,10 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: Mainframe ${{ github.ref_name }}
           releaseDraft: true
-          prerelease: false
+          # Any tag with a pre-release suffix (v2.0.0-rc.1, -nightly.N, …) is a
+          # pre-release, so it never becomes the "latest" release the in-app updater
+          # tracks. Clean vX.Y.Z tags publish as stable.
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   release:
     needs: [build-desktop, build-daemon, build-app-tauri]
@@ -229,6 +232,8 @@ jobs:
         with:
           files: artifacts/*
           draft: true
+          # Mirror the tauri-action job: pre-release suffix → GitHub pre-release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           body: |
             ---


### PR DESCRIPTION
Sets up the 2.0 line to build **pre-releases** instead of prematurely shipping a stable `v2.0.0`.

## Why
PR #398 (Electron→Tauri migration) merged to `main`, so the auto-opened **"chore: version packages" PR (#397)** currently bumps to `2.0.0`. Merging it would make `prepare-release.yml` auto-tag a stable **`v2.0.0`**, which the in-app updater would serve as "latest" — before 2.0 is ready.

## What
- **`.changeset/pre.json` (tag: `rc`)** — enters changesets pre mode. `changeset version` now yields `2.0.0-rc.N`, so the auto-tagger cuts **`v2.0.0-rc.N`** (a pre-release). `changeset pre exit` when 2.0 goes stable.
- **`release.yml`** — both the `tauri-action` and `softprops` jobs now set `prerelease: ${{ contains(github.ref_name, '-') }}`, so any suffixed tag (`-rc.N`, `-nightly.N`) publishes as a GitHub pre-release and never becomes "latest". Clean `vX.Y.Z` tags still publish stable.
- `mobile` is omitted from `pre.json` `initialVersions` — the submodule isn't checked out in CI, and listing an absent package there risks the same failure the changeset `ignore` entry hit.

## Merge order (important)
1. Merge **this** PR first.
2. `version.yml` will regenerate **#397** to bump to `2.0.0-rc.0`.
3. Merging **#397** then auto-tags `v2.0.0-rc.0` → a pre-release build.

Do **not** merge #397 before this PR, or it ships a stable `v2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)