### PR TITLE
fix(ui): session navigation & transcript correctness (4 fixes)

### DIFF
--- a/.changeset/fix-archive-active-fallback.md
+++ b/.changeset/fix-archive-active-fallback.md
@@ -1,0 +1,15 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix archiving the active session dumping you on the empty new-session screen.
+
+assistant-ui's remote thread list calls `switchToNewThread()` off the archived
+thread *before* marking it archived, so `mainThreadId` becomes a fresh
+`__LOCALID_*` draft and the existing archived-active fallback (which keyed on the
+active thread still being archived) never fired. The session router now remembers
+the last real (non-draft) thread and, when an archive bumps you onto an empty
+draft, redirects to a fallback session — the last-used one if still live, else
+the most-recently-updated non-archived session, respecting the active project
+filter. A deliberate "New" leaves the previous session regular, so it is not
+redirected.

--- a/.changeset/fix-dormant-chat-reseed.md
+++ b/.changeset/fix-dormant-chat-reseed.md
@@ -1,0 +1,19 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix background sessions losing messages while another chat is open.
+
+A chat's live WS subscription is gated to the active thread, so a backgrounded
+chat receives no message events while dormant — the daemon still persists them,
+but the transcript stayed frozen at the pre-dormancy snapshot. On `subscribe:ack`
+the catch-up re-seed only fired for a socket reconnect or an unreconciled
+optimistic send, so simply switching back to a chat never healed the gap and the
+messages that arrived while it was backgrounded stayed invisible until a full
+reconnect.
+
+The controller now tracks when a live sub is torn down and treats the next
+attach as a post-dormancy reattach, re-seeding history from REST on the reattach
+ack (like a reconnect). Row-level unread notifications were unaffected — they run
+on a separate always-on session-list subscription — so this only restores the
+missed transcript content on switch-back.

--- a/.changeset/fix-session-draft-and-md-copy.md
+++ b/.changeset/fix-session-draft-and-md-copy.md
@@ -1,0 +1,11 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix two session/editor UX bugs:
+
+- Selecting a project filter with no sessions now opens a new-session draft
+  instead of stranding the previously-selected session from another project.
+- The Markdown preview is now selectable, so its prose can be copied — the
+  `mf-editor-selectable` opt-in class was referenced by the editor surfaces but
+  never defined in the selection whitelist.

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-initial-subscribe-refresh.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-initial-subscribe-refresh.test.ts
@@ -116,6 +116,45 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe('reactivation after dormancy — re-seeds on the reattach ack', () => {
+  it('refreshes history when a warm controller re-attaches, even with no pending send', async () => {
+    // First activation: the chat already holds one message; the mount load() seeds it.
+    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-1', 'first')]);
+
+    const { fakeClient, pushEvent } = makeFakeWs();
+    const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
+
+    const stop = ctrl.subscribeLive();
+    await ctrl.load();
+    await flushMicrotasks();
+
+    // Initial attach ack: no reconnect, no pending → the first attach must NOT
+    // force a reseed (the streaming-clobber optimization is preserved).
+    pushEvent({ type: 'subscribe:ack', chatId: CHAT_ID });
+    await flushMicrotasks();
+    expect(ctrl.getState().messageOrder).toEqual(['srv-1']);
+
+    // Switch away — the live sub is torn down (dormancy).
+    stop();
+
+    // While dormant, the daemon appended a message. It is persisted (REST now
+    // returns it) but was never delivered live — the controller had no sub.
+    vi.mocked(getChatMessages).mockResolvedValue([
+      userDisplayMsg('srv-1', 'first'),
+      userDisplayMsg('srv-2', 'arrived while backgrounded'),
+    ]);
+
+    // Switch back — a fresh sub attaches. The user was only reading, so there is
+    // NO unreconciled pending; only the reattach signal can trigger the catch-up.
+    ctrl.subscribeLive();
+    pushEvent({ type: 'subscribe:ack', chatId: CHAT_ID });
+    await flushMicrotasks();
+
+    // The reattach ack must re-seed history so the missed message appears.
+    expect(ctrl.getState().messageOrder).toEqual(['srv-1', 'srv-2']);
+  });
+});
+
 describe('initial subscribe:ack — recovers a missed handoff event', () => {
   it('refreshes history on the first ack so the optimistic pending is reconciled', async () => {
     // The just-created chat is empty when the first load + send happen.

--- a/packages/ui/src/features/chat/controller/__tests__/chat-ws-subscription.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-ws-subscription.test.ts
@@ -158,6 +158,7 @@ function makeHost(
     dispatchPermission: dispatchSpy,
     onSubscribeRefresh: subscribeRefreshSpy,
     hasUnreconciledPendings: () => false,
+    isReattach: () => false,
     isDisposed: () => false,
     ...overrides,
   };
@@ -402,6 +403,25 @@ describe('chat-ws-subscription reconnect', () => {
     // and re-seeding reconciles it.
     const fakeWs = makeFakeWs(true);
     const { host, subscribeRefreshSpy } = makeHost(fakeWs, { hasUnreconciledPendings: () => true });
+    const sub = new ChatWsSubscription(host);
+    activeSub = sub;
+
+    sub.attach();
+    fakeWs.pushEvent({ type: 'subscribe:ack', chatId: CHAT_ID });
+    await flushMicrotasks();
+
+    expect(subscribeRefreshSpy).toHaveBeenCalledOnce();
+  });
+
+  it('calls onSubscribeRefresh after the initial ack when this is a reattach after dormancy', async () => {
+    // Switching away tears down the sub; a backgrounded chat receives nothing while
+    // dormant even though the daemon keeps persisting messages. The reattach ack must
+    // re-seed to catch up — with no pending and no reconnect, isReattach is the signal.
+    const fakeWs = makeFakeWs(true);
+    const { host, subscribeRefreshSpy } = makeHost(fakeWs, {
+      hasUnreconciledPendings: () => false,
+      isReattach: () => true,
+    });
     const sub = new ChatWsSubscription(host);
     activeSub = sub;
 

--- a/packages/ui/src/features/chat/controller/chat-thread-controller.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-controller.ts
@@ -43,6 +43,11 @@ export class ChatThreadController {
   private daemonId: string;
   private remoteIdSet = false;
   private liveRefs = 0;
+  // True once a live sub has been torn down (the thread went dormant). A warm
+  // controller that reactivates may have missed events streamed while dormant —
+  // its next attach must re-seed from REST to catch up. Distinguishes a genuine
+  // reattach from the controller's first-ever attach (already seeded by load()).
+  private hasBeenLive = false;
   // The stable aui item.id (constructor chatId) — never changes on adopt, so onNew
   // uses it as the createForLocal localId (same key the picker's draft uses).
   private readonly threadId: string;
@@ -119,6 +124,8 @@ export class ChatThreadController {
       if (this.liveRefs === 0) {
         this.wsSub?.detach();
         this.wsSub = null;
+        // Went dormant: the next attach is a reattach that must re-seed.
+        this.hasBeenLive = true;
       }
     };
   }
@@ -145,6 +152,7 @@ export class ChatThreadController {
         this.dispatch({ type: 'permission.requested', requestId: request.requestId, request }),
       onSubscribeRefresh: () => this.refreshInBackground(),
       hasUnreconciledPendings: () => Object.keys(this.state.pendingUserMessages).length > 0,
+      isReattach: () => this.hasBeenLive,
       isDisposed: () => this.disposed,
     };
   }

--- a/packages/ui/src/features/chat/controller/chat-ws-subscription.ts
+++ b/packages/ui/src/features/chat/controller/chat-ws-subscription.ts
@@ -28,20 +28,27 @@ export interface ChatWsHost {
   /** Seed the gate from a REST-read pending permission. */
   dispatchPermission: (request: ControlRequest) => void;
   /**
-   * Background history re-seed after a subscribe:ack. Always fires on a reconnect
-   * (the daemon kept emitting while the socket was down — catch up). On the INITIAL
-   * attach it fires ONLY when `hasUnreconciledPendings()` is true: a clean open is
-   * already seeded by the mount/setRemoteId `load()`, and re-seeding there would
-   * wholesale-replace messageOrder from a possibly-stale REST snapshot, clobbering
-   * messages an actively-streaming chat just delivered. The one initial-attach gap
-   * worth healing is the first-message handoff: the first send happens during the
-   * __LOCALID_* → remoteId window before the sub attaches, so the daemon's
-   * `display.messages.set [user]` lands with no subscriber and the optimistic
-   * pending lingers — a pending at ack time is exactly that signal.
+   * Background history re-seed after a subscribe:ack. Fires on:
+   *  - a reconnect (the daemon kept emitting while the socket was down — catch up);
+   *  - a reattach after dormancy (`isReattach()`): switching away tears down the
+   *    per-chat sub, so a backgrounded chat receives NOTHING while dormant even
+   *    though the daemon keeps persisting messages — the reattach must re-seed or
+   *    the transcript stays stuck at the pre-dormancy snapshot; and
+   *  - the first-message handoff (`hasUnreconciledPendings()`): the first send
+   *    happens during the __LOCALID_* → remoteId window before the sub attaches,
+   *    so the daemon's `display.messages.set [user]` lands with no subscriber and
+   *    the optimistic pending lingers — a pending at ack time is exactly that signal.
+   *
+   * It does NOT fire on the controller's FIRST-EVER attach with no pending: that
+   * open is already seeded by the mount/setRemoteId `load()`, and re-seeding there
+   * would wholesale-replace messageOrder from a possibly-stale REST snapshot,
+   * clobbering messages an actively-streaming chat just delivered.
    */
   onSubscribeRefresh: () => void;
   /** True when an optimistic send has not yet been reconciled (handoff-gap signal). */
   hasUnreconciledPendings: () => boolean;
+  /** True when a live sub was previously torn down — this attach is a post-dormancy reattach. */
+  isReattach: () => boolean;
   /** True once the controller is disposed — gates all async tails. */
   isDisposed: () => boolean;
 }
@@ -117,11 +124,13 @@ export class ChatWsSubscription {
       console.warn('[chat-ws] resumeChat failed', err),
     );
     this.restorePendingPermission();
-    // Reconnect always re-seeds (catch up on events missed while disconnected).
-    // Initial attach re-seeds only to heal the first-message handoff gap — i.e.
-    // when an optimistic pending is still unreconciled — so a clean open of a
-    // streaming chat is not clobbered by a stale REST snapshot.
-    if (reconnect || this.host.hasUnreconciledPendings()) {
+    // Re-seed to catch up on anything received without a live subscriber:
+    //  - reconnect: events missed while the socket was down;
+    //  - reattach after dormancy: events streamed while this chat was backgrounded;
+    //  - unreconciled pending: the first-message handoff gap.
+    // The controller's first-ever attach with no pending is skipped — it is already
+    // seeded by the mount load(), so re-seeding there could clobber a live stream.
+    if (reconnect || this.host.isReattach() || this.host.hasUnreconciledPendings()) {
       this.host.onSubscribeRefresh();
     }
   }

--- a/packages/ui/src/features/editor/__tests__/MarkdownPreview.test.tsx
+++ b/packages/ui/src/features/editor/__tests__/MarkdownPreview.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * MarkdownPreview — text-selection opt-in.
+ *
+ * The app shell sets `user-select: none` on <body> (native-desktop feel) and
+ * re-enables selection only for a whitelist of content selectors in
+ * `styles/globals.css`. The preview opts in via the `mf-editor-selectable`
+ * class; if that class is dropped from the wrapper OR removed from the CSS
+ * whitelist, prose in the preview becomes unselectable (can't copy/paste).
+ * Both halves are asserted here so a regression in either surfaces.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MarkdownPreview } from '../MarkdownPreview';
+
+describe('MarkdownPreview — selection opt-in', () => {
+  it('renders the wrapper with the mf-editor-selectable class', () => {
+    const { getByTestId } = render(<MarkdownPreview value="# Hello\n\nSome copyable text." />);
+    expect(getByTestId('markdown-preview').classList.contains('mf-editor-selectable')).toBe(true);
+  });
+
+  it('lists .mf-editor-selectable in the globals.css selection whitelist', () => {
+    // vitest runs with cwd at the package root (packages/ui).
+    const css = readFileSync(resolve(process.cwd(), 'src/styles/globals.css'), 'utf8');
+    // The rule must both mention the class and set user-select: text.
+    const optInRule = css.match(/\.mf-editor-selectable[^{]*\{[^}]*user-select:\s*text/);
+    const groupedWhitelist = /\.mf-editor-selectable[\s\S]{0,200}?user-select:\s*text/.test(css);
+    expect(optInRule != null || groupedWhitelist).toBe(true);
+  });
+});

--- a/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
@@ -133,7 +133,10 @@ function SessionSidebarImpl() {
   const filterProjectName = filterProjectId != null ? projectNameOf(filterProjectId) : null;
 
   // Selecting a project pill sets the filter AND activates that project's
-  // most-recent (or remembered) session. Toggling OFF only clears the filter.
+  // most-recent (or remembered) session. When the project has no sessions,
+  // open a new-thread draft so the chat pane reflects the empty project
+  // instead of stranding the previous project's session. Toggling OFF only
+  // clears the filter.
   const onSelectProject = useCallback(
     (projectId: string | null) => {
       setFilterProjectId(projectId);
@@ -141,6 +144,8 @@ function SessionSidebarImpl() {
         const target = resolveProjectSession(allItems, projectId, useLastSessionStore.getState().lastByProject);
         if (target != null) {
           runtime.threads.switchToThread(target);
+        } else {
+          void runtime.threads.switchToNewThread();
         }
       }
     },

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
@@ -55,6 +55,7 @@ const newThreadClickSpy = vi.fn();
 // assertions see the SAME spy instance — a fresh vi.fn() per call would be
 // unobservable from the test.
 const switchToThreadSpy = vi.fn();
+const switchToNewThreadSpy = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Mock @assistant-ui/react
@@ -70,6 +71,7 @@ vi.mock('@assistant-ui/react', () => ({
       },
       getItemById: (_id: string) => ({ rename: vi.fn(), archive: vi.fn() }),
       switchToThread: switchToThreadSpy,
+      switchToNewThread: switchToNewThreadSpy,
     },
   }),
   // SessionSidebar now subscribes reactively via useAuiState((s) => s.threads.threadItems)
@@ -198,14 +200,21 @@ vi.mock('../SessionSortMenu', () => ({
 
 vi.mock('../ProjectFilterPillBar', () => ({
   ProjectFilterPillBar: ({
+    projects,
     filterProjectId: _fid,
-    onSelect: _onSelect,
+    onSelect,
   }: {
     projects: Project[];
     filterProjectId: string | null;
     attentionCounts: Record<string, number>;
     onSelect: (id: string | null) => void;
-  }) => <div data-testid="sessions-filter-pill-all" aria-pressed={_fid == null ? 'true' : 'false'} />,
+  }) => (
+    <div data-testid="sessions-filter-pill-all" aria-pressed={_fid == null ? 'true' : 'false'}>
+      {projects.map((p) => (
+        <button key={p.id} data-testid={`sessions-filter-pill-${p.id}`} type="button" onClick={() => onSelect(p.id)} />
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('../ArchiveWorktreeDialog', () => ({
@@ -298,6 +307,7 @@ beforeEach(() => {
   setSortModeSpy.mockReset();
   newThreadClickSpy.mockReset();
   switchToThreadSpy.mockReset();
+  switchToNewThreadSpy.mockReset();
   useDraftConfigStore.setState({ drafts: new Map() });
   useNewThreadReady.setState({ readyIds: new Set() });
   useDraftReturnTarget.setState({ returnThreadId: null });
@@ -385,6 +395,39 @@ describe('SessionSidebar — new-button resets a stale reused-slot draft', () =>
     expect(useNewThreadReady.getState().isReady('__LOCALID_reuse')).toBe(false);
     // The switch still fires — the reset composes BEFORE it, not instead of it.
     expect(newThreadClickSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2d. Selecting a project pill activates that project's session, or opens a
+//     new-thread draft when the project is empty — so the chat pane never
+//     strands the previously-selected session from a different project.
+// ---------------------------------------------------------------------------
+
+describe('SessionSidebar — selecting a project pill reconciles the active thread', () => {
+  it('switches to the project session when the project has one', async () => {
+    __projects = [makeProject('p1', 'Alpha'), makeProject('p2', 'Beta')];
+    __threads = [makeThread('t1', { projectId: 'p1' })];
+    render(<SessionSidebar />);
+
+    await userEvent.click(screen.getByTestId('sessions-filter-pill-p1'));
+
+    expect(setFilterProjectIdSpy).toHaveBeenCalledWith('p1');
+    expect(switchToThreadSpy).toHaveBeenCalledWith('t1');
+    expect(switchToNewThreadSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens a new-thread draft when the selected project is empty', async () => {
+    __projects = [makeProject('p1', 'Alpha'), makeProject('p2', 'Beta')];
+    __threads = [makeThread('t1', { projectId: 'p1' })];
+    render(<SessionSidebar />);
+
+    // p2 has no sessions — must not leave p1's session active.
+    await userEvent.click(screen.getByTestId('sessions-filter-pill-p2'));
+
+    expect(setFilterProjectIdSpy).toHaveBeenCalledWith('p2');
+    expect(switchToNewThreadSpy).toHaveBeenCalledTimes(1);
+    expect(switchToThreadSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/features/sessions/view-model/__tests__/session-fallback.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/session-fallback.test.ts
@@ -1,0 +1,51 @@
+/**
+ * pickArchiveFallback — pure selection of the session to land on after an archive.
+ */
+import { describe, it, expect } from 'vitest';
+import type { SessionItem } from '../chat-to-thread-custom';
+import { pickArchiveFallback } from '../session-fallback';
+
+function item(id: string, updatedAt: number, projectId: string, status: 'regular' | 'archived' = 'regular'): SessionItem {
+  return {
+    id,
+    remoteId: id,
+    status,
+    custom: {
+      projectId,
+      adapterId: 'claude',
+      tags: [],
+      pinned: false,
+      status: 'active',
+      displayStatus: 'idle',
+      hasPending: false,
+      detectedPrs: [],
+      worktreeMissing: false,
+      updatedAt,
+    },
+  } as unknown as SessionItem;
+}
+
+describe('pickArchiveFallback', () => {
+  it('picks the most-recently-updated non-archived session', () => {
+    const items = [item('a', 3000, 'p1', 'archived'), item('b', 1000, 'p1'), item('c', 2000, 'p1')];
+    expect(pickArchiveFallback(items, null, null)).toBe('c');
+  });
+
+  it('prefers the last-used session when it is still live', () => {
+    const items = [item('b', 1000, 'p1'), item('c', 2000, 'p1')];
+    // preferred matches remoteId 'b' even though 'c' is newer.
+    expect(pickArchiveFallback(items, null, 'b')).toBe('b');
+  });
+
+  it('stays within the active project filter, widening only when it has none left', () => {
+    const items = [item('a', 4000, 'p1', 'archived'), item('b', 1000, 'p1'), item('other', 9000, 'p2')];
+    expect(pickArchiveFallback(items, 'p1', null)).toBe('b');
+    // p3 has no sessions → widen to the newest overall non-archived.
+    expect(pickArchiveFallback(items, 'p3', null)).toBe('other');
+  });
+
+  it('returns null when nothing non-archived remains', () => {
+    const items = [item('a', 4000, 'p1', 'archived')];
+    expect(pickArchiveFallback(items, null, null)).toBeNull();
+  });
+});

--- a/packages/ui/src/features/sessions/view-model/session-fallback.ts
+++ b/packages/ui/src/features/sessions/view-model/session-fallback.ts
@@ -1,0 +1,24 @@
+/**
+ * pickArchiveFallback — which session to activate when the current one is
+ * archived, or when an archive bumped us onto an empty new-thread draft (aui
+ * calls `switchToNewThread()` off the archived thread before marking it archived).
+ *
+ * Two-tier, mirroring boot (`pickInitialSession`): the last-used session if it is
+ * still live and non-archived, else the most-recently-updated non-archived
+ * session — preferring the active project filter, widening to all sessions only
+ * when the filtered project has none left. Returns null when nothing remains to
+ * open (the caller then leaves the empty new-thread surface up).
+ *
+ * Pure.
+ */
+import type { SessionItem } from './chat-to-thread-custom';
+import { pickInitialSession } from './initial-session';
+
+export function pickArchiveFallback(
+  items: readonly SessionItem[],
+  filterProjectId: string | null,
+  preferredRemoteId?: string | null,
+): string | null {
+  const inProject = filterProjectId != null ? items.filter((i) => i.custom.projectId === filterProjectId) : items;
+  return pickInitialSession(inProject, preferredRemoteId) ?? pickInitialSession(items, preferredRemoteId);
+}

--- a/packages/ui/src/features/sessions/ws/__tests__/use-session-list-router.test.tsx
+++ b/packages/ui/src/features/sessions/ws/__tests__/use-session-list-router.test.tsx
@@ -355,6 +355,57 @@ describe('useSessionListRouter — archived active with no fallback thread', () 
 });
 
 // ---------------------------------------------------------------------------
+// 10a. Archive of the ACTIVE session: aui switchToNewThread()s off it FIRST, so
+//   mainThreadId becomes a fresh __LOCALID_* draft while the session it left is
+//   now archived. The router must redirect to a fallback, not strand the user on
+//   the empty new-thread surface.
+// ---------------------------------------------------------------------------
+
+describe('useSessionListRouter — archiving the active session redirects off the empty draft', () => {
+  it('switches to the most-recent non-archived session after aui bumps to a new draft', () => {
+    // 1) Active on chat-A — establishes it as the last real (non-draft) thread.
+    mainThreadIdValue = 'chat-A';
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: 'chat-B', remoteId: 'chat-B', status: 'regular', custom: { projectId: 'p1', updatedAt: 2000 } },
+    ];
+    const { rerender } = renderHook(() => useSessionListRouter());
+    switchSpy.mockClear();
+
+    // 2) Archive chat-A: mainThreadId becomes a fresh draft; chat-A is now archived.
+    mainThreadIdValue = '__LOCALID_new';
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'archived', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: 'chat-B', remoteId: 'chat-B', status: 'regular', custom: { projectId: 'p1', updatedAt: 2000 } },
+    ];
+    rerender();
+
+    expect(switchSpy).toHaveBeenCalledTimes(1);
+    expect(switchSpy).toHaveBeenCalledWith('chat-B');
+  });
+
+  it('does NOT redirect when the user deliberately opens a New thread (left session still regular)', () => {
+    mainThreadIdValue = 'chat-A';
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: 'chat-B', remoteId: 'chat-B', status: 'regular', custom: { projectId: 'p1', updatedAt: 2000 } },
+    ];
+    const { rerender } = renderHook(() => useSessionListRouter());
+    switchSpy.mockClear();
+
+    // User clicks New → draft, but chat-A stays 'regular' (nothing was archived).
+    mainThreadIdValue = '__LOCALID_new';
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: 'chat-B', remoteId: 'chat-B', status: 'regular', custom: { projectId: 'p1', updatedAt: 2000 } },
+    ];
+    rerender();
+
+    expect(switchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 11. unmount → dispose() called once
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/src/features/sessions/ws/use-session-list-router.ts
+++ b/packages/ui/src/features/sessions/ws/use-session-list-router.ts
@@ -28,9 +28,32 @@ import { useUnreadStore } from '../../../store/unread-store';
 import { useSessionFilters } from '../../../store/session-filters';
 import { useLayoutStore } from '../../../store/layout';
 import { useLastSessionStore } from '../../../store/last-session';
+import type { SessionItem } from '../view-model/chat-to-thread-custom';
 import { threadItemsToSessionItems } from '../view-model/chat-to-thread-custom';
 import { pickInitialSession } from '../view-model/initial-session';
+import { pickArchiveFallback } from '../view-model/session-fallback';
 import { createSessionListRouter } from './session-list-router';
+
+/** Persist the newly-active session (boot restore + per-project + workspace layout). */
+function rememberActiveSession(active: SessionItem | undefined): void {
+  if (active?.remoteId == null) return;
+  useLastSessionStore.getState().setLastSessionId(active.remoteId);
+  if (active.custom?.projectId != null) {
+    useLastSessionStore.getState().setLastForProject(active.custom.projectId, active.remoteId);
+  }
+  // Follow the active session with its remembered workspace layout, keyed by the
+  // stable daemon chat id. Skipped for the __LOCALID_* draft (no remoteId yet).
+  useLayoutStore.getState().setActiveSession(active.remoteId);
+}
+
+/** Clear the project filter when the activated chat belongs to a different project. */
+function clearFilterOnCrossProject(active: SessionItem | undefined): void {
+  const { filterProjectId, setFilterProjectId } = useSessionFilters.getState();
+  const projectId = active?.custom?.projectId;
+  if (filterProjectId != null && projectId != null && projectId !== filterProjectId) {
+    setFilterProjectId(null);
+  }
+}
 
 export function useSessionListRouter(): void {
   const runtime = useAssistantRuntime();
@@ -88,54 +111,54 @@ export function useSessionListRouter(): void {
     };
   }, [runtime]);
 
-  // Active-thread side-effects: unread clear, cross-project filter clear,
-  // archived-active fallback. Guarded so each fires once per active change.
+  // Active-thread side-effects: unread clear, cross-project filter clear, and the
+  // archived-active fallback. `lastActiveRef` dedupes the once-per-activation work;
+  // `prevRealActiveRef` remembers the last non-draft thread so an archive-induced
+  // bump onto an empty draft (redirect) is told apart from a deliberate New (stay).
   const lastActiveRef = useRef<string | null>(null);
+  const prevRealActiveRef = useRef<string | null>(null);
   useEffect(() => {
     if (mainThreadId == null) return;
     const active = items.find((t) => t.id === mainThreadId);
+    const onDraft = active == null || mainThreadId.startsWith('__LOCALID_');
 
-    if (active != null && active.status === 'archived') {
-      // Desktop parity: fall back to the most recently USED session, not the
-      // first in list order. pickInitialSession ranks by custom.updatedAt and
-      // skips archived items (including this one), so it can't re-pick the active.
-      // Respect the active project filter: prefer the newest session within the
-      // filtered project; only when that project has none left widen to all
-      // sessions (the cross-project effect below then clears the empty filter).
-      const { filterProjectId } = useSessionFilters.getState();
-      const inProject = filterProjectId != null ? items.filter((t) => t.custom.projectId === filterProjectId) : items;
-      const fallback = pickInitialSession(inProject) ?? pickInitialSession(items);
-      if (fallback != null) runtime.threads.switchToThread(fallback);
+    // Desktop parity: land on the last-used (else most-recent) non-archived session,
+    // respecting the active project filter. pickArchiveFallback skips archived items.
+    const fallback = (): string | null =>
+      pickArchiveFallback(items, useSessionFilters.getState().filterProjectId, useLastSessionStore.getState().lastSessionId);
+
+    if (onDraft) {
+      // Archive-induced empty state: aui `switchToNewThread()`s off the archived
+      // thread, so we land on a fresh draft rather than staying on the (now
+      // archived) session. If the real thread we just left is now archived, redirect
+      // to a fallback. A deliberate New leaves that thread 'regular', so it stays.
+      const leftItem = items.find((t) => t.id === prevRealActiveRef.current);
+      if (leftItem?.status === 'archived') {
+        const target = fallback();
+        if (target != null) {
+          prevRealActiveRef.current = null;
+          runtime.threads.switchToThread(target);
+        }
+      }
+      return;
+    }
+    if (active == null) return; // unreachable (onDraft covers it) — narrows for TS
+
+    // Defensive: aui usually switches away first, but if the active thread itself
+    // is archived out from under us, fall back the same way.
+    if (active.status === 'archived') {
+      const target = fallback();
+      if (target != null) runtime.threads.switchToThread(target);
       return;
     }
 
+    prevRealActiveRef.current = mainThreadId;
     if (mainThreadId === lastActiveRef.current) return;
     lastActiveRef.current = mainThreadId;
 
     useUnreadStore.getState().clearUnread(mainThreadId);
-
-    // Remember the open session (by stable daemon chat id) so the next boot can
-    // restore it. Skip the new-thread draft, which has no backing chat yet.
-    if (active?.remoteId != null) {
-      useLastSessionStore.getState().setLastSessionId(active.remoteId);
-      if (active.custom?.projectId != null) {
-        useLastSessionStore.getState().setLastForProject(active.custom.projectId, active.remoteId);
-      }
-
-      // Follow the active session with its remembered workspace layout (surface
-      // placement + Run panes), keyed by the stable daemon chat id — same key as
-      // pruneSessions above. Skip while on the __LOCALID_* draft: it has no
-      // remoteId (no backing chat yet), so there's nothing to key a workspace
-      // off; the previously active session's layout stays on screen until a
-      // real session is activated.
-      useLayoutStore.getState().setActiveSession(active.remoteId);
-    }
-
-    const { filterProjectId, setFilterProjectId } = useSessionFilters.getState();
-    const projectId = active?.custom?.projectId;
-    if (filterProjectId != null && projectId != null && projectId !== filterProjectId) {
-      setFilterProjectId(null);
-    }
+    rememberActiveSession(active);
+    clearFilterOnCrossProject(active);
   }, [mainThreadId, items, runtime]);
 
   // Boot auto-select: open a session once the list first loads, so the app doesn't

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -925,8 +925,11 @@ body {
 }
 
 /* Re-enable text selection for actual content: rendered markdown (chat
-   messages — also what select-to-quote selects), form fields, and code. */
+   messages — also what select-to-quote selects), form fields, code, and the
+   editor surfaces (markdown preview, CodeMirror source + diff) that opt in via
+   `.mf-editor-selectable`. */
 .aui-md,
+.mf-editor-selectable,
 input,
 textarea,
 [contenteditable],


### PR DESCRIPTION
Four independent renderer correctness fixes, each with its own changeset. All on `@qlan-ro/mainframe-ui`.

## 1. Background sessions lose messages (most impactful)
A chat's live WS subscription is gated to the active thread, so a **backgrounded** chat received no message events while another chat was open — the daemon still persisted them, but the transcript stayed frozen at the pre-dormancy snapshot. The `subscribe:ack` re-seed only fired on a socket reconnect or an unreconciled optimistic send, so simply switching back never healed the gap.

**Fix:** the controller now marks a torn-down sub as dormant and treats the next attach as a post-dormancy reattach, re-seeding history from REST on the reattach ack (like a reconnect). Row-level unread notifications were unaffected — they run on a separate always-on session-list subscription.

## 2. Archiving the active session dumps you on the empty new-session screen
assistant-ui's remote thread list calls `switchToNewThread()` off the archived thread **before** marking it archived, so `mainThreadId` becomes a fresh `__LOCALID_*` draft and the existing archived-active fallback (which keyed on the active thread still being archived) never fired.

**Fix:** the session router remembers the last real (non-draft) thread; when an archive bumps you onto an empty draft, it redirects to a fallback — the last-used session if still live, else the most-recently-updated non-archived one, respecting the active project filter. A deliberate "New" leaves the previous session regular, so it is not redirected.

## 3. Selecting an empty project shows the previous project's session
Selecting a project pill with no sessions set the filter but never switched the active thread, stranding the previously-selected session from another project.

**Fix:** open a new-session draft when the selected project has no sessions.

## 4. Markdown preview text can't be copied
The preview opts into text selection via `mf-editor-selectable`, but that class was referenced by the editor surfaces and never added to the `globals.css` selection whitelist, so preview prose inherited the app-shell `user-select: none`.

**Fix:** add `.mf-editor-selectable` to the whitelist (also fixes CodeMirror source/diff surfaces that reference it).

## Testing
- Typecheck clean.
- New tests for every fix (controller reattach re-seed, archive→fallback redirect + deliberate-New negative, empty-project draft, MD-preview selectable + CSS-whitelist guard, pure `pickArchiveFallback`).
- Full `chat` + `sessions` suites green.

Note: verification is at the controller/router seam — the desktop GUI wasn't driven in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)