### PR TITLE
fix(editor): preserve scroll position on external file refresh

### DIFF
--- a/.changeset/editor-scroll-refresh.md
+++ b/.changeset/editor-scroll-refresh.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix the editor jumping to the top when an open file is refreshed after an external change: applyValueUpdate now dispatches a minimal diff instead of replacing the whole document, so CodeMirror's scroll anchoring and selection mapping survive the reload.

--- a/packages/ui/src/lib/editor/__tests__/apply-value-update.test.ts
+++ b/packages/ui/src/lib/editor/__tests__/apply-value-update.test.ts
@@ -1,85 +1,128 @@
-import { describe, expect, it, vi } from 'vitest';
-import { applyValueUpdate } from '../apply-value-update';
+import { describe, expect, it } from 'vitest';
+import { EditorSelection, EditorState, type Transaction, type TransactionSpec } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
-import type { Transaction } from '@codemirror/state';
+import { applyValueUpdate, externalValueUpdate } from '../apply-value-update';
 
 /**
- * Stub an EditorView for apply-value-update tests.
+ * Stub an EditorView backed by a REAL EditorState so every dispatched spec is
+ * actually applied and validated by CM6 (invalid change ranges would throw).
  *
- * The CM6 implementation operates on:
- *   - view.state.doc.toString() — read current value
- *   - view.dispatch(transaction) — apply changes
- *   - view.state.selection — read selection before update
- *   - view.scrollDOM.scrollTop — read scroll before update
+ * Scroll behavior contract: applyValueUpdate must NOT touch scrollDOM.scrollTop.
+ * A whole-doc replace maps CM6's internal scroll anchor to position 0, and the
+ * next measure cycle scrolls to the top regardless of any manual scrollTop
+ * restore — so the fix is a minimal change span that keeps the anchor valid,
+ * not a scrollTop write. The setter spy below catches regressions.
  */
-function makeStubView(initialDoc: string) {
-  const scrollTop = { current: 42 };
-  let doc = initialDoc;
-  const selection = { main: { anchor: 5, head: 5 } };
-
-  const dispatch = vi.fn((tx: Partial<Transaction>) => {
-    if (tx && typeof tx === 'object') {
-      // Simulate applying changes — track that dispatch was called
-    }
+function makeView(initialDoc: string, selection?: { anchor: number; head?: number }) {
+  let state = EditorState.create({
+    doc: initialDoc,
+    selection: selection ? EditorSelection.single(selection.anchor, selection.head ?? selection.anchor) : undefined,
+  });
+  const specs: TransactionSpec[] = [];
+  const transactions: Transaction[] = [];
+  const scrollWrites: number[] = [];
+  const scrollDOM = {};
+  Object.defineProperty(scrollDOM, 'scrollTop', {
+    get: () => 42,
+    set: (v: number) => {
+      scrollWrites.push(v);
+    },
   });
 
   const view = {
-    state: {
-      get doc() {
-        return { toString: () => doc, length: doc.length };
-      },
-      get selection() {
-        return selection;
-      },
+    get state() {
+      return state;
     },
-    get scrollDOM() {
-      return { scrollTop: scrollTop.current };
+    scrollDOM,
+    dispatch(spec: TransactionSpec) {
+      specs.push(spec);
+      const tr = state.update(spec);
+      transactions.push(tr);
+      state = tr.state;
     },
-    dispatch,
   } as unknown as EditorView;
 
-  return {
-    view,
-    dispatch,
-    scrollTop,
-    setDoc: (v: string) => {
-      doc = v;
-    },
-  };
+  return { view, specs, transactions, scrollWrites, getState: () => state };
 }
 
 describe('applyValueUpdate', () => {
-  it('dispatches a transaction when the value changes', () => {
-    const { view, dispatch } = makeStubView('original');
-    applyValueUpdate(view, 'changed');
-    expect(dispatch).toHaveBeenCalledOnce();
-  });
-
   it('is a no-op when the value is unchanged', () => {
-    const { view, dispatch } = makeStubView('same value');
+    const { view, specs } = makeView('same value');
     applyValueUpdate(view, 'same value');
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(specs).toHaveLength(0);
   });
 
-  it('preserves selection anchor in the dispatched transaction', () => {
-    const { view, dispatch } = makeStubView('hello world');
-    applyValueUpdate(view, 'hello world changed');
-    expect(dispatch).toHaveBeenCalledOnce();
-    const tx = dispatch.mock.calls[0]?.[0] as { selection?: { anchor: number } };
-    // Selection should be preserved (anchor maps to same position or clamped)
-    expect(tx).toBeDefined();
-  });
-
-  it('handles empty string update', () => {
-    const { view, dispatch } = makeStubView('some content');
-    applyValueUpdate(view, '');
-    expect(dispatch).toHaveBeenCalledOnce();
-  });
-
-  it('handles update to identical multi-line content', () => {
+  it('is a no-op for identical multi-line content', () => {
     const multiLine = 'line1\nline2\nline3';
-    const { view, dispatch } = makeStubView(multiLine);
+    const { view, specs } = makeView(multiLine);
     applyValueUpdate(view, multiLine);
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(specs).toHaveLength(0);
+  });
+
+  it('updates the document to the new value', () => {
+    const { view, getState } = makeView('hello world');
+    applyValueUpdate(view, 'hello brave world');
+    expect(getState().doc.toString()).toBe('hello brave world');
+  });
+
+  it('dispatches a minimal change span, not a whole-doc replace', () => {
+    const { view, specs } = makeView('line1\nline2\nline3');
+    applyValueUpdate(view, 'line1\nCHANGED\nline3');
+    expect(specs).toHaveLength(1);
+    expect(specs[0]?.changes).toEqual({ from: 6, to: 11, insert: 'CHANGED' });
+  });
+
+  it('dispatches an insertion-only change for appends', () => {
+    const { view, specs, getState } = makeView('abc');
+    applyValueUpdate(view, 'abc\ndef');
+    expect(specs[0]?.changes).toEqual({ from: 3, to: 3, insert: '\ndef' });
+    expect(getState().doc.toString()).toBe('abc\ndef');
+  });
+
+  it('does not let the prefix and suffix scans overlap', () => {
+    const shrink = makeView('aa');
+    applyValueUpdate(shrink.view, 'a');
+    expect(shrink.specs[0]?.changes).toEqual({ from: 1, to: 2, insert: '' });
+    expect(shrink.getState().doc.toString()).toBe('a');
+
+    const grow = makeView('a');
+    applyValueUpdate(grow.view, 'aa');
+    expect(grow.specs[0]?.changes).toEqual({ from: 1, to: 1, insert: 'a' });
+    expect(grow.getState().doc.toString()).toBe('aa');
+  });
+
+  it('does not dispatch an explicit selection — CM6 maps it through the change', () => {
+    // Cursor at the end of doc; an insertion before it must shift it, not clamp it.
+    const { view, specs, getState } = makeView('AAA\nBBB', { anchor: 7 });
+    applyValueUpdate(view, 'AAAX\nBBB');
+    expect(specs[0]?.selection).toBeUndefined();
+    expect(getState().selection.main.anchor).toBe(8);
+  });
+
+  it('maps a selection inside the replaced span to a valid position', () => {
+    const { view, getState } = makeView('hello world', { anchor: 8 });
+    applyValueUpdate(view, 'hello');
+    const { anchor } = getState().selection.main;
+    expect(anchor).toBeLessThanOrEqual(getState().doc.length);
+    expect(anchor).toBe(5);
+  });
+
+  it('never writes scrollDOM.scrollTop — scroll is preserved by CM6 anchoring', () => {
+    const { view, scrollWrites } = makeView('line1\nline2\nline3');
+    applyValueUpdate(view, 'line1\nCHANGED\nline3');
+    expect(scrollWrites).toHaveLength(0);
+  });
+
+  it('marks the transaction as an external value update', () => {
+    const { view, transactions } = makeView('original');
+    applyValueUpdate(view, 'changed');
+    expect(transactions[0]?.annotation(externalValueUpdate)).toBe(true);
+  });
+
+  it('handles an update to the empty string', () => {
+    const { view, specs, getState } = makeView('some content');
+    applyValueUpdate(view, '');
+    expect(specs[0]?.changes).toEqual({ from: 0, to: 12, insert: '' });
+    expect(getState().doc.toString()).toBe('');
   });
 });

--- a/packages/ui/src/lib/editor/apply-value-update.ts
+++ b/packages/ui/src/lib/editor/apply-value-update.ts
@@ -9,41 +9,59 @@ import { Annotation } from '@codemirror/state';
  */
 export const externalValueUpdate = Annotation.define<boolean>();
 
+/** The span that differs between two strings, as a CM6 change spec. */
+interface ChangeSpan {
+  from: number;
+  to: number;
+  insert: string;
+}
+
 /**
- * Apply a new value to a CM6 EditorView while preserving the cursor position
- * and scroll offset on external buffer updates (e.g. file-changed-on-disk
- * reload, or daemon context.updated event).
+ * Trim the common prefix and suffix so only the differing middle is replaced.
+ * The suffix scan stops at the prefix boundary so the two never overlap
+ * (e.g. 'aa' → 'a' must yield {from:1, to:2} and not double-count the 'a').
+ */
+function diffSpan(oldValue: string, newValue: string): ChangeSpan {
+  let from = 0;
+  const maxPrefix = Math.min(oldValue.length, newValue.length);
+  while (from < maxPrefix && oldValue.charCodeAt(from) === newValue.charCodeAt(from)) from++;
+
+  let oldEnd = oldValue.length;
+  let newEnd = newValue.length;
+  while (oldEnd > from && newEnd > from && oldValue.charCodeAt(oldEnd - 1) === newValue.charCodeAt(newEnd - 1)) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  return { from, to: oldEnd, insert: newValue.slice(from, newEnd) };
+}
+
+/**
+ * Apply a new value to a CM6 EditorView while preserving the scroll position
+ * and selection on external buffer updates (e.g. file-changed-on-disk reload,
+ * or daemon context.updated event).
  *
- * CM6 equivalent of the Monaco `applyValueUpdate`: replaces the entire doc
- * with a single transaction that also restores the prior selection (clamped
- * to the new doc length) and the scroll position. No-ops when the value is
- * unchanged so the editor does not flicker on spurious re-renders.
+ * Dispatches a MINIMAL change (common prefix/suffix trimmed) instead of a
+ * whole-doc replace. This is what actually preserves scroll: CM6 keeps an
+ * internal scroll anchor (the line block at the top of the viewport) and maps
+ * it through each transaction's changes. A whole-doc replace maps every
+ * position to 0, so the next measure cycle "corrects" the scroll back to the
+ * top — overriding any manual scrollDOM.scrollTop restore (the previous
+ * implementation; issues #151/#196). With a minimal span the anchor maps
+ * correctly and the viewport stays on the content the user was reading, even
+ * when lines are added or removed above it.
  *
- * Behavior contract (matches the Monaco original, issue #151 fix):
- *   1. Save selection + scroll before touching the doc.
- *   2. Replace the doc content.
- *   3. Restore the selection (clamped) in the same transaction.
- *   4. Re-apply scroll after dispatch (scrollDOM is a DOM side-effect, not a
- *      CM6 state concern, so it must run after the transaction is committed).
+ * The selection is likewise left to CM6's change mapping (positions outside
+ * the changed span are untouched; positions inside collapse to its start),
+ * which supersedes the old manual clamp. No-ops when the value is unchanged
+ * so the editor does not flicker on spurious re-renders.
  */
 export function applyValueUpdate(view: EditorView, nextValue: string): void {
-  if (view.state.doc.toString() === nextValue) return;
-
-  // Snapshot state before modifying so we can restore it.
-  const { anchor, head } = view.state.selection.main;
-  const scrollTop = view.scrollDOM.scrollTop;
-  const docLen = nextValue.length;
-
-  // Clamp selection to the new doc length — the new content may be shorter.
-  const safeAnchor = Math.min(anchor, docLen);
-  const safeHead = Math.min(head, docLen);
+  const currentValue = view.state.doc.toString();
+  if (currentValue === nextValue) return;
 
   view.dispatch({
-    changes: { from: 0, to: view.state.doc.length, insert: nextValue },
-    selection: { anchor: safeAnchor, head: safeHead },
+    changes: diffSpan(currentValue, nextValue),
     annotations: externalValueUpdate.of(true),
   });
-
-  // Restore scroll as a DOM side-effect after the transaction is committed.
-  view.scrollDOM.scrollTop = scrollTop;
 }


### PR DESCRIPTION
Fixes todo #196: the editor jumped to the top whenever an open file was refreshed after an external modify/update event.

## Root cause

`applyValueUpdate` replaced the **whole document** on a disk-change reload, then manually restored `scrollDOM.scrollTop`. That restore cannot work: CodeMirror keeps an internal scroll anchor (the line block at the top of the viewport) and maps it through each transaction's changes (`ViewState.update`, `@codemirror/view` 6.43.1). A full-doc replace maps every position — including the anchor — to 0 while keeping the old pixel height, so the next async measure cycle computes `diff = 0 - oldAnchorTop` and applies `scrollTop += diff`, yanking the view to the top *after* the manual restore. Verified by reading the installed `@codemirror/view` source (scroll-anchor capture at `ViewState.update`, correction in the `measure()` loop; `scrollParent` defaults to `scrollDOM`, so the correction always fires).

## Fix

Dispatch a **minimal change** instead: trim the common prefix/suffix and replace only the differing span. CM6's own anchoring and selection mapping then do the right thing — the viewport stays on the content being read even when lines are added/removed above it, and the selection maps instead of being clamped. The manual `scrollTop` write and selection clamp are removed (superseded). A genuinely rewritten file (no common prefix/suffix) still degrades to a full replace and lands at the top, which is the sensible outcome there.

## Tests

Rewrote `apply-value-update.test.ts` around a real `EditorState`-backed stub so every dispatched spec is applied and validated by CM6: minimal-span shape, prefix/suffix overlap guard, append-only case, no explicit `selection`, no `scrollTop` writes, `externalValueUpdate` annotation, empty-string update. TDD red-green: 5 targeted failures against the old implementation, 11/11 after.

- `vitest run apply-value-update.test.ts EditorTab.test.tsx CmEditor.test.tsx` — 51/51 pass
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean
- eslint on changed files — clean

## Needs live verification

jsdom has no layout, so the actual scroll/measure cycle cannot run in unit tests. The mechanism is verified against the CM6 source, but please confirm in the live app: open a long file, scroll down, have an agent (or external edit) touch the file — the viewport should stay put.

Generated with Claude Code.