### PR TITLE
fix(release): unblock the Tauri/daemon release pipeline

### DIFF
--- a/.changeset/fix-release-pipeline-tauri-runner.md
+++ b/.changeset/fix-release-pipeline-tauri-runner.md
@@ -1,0 +1,8 @@
+---
+---
+
+Release CI only: drop the macOS Intel (macos-13) Tauri leg that never gets a
+runner, find the draft release by listing (the tags endpoint 404s on drafts) so
+the dmg-rename step stops failing, and publish the release whenever the daemon
+built so `mainframe update` artifacts are never blocked by a desktop build.
+No package changelog.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,13 @@ jobs:
         # TEMPORARILY macOS-only (2026-07-06) — see build-desktop note. Windows
         # (pnpm-on-PATH in the tauri beforeBuildCommand) and Linux (updater signing-key
         # secret) are disabled until fixed; restore the ubuntu/windows entries then.
+        #
+        # macos-13 (Intel) removed 2026-07-07: GitHub-hosted macOS Intel runners are
+        # no longer being provisioned for this repo — the leg sat `queued` with no
+        # runner across every release run, indefinitely blocking the pipeline. Ship
+        # Apple Silicon only; re-add an Intel leg via a self-hosted runner if needed.
         include:
           - os: macos-14 # Apple Silicon (arm64)
-          - os: macos-13 # Intel (x86_64)
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -234,13 +238,22 @@ jobs:
       # Idempotent: renamed assets no longer match `^Mainframe_`, so re-runs skip them.
       - name: Normalize Tauri dmg asset name
         if: runner.os == 'macOS'
+        # Cosmetic asset rename — never let it fail the job (and, via `needs`, the release).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          release_id=$(gh api "repos/$REPO/releases/tags/$TAG" -q '.id')
+          # tauri-action creates the release as a DRAFT, and GET /releases/tags/{tag}
+          # returns published releases only (404s on drafts). Find it by listing.
+          release_id=$(gh api "repos/$REPO/releases?per_page=100" \
+            --jq "[.[] | select(.tag_name == \"$TAG\")][0].id // empty")
+          if [ -z "$release_id" ]; then
+            echo "No release found for $TAG yet — skipping dmg rename."
+            exit 0
+          fi
           gh api "repos/$REPO/releases/$release_id/assets" \
             -q '.[] | select(.name | test("^Mainframe_.*\\.dmg$")) | "\(.id) \(.name)"' \
           | while read -r id name; do
@@ -253,6 +266,11 @@ jobs:
 
   release:
     needs: [build-desktop, build-daemon, build-app-tauri]
+    # Publish as long as the daemon built — the daemon tarballs back `mainframe update`
+    # and must never be blocked by a desktop/Tauri build failure. `always()` overrides
+    # the default "skip if any need failed"; download-artifact then attaches whatever
+    # desktop/tauri artifacts did succeed.
+    if: ${{ always() && needs.build-daemon.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Every 2.0 release run (rc.0, rc.1, the nightlies) failed to publish daemon tarballs — the artifacts that back `mainframe update`. Three compounding causes:

## 1. `build-app-tauri (macos-13)` never gets a runner
GitHub-hosted macOS **Intel** runners are no longer being provisioned for this repo. Across all 6 recent release runs the leg sat `status: queued` with `runner=""` and never started — indefinitely blocking the job (and the `release` job gated on it). **Fix:** drop `macos-13` from the matrix; ship Apple Silicon (`macos-14`) only. Re-add via a self-hosted runner if an Intel build is needed.

## 2. `build-app-tauri (macos-14)` fails at "Normalize Tauri dmg asset name"
`tauri-action` creates the release as a **draft**, and `GET /releases/tags/{tag}` returns *published* releases only — it **404s on drafts**. Under `set -euo pipefail` that 404 failed the step. **Fix:** find the release by listing `/releases` and matching `tag_name`, skip cleanly if it isn't there yet, and mark the cosmetic rename `continue-on-error`.

Verified against the live API — the new lookup returns rc.1's release id (`349948665`) where `releases/tags/v2.0.0-rc.1` gives `404 Not Found`.

## 3. The `release` job hard-depended on the desktop build
`needs: [build-desktop, build-daemon, build-app-tauri]` meant any desktop/Tauri failure (or the macos-13 hang) blocked publishing the **successfully built** daemon tarballs. **Fix:** `if: ${{ always() && needs.build-daemon.result == 'success' }}` — the daemon (and therefore `mainframe update`) always publishes; desktop installers attach when they succeed.

## Notes
- CI-only change; empty changeset.
- `release.yml` validated as parseable YAML.
- Does not retroactively fix rc.1 (its run is already queued/superseded) — the next tag pushed after this merges will exercise the fixed pipeline. The rc.1 daemon is available now as the `daemon-linux-x64` CI artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)