### PR TITLE
feat(ui): always show the titlebar branch chip

### DIFF
--- a/.changeset/always-show-branch-chip.md
+++ b/.changeset/always-show-branch-chip.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Always show the branch chip in the titlebar, for main-repo sessions too.
+
+The toolbar branch chip used to render only for worktree sessions, because it derived its label from the persisted `chat.branchName`, which is set only when a session runs in a worktree. It now reads the live current branch from git on mount, so a session on the shared main repo shows and can switch its branch as well. Matching the Workspace Surfaces artboard, a worktree session gets an accent-tinted chip with a fork glyph and a "WT" badge, while a main-repo session stays neutral; the tooltip names which.

--- a/packages/ui/src/app/AppShell.tsx
+++ b/packages/ui/src/app/AppShell.tsx
@@ -164,6 +164,7 @@ function RuntimeBody({ port }: { port: number }) {
           onExpandSidebar={expandSidebar}
           projectName={projectName}
           branchName={branchName}
+          isWorktree={Boolean(worktreePath)}
           windowStyle={windowStyle}
           port={port}
           projectId={projectId}

--- a/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
@@ -8,6 +8,7 @@
  * density pass) — no text pill here, so worktree + PR keep the room.
  */
 
+import { GitFork } from 'lucide-react';
 import type { TagColor } from '@qlan-ro/mainframe-types';
 import type { DetectedPr } from '@qlan-ro/mainframe-types';
 import { TAG_DOT_STYLE } from '../tags/tag-colors';
@@ -73,20 +74,7 @@ export function SessionRowMeta({
             ].join(' ')}
           >
             {worktreeMissing && <span data-testid="sessions-row-meta-worktree-missing" aria-label="worktree missing" />}
-            <svg
-              width="9"
-              height="9"
-              viewBox="0 0 16 16"
-              fill="none"
-              className="flex-shrink-0 text-mf-text-3"
-              aria-hidden
-            >
-              <path
-                d="M5 3a2 2 0 1 0 0 4 2 2 0 0 0 0-4ZM3 9a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm10 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"
-                fill="currentColor"
-              />
-              <path d="M5 7v1.17A3 3 0 0 1 6.83 10H9a2 2 0 0 0 2-2V7" stroke="currentColor" strokeWidth="1.5" />
-            </svg>
+            <GitFork size={9} className="flex-shrink-0 text-mf-text-3" aria-hidden />
             <span className="max-w-[8rem] truncate">{worktreeBasename(worktreePath)}</span>
           </span>
         </Hint>

--- a/packages/ui/src/layout/MainToolbar.tsx
+++ b/packages/ui/src/layout/MainToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { ChevronDown, GitBranch, Moon, Search, Sun } from 'lucide-react';
+import { ChevronDown, GitBranch, GitFork, Moon, Search, Sun } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTheme, type WindowStyle } from '@/store/theme';
 import { useUiPrefs } from '@/store/ui-prefs';
@@ -21,6 +21,8 @@ interface MainToolbarProps {
   onExpandSidebar: () => void;
   projectName: string;
   branchName?: string;
+  /** Whether the active session runs in a git worktree (vs. the shared main repo). */
+  isWorktree?: boolean;
   windowStyle: WindowStyle;
   port: number;
   projectId?: string;
@@ -29,6 +31,22 @@ interface MainToolbarProps {
 
 const ICON_BTN =
   'inline-flex h-[24px] w-[28px] flex-shrink-0 items-center justify-center rounded-[6px] border-none bg-transparent text-muted-foreground cursor-pointer transition-[background] duration-[120ms] hover:bg-accent';
+
+const CHIP_BASE =
+  'inline-flex h-[22px] min-w-0 max-w-[230px] items-center gap-[5px] rounded-[6px] border-[0.5px] border-solid px-[6px] font-mono text-caption font-normal';
+
+/**
+ * Worktree vs main-repo chip styling — mirrors the Workspace Surfaces artboard
+ * (02-chrome.jsx MainToolbar). Worktree: accent border + tint, foreground text;
+ * main-repo: transparent border (no layout shift), neutral hover. Both keep the
+ * open popover state subtle — the main-repo chip never turns accent.
+ */
+function chipClass(open: boolean, isWorktree: boolean): string {
+  if (isWorktree) {
+    return cn('border-primary/25 text-foreground', open ? 'bg-primary/15' : 'bg-primary/8 hover:bg-primary/12');
+  }
+  return cn('border-transparent text-muted-foreground', open ? 'bg-accent' : 'hover:bg-accent');
+}
 
 /**
  * Shell-level surface-area toolbar (above SurfaceHost): project · branch identity
@@ -42,6 +60,7 @@ export function MainToolbar({
   onExpandSidebar,
   projectName,
   branchName,
+  isWorktree = false,
   windowStyle,
   port,
   projectId,
@@ -55,16 +74,28 @@ export function MainToolbar({
   const toggleInspector = useUiPrefs((s) => s.toggleInspector);
   const geo = windowStyleGeometry(windowStyle);
 
-  // BranchPopover writes (checkout/merge/rebase/rename/delete/new-branch) don't
-  // update the persisted `chat.branchName` the label prop derives from — no
-  // git-write route broadcasts `chat.updated`. Re-read the live current branch
-  // straight from git on `onBranchChanged` so the chip never goes stale; reset
-  // whenever the identity itself changes (chat switch) so a stale override from
-  // a previous chat can never leak.
+  // Read the live current branch from git so the chip shows for EVERY session,
+  // not just worktrees: a main-repo session has no persisted `chat.branchName`,
+  // so without this fetch the whole chip disappears. Re-runs on identity change
+  // (fresh, cancellation-guarded so a late response from a previous chat can't
+  // leak) and after a popover write via handleBranchChanged — BranchPopover
+  // writes don't broadcast `chat.updated`, so the prop alone would go stale.
   const [liveBranch, setLiveBranch] = useState<string | undefined>(undefined);
   useEffect(() => {
     setLiveBranch(undefined);
-  }, [chatId, branchName]);
+    if (!projectId) return;
+    let cancelled = false;
+    getGitBranch(port, projectId, chatId)
+      .then(({ branch }) => {
+        if (!cancelled) setLiveBranch(branch ?? undefined);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) console.warn('[MainToolbar] failed to read current branch', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [port, projectId, chatId, branchName]);
   const handleBranchChanged = useCallback(() => {
     if (!projectId) return;
     getGitBranch(port, projectId, chatId)
@@ -106,7 +137,7 @@ export function MainToolbar({
                   open={branchOpen}
                   onOpenChange={setBranchOpen}
                   onBranchChanged={handleBranchChanged}
-                  triggerLabel="Switch branch"
+                  triggerLabel={isWorktree ? 'Switch branch · worktree' : 'Switch branch · main repo'}
                 >
                   {/* Bare trigger — BranchPopover wraps this in Hint itself (via
                       triggerLabel), around PopoverTrigger. Wrapping Hint here would
@@ -115,17 +146,25 @@ export function MainToolbar({
                       content (see BranchPopover.tsx's file header). */}
                   <button
                     data-testid="main-toolbar-branch"
+                    data-worktree={isWorktree ? 'true' : 'false'}
                     type="button"
                     onClick={() => setBranchOpen((o) => !o)}
-                    className={cn(
-                      'inline-flex h-[22px] min-w-0 max-w-[230px] cursor-pointer items-center gap-[5px] rounded-[6px] px-[6px] font-mono text-caption font-normal',
-                      branchOpen
-                        ? 'bg-primary/10 border border-primary/40 text-foreground'
-                        : 'text-muted-foreground hover:bg-accent',
-                    )}
+                    className={cn(CHIP_BASE, 'cursor-pointer', chipClass(branchOpen, isWorktree))}
                   >
-                    <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
+                    {isWorktree ? (
+                      <GitFork size={11} className="flex-shrink-0 text-primary" />
+                    ) : (
+                      <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
+                    )}
                     <span className="truncate">{displayBranch}</span>
+                    {isWorktree && (
+                      <span
+                        data-testid="main-toolbar-branch-wt"
+                        className="ml-[1px] inline-flex h-[14px] flex-shrink-0 items-center rounded-[4px] bg-primary/12 px-[5px] text-micro font-semibold uppercase tracking-wide text-primary"
+                      >
+                        wt
+                      </span>
+                    )}
                     <ChevronDown size={8} className="flex-shrink-0 text-mf-text-4" />
                   </button>
                 </BranchPopover>
@@ -133,9 +172,10 @@ export function MainToolbar({
                 <Hint label="Switch branch — coming with its surface">
                   <button
                     data-testid="main-toolbar-branch"
+                    data-worktree={isWorktree ? 'true' : 'false'}
                     type="button"
                     disabled
-                    className="inline-flex h-[22px] min-w-0 max-w-[230px] cursor-not-allowed items-center gap-[5px] rounded-[6px] px-[6px] font-mono text-caption font-normal text-muted-foreground opacity-80"
+                    className={cn(CHIP_BASE, 'cursor-not-allowed text-muted-foreground opacity-80')}
                   >
                     <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
                     <span className="truncate">{displayBranch}</span>

--- a/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
+++ b/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
@@ -70,7 +70,57 @@ describe('MainToolbar — project name', () => {
 });
 
 describe('MainToolbar — branch chip', () => {
-  it('renders main-toolbar-branch containing the branch name when branchName is given', () => {
+  it('renders a neutral, interactive chip for a main-repo session using the live git branch', async () => {
+    mockGetGitBranch.mockResolvedValue({ branch: 'main' });
+
+    render(
+      <MainToolbar
+        leadingInset={0}
+        sidebarRendered={true}
+        onExpandSidebar={vi.fn()}
+        projectName="mainframe"
+        projectId="p1"
+        chatId="c1"
+        windowStyle="glass"
+        port={31415}
+      />,
+    );
+
+    const chip = await screen.findByTestId('main-toolbar-branch');
+    expect(chip.textContent).toContain('main');
+    expect(chip).not.toBeDisabled();
+    expect(chip.getAttribute('data-worktree')).toBe('false');
+    expect(chip.className).not.toContain('border-primary');
+    expect(screen.queryByTestId('main-toolbar-branch-wt')).toBeNull();
+    expect(mockGetGitBranch).toHaveBeenCalledWith(31415, 'p1', 'c1');
+  });
+
+  it('renders an accented chip with a WT badge for a worktree session', async () => {
+    mockGetGitBranch.mockResolvedValue({ branch: 'feat/x' });
+
+    render(
+      <MainToolbar
+        leadingInset={0}
+        sidebarRendered={true}
+        onExpandSidebar={vi.fn()}
+        projectName="mainframe"
+        branchName="feat/x"
+        isWorktree
+        projectId="p1"
+        chatId="c1"
+        windowStyle="glass"
+        port={31415}
+      />,
+    );
+
+    const chip = await screen.findByTestId('main-toolbar-branch');
+    expect(chip.textContent).toContain('feat/x');
+    expect(chip.getAttribute('data-worktree')).toBe('true');
+    expect(chip.className).toContain('border-primary');
+    expect(screen.getByTestId('main-toolbar-branch-wt').textContent?.trim()).toBe('wt');
+  });
+
+  it('renders a disabled stub chip when a branch is persisted but no projectId is available', () => {
     render(
       <MainToolbar
         leadingInset={0}
@@ -86,9 +136,30 @@ describe('MainToolbar — branch chip', () => {
     const chip = screen.getByTestId('main-toolbar-branch');
     expect(chip.textContent).toContain('feat/x');
     expect(chip).toBeDisabled();
+    expect(mockGetGitBranch).not.toHaveBeenCalled();
   });
 
-  it('does not render main-toolbar-branch when branchName is absent', () => {
+  it('does not render the chip when git reports no branch and none is persisted', async () => {
+    mockGetGitBranch.mockResolvedValue({ branch: null });
+
+    render(
+      <MainToolbar
+        leadingInset={0}
+        sidebarRendered={true}
+        onExpandSidebar={vi.fn()}
+        projectName="mainframe"
+        projectId="p1"
+        chatId="c1"
+        windowStyle="glass"
+        port={31415}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetGitBranch).toHaveBeenCalled());
+    expect(screen.queryByTestId('main-toolbar-branch')).toBeNull();
+  });
+
+  it('does not render the chip when there is no projectId and no persisted branch', () => {
     render(
       <MainToolbar
         leadingInset={0}
@@ -101,12 +172,15 @@ describe('MainToolbar — branch chip', () => {
     );
 
     expect(screen.queryByTestId('main-toolbar-branch')).toBeNull();
+    expect(mockGetGitBranch).not.toHaveBeenCalled();
   });
 });
 
 describe('MainToolbar — branch chip refresh after popover write', () => {
   it('refetches and displays the live branch after BranchPopover reports onBranchChanged', async () => {
-    mockGetGitBranch.mockResolvedValue({ branch: 'feat/after-checkout' });
+    mockGetGitBranch
+      .mockResolvedValueOnce({ branch: 'feat/before' })
+      .mockResolvedValueOnce({ branch: 'feat/after-checkout' });
 
     render(
       <MainToolbar
@@ -115,6 +189,7 @@ describe('MainToolbar — branch chip refresh after popover write', () => {
         onExpandSidebar={vi.fn()}
         projectName="mainframe"
         branchName="feat/before"
+        isWorktree
         projectId="p1"
         chatId="c1"
         windowStyle="glass"
@@ -122,7 +197,7 @@ describe('MainToolbar — branch chip refresh after popover write', () => {
       />,
     );
 
-    expect(screen.getByTestId('main-toolbar-branch').textContent).toContain('feat/before');
+    expect((await screen.findByTestId('main-toolbar-branch')).textContent).toContain('feat/before');
 
     fireEvent.click(screen.getByTestId('mock-branch-changed'));
 


### PR DESCRIPTION
## What

The toolbar branch chip only rendered for **worktree** sessions. It derived its label from the persisted `chat.branchName`, which the daemon sets only when a session runs in a worktree — so on a **main-repo** session the chip disappeared entirely, taking the branch manager with it.

Now the chip reads the **live current branch from git on mount** (`getGitBranch`, which the daemon resolves to the main-repo checkout when there's no worktree). So it shows for every git session — main-repo included — and can switch its branch in place. Non-git projects (branch `null`) still hide the chip.

## Design

Matches the `Workspace Surfaces.html` artboard (`02-chrome.jsx` `MainToolbar`):

- **Worktree session** → accent-tinted chip, `GitFork` glyph, `WT` badge, foreground text.
- **Main-repo session** → neutral chip (no accent even when the popover is open).
- Tooltip names which: `Switch branch · worktree` / `· main repo`.

Also **unifies the worktree glyph** on lucide `GitFork` across the app — the sidebar session-row meta pill used a hand-rolled SVG; it now matches the composer worktree trigger, the git panel `WorktreeSection`, and the new chip.

## Note / tradeoff

On a main-repo session, switching branches via the popover does an in-place `git checkout` on the **shared** main repo, affecting every other main-repo session on that project. That's inherent to git; the chip labels the context so it's not surprising.

## Verification

- MainToolbar + SessionRowMeta suites: **35/35 pass**; UI typecheck clean; ESLint clean.
- **Driven live** (browser-mode renderer → running daemon, real sessions): confirmed the chip renders neutral for a main-repo session (previously absent) and accent + `WT` for a worktree session.

## Files

- `packages/ui/src/layout/MainToolbar.tsx` — mount-fetch, `isWorktree` prop, artboard styling, `GitFork`/`GitBranch` glyphs, `WT` badge.
- `packages/ui/src/app/AppShell.tsx` — passes `isWorktree`.
- `packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx` — worktree pill → `GitFork`.
- `packages/ui/src/layout/__tests__/MainToolbar.test.tsx` — updated suite.
- changeset (patch, `@qlan-ro/mainframe-ui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)