### PR TITLE
fix(release)+feat(cli): complete standalone daemon bundle, rename CLI to `mainframe`, add `mainframe update`

### DIFF
--- a/.changeset/fix-standalone-daemon-node-modules.md
+++ b/.changeset/fix-standalone-daemon-node-modules.md
@@ -1,0 +1,11 @@
+---
+"@qlan-ro/mainframe-core": patch
+---
+
+Fix the standalone daemon tarball (the `linux`/`darwin` release artifacts installed
+via `scripts/install.sh`) so it ships a complete `node_modules` sibling to
+`daemon.cjs`. Previously `build-standalone.sh` only copied better-sqlite3's raw
+`.node` binary, so the bundled daemon's `require('better-sqlite3')` (and the LSP
+servers + ripgrep) could not resolve and the daemon failed to start with
+`Cannot find module 'better-sqlite3'`. The standalone build now uses the same
+dependency collector as the Tauri sidecar bundler.

--- a/.changeset/mainframe-cli-and-update.md
+++ b/.changeset/mainframe-cli-and-update.md
@@ -1,0 +1,12 @@
+---
+"@qlan-ro/mainframe-core": minor
+---
+
+Rename the daemon CLI to `mainframe` and add a `mainframe update` command.
+
+The standalone binary is now `mainframe` (the old `mainframe-daemon` name still
+ships as an alias, so existing systemd units keep working). `mainframe update`
+upgrades a standalone install in place: it downloads the matching release tarball
+for the host platform and unpacks it over `~/.mainframe/bin`. Supports
+`--pre` (include pre-releases), `--version <tag>`, and `--dir <path>`; the daemon
+keeps serving until you restart it.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For servers, headless use, or building on the API:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/install.sh | bash
-mainframe-daemon
+mainframe
 ```
 
 That's the whole quick start. For running it as a systemd service, prerequisites in detail, and troubleshooting, see **[Running the Daemon](docs/guides/running-the-daemon.md)**. To expose it for remote clients, see **[Cloudflare Tunnel Setup](docs/guides/cloudflare-tunnel.md)**.
@@ -116,7 +116,7 @@ Every client pairs the same way: the daemon shows a short-lived pairing code, yo
 
 | Client | Start pairing in | Get the code from |
 |---|---|---|
-| **Mobile app** — publishing soon; ping me to join TestFlight | Tap **Connect**, scan the QR or type the code | Desktop: **Settings → Devices → Pair New Device**. Headless: `mainframe-daemon pair` |
+| **Mobile app** — publishing soon; ping me to join TestFlight | Tap **Connect**, scan the QR or type the code | Desktop: **Settings → Devices → Pair New Device**. Headless: `mainframe pair` |
 | **Desktop app → remote daemon** *(new)* | Sidebar daemon picker → **Add remote daemon** → paste the daemon's tunnel URL → enter the code | Same as above, on the remote daemon |
 
 Pairing over the internet requires a tunnel on the daemon's machine — and remote daemons need a **named** tunnel (a quick tunnel's URL changes on restart, which breaks the pairing). See the [tunnel guide](docs/guides/cloudflare-tunnel.md).

--- a/docs/guides/cloudflare-tunnel.md
+++ b/docs/guides/cloudflare-tunnel.md
@@ -23,7 +23,7 @@ The simplest approach. The daemon spawns `cloudflared` as a child process and te
 No Cloudflare account needed. The URL changes on every restart.
 
 ```bash
-TUNNEL=true mainframe-daemon
+TUNNEL=true mainframe
 ```
 
 Or in the desktop app: **Settings → Tunnel → Enable**.
@@ -41,7 +41,7 @@ Requires a Cloudflare account and a domain managed by Cloudflare.
 5. Start the daemon with the token and URL:
 
 ```bash
-TUNNEL=true TUNNEL_TOKEN=<TOKEN> TUNNEL_URL=https://mainframe.example.com mainframe-daemon
+TUNNEL=true TUNNEL_TOKEN=<TOKEN> TUNNEL_URL=https://mainframe.example.com mainframe
 ```
 
 Or configure once and forget:
@@ -66,7 +66,7 @@ If you prefer to manage the tunnel process independently — for example, runnin
 cloudflared tunnel run --token <TOKEN>
 
 # Terminal 2: start the daemon with the known URL
-TUNNEL_URL=https://mainframe.example.com mainframe-daemon
+TUNNEL_URL=https://mainframe.example.com mainframe
 ```
 
 In this mode the daemon does not spawn or stop `cloudflared`. It uses the URL for mobile pairing and push notifications.

--- a/docs/guides/running-the-daemon.md
+++ b/docs/guides/running-the-daemon.md
@@ -121,7 +121,7 @@ To reach the daemon from the mobile app or another machine, expose it with a Clo
 ## Troubleshooting
 
 - **`GLIBC_2.28 not found` / `libatomic.so.1: cannot open shared object file`** — see [System requirements](#system-requirements). Old OS or missing `libatomic`.
-- **`Cannot find module 'better-sqlite3'`** — the native module belongs in a `node_modules` next to the bundled daemon. If a release is missing it, install it beside the bundle: `cd ~/.mainframe/bin/lib && npm init -y && npm install better-sqlite3@^12`.
+- **`Cannot find module 'better-sqlite3'`** — releases now bundle a full `node_modules` next to the daemon, so a fresh install shouldn't hit this. If you're on an **older tarball** that predates the fix, either re-run the [install](#2-install-the-daemon) to pull a current release, or install the module beside the bundle as a stopgap: `cd ~/.mainframe/bin/lib && npm init -y && npm install better-sqlite3@^12`.
 - **`claude`/`codex` not found (only under systemd)** — the unit's `PATH` is missing the CLI directory. Add `~/.local/bin`, then `systemctl show mainframe-daemon -p Environment` to confirm.
 - **`--dangerously-skip-permissions cannot be used with root/sudo`** — you're running the daemon as root. Run as a non-root user (recommended), or set `IS_SANDBOX=1` only inside a genuinely contained environment.
 - **Pairing works locally but not remotely** — you need a tunnel; see [step 5](#5-remote-access).

--- a/docs/guides/running-the-daemon.md
+++ b/docs/guides/running-the-daemon.md
@@ -47,22 +47,24 @@ Sign each CLI into its account once (`claude`, `codex`) before the daemon drives
 curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/install.sh | bash
 ```
 
-This downloads a self-contained release tarball to `~/.mainframe/bin` — a bundled Node runtime, `cloudflared`, and the daemon. The launcher is `~/.mainframe/bin/bin/mainframe-daemon`. Add it to your `PATH`:
+This downloads a self-contained release tarball to `~/.mainframe/bin` — a bundled Node runtime, `cloudflared`, and the daemon. The launcher is `~/.mainframe/bin/bin/mainframe`. Add it to your `PATH`:
 
 ```bash
 export PATH="$HOME/.mainframe/bin/bin:$PATH"   # add to ~/.bashrc or ~/.zshrc
 ```
 
+> The command is `mainframe`. Older installs exposed it as `mainframe-daemon`; that name still ships as an alias, so existing systemd units keep working after an update.
+
 ## 3. Run it
 
 ```bash
-mainframe-daemon
+mainframe
 ```
 
 The daemon listens on `http://127.0.0.1:31415` by default. To connect the mobile app, generate a pairing code from a second shell (the daemon must already be running):
 
 ```bash
-mainframe-daemon pair
+mainframe pair
 ```
 
 Enter the code in the mobile app. Pairing over the internet requires a tunnel — see [step 5](#5-remote-access).
@@ -77,14 +79,14 @@ Configuration is read from `~/.mainframe/config.json` and these environment vari
 
 ## 4. Run as a service (systemd)
 
-A raw `mainframe-daemon` dies when your SSH session ends. On Linux, run it under systemd so it survives logout and restarts on boot or crash.
+A raw `mainframe` dies when your SSH session ends. On Linux, run it under systemd so it survives logout and restarts on boot or crash.
 
 **Run as a dedicated non-root user.** The daemon drives AI agents that execute shell commands; running them as root gives every command unrestricted power over the host. A normal user also means you don't need the `IS_SANDBOX=1` escape hatch (Claude Code refuses `--dangerously-skip-permissions` as root unless a sandbox is asserted).
 
 The key gotcha: **systemd does not inherit your login `PATH`**, so the unit must list the directory holding `claude`/`codex` (usually `~/.local/bin`) or the daemon can't spawn them.
 
 ```ini
-# /etc/systemd/system/mainframe-daemon.service
+# /etc/systemd/system/mainframe.service
 [Unit]
 Description=Mainframe Daemon
 After=network-online.target
@@ -95,7 +97,7 @@ Type=simple
 User=mainframe
 Environment=HOME=/home/mainframe
 Environment=PATH=/home/mainframe/.local/bin:/home/mainframe/.mainframe/bin/bin:/home/mainframe/.mainframe/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/home/mainframe/.mainframe/bin/bin/mainframe-daemon
+ExecStart=/home/mainframe/.mainframe/bin/bin/mainframe
 Restart=on-failure
 RestartSec=3
 
@@ -105,12 +107,12 @@ WantedBy=multi-user.target
 
 ```bash
 systemctl daemon-reload
-systemctl enable --now mainframe-daemon
-systemctl status mainframe-daemon
-journalctl -u mainframe-daemon -f      # live logs
+systemctl enable --now mainframe
+systemctl status mainframe
+journalctl -u mainframe -f      # live logs
 ```
 
-Note the launcher path is `.mainframe/bin/bin/mainframe-daemon` (nested `bin/bin` — the release tarball's `bin/` extracted under the install dir).
+Note the launcher path is `.mainframe/bin/bin/mainframe` (nested `bin/bin` — the release tarball's `bin/` extracted under the install dir).
 
 ## 5. Remote access
 
@@ -118,10 +120,28 @@ To reach the daemon from the mobile app or another machine, expose it with a Clo
 
 **See [Cloudflare Tunnel Setup](./cloudflare-tunnel.md)** for quick vs. named tunnels, the runtime API, and troubleshooting. To enable it under systemd, add `Environment=TUNNEL=true` (plus `TUNNEL_TOKEN`/`TUNNEL_URL` for a named tunnel) to the unit above.
 
+## Updating
+
+Upgrade in place with the built-in updater. It downloads the latest release tarball for your platform and unpacks it over `~/.mainframe/bin`:
+
+```bash
+mainframe update            # latest stable release
+mainframe update --pre      # include pre-releases (e.g. the current 2.0 rc line)
+mainframe update --version v2.0.0-rc.1   # a specific tag
+```
+
+`update` replaces the on-disk files only — the running daemon keeps serving until you restart it, so finish with:
+
+```bash
+systemctl restart mainframe      # or: kill the foreground process and re-run `mainframe`
+```
+
+Re-running the [install script](#2-install-the-daemon) does the same thing and is the fallback if the daemon is too broken to run `mainframe update`.
+
 ## Troubleshooting
 
 - **`GLIBC_2.28 not found` / `libatomic.so.1: cannot open shared object file`** — see [System requirements](#system-requirements). Old OS or missing `libatomic`.
 - **`Cannot find module 'better-sqlite3'`** — releases now bundle a full `node_modules` next to the daemon, so a fresh install shouldn't hit this. If you're on an **older tarball** that predates the fix, either re-run the [install](#2-install-the-daemon) to pull a current release, or install the module beside the bundle as a stopgap: `cd ~/.mainframe/bin/lib && npm init -y && npm install better-sqlite3@^12`.
-- **`claude`/`codex` not found (only under systemd)** — the unit's `PATH` is missing the CLI directory. Add `~/.local/bin`, then `systemctl show mainframe-daemon -p Environment` to confirm.
+- **`claude`/`codex` not found (only under systemd)** — the unit's `PATH` is missing the CLI directory. Add `~/.local/bin`, then `systemctl show mainframe -p Environment` to confirm.
 - **`--dangerously-skip-permissions cannot be used with root/sudo`** — you're running the daemon as root. Run as a non-root user (recommended), or set `IS_SANDBOX=1` only inside a genuinely contained environment.
 - **Pairing works locally but not remotely** — you need a tunnel; see [step 5](#5-remote-access).

--- a/packages/app-tauri/scripts/bundle-daemon.mjs
+++ b/packages/app-tauri/scripts/bundle-daemon.mjs
@@ -25,10 +25,10 @@
  */
 import { build } from 'esbuild';
 import { execFileSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { mkdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { collectDaemonDeps } from '../../../scripts/collect-daemon-deps.mjs';
 import { signMachOTree } from './lib/mach-o-sign.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -73,69 +73,18 @@ await build({
 
 console.log('[bundle-daemon] 3/4 collecting runtime deps → resources/daemon/node_modules …');
 // Each EXTERNAL stays a runtime require(), so it must exist in a node_modules
-// SIBLING of daemon.cjs. Seed from the externals and walk each package.json's
-// (optional) dependencies, deref-copying the real (pnpm-symlinked) package dirs
-// into one flat tree — the transitive deps of the LSP servers come along.
-const coreRequire = createRequire(join(repoRoot, 'packages/core/package.json'));
+// SIBLING of daemon.cjs. The shared collector seeds from the externals and walks
+// each package.json's (optional) dependencies, deref-copying the real
+// (pnpm-symlinked) package dirs into one flat tree — the transitive deps of the
+// LSP servers come along. Same logic backs the standalone tarball (build-standalone.sh).
+const copied = collectDaemonDeps({
+  requireBasePkgJson: join(repoRoot, 'packages/core/package.json'),
+  externals: EXTERNAL,
+  destNodeModules: join(daemonDir, 'node_modules'),
+  onWarn: (m) => console.warn(`[bundle-daemon]   ${m}`),
+});
 
-/** Resolve a package's root dir (the dir holding its package.json). */
-function pkgDirOf(name, requireFn) {
-  try {
-    return dirname(requireFn.resolve(`${name}/package.json`));
-  } catch {
-    // Package blocks the ./package.json subpath via exports — resolve an entry
-    // and walk up to the package.json whose "name" matches.
-    let dir = dirname(requireFn.resolve(name));
-    for (;;) {
-      const pj = join(dir, 'package.json');
-      if (existsSync(pj)) {
-        try {
-          if (JSON.parse(readFileSync(pj, 'utf8')).name === name) return dir;
-        } catch {
-          /* keep walking */
-        }
-      }
-      const parent = dirname(dir);
-      if (parent === dir) throw new Error(`cannot locate package root for ${name}`);
-      dir = parent;
-    }
-  }
-}
-
-/** Transitively gather a package + its (optional) deps into `found: name→dir`. */
-function collect(name, requireFn, found) {
-  if (found.has(name)) return;
-  let dir;
-  try {
-    dir = pkgDirOf(name, requireFn);
-  } catch {
-    console.warn(`[bundle-daemon]   skip unresolved dep: ${name}`);
-    return;
-  }
-  found.set(name, dir);
-  let pkg;
-  try {
-    pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
-  } catch {
-    return;
-  }
-  const next = createRequire(join(dir, 'package.json'));
-  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.optionalDependencies ?? {}) };
-  for (const dep of Object.keys(deps)) collect(dep, next, found);
-}
-
-const found = new Map();
-for (const name of EXTERNAL.filter((e) => e !== '*.node')) collect(name, coreRequire, found);
-
-const destModules = join(daemonDir, 'node_modules');
-rmSync(destModules, { recursive: true, force: true });
-for (const [name, dir] of found) {
-  const dest = join(destModules, name); // scoped names (@vscode/ripgrep) nest correctly
-  mkdirSync(dirname(dest), { recursive: true });
-  cpSync(dir, dest, { recursive: true, dereference: true });
-}
-
-console.log(`[bundle-daemon] done → ${daemonDir} (${found.size} runtime packages)`);
+console.log(`[bundle-daemon] done → ${daemonDir} (${copied.length} runtime packages)`);
 
 console.log('[bundle-daemon] 4/4 codesigning nested Mach-O binaries (macOS release only) …');
 // Covers the daemon's own native addons (better-sqlite3, fsevents, node-pty,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./messages": "./dist/messages/index.js"
   },
   "bin": {
+    "mainframe": "./dist/index.js",
     "mainframe-daemon": "./dist/index.js"
   },
   "scripts": {

--- a/packages/core/src/cli/__tests__/update.test.ts
+++ b/packages/core/src/cli/__tests__/update.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  standaloneArtifactName,
+  pickRelease,
+  assetUrl,
+  parseUpdateArgs,
+  resolveInstallRoot,
+  type GhRelease,
+} from '../update.js';
+
+function release(tag: string, prerelease: boolean, assetNames: string[] = []): GhRelease {
+  return {
+    tag_name: tag,
+    prerelease,
+    assets: assetNames.map((name) => ({
+      name,
+      browser_download_url: `https://example.com/${tag}/${name}`,
+    })),
+  };
+}
+
+describe('standaloneArtifactName', () => {
+  it('maps supported platform/arch pairs to the release artifact name', () => {
+    expect(standaloneArtifactName('linux', 'x64')).toBe('mainframe-daemon-linux-x64.tar.gz');
+    expect(standaloneArtifactName('linux', 'arm64')).toBe('mainframe-daemon-linux-arm64.tar.gz');
+    expect(standaloneArtifactName('darwin', 'arm64')).toBe('mainframe-daemon-darwin-arm64.tar.gz');
+  });
+
+  it('rejects unsupported platforms', () => {
+    expect(() => standaloneArtifactName('win32', 'x64')).toThrow(/Unsupported platform/);
+    expect(() => standaloneArtifactName('linux', 'ia32')).toThrow(/Unsupported platform/);
+  });
+});
+
+describe('pickRelease', () => {
+  const list = [
+    release('v2.1.0-rc.1', true),
+    release('v2.0.0', false),
+    release('v1.9.0', false),
+  ];
+
+  it('defaults to the newest stable release, skipping pre-releases', () => {
+    expect(pickRelease(list, {}).tag_name).toBe('v2.0.0');
+  });
+
+  it('picks the newest pre-release when --pre is set', () => {
+    expect(pickRelease(list, { includePrerelease: true }).tag_name).toBe('v2.1.0-rc.1');
+  });
+
+  it('selects an explicit version, with or without a leading v', () => {
+    expect(pickRelease(list, { version: 'v1.9.0' }).tag_name).toBe('v1.9.0');
+    expect(pickRelease(list, { version: '1.9.0' }).tag_name).toBe('v1.9.0');
+  });
+
+  it('ignores draft releases', () => {
+    const withDraft = [{ ...release('v3.0.0', false), draft: true }, release('v2.0.0', false)];
+    expect(pickRelease(withDraft, {}).tag_name).toBe('v2.0.0');
+  });
+
+  it('hints at --pre when only pre-releases exist', () => {
+    expect(() => pickRelease([release('v2.0.0-rc.1', true)], {})).toThrow(/mainframe update --pre/);
+  });
+
+  it('throws for an unknown explicit version', () => {
+    expect(() => pickRelease(list, { version: 'v9.9.9' })).toThrow(/No release found for version/);
+  });
+});
+
+describe('assetUrl', () => {
+  it('returns the download URL for a matching asset', () => {
+    const r = release('v2.0.0', false, ['mainframe-daemon-linux-x64.tar.gz']);
+    expect(assetUrl(r, 'mainframe-daemon-linux-x64.tar.gz')).toBe(
+      'https://example.com/v2.0.0/mainframe-daemon-linux-x64.tar.gz',
+    );
+  });
+
+  it('throws when the artifact is absent from the release', () => {
+    const r = release('v2.0.0', false, ['mainframe-daemon-darwin-arm64.tar.gz']);
+    expect(() => assetUrl(r, 'mainframe-daemon-linux-x64.tar.gz')).toThrow(/does not include/);
+  });
+});
+
+describe('parseUpdateArgs', () => {
+  it('parses flags and their values', () => {
+    expect(parseUpdateArgs(['--pre'])).toEqual({ includePrerelease: true });
+    expect(parseUpdateArgs(['--version', 'v2.0.0-rc.1'])).toEqual({ version: 'v2.0.0-rc.1' });
+    expect(parseUpdateArgs(['--dir', '/opt/mf'])).toEqual({ dir: '/opt/mf' });
+    expect(parseUpdateArgs(['--help'])).toEqual({ help: true });
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseUpdateArgs(['--nope'])).toThrow(/Unknown argument/);
+  });
+});
+
+describe('resolveInstallRoot', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function standaloneLayout(): string {
+    const root = mkdtempSync(join(tmpdir(), 'mf-root-'));
+    dirs.push(root);
+    mkdirSync(join(root, 'lib'), { recursive: true });
+    writeFileSync(join(root, 'lib', 'daemon.cjs'), '// daemon');
+    return root;
+  }
+
+  it('uses MAINFRAME_STANDALONE_ROOT when it points at a real install', () => {
+    const root = standaloneLayout();
+    expect(resolveInstallRoot({ MAINFRAME_STANDALONE_ROOT: root }, '/usr/bin/node')).toBe(root);
+  });
+
+  it('falls back to deriving the root from the bundled node path', () => {
+    const root = standaloneLayout();
+    // <root>/bin/node → <root>
+    expect(resolveInstallRoot({}, join(root, 'bin', 'node'))).toBe(root);
+  });
+
+  it('throws with install-script guidance when no standalone layout is found', () => {
+    expect(() => resolveInstallRoot({}, '/usr/bin/node')).toThrow(/install script/);
+  });
+});

--- a/packages/core/src/cli/pair.ts
+++ b/packages/core/src/cli/pair.ts
@@ -65,7 +65,7 @@ export async function runPair(): Promise<void> {
   setTimeout(
     () => {
       clearInterval(pollInterval);
-      console.log('\n  Pairing code expired. Run `mainframe-daemon pair` to try again.\n');
+      console.log('\n  Pairing code expired. Run `mainframe pair` to try again.\n');
       process.exit(1);
     },
     5 * 60 * 1000,

--- a/packages/core/src/cli/update.ts
+++ b/packages/core/src/cli/update.ts
@@ -1,0 +1,171 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const REPO = 'qlan-ro/mainframe';
+
+export interface GhAsset {
+  name: string;
+  browser_download_url: string;
+}
+export interface GhRelease {
+  tag_name: string;
+  prerelease: boolean;
+  draft?: boolean;
+  assets: GhAsset[];
+}
+
+export interface UpdateOptions {
+  /** Specific tag to install (e.g. `v2.0.0-rc.1`). Overrides the latest lookup. */
+  version?: string;
+  /** Consider pre-releases when picking the newest release. */
+  includePrerelease?: boolean;
+}
+
+/** Map the running platform to the release artifact filename it should install. */
+export function standaloneArtifactName(platform: NodeJS.Platform, arch: string): string {
+  const os = platform === 'darwin' ? 'darwin' : platform === 'linux' ? 'linux' : null;
+  const cpu = arch === 'x64' ? 'x64' : arch === 'arm64' ? 'arm64' : null;
+  if (!os || !cpu) {
+    throw new Error(`Unsupported platform for self-update: ${platform}-${arch}`);
+  }
+  return `mainframe-daemon-${os}-${cpu}.tar.gz`;
+}
+
+/** Pick the release to install from a GitHub `/releases` list (newest first). */
+export function pickRelease(releases: GhRelease[], opts: UpdateOptions): GhRelease {
+  const published = releases.filter((r) => !r.draft);
+
+  if (opts.version) {
+    const norm = (t: string) => t.replace(/^v/, '');
+    const found = published.find(
+      (r) => r.tag_name === opts.version || norm(r.tag_name) === norm(opts.version!),
+    );
+    if (!found) throw new Error(`No release found for version ${opts.version}`);
+    return found;
+  }
+
+  const candidates = published.filter((r) => opts.includePrerelease || !r.prerelease);
+  const newest = candidates[0]; // GitHub returns releases newest-first
+  if (!newest) {
+    const hint = published.some((r) => r.prerelease)
+      ? ' Only pre-releases exist — retry with `mainframe update --pre`.'
+      : '';
+    throw new Error(`No matching release found.${hint}`);
+  }
+  return newest;
+}
+
+/** Resolve the download URL of `artifact` within a release, or throw. */
+export function assetUrl(release: GhRelease, artifact: string): string {
+  const asset = release.assets.find((a) => a.name === artifact);
+  if (!asset) {
+    throw new Error(`Release ${release.tag_name} does not include ${artifact}.`);
+  }
+  return asset.browser_download_url;
+}
+
+/** Parse `update` argv (everything after the subcommand) into options. */
+export function parseUpdateArgs(argv: string[]): UpdateOptions & { help?: boolean; dir?: string } {
+  const opts: UpdateOptions & { help?: boolean; dir?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pre' || arg === '--prerelease') opts.includePrerelease = true;
+    else if (arg === '-h' || arg === '--help') opts.help = true;
+    else if (arg === '--version') opts.version = argv[++i];
+    else if (arg === '--dir') opts.dir = argv[++i];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+/**
+ * Locate the standalone install root (the dir holding `bin/` and `lib/`). The
+ * wrapper exports MAINFRAME_STANDALONE_ROOT; fall back to deriving it from the
+ * bundled node's path (`<root>/bin/node`).
+ */
+export function resolveInstallRoot(env = process.env, execPath = process.execPath): string {
+  const fromEnv = env['MAINFRAME_STANDALONE_ROOT'];
+  if (fromEnv && existsSync(join(fromEnv, 'lib', 'daemon.cjs'))) return fromEnv;
+
+  const derived = dirname(dirname(execPath)); // <root>/bin/node → <root>
+  if (existsSync(join(derived, 'lib', 'daemon.cjs'))) return derived;
+
+  throw new Error(
+    'Could not locate a standalone install to update. This looks like a dev or ' +
+      'non-standalone build. Re-run the install script instead:\n' +
+      '  curl -fsSL https://raw.githubusercontent.com/qlan-ro/mainframe/main/scripts/install.sh | bash',
+  );
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const headers: Record<string, string> = { 'User-Agent': 'mainframe-updater' };
+  if (process.env['GITHUB_TOKEN']) headers['Authorization'] = `Bearer ${process.env['GITHUB_TOKEN']}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`GitHub API ${res.status} for ${url}`);
+  return (await res.json()) as T;
+}
+
+async function downloadTarball(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { headers: { 'User-Agent': 'mainframe-updater' }, redirect: 'follow' });
+  if (!res.ok) throw new Error(`Download failed (${res.status}) for ${url}`);
+  await writeFile(dest, Buffer.from(await res.arrayBuffer()));
+}
+
+export async function runUpdate(argv: string[] = process.argv.slice(3)): Promise<void> {
+  let opts: UpdateOptions & { help?: boolean; dir?: string };
+  try {
+    opts = parseUpdateArgs(argv);
+  } catch (err) {
+    console.error(`  ${(err as Error).message}`);
+    printUsage();
+    process.exit(1);
+  }
+  if (opts.help) return printUsage();
+
+  const root = opts.dir ?? resolveInstallRoot();
+  const artifact = standaloneArtifactName(process.platform, process.arch);
+
+  console.log('  Checking for updates…');
+  const listUrl = opts.version
+    ? `https://api.github.com/repos/${REPO}/releases/tags/${opts.version}`
+    : `https://api.github.com/repos/${REPO}/releases?per_page=30`;
+  const payload = await fetchJson<GhRelease | GhRelease[]>(listUrl);
+  const release = pickRelease(Array.isArray(payload) ? payload : [payload], opts);
+  const url = assetUrl(release, artifact);
+
+  console.log(`  Installing ${release.tag_name} (${artifact}) → ${root}`);
+  const tmp = await mkdtemp(join(tmpdir(), 'mainframe-update-'));
+  try {
+    const tarball = join(tmp, artifact);
+    await downloadTarball(url, tarball);
+    // Overwrite bin/ and lib/ in place; the running daemon keeps its loaded copy.
+    await execFileAsync('tar', ['-xzf', tarball, '-C', root, '--strip-components=1']);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+
+  console.log(`\n  Updated to ${release.tag_name}.`);
+  console.log('  Restart the daemon to run it: `systemctl restart mainframe` (or restart the process).\n');
+}
+
+function printUsage(): void {
+  console.log(
+    [
+      '',
+      '  mainframe update — upgrade the standalone daemon in place',
+      '',
+      '  Usage: mainframe update [--pre] [--version <tag>] [--dir <path>]',
+      '',
+      '    --pre              include pre-releases when picking the newest',
+      '    --version <tag>    install a specific release tag (e.g. v2.0.0-rc.1)',
+      '    --dir <path>       install root to unpack over (default: auto-detected)',
+      '',
+    ].join('\n'),
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -253,6 +253,13 @@ if (subcommand === 'pair') {
   import('./cli/pair.js').then(({ runPair }) => runPair());
 } else if (subcommand === 'status') {
   import('./cli/status.js').then(({ runStatus }) => runStatus());
+} else if (subcommand === 'update') {
+  import('./cli/update.js').then(({ runUpdate }) =>
+    runUpdate().catch((error) => {
+      console.error(`  Update failed: ${(error as Error).message}`);
+      process.exit(1);
+    }),
+  );
 } else {
   main().catch((error) => {
     logger.fatal({ err: error }, 'Fatal error');

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -64,16 +64,22 @@ else
 fi
 chmod +x "${DIST_DIR}/bin/cloudflared"
 
-# 5. Create wrapper script
-cat > "${DIST_DIR}/bin/mainframe-daemon" << 'WRAPPER'
+# 5. Create wrapper script.
+# MAINFRAME_STANDALONE_ROOT tells `mainframe update` where the install lives so it
+# can extract a new release over it.
+cat > "${DIST_DIR}/bin/mainframe" << 'WRAPPER'
 #!/usr/bin/env bash
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE_DIR="$(dirname "$SCRIPT_DIR")"
 export MAINFRAME_ORIG_PATH="${PATH}"
+export MAINFRAME_STANDALONE_ROOT="${BASE_DIR}"
 export PATH="${SCRIPT_DIR}:${PATH}"
 exec "${SCRIPT_DIR}/node" "${BASE_DIR}/lib/daemon.cjs" "$@"
 WRAPPER
-chmod +x "${DIST_DIR}/bin/mainframe-daemon"
+chmod +x "${DIST_DIR}/bin/mainframe"
+
+# Back-compat alias: existing systemd units / PATHs reference `mainframe-daemon`.
+ln -sf mainframe "${DIST_DIR}/bin/mainframe-daemon"
 
 # 6. Package
 tar -czf "dist-standalone/${DIST_NAME}.tar.gz" -C dist-standalone "$DIST_NAME"

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -21,19 +21,26 @@ pnpm --filter @qlan-ro/mainframe-types build
 pnpm --filter @qlan-ro/mainframe-core build
 node packages/app-electron/scripts/bundle-daemon.mjs "${DIST_DIR}/lib/daemon.cjs"
 
-# 2. Copy better-sqlite3 native binary for target platform
-SQLITE_PKG="$(node -e "console.log(require('path').dirname(require.resolve('better-sqlite3/package.json')))")"
-PREBUILD_DIR="${SQLITE_PKG}/prebuilds/${OS}-${ARCH}"
-BUILD_DIR="${SQLITE_PKG}/build/Release"
+# 2. Collect the daemon's external runtime packages into a node_modules SIBLING of
+#    daemon.cjs. The daemon is esbuilt with these left external (better-sqlite3 +
+#    its native binary, the LSP servers, ripgrep), so each stays a runtime require()
+#    that Node resolves from node_modules next to daemon.cjs. Same collector backs
+#    the Tauri sidecar bundler. Copying the whole better-sqlite3 package brings its
+#    per-platform prebuild along (the CI runner installed it for this target).
+node scripts/collect-daemon-deps.mjs \
+  packages/core/package.json \
+  "${DIST_DIR}/lib/node_modules" \
+  better-sqlite3 typescript-language-server pyright @vscode/ripgrep
 
-if [ -d "$PREBUILD_DIR" ]; then
-  mkdir -p "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}"
-  cp -r "${PREBUILD_DIR}/." "${DIST_DIR}/lib/prebuilds/${OS}-${ARCH}/"
-elif [ -f "${BUILD_DIR}/better_sqlite3.node" ]; then
-  mkdir -p "${DIST_DIR}/lib/build/Release"
-  cp "${BUILD_DIR}/better_sqlite3.node" "${DIST_DIR}/lib/build/Release/"
-else
-  echo "No better-sqlite3 binary found at ${PREBUILD_DIR} or ${BUILD_DIR}" >&2
+SQLITE_DEST="${DIST_DIR}/lib/node_modules/better-sqlite3"
+if [ ! -f "${SQLITE_DEST}/package.json" ]; then
+  echo "better-sqlite3 was not collected into the bundle" >&2
+  exit 1
+fi
+# The JS package resolving is not enough — the daemon crashes at runtime without the
+# compiled native addon. `pnpm install` on this CI runner must have built/fetched it.
+if [ -z "$(find "$SQLITE_DEST" -name '*.node' -print -quit)" ]; then
+  echo "No better-sqlite3 native binary (*.node) in ${SQLITE_DEST}" >&2
   exit 1
 fi
 

--- a/scripts/collect-daemon-deps.mjs
+++ b/scripts/collect-daemon-deps.mjs
@@ -1,0 +1,115 @@
+/**
+ * Collect the daemon's external/native runtime packages into a `node_modules/`
+ * tree so a bundled, single-file `daemon.cjs` can `require()` them at runtime.
+ *
+ * The daemon is esbuilt with a handful of packages marked EXTERNAL (native addons
+ * that can't be bundled + the LSP servers + ripgrep, which ship their own
+ * binaries/files). Each stays a real `require()` that Node resolves from a
+ * `node_modules` SIBLING of the requiring file. This walks each external plus its
+ * transitive (optional) dependencies and deref-copies the real (pnpm-symlinked)
+ * package dirs into one flat tree.
+ *
+ * Shared by the Tauri sidecar bundler (packages/app-tauri/scripts/bundle-daemon.mjs)
+ * and the standalone daemon tarball (scripts/build-standalone.sh) so both ship a
+ * complete, self-resolving daemon.
+ */
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+
+/** Resolve a package's root dir (the dir holding its package.json). */
+function pkgDirOf(name, requireFn) {
+  try {
+    return dirname(requireFn.resolve(`${name}/package.json`));
+  } catch {
+    // Package blocks the ./package.json subpath via exports — resolve an entry
+    // and walk up to the package.json whose "name" matches.
+    let dir = dirname(requireFn.resolve(name));
+    for (;;) {
+      const pj = join(dir, 'package.json');
+      if (existsSync(pj)) {
+        try {
+          if (JSON.parse(readFileSync(pj, 'utf8')).name === name) return dir;
+        } catch {
+          /* keep walking */
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) throw new Error(`cannot locate package root for ${name}`);
+      dir = parent;
+    }
+  }
+}
+
+/** Transitively gather a package + its (optional) deps into `found: name→dir`. */
+function collect(name, requireFn, found, onWarn) {
+  if (found.has(name)) return;
+  let dir;
+  try {
+    dir = pkgDirOf(name, requireFn);
+  } catch {
+    onWarn(`skip unresolved dep: ${name}`);
+    return;
+  }
+  found.set(name, dir);
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+  } catch {
+    return;
+  }
+  const next = createRequire(join(dir, 'package.json'));
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.optionalDependencies ?? {}) };
+  for (const dep of Object.keys(deps)) collect(dep, next, found, onWarn);
+}
+
+/**
+ * Populate `destNodeModules` with each external package + its transitive deps.
+ *
+ * @param {object}   opts
+ * @param {string}   opts.requireBasePkgJson  Absolute path to a package.json whose
+ *                                            directory anchors dependency resolution
+ *                                            (typically packages/core/package.json).
+ * @param {string[]} opts.externals           Package names to seed from (e.g.
+ *                                            ['better-sqlite3', 'pyright']). Glob
+ *                                            entries like '*.node' are ignored.
+ * @param {string}   opts.destNodeModules      Absolute path to the node_modules dir to
+ *                                            (re)create.
+ * @param {(msg: string) => void} [opts.onWarn]  Warning sink for unresolved deps.
+ * @returns {string[]} the resolved package names that were copied.
+ */
+export function collectDaemonDeps({ requireBasePkgJson, externals, destNodeModules, onWarn }) {
+  const warn = onWarn ?? ((m) => console.warn(`[collect-daemon-deps] ${m}`));
+  const requireBase = createRequire(requireBasePkgJson);
+
+  const found = new Map();
+  for (const name of externals.filter((e) => !e.includes('*'))) {
+    collect(name, requireBase, found, warn);
+  }
+
+  rmSync(destNodeModules, { recursive: true, force: true });
+  for (const [name, dir] of found) {
+    const dest = join(destNodeModules, name); // scoped names (@vscode/ripgrep) nest correctly
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(dir, dest, { recursive: true, dereference: true });
+  }
+  return [...found.keys()];
+}
+
+// CLI: node collect-daemon-deps.mjs <requireBasePkgJson> <destNodeModules> <external...>
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [requireBasePkgJson, destNodeModules, ...externals] = process.argv.slice(2);
+  if (!requireBasePkgJson || !destNodeModules || externals.length === 0) {
+    console.error(
+      'Usage: node collect-daemon-deps.mjs <requireBasePkgJson> <destNodeModules> <external...>',
+    );
+    process.exit(1);
+  }
+  // createRequire needs an absolute path; CLI callers pass repo-relative ones.
+  const copied = collectDaemonDeps({
+    requireBasePkgJson: resolve(process.cwd(), requireBasePkgJson),
+    destNodeModules: resolve(process.cwd(), destNodeModules),
+    externals,
+  });
+  console.log(`[collect-daemon-deps] copied ${copied.length} packages → ${destNodeModules}`);
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ echo "Installing to ${INSTALL_DIR}..."
 mkdir -p "$INSTALL_DIR"
 tar -xzf "${TMP_DIR}/${ARTIFACT}" -C "$INSTALL_DIR" --strip-components=1
 
-chmod +x "${INSTALL_DIR}/bin/mainframe-daemon"
+chmod +x "${INSTALL_DIR}/bin/mainframe"
 
 # PATH check
 if ! echo "$PATH" | tr ':' '\n' | grep -q "${INSTALL_DIR}/bin"; then
@@ -53,6 +53,6 @@ if ! echo "$PATH" | tr ':' '\n' | grep -q "${INSTALL_DIR}/bin"; then
 fi
 
 echo ""
-echo "Installed mainframe-daemon to ${INSTALL_DIR}/bin/mainframe-daemon"
-echo "Run 'mainframe-daemon' to start the daemon"
+echo "Installed mainframe to ${INSTALL_DIR}/bin/mainframe"
+echo "Run 'mainframe' to start the daemon, or 'mainframe update' to upgrade later"
 echo ""


### PR DESCRIPTION
Three related changes to the standalone daemon (the tarball installed on servers/VMs via `scripts/install.sh`).

## 1. Fix: ship a complete `node_modules` in the tarball

The daemon is esbuilt with `better-sqlite3`, the LSP servers, and `@vscode/ripgrep` left **external** (runtime `require()`s resolving from a `node_modules` sibling of `daemon.cjs`). `build-standalone.sh` only copied better-sqlite3's raw `.node` binary and **never created a `node_modules`**, so a fresh VM crashed on startup with `Cannot find module 'better-sqlite3'` (and lost LSP + ripgrep). Fixed by extracting the Tauri sidecar bundler's proven dependency collector into a shared `scripts/collect-daemon-deps.mjs`, used by both bundlers. Build-time guards fail fast if the package or its `.node` addon is missing.

**Verified:** `require('better-sqlite3')` loads and runs a query from a sibling `daemon.cjs`; the native addon and ripgrep binary are present; LSP packages resolve as `lsp-registry.ts` expects.

## 2. Rename the CLI to `mainframe`

`mainframe-daemon` → `mainframe` across the npm bin, tarball wrapper, installer, and docs. The old name still ships as a **symlink alias**, so existing systemd units on deployed VMs keep working after an update. Desktop shells spawn `lib/daemon.cjs` directly and are unaffected. The release **artifact** name stays `mainframe-daemon-<os>-<arch>.tar.gz`.

## 3. Add `mainframe update`

Upgrades a standalone install in place: resolves the host artifact, fetches the target GitHub release (latest stable by default; `--pre` for pre-releases, `--version <tag>` for a specific tag), downloads the tarball, and unpacks it over the install root (auto-detected via `MAINFRAME_STANDALONE_ROOT`, or `--dir`). The running daemon keeps serving until restarted.

**Verified:** 15 unit tests over the pure release-selection / arg-parsing / root-resolution logic, plus a real end-to-end run — `mainframe update --dir <tmp>` against the live GitHub API fetched `v1.0.0` and unpacked the correct `bin/` + `lib/` layout.

## Docs

`running-the-daemon.md` gains an **Updating** section and an alias note; the stale `better-sqlite3` troubleshooting workaround is softened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)