### PR TITLE
fix(release): auto-tagger skips version PRs in changesets pre mode

### DIFF
--- a/.changeset/fix-prepare-release-title.md
+++ b/.changeset/fix-prepare-release-title.md
@@ -1,0 +1,5 @@
+---
+---
+
+Release tooling only: match the version-PR title by prefix so the auto-tagger
+fires in changesets pre mode (title gains an "(rc)" suffix). No package changelog.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,9 +7,12 @@ on:
 
 jobs:
   release:
+    # In changesets pre mode the version PR title gains the pre-tag suffix
+    # ("chore: version packages (rc)"), so match on prefix — this covers the
+    # normal title, every pre-mode tag, and the stable title after `pre exit`.
     if: >-
       github.event.pull_request.merged == true &&
-      github.event.pull_request.title == 'chore: version packages'
+      startsWith(github.event.pull_request.title, 'chore: version packages')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem
Merging the `chore: version packages (rc)` PR (#397) did **not** cut a release — the `prepare-release.yml` job [skipped](https://github.com/qlan-ro/mainframe/actions/runs/28824639605).

Its gate was an exact title match:
```yaml
github.event.pull_request.title == 'chore: version packages'
```
But in changesets **pre mode**, the version PR title gains the pre-tag suffix → `chore: version packages (rc)`, so the equality was false and the job skipped. No tag, no release.

## Fix
Match by prefix — covers the normal title, every pre-mode tag (`(rc)`, `(beta)`, …), and the stable title after `changeset pre exit`:
```yaml
startsWith(github.event.pull_request.title, 'chore: version packages')
```

The missed `v2.0.0-rc.0` build is being recovered by tagging it manually (release.yml already marks suffixed tags as pre-releases). Once this merges, future `rc.N` version-PR merges auto-tag correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)