### PR TITLE
fix(release): title releases with the bare tag, not "Mainframe <tag>"

### DIFF
--- a/.changeset/release-title-bare-tag.md
+++ b/.changeset/release-title-bare-tag.md
@@ -1,0 +1,5 @@
+---
+---
+
+Release CI only: title GitHub releases with the bare tag (`v2.0.0-rc.2`) instead
+of `Mainframe v2.0.0-rc.2`, matching the pre-2.0 release naming. No package changelog.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
         with:
           projectPath: packages/app-tauri
           tagName: ${{ github.ref_name }}
-          releaseName: Mainframe ${{ github.ref_name }}
+          releaseName: ${{ github.ref_name }}
           releaseDraft: true
           # Any tag with a pre-release suffix (v2.0.0-rc.1, -nightly.N, …) is a
           # pre-release, so it never becomes the "latest" release the in-app updater


### PR DESCRIPTION
The Tauri build's `tauri-action` step sets `releaseName: Mainframe ${{ github.ref_name }}`, which retitled every GitHub release to `Mainframe v2.0.0-rc.2` — a change from the pre-2.0 bare-tag titles (`v0.22.2`, etc.). This drops the `Mainframe ` prefix so release titles are just the tag again.

```diff
-          releaseName: Mainframe ${{ github.ref_name }}
+          releaseName: ${{ github.ref_name }}
```

- The **tag** is unchanged (`v2.0.0-rc.2`); only the release **title** changes.
- Takes effect on the next tag pushed after merge; existing releases keep their titles (rename manually if wanted).
- The `rc.2` → `rc2` version-format change was considered and dropped as not worth the complexity — the dot form stays.
- CI-only; empty changeset. `release.yml` validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)