### PR TITLE
fix(core): backport daemon/core bug fixes from 2.0 to 1.0

### DIFF
--- a/.changeset/backport-1_0-daemon-fixes.md
+++ b/.changeset/backport-1_0-daemon-fixes.md
@@ -1,0 +1,16 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-desktop': patch
+---
+
+Backport daemon/core bug fixes from the 2.0 line to 1.0:
+
+- **Cross-project path guard**: `getEffectivePath` now rejects a `chatId` that belongs to a different project, preventing file/git reads and writes from being re-based onto another project's worktree.
+- **Stuck "working" chats**: reset orphaned `processState: 'working'` chats to `idle` on daemon boot, so chats left mid-run by a restart/crash no longer appear running and queue new messages forever.
+- **Tunnel timeout race**: clear the pre-connection start timeout the moment a tunnel connects, so a tunnel that takes longer than the start window to verify DNS is no longer torn down while healthy.
+- **Codex history ids**: derive message ids from stable Codex thread-item ids instead of `nanoid()`, so reloading a Codex chat emits incremental display deltas instead of re-broadcasting the whole transcript.
+- **AskUserQuestion parsing**: accept the newer Claude CLI result wording ("Your questions have been answered: …") so answers keep parsing across CLI versions.
+- **Title generation**: pass `--no-session-persistence` so throwaway title prompts no longer leave ghost sessions in the CLI session list / external-session scan.
+- **Codex external sessions**: honor `excludeSessionIds` so already-active sessions no longer appear as duplicates in the resume picker.
+- **Deleted worktree path**: `ChatManager.getEffectivePath` returns `null` when the chat's worktree is missing instead of a stale path.

--- a/packages/core/src/__tests__/routes/types.test.ts
+++ b/packages/core/src/__tests__/routes/types.test.ts
@@ -37,7 +37,7 @@ describe('getEffectivePath', () => {
 
   it('returns worktreePath when chat has one', () => {
     (ctx.db.projects.get as any).mockReturnValue({ id: 'p1', path: '/my/project' });
-    (ctx.chats.getChat as any).mockReturnValue({ id: 'c1', worktreePath: '/worktree/path' });
+    (ctx.chats.getChat as any).mockReturnValue({ id: 'c1', projectId: 'p1', worktreePath: '/worktree/path' });
 
     const result = getEffectivePath(ctx, 'p1', 'c1');
     expect(result).toBe('/worktree/path');
@@ -45,7 +45,7 @@ describe('getEffectivePath', () => {
 
   it('returns project path when chat has no worktreePath', () => {
     (ctx.db.projects.get as any).mockReturnValue({ id: 'p1', path: '/my/project' });
-    (ctx.chats.getChat as any).mockReturnValue({ id: 'c1', worktreePath: null });
+    (ctx.chats.getChat as any).mockReturnValue({ id: 'c1', projectId: 'p1', worktreePath: null });
 
     const result = getEffectivePath(ctx, 'p1', 'c1');
     expect(result).toBe('/my/project');
@@ -63,9 +63,18 @@ describe('getEffectivePath', () => {
     (ctx.db.projects.get as any).mockReturnValue({ id: 'p1', path: '/my/project' });
     (ctx.chats.getChat as any).mockReturnValue({
       id: 'c1',
+      projectId: 'p1',
       worktreePath: '/deleted/worktree',
       worktreeMissing: true,
     });
+
+    const result = getEffectivePath(ctx, 'p1', 'c1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when chatId belongs to a different project (cross-project guard)', () => {
+    (ctx.db.projects.get as any).mockReturnValue({ id: 'p1', path: '/my/project' });
+    (ctx.chats.getChat as any).mockReturnValue({ id: 'c1', projectId: 'p2', worktreePath: '/other/worktree' });
 
     const result = getEffectivePath(ctx, 'p1', 'c1');
     expect(result).toBeNull();

--- a/packages/core/src/chat/__tests__/chat-manager-recover-working.test.ts
+++ b/packages/core/src/chat/__tests__/chat-manager-recover-working.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Chat } from '@qlan-ro/mainframe-types';
+import type { DatabaseManager } from '../../db/index.js';
+import type { AdapterRegistry } from '../../adapters/index.js';
+import { ChatManager } from '../chat-manager.js';
+import { BackgroundTaskTracker } from '../../background-tasks/tracker.js';
+
+/**
+ * Builds a minimal stateful mock DB whose chats.update() writes back into the
+ * in-memory store so chats.get() and chats.listAll() reflect post-mutation state.
+ * Only the fields exercised by recoverStaleWorkingState are modelled.
+ */
+function makeStatefulDb(initial: Array<Partial<Chat> & { id: string }>): DatabaseManager {
+  const store = new Map<string, Partial<Chat> & { id: string }>(initial.map((c) => [c.id, { ...c }]));
+
+  return {
+    chats: {
+      listAll: () => [...store.values()] as Chat[],
+      get: (id: string) => (store.get(id) ?? null) as Chat | null,
+      update: (_id: string, partial: Partial<Chat>) => {
+        const existing = store.get(_id);
+        if (existing) store.set(_id, { ...existing, ...partial });
+      },
+      resetWorkingToIdle: () => {
+        let count = 0;
+        for (const [id, chat] of store) {
+          if (chat.processState === 'working') {
+            store.set(id, { ...chat, processState: 'idle' });
+            count++;
+          }
+        }
+        return count;
+      },
+      list: vi.fn().mockReturnValue([]),
+      create: vi.fn(),
+      archive: vi.fn(),
+      listFiltered: vi.fn().mockReturnValue([]),
+      addMention: vi.fn(),
+    },
+    projects: {
+      list: vi.fn(),
+      get: vi.fn(),
+      getByPath: vi.fn(),
+      create: vi.fn(),
+      remove: vi.fn(),
+      updateLastOpened: vi.fn(),
+    },
+    settings: { get: vi.fn(), getByCategory: vi.fn(), set: vi.fn(), delete: vi.fn() },
+  } as unknown as DatabaseManager;
+}
+
+function makeAdapters(): AdapterRegistry {
+  return {
+    get: vi.fn().mockReturnValue(undefined),
+    list: vi.fn(),
+    all: vi.fn().mockReturnValue([]),
+  } as unknown as AdapterRegistry;
+}
+
+describe('ChatManager.recoverStaleWorkingState', () => {
+  it('resets a working chat to idle', () => {
+    const db = makeStatefulDb([
+      { id: 'c-working', projectId: 'p1', processState: 'working' },
+      { id: 'c-idle', projectId: 'p1', processState: 'idle' },
+      { id: 'c-null', projectId: 'p1', processState: null as unknown as undefined },
+    ]);
+    const manager = new ChatManager(db, makeAdapters(), new BackgroundTaskTracker());
+
+    manager.recoverStaleWorkingState();
+
+    expect(db.chats.get('c-working')?.processState).toBe('idle');
+  });
+
+  it('leaves an already-idle chat unchanged', () => {
+    const db = makeStatefulDb([
+      { id: 'c-working', projectId: 'p1', processState: 'working' },
+      { id: 'c-idle', projectId: 'p1', processState: 'idle' },
+      { id: 'c-null', projectId: 'p1', processState: null as unknown as undefined },
+    ]);
+    const manager = new ChatManager(db, makeAdapters(), new BackgroundTaskTracker());
+
+    manager.recoverStaleWorkingState();
+
+    expect(db.chats.get('c-idle')?.processState).toBe('idle');
+  });
+
+  it('does not touch a chat whose processState is null', () => {
+    const db = makeStatefulDb([
+      { id: 'c-working', projectId: 'p1', processState: 'working' },
+      { id: 'c-idle', projectId: 'p1', processState: 'idle' },
+      { id: 'c-null', projectId: 'p1', processState: null as unknown as undefined },
+    ]);
+    const manager = new ChatManager(db, makeAdapters(), new BackgroundTaskTracker());
+
+    manager.recoverStaleWorkingState();
+
+    expect(db.chats.get('c-null')?.processState).toBeNull();
+  });
+
+  it('is a no-op when no chats are stored', () => {
+    const db = makeStatefulDb([]);
+    const manager = new ChatManager(db, makeAdapters(), new BackgroundTaskTracker());
+
+    expect(() => manager.recoverStaleWorkingState()).not.toThrow();
+  });
+
+  it('resets every working chat when multiple are stale', () => {
+    const db = makeStatefulDb([
+      { id: 'w1', projectId: 'p1', processState: 'working' },
+      { id: 'w2', projectId: 'p1', processState: 'working' },
+      { id: 'ok', projectId: 'p1', processState: 'idle' },
+    ]);
+    const manager = new ChatManager(db, makeAdapters(), new BackgroundTaskTracker());
+
+    manager.recoverStaleWorkingState();
+
+    expect(db.chats.get('w1')?.processState).toBe('idle');
+    expect(db.chats.get('w2')?.processState).toBe('idle');
+    expect(db.chats.get('ok')?.processState).toBe('idle');
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -124,6 +124,21 @@ export class ChatManager {
     this.idleScanner.start();
   }
 
+  /**
+   * On boot, no in-memory CLI sessions exist, so any persisted
+   * `processState: 'working'` was orphaned by a previous daemon restart/crash.
+   * Reset it to 'idle' so the UI doesn't treat the chat as running — otherwise a
+   * new message queues forever ("sends after the current run") because there is
+   * no live run to finish. A chat that was genuinely mid-run is interrupted by
+   * the restart anyway (the CLI dies with the daemon), so 'idle' is correct.
+   *
+   * Call once at daemon boot, after construction (see `index.ts`).
+   */
+  recoverStaleWorkingState(): void {
+    const count = this.db.chats.resetWorkingToIdle();
+    logger.info({ count }, 'reset orphaned working chats to idle on boot');
+  }
+
   /** Stop background timers. Idempotent. Tests and shutdown should call this. */
   dispose(): void {
     this.idleScanner.stop();
@@ -551,10 +566,23 @@ export class ChatManager {
     }
   }
 
+  /**
+   * Returns the working directory for `chatId`:
+   * - the chat's worktree path when it has one and the directory still exists;
+   * - the project root otherwise.
+   *
+   * Returns `null` when the chat is unknown, the project is unknown, or the
+   * chat's worktree has been deleted (`worktreeMissing === true`).
+   * Callers that need to distinguish "worktree missing" from "chat not found"
+   * should check `getChat(chatId)?.worktreeMissing` after receiving `null`.
+   */
   getEffectivePath(chatId: string): string | null {
     const chat = this.getChat(chatId);
     if (!chat) return null;
-    if (chat.worktreePath) return chat.worktreePath;
+    if (chat.worktreePath) {
+      if (chat.worktreeMissing) return null;
+      return chat.worktreePath;
+    }
     const project = this.db.projects.get(chat.projectId);
     return project?.path ?? null;
   }

--- a/packages/core/src/chat/title-generator.ts
+++ b/packages/core/src/chat/title-generator.ts
@@ -28,7 +28,21 @@ export async function generateTitle(content: string, binary: string): Promise<st
 
   const { stdout } = await execFileNoStdin(
     binary,
-    ['-p', prompt, '--output-format', 'text', '--model', 'claude-haiku-4-5-20251001', '--max-turns', '1'],
+    [
+      '-p',
+      prompt,
+      // Don't persist this throwaway prompt as a resumable session on disk —
+      // otherwise it pollutes the CLI's session list (and our external-sessions
+      // scan) as a "Generate a short title…" ghost. The CLI's own title gen
+      // avoids this by calling the API directly; we shell out, so we opt out here.
+      '--no-session-persistence',
+      '--output-format',
+      'text',
+      '--model',
+      'claude-haiku-4-5-20251001',
+      '--max-turns',
+      '1',
+    ],
     { timeout: 30_000, maxBuffer: 8192, env: { ...process.env, NO_COLOR: '1' } },
   );
 

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -298,6 +298,15 @@ export class ChatsRepository {
     this.db.prepare('UPDATE chats SET todos = ? WHERE id = ?').run(JSON.stringify(todos), chatId);
   }
 
+  /**
+   * Bulk-reset every chat whose process_state is 'working' to 'idle'.
+   * Returns the number of rows affected.
+   */
+  resetWorkingToIdle(): number {
+    const result = this.db.prepare("UPDATE chats SET process_state = 'idle' WHERE process_state = 'working'").run();
+    return result.changes;
+  }
+
   getImportedSessionIds(projectId: string): string[] {
     const stmt = this.db.prepare(`
       SELECT claude_session_id FROM chats

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,10 @@ async function main(): Promise<void> {
   // server.start() (plugin loading) are safely dropped — no WS clients yet.
   let broadcastEvent: (event: DaemonEvent) => void = () => {};
   const chats = new ChatManager(db, adapters, backgroundTasks, attachmentStore, (event) => broadcastEvent(event));
+  // No in-memory CLI sessions survive a restart, so reset any persisted
+  // processState:'working' (orphaned by the previous shutdown/crash) to 'idle' —
+  // otherwise those chats look "running" and new messages queue forever.
+  chats.recoverStaleWorkingState();
   const tunnelManager = new TunnelManager((event) => broadcastEvent(event));
   const launchRegistry = new LaunchRegistry((event) => broadcastEvent(event), tunnelManager);
 

--- a/packages/core/src/messages/__tests__/parse-ask-user-question.test.ts
+++ b/packages/core/src/messages/__tests__/parse-ask-user-question.test.ts
@@ -118,6 +118,47 @@ describe('parseAskUserQuestionResult', () => {
     expect(parseAskUserQuestionResult(`${PREFIX}garbage no quotes${SUFFIX}`)).toEqual([]);
   });
 
+  describe('new CLI wording (Your questions have been answered: …)', () => {
+    const NEW_PREFIX = 'Your questions have been answered: ';
+    const NEW_SUFFIX = '. You can now continue with these answers in mind.';
+
+    it('single question — suffix does not leak into the answer', () => {
+      const s = `${NEW_PREFIX}"What size pizza?"="Small"${NEW_SUFFIX}`;
+      expect(parseAskUserQuestionResult(s, [{ question: 'What size pizza?' }])).toEqual([
+        { question: 'What size pizza?', answer: ['Small'] },
+      ]);
+    });
+
+    it('multiple questions — each answer is isolated', () => {
+      const s = `${NEW_PREFIX}"Q1"="A1", "Q2"="A2"${NEW_SUFFIX}`;
+      expect(
+        parseAskUserQuestionResult(s, [
+          { question: 'Q1', multiSelect: false },
+          { question: 'Q2', multiSelect: false },
+        ]),
+      ).toEqual([
+        { question: 'Q1', answer: ['A1'] },
+        { question: 'Q2', answer: ['A2'] },
+      ]);
+    });
+
+    it('no questions arg (legacy/regex path) — suffix is still stripped', () => {
+      const s = `${NEW_PREFIX}"What size pizza?"="Small"${NEW_SUFFIX}`;
+      expect(parseAskUserQuestionResult(s)).toEqual([{ question: 'What size pizza?', answer: ['Small'] }]);
+    });
+
+    it('old wording still parses correctly (regression guard)', () => {
+      const s = `User has answered your questions: "What size pizza?"="Small". You can now continue with the user's answers in mind.`;
+      expect(parseAskUserQuestionResult(s, [{ question: 'What size pizza?' }])).toEqual([
+        { question: 'What size pizza?', answer: ['Small'] },
+      ]);
+    });
+
+    it('unrecognised prefix returns []', () => {
+      expect(parseAskUserQuestionResult('User skipped the question')).toEqual([]);
+    });
+  });
+
   it('parser output for the canonical CLI string equals the shared fixture', () => {
     const s =
       'User has answered your questions: "Which DB?"="Postgres", "Pick"="Red,Blue" user notes: dense' +

--- a/packages/core/src/messages/parse-ask-user-question.ts
+++ b/packages/core/src/messages/parse-ask-user-question.ts
@@ -1,7 +1,14 @@
 import type { AskUserQuestionAnswer } from '@qlan-ro/mainframe-types';
 
-const PREFIX = 'User has answered your questions: ';
-const SUFFIX = ". You can now continue with the user's answers in mind.";
+// The CLI's AskUserQuestion result wording varies across versions — match every
+// known prefix/suffix variant so answers keep parsing. Older builds emit
+// "User has answered your questions: … the user's answers in mind."; newer ones
+// emit "Your questions have been answered: … these answers in mind."
+const PREFIXES = ['User has answered your questions: ', 'Your questions have been answered: '];
+const SUFFIXES = [
+  ". You can now continue with the user's answers in mind.",
+  '. You can now continue with these answers in mind.',
+];
 const PAIR = /"([^"]*)"="([^"]*)"/g;
 
 export interface KnownQuestion {
@@ -11,9 +18,12 @@ export interface KnownQuestion {
 }
 
 function stripBody(content: string): string | undefined {
-  if (typeof content !== 'string' || !content.startsWith(PREFIX)) return undefined;
-  let body = content.slice(PREFIX.length);
-  if (body.endsWith(SUFFIX)) body = body.slice(0, -SUFFIX.length);
+  if (typeof content !== 'string') return undefined;
+  const prefix = PREFIXES.find((p) => content.startsWith(p));
+  if (prefix === undefined) return undefined;
+  let body = content.slice(prefix.length);
+  const suffix = SUFFIXES.find((s) => body.endsWith(s));
+  if (suffix) body = body.slice(0, -suffix.length);
   return body;
 }
 

--- a/packages/core/src/plugins/builtin/codex/__tests__/history.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/history.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { convertThreadItems } from '../history.js';
 import type { ThreadItem } from '../types.js';
+import type { UserMessageItem, AgentMessageItem, CommandExecutionItem, FileChangeItem } from '../item-types.js';
 
 describe('convertThreadItems — userMessage shapes', () => {
   it('extracts text from content[0].text (the thread/read shape)', () => {
@@ -41,5 +42,71 @@ describe('convertThreadItems — userMessage shapes', () => {
     ] as unknown as ThreadItem[];
     const out = convertThreadItems(items, 'chat1');
     expect(out).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Representative fixture shared across determinism tests.
+//
+// Item counts → expected message counts:
+//   userMessage  (u1)  → 1 message
+//   agentMessage (a1)  → 1 message
+//   commandExec  (c1)  → 2 messages (tool_use + tool_result)
+//   fileChange   (f1)  → 2 messages (tool_use + tool_result, one change)
+//   total             → 6 messages
+// ---------------------------------------------------------------------------
+const baseItems: ThreadItem[] = [
+  {
+    id: 'u1',
+    type: 'userMessage',
+    content: [{ type: 'text', text: 'test message' }],
+  } satisfies UserMessageItem,
+  {
+    id: 'a1',
+    type: 'agentMessage',
+    text: 'hi',
+    phase: null,
+  } satisfies AgentMessageItem,
+  {
+    id: 'c1',
+    type: 'commandExecution',
+    command: 'ls',
+    aggregatedOutput: 'out',
+    exitCode: 0,
+    status: 'completed',
+  } satisfies CommandExecutionItem,
+  {
+    id: 'f1',
+    type: 'fileChange',
+    status: 'completed',
+    changes: [{ path: 'x.ts', kind: { type: 'add' }, diff: '+hello\n' }],
+  } satisfies FileChangeItem,
+];
+
+describe('convertThreadItems — stable/deterministic ids', () => {
+  it('produces identical message ids on repeated reconstructions of the same items', () => {
+    const a = convertThreadItems(baseItems, 'chat1').map((m) => m.id);
+    const b = convertThreadItems(baseItems, 'chat1').map((m) => m.id);
+    expect(a).toEqual(b);
+  });
+
+  it('all ids are unique within one reconstruction (no collision)', () => {
+    const ids = convertThreadItems(baseItems, 'chat1').map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('appending an item preserves the ids of the original messages as a stable prefix', () => {
+    const extraItem: AgentMessageItem = {
+      id: 'a2',
+      type: 'agentMessage',
+      text: 'more',
+      phase: null,
+    };
+
+    const base = convertThreadItems(baseItems, 'chat1').map((m) => m.id);
+    const withExtra = convertThreadItems([...baseItems, extraItem], 'chat1').map((m) => m.id);
+
+    // The ids for the original items must be identical — only the new item's ids differ.
+    expect(withExtra.slice(0, base.length)).toEqual(base);
   });
 });

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -104,7 +104,7 @@ export class CodexAdapter implements Adapter {
   // TODO: implement listAgents, createAgent, updateAgent, deleteAgent
   // TODO: implement listCommands
 
-  async listExternalSessions(projectPath: string, _excludeSessionIds: string[]): Promise<ExternalSession[]> {
+  async listExternalSessions(projectPath: string, excludeSessionIds: string[]): Promise<ExternalSession[]> {
     let client: JsonRpcClient | null = null;
     try {
       client = await this.spawnTempAppServer();
@@ -132,7 +132,10 @@ export class CodexAdapter implements Adapter {
       } catch (err) {
         log.warn({ err, projectPath }, 'codex: failed to list external sessions for path');
       }
-      return aggregated;
+      // Exclude already-imported/active sessions so they don't appear as
+      // duplicates in the resume picker (parity with the Claude adapter).
+      const excludeSet = new Set(excludeSessionIds);
+      return aggregated.filter((s) => !excludeSet.has(s.sessionId));
     } catch (err) {
       log.warn({ err }, 'codex: failed to list external sessions');
       return [];

--- a/packages/core/src/plugins/builtin/codex/history.ts
+++ b/packages/core/src/plugins/builtin/codex/history.ts
@@ -1,5 +1,4 @@
 // packages/core/src/plugins/builtin/codex/history.ts
-import { nanoid } from 'nanoid';
 import type { ChatMessage, MessageContent } from '@qlan-ro/mainframe-types';
 import type { ThreadItem, PatchChangeKind } from './types.js';
 import type { CollabAgentToolCallItem } from './item-types.js';
@@ -20,12 +19,12 @@ export function convertThreadItems(
   for (const item of items) {
     switch (item.type) {
       case 'agentMessage':
-        messages.push(makeMessage(chatId, 'assistant', [{ type: 'text', text: item.text }]));
+        messages.push(makeMessage(item.id, chatId, 'assistant', [{ type: 'text', text: item.text }]));
         break;
 
       case 'reasoning':
         messages.push(
-          makeMessage(chatId, 'assistant', [
+          makeMessage(item.id, chatId, 'assistant', [
             { type: 'thinking', thinking: item.summary.join('\n') || item.content.join('\n') },
           ]),
         );
@@ -33,7 +32,7 @@ export function convertThreadItems(
 
       case 'commandExecution':
         messages.push(
-          makeMessage(chatId, 'assistant', [
+          makeMessage(item.id, chatId, 'assistant', [
             {
               type: 'tool_use',
               id: item.id,
@@ -43,7 +42,7 @@ export function convertThreadItems(
           ]),
         );
         messages.push(
-          makeMessage(chatId, 'tool_result', [
+          makeMessage(`${item.id}:result`, chatId, 'tool_result', [
             {
               type: 'tool_result',
               toolUseId: item.id,
@@ -71,9 +70,11 @@ export function convertThreadItems(
                   ? { move_path: (change.kind as Extract<PatchChangeKind, { type: 'update' }>).move_path }
                   : {}),
               };
-          messages.push(makeMessage(chatId, 'assistant', [{ type: 'tool_use', id: toolId, name: toolName, input }]));
           messages.push(
-            makeMessage(chatId, 'tool_result', [
+            makeMessage(toolId, chatId, 'assistant', [{ type: 'tool_use', id: toolId, name: toolName, input }]),
+          );
+          messages.push(
+            makeMessage(`${toolId}:result`, chatId, 'tool_result', [
               {
                 type: 'tool_result',
                 toolUseId: toolId,
@@ -91,7 +92,7 @@ export function convertThreadItems(
         const server = item.server ?? 'codex';
         const toolName = `mcp__${server}__${item.tool}`;
         messages.push(
-          makeMessage(chatId, 'assistant', [
+          makeMessage(item.id, chatId, 'assistant', [
             {
               type: 'tool_use',
               id: item.id,
@@ -101,7 +102,7 @@ export function convertThreadItems(
           ]),
         );
         messages.push(
-          makeMessage(chatId, 'tool_result', [
+          makeMessage(`${item.id}:result`, chatId, 'tool_result', [
             {
               type: 'tool_result',
               toolUseId: item.id,
@@ -120,7 +121,7 @@ export function convertThreadItems(
         const block = item.content?.find((b) => typeof b.text === 'string' && b.text.length > 0);
         const text = block?.text ?? item.text ?? '';
         if (!text) break;
-        messages.push(makeMessage(chatId, 'user', [{ type: 'text', text }]));
+        messages.push(makeMessage(item.id, chatId, 'user', [{ type: 'text', text }]));
         break;
       }
 
@@ -203,13 +204,13 @@ function emitCollabAgent(
     }
   }
 
-  messages.push(makeMessage(chatId, 'assistant', content));
-  for (const r of childToolResults) {
-    messages.push(makeMessage(chatId, 'tool_result', [r]));
+  messages.push(makeMessage(item.id, chatId, 'assistant', content));
+  for (const [index, r] of childToolResults.entries()) {
+    messages.push(makeMessage(`${item.id}:child:${index}:result`, chatId, 'tool_result', [r]));
   }
   // Close the card with the CollabAgent's own tool_result (sub-agent's final message).
   messages.push(
-    makeMessage(chatId, 'tool_result', [
+    makeMessage(`${item.id}:result`, chatId, 'tool_result', [
       {
         type: 'tool_result',
         toolUseId: item.id,
@@ -221,9 +222,17 @@ function emitCollabAgent(
   if (childId) spawnPrompts.delete(childId);
 }
 
-function makeMessage(chatId: string, type: ChatMessage['type'], content: MessageContent[]): ChatMessage {
+/**
+ * Build a ChatMessage with a CALLER-SUPPLIED deterministic id. The id is derived
+ * from the Codex thread item's stable `id` (+ a slot suffix for items that emit
+ * more than one message), so reconstructing the same items yields the same ids
+ * every turn. That lets the display delta emitter detect appends/updates instead
+ * of re-broadcasting the whole list (a `display.messages.set`) on every turn —
+ * which previously happened because `id: nanoid()` changed the ids each pass.
+ */
+function makeMessage(id: string, chatId: string, type: ChatMessage['type'], content: MessageContent[]): ChatMessage {
   return {
-    id: nanoid(),
+    id,
     chatId,
     type,
     content,

--- a/packages/core/src/server/routes/types.ts
+++ b/packages/core/src/server/routes/types.ts
@@ -38,9 +38,14 @@ export function getEffectivePath(ctx: RouteContext, projectId: string, chatId?: 
   if (!project) return null;
   if (chatId) {
     const chat = ctx.chats.getChat(chatId);
-    if (chat?.worktreePath) {
-      if (chat.worktreeMissing) return null;
-      return chat.worktreePath;
+    if (chat) {
+      // Guard: reject cross-project access — a chatId from project B must not
+      // silently re-base reads/writes under project A's URL.
+      if (chat.projectId !== projectId) return null;
+      if (chat.worktreePath) {
+        if (chat.worktreeMissing) return null;
+        return chat.worktreePath;
+      }
     }
   }
   return project.path;

--- a/packages/core/src/tunnel/tunnel-manager.ts
+++ b/packages/core/src/tunnel/tunnel-manager.ts
@@ -72,6 +72,12 @@ export class TunnelManager {
       let pendingUrl: string | null = isNamed ? (options.url ?? null) : null;
       let registered = false;
 
+      // Guards only the pre-connection phase (cloudflared never spawning, never
+      // printing a URL, never registering). Once the tunnel is established below,
+      // waitForDns takes over — it has its own DNS_TIMEOUT_MS and both of its
+      // branches resolve the promise, so this timeout must be cleared then.
+      // Otherwise it fires 45s after start() regardless of connection time and
+      // kills an already-healthy tunnel out from under the DNS grace path.
       const timeout = setTimeout(() => {
         if (!done) {
           done = true;
@@ -87,6 +93,7 @@ export class TunnelManager {
         const url = pendingUrl;
         const tunnel: ManagedTunnel = { process: child, url, ready: false };
         this.tunnels.set(label, tunnel);
+        clearTimeout(timeout);
         log.info({ label, url, port }, 'tunnel connected, waiting for DNS propagation…');
         this.broadcast({ type: 'tunnel:status', state: 'ready', label, url, dnsVerified: false });
 
@@ -95,7 +102,6 @@ export class TunnelManager {
             if (done) return;
             done = true;
             tunnel.ready = true;
-            clearTimeout(timeout);
             log.info({ label, url }, 'tunnel ready (DNS verified)');
             this.broadcast({ type: 'tunnel:status', state: 'dns_verified', label, url, dnsVerified: true });
             resolve(url);
@@ -104,7 +110,6 @@ export class TunnelManager {
             if (done) return;
             done = true;
             tunnel.ready = true;
-            clearTimeout(timeout);
             log.warn({ label, url }, 'tunnel DNS verification timed out, emitting anyway');
             this.broadcast({ type: 'tunnel:status', state: 'dns_verified', label, url, dnsVerified: false });
             resolve(url);


### PR DESCRIPTION
Backports genuine daemon/core **defect fixes** that landed in the 2.0 work (the Electron→Tauri migration PR) but also affect the 1.0 line. Each was lifted from the merged 2.0 code and **stripped of all 2.0-only feature code** (WorkflowService, host-bridge, trust-store, MessageTiming, `emitChatUpdated`, the `message.queued.cancel_failed` removal, `isWorktreePresent`). Based on `release/1.0`; the commit is only the 14 files below.

## Fixes

| Fix | Impact on 1.0 |
|-----|---------------|
| **Cross-project path guard** (`server/routes/types.ts`) | `getEffectivePath` now rejects a `chatId` owned by a different project — previously `GET/PUT /api/projects/A/files?chatId=<chat-in-B>` (and git routes) re-based reads/**writes** onto project B's worktree. |
| **Stuck "working" on boot** (`db/chats.ts`, `chat/chat-manager.ts`, `index.ts`) | Persisted `processState:'working'` orphaned by a restart/crash left chats looking "running" and queued new messages forever. Now reset to `idle` at boot. |
| **Tunnel timeout race** (`tunnel/tunnel-manager.ts`) | The 45s pre-connection guard was only cleared after DNS verification, so a tunnel taking longer to verify got torn down while healthy. Now cleared on connect. |
| **Codex history ids** (`plugins/builtin/codex/history.ts`) | Message ids were `nanoid()`, so every reload re-broadcast the whole transcript (`display.messages.set`) instead of incremental deltas. Now derived from stable thread-item ids. |
| **AskUserQuestion parsing** (`messages/parse-ask-user-question.ts`) | Newer Claude CLI wording ("Your questions have been answered: …") stopped parsing. Now both wordings are accepted. |
| **Title-gen ghost sessions** (`chat/title-generator.ts`) | Added `--no-session-persistence` so throwaway title prompts no longer pollute the CLI session list / external-session scan. |
| **Codex `excludeSessionIds`** (`plugins/builtin/codex/adapter.ts`) | Already-active Codex sessions showed as duplicates in the resume picker (Claude already filtered). Now honored. |
| **Deleted worktree path** (`chat/chat-manager.ts`) | `ChatManager.getEffectivePath` now returns `null` for a missing worktree instead of a stale path. |

## Tests
Ported from the 2.0 branch: `chat-manager-recover-working.test.ts`, cross-project guard case in `routes/types.test.ts`, new-wording cases in `parse-ask-user-question.test.ts`, and Codex id-determinism cases in `codex/__tests__/history.test.ts`. Changeset included (patch to the fixed package group).

## ⚠️ Not validated locally
This was prepared in an environment without the JS toolchain (`pnpm`/`node_modules` absent), so **`tsc`/`vitest` were not run here** — CI is the gate. Every change is a faithful subset of code that already passed CI on 2.0. One thing to confirm: fix #6 assumes the 1.0-pinned Claude CLI supports `--no-session-persistence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)