### PR TITLE
feat(cli): add `mainframe --version` and show version in status/health

### DIFF
--- a/.changeset/daemon-version-command.md
+++ b/.changeset/daemon-version-command.md
@@ -1,0 +1,9 @@
+---
+"@qlan-ro/mainframe-core": minor
+---
+
+Surface the daemon version. `mainframe --version` (also `-v` / `version`) prints
+the installed binary's version, `mainframe status` shows the **running** daemon's
+version, and `GET /health` now returns a `version` field. The version is inlined
+into the bundle at build time (esbuild `define`), with a `package.json` fallback
+for dev and unbundled runs.

--- a/docs/guides/running-the-daemon.md
+++ b/docs/guides/running-the-daemon.md
@@ -136,6 +136,8 @@ mainframe update --version v2.0.0-rc.1   # a specific tag
 systemctl restart mainframe      # or: kill the foreground process and re-run `mainframe`
 ```
 
+Check versions with `mainframe --version` (the installed binary) and `mainframe status` (the **running** daemon) — after a restart they should match.
+
 Re-running the [install script](#2-install-the-daemon) does the same thing and is the fallback if the daemon is too broken to run `mainframe update`.
 
 ## Troubleshooting

--- a/packages/app-electron/scripts/bundle-daemon.mjs
+++ b/packages/app-electron/scripts/bundle-daemon.mjs
@@ -3,11 +3,15 @@
  * Native modules (better-sqlite3) are kept external and copied separately via extraResources.
  */
 import { build } from 'esbuild';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const coreEntry = join(__dirname, '../../../packages/core/dist/index.js');
+const coreVersion = JSON.parse(
+  readFileSync(join(__dirname, '../../../packages/core/package.json'), 'utf8'),
+).version;
 const outfile = process.argv[2] ?? join(__dirname, '../resources/daemon.cjs');
 
 await build({
@@ -20,6 +24,8 @@ await build({
   external: ['better-sqlite3', '*.node', 'typescript-language-server', 'pyright', '@vscode/ripgrep'],
   outfile,
   logLevel: 'info',
+  // Inline the daemon's version — the standalone tarball ships no package.json at runtime.
+  define: { __DAEMON_VERSION__: JSON.stringify(coreVersion) },
   // import.meta.url is guarded with ?? fallback in manager.ts; suppress the cosmetic warning
   logOverride: { 'empty-import-meta': 'silent' },
 });

--- a/packages/app-tauri/scripts/bundle-daemon.mjs
+++ b/packages/app-tauri/scripts/bundle-daemon.mjs
@@ -25,7 +25,7 @@
  */
 import { build } from 'esbuild';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { collectDaemonDeps } from '../../../scripts/collect-daemon-deps.mjs';
@@ -35,6 +35,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const appTauri = resolve(here, '..'); // packages/app-tauri
 const repoRoot = resolve(appTauri, '../..'); // monorepo root
 const coreEntry = join(repoRoot, 'packages/core/dist/index.js');
+const coreVersion = JSON.parse(
+  readFileSync(join(repoRoot, 'packages/core/package.json'), 'utf8'),
+).version;
 const daemonDir = join(appTauri, 'src-tauri/resources/daemon');
 const binariesDir = join(appTauri, 'src-tauri/binaries'); // provisioned `node-<triple>` (provision-node.mjs)
 const outfile = join(daemonDir, 'daemon.cjs');
@@ -67,6 +70,8 @@ await build({
   external: EXTERNAL,
   outfile,
   logLevel: 'info',
+  // Inline the daemon's version — the tarball ships no package.json to read at runtime.
+  define: { __DAEMON_VERSION__: JSON.stringify(coreVersion) },
   // import.meta.url is guarded with ?? in core; suppress the cosmetic warning.
   logOverride: { 'empty-import-meta': 'silent' },
 });

--- a/packages/core/src/__tests__/version.test.ts
+++ b/packages/core/src/__tests__/version.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { DAEMON_VERSION } from '../version.js';
+
+describe('DAEMON_VERSION', () => {
+  it('resolves to the core package.json version (dev/fallback path)', () => {
+    // vitest does not apply the esbuild `__DAEMON_VERSION__` define, so this
+    // exercises the package.json fallback used by `node dist/index.js` too.
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
+    const expected = JSON.parse(readFileSync(pkgPath, 'utf8')).version as string;
+    expect(DAEMON_VERSION).toBe(expected);
+  });
+
+  it('is a non-empty version string', () => {
+    expect(DAEMON_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    expect(DAEMON_VERSION).not.toBe('0.0.0-dev');
+  });
+});

--- a/packages/core/src/cli/early-flags.ts
+++ b/packages/core/src/cli/early-flags.ts
@@ -1,0 +1,14 @@
+import { DAEMON_VERSION } from '../version.js';
+
+/**
+ * Handle argv flags that must answer *before* the daemon's module graph loads.
+ *
+ * index.ts imports this first, so `mainframe --version` prints and exits before
+ * the logger (and its pino file destination), the DB, or the server are ever
+ * evaluated — no log-line noise on stdout, no slow boot, no sonic-boom flush race.
+ */
+const arg = process.argv[2];
+if (arg === '--version' || arg === '-v' || arg === 'version') {
+  console.log(`mainframe ${DAEMON_VERSION}`);
+  process.exit(0);
+}

--- a/packages/core/src/cli/status.ts
+++ b/packages/core/src/cli/status.ts
@@ -5,7 +5,7 @@ export async function runStatus(): Promise<void> {
   const baseUrl = `http://127.0.0.1:${config.port}`;
 
   // Fetch health
-  let health: { status: string; timestamp: string; tunnelUrl?: string | null };
+  let health: { status: string; version?: string; timestamp: string; tunnelUrl?: string | null };
   try {
     const res = await fetch(`${baseUrl}/health`);
     health = (await res.json()) as typeof health;
@@ -16,6 +16,7 @@ export async function runStatus(): Promise<void> {
 
   console.log('\n  Mainframe Daemon');
   console.log('  Status:     %s', health.status);
+  console.log('  Version:    %s', health.version ?? 'unknown');
   console.log('  Port:       %d', config.port);
   console.log('  Tunnel:     %s', health.tunnelUrl ?? 'not active');
   console.log('  Data dir:   %s', config.dataDir);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import './cli/early-flags.js'; // MUST be first — answers `--version` before the logger/daemon graph loads
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { mkdirSync } from 'node:fs';
@@ -249,6 +250,7 @@ async function main(): Promise<void> {
 
 const subcommand = process.argv[2];
 
+// `--version`/`version` is handled earlier by ./cli/early-flags.js.
 if (subcommand === 'pair') {
   import('./cli/pair.js').then(({ runPair }) => runPair());
 } else if (subcommand === 'status') {

--- a/packages/core/src/server/http.ts
+++ b/packages/core/src/server/http.ts
@@ -5,6 +5,7 @@ import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
 import type { LaunchRegistry } from '../launch/index.js';
 import { createChildLogger } from '../logger.js';
+import { DAEMON_VERSION } from '../version.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import {
   projectRoutes,
@@ -101,6 +102,7 @@ export function createHttpServer(deps: HttpServerDeps): { app: Express; pushServ
   app.get('/health', (_req, res) => {
     res.json({
       status: 'ok',
+      version: DAEMON_VERSION,
       timestamp: new Date().toISOString(),
       tunnelUrl: ctx.tunnelUrl ?? getTunnelUrl?.() ?? null,
     });

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,24 @@
+import { createRequire } from 'node:module';
+
+/**
+ * The daemon's own version.
+ *
+ * Bundled builds inline it: the esbuild `define` in the bundle-daemon scripts
+ * replaces `__DAEMON_VERSION__` with the package version at build time (the
+ * standalone tarball ships no package.json to read at runtime). In dev (tsx) and
+ * unbundled `node dist/index.js` runs the token is absent, so we fall back to
+ * reading the package.json next to this module.
+ */
+declare const __DAEMON_VERSION__: string | undefined;
+
+function resolveVersion(): string {
+  if (typeof __DAEMON_VERSION__ === 'string' && __DAEMON_VERSION__) return __DAEMON_VERSION__;
+  try {
+    const require = createRequire(import.meta.url);
+    return (require('../package.json') as { version: string }).version;
+  } catch {
+    return '0.0.0-dev';
+  }
+}
+
+export const DAEMON_VERSION = resolveVersion();


### PR DESCRIPTION
Surfaces the daemon's own version — there was no version plumbing anywhere before (no constant, no `/health` field, no build injection).

## What's new
- **`mainframe --version`** (also `-v` / `version`) → prints `mainframe <version>` for the installed binary.
- **`mainframe status`** → now shows a `Version:` line (the **running** daemon, read from `/health`).
- **`GET /health`** → returns a `version` field.

## How the version is resolved
Single source of truth in `packages/core/src/version.ts`. The daemon is bundled to a single `daemon.cjs` that ships no `package.json`, so the version is inlined at build time via esbuild `define: { __DAEMON_VERSION__ }` in **both** bundlers (Tauri sidecar + standalone). Dev (`tsx`) and unbundled `node dist/index.js` runs fall back to reading `package.json`.

## The `--version` fast path
`--version` is handled by a first-import guard (`cli/early-flags.ts`) so it answers **before** the logger (pino file destination), DB, or server are evaluated. Without this, an immediate `process.exit(0)` right after boot leaks a `logger initialized` JSON line to stdout and trips pino's `sonic boom is not ready yet` flush race. Now it's a clean `mainframe <version>`, exit 0.

## Verification
- Unit test (`version.test.ts`) — `DAEMON_VERSION` matches `package.json` on the fallback path.
- `mainframe --version` / `-v` / `version`: clean output, exit 0, on both the compiled `dist` (fallback) **and** a real esbuild bundle (the `define` path — literal inlined, `__DAEMON_VERSION__` fully replaced).
- Booted a daemon: `/health` → `"version":"2.0.0-rc.1"`, `status` → `Version: 2.0.0-rc.1`.
- Typecheck clean; no test pins the `/health` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)