### PR TITLE
fix(ui): select the newly created session on first send (todo #210)

### DIFF
--- a/.changeset/preview-empty-new-session.md
+++ b/.changeset/preview-empty-new-session.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix the empty preview surface after starting a New Session: the first send now selects the newly created session automatically, so a running preview on the same project/branch re-attaches without a manual sidebar click.

--- a/packages/ui/src/features/sessions/ws/__tests__/use-session-list-router.test.tsx
+++ b/packages/ui/src/features/sessions/ws/__tests__/use-session-list-router.test.tsx
@@ -42,7 +42,7 @@ let setLastSessionIdSpy: ReturnType<typeof vi.fn>;
 let setLastForProjectSpy: ReturnType<typeof vi.fn>;
 let fakeThreadItems: Array<{
   id: string;
-  remoteId: string;
+  remoteId?: string;
   status?: string;
   custom?: { projectId?: string; updatedAt?: number };
 }>;
@@ -408,6 +408,69 @@ describe('useSessionListRouter — archiving the active session redirects off th
     fakeThreadItems = [
       { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
       { id: 'chat-B', remoteId: 'chat-B', status: 'regular', custom: { projectId: 'p1', updatedAt: 2000 } },
+    ];
+    rerender();
+
+    expect(switchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10b. First-send handoff: adopt the created session as the active thread
+// ---------------------------------------------------------------------------
+
+describe('useSessionListRouter — first send adopts the created session (todo #210)', () => {
+  /** Boot on chat-A, then open a deliberate New draft. Returns the rerender fn. */
+  function startOnDraft() {
+    mainThreadIdValue = 'chat-A';
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+    ];
+    const { rerender } = renderHook(() => useSessionListRouter());
+    mainThreadIdValue = '__LOCALID_new';
+    rerender();
+    switchSpy.mockClear();
+    return rerender;
+  }
+
+  it('switches to the new remote session once the reloaded list carries it', () => {
+    const rerender = startOnDraft();
+
+    // First send: initialize stamped remoteId on the draft entry, and the
+    // chat.created reload landed the canonical remote row — aui re-keys the
+    // list to it, stranding the selection on the custom-less draft.
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: '__LOCALID_new', remoteId: 'chat-new', status: 'regular' },
+      { id: 'chat-new', remoteId: 'chat-new', status: 'regular', custom: { projectId: 'p1', updatedAt: 4000 } },
+    ];
+    rerender();
+
+    expect(switchSpy).toHaveBeenCalledTimes(1);
+    expect(switchSpy).toHaveBeenCalledWith('chat-new');
+  });
+
+  it('does NOT switch while the created chat has not appeared in the list yet', () => {
+    const rerender = startOnDraft();
+
+    // remoteId stamped, but the reloaded list does not carry the chat yet.
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: '__LOCALID_new', remoteId: 'chat-new', status: 'regular' },
+    ];
+    rerender();
+
+    expect(switchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT switch for a fresh draft with no remoteId when the list reloads', () => {
+    const rerender = startOnDraft();
+
+    // Unrelated reload (e.g. another window created a chat) while composing.
+    fakeThreadItems = [
+      { id: 'chat-A', remoteId: 'chat-A', status: 'regular', custom: { projectId: 'p1', updatedAt: 3000 } },
+      { id: '__LOCALID_new', status: 'new' },
+      { id: 'chat-other', remoteId: 'chat-other', status: 'regular', custom: { projectId: 'p2', updatedAt: 5000 } },
     ];
     rerender();
 

--- a/packages/ui/src/features/sessions/ws/use-session-list-router.ts
+++ b/packages/ui/src/features/sessions/ws/use-session-list-router.ts
@@ -10,10 +10,12 @@
  *   chat.notification / permission(notify) → unread.markUnread()
  *
  * On every active-thread change it also: clears the active chat's unread,
- * clears the project filter when the activated chat crosses projects, and
- * falls back to the most-recently-updated non-archived thread (desktop parity,
- * preferring the active project filter's sessions) when the active chat was
- * archived out from under us (blank surface if none remain).
+ * clears the project filter when the activated chat crosses projects, adopts
+ * the freshly created remote session when the first send strands the selection
+ * on the local draft (todo #210), and falls back to the most-recently-updated
+ * non-archived thread (desktop parity, preferring the active project filter's
+ * sessions) when the active chat was archived out from under us (blank surface
+ * if none remain).
  *
  * On boot it auto-opens the most-recently-updated session ONCE (desktop parity,
  * renderer `useAppInit`), so the app never starts on the empty new-thread picker
@@ -135,6 +137,17 @@ export function useSessionListRouter(): void {
       );
 
     if (onDraft) {
+      // First-send handoff (todo #210): the draft's initialize stamped a remoteId,
+      // and the chat.created reload re-keyed the list to the canonical remote item —
+      // stranding the selection on the orphaned local draft (custom-less → no launch
+      // scope → the Run surface empties; the sidebar shows the new session
+      // unselected). Adopt the remote item, exactly like the manual sidebar click.
+      const draftRemoteId = threadItems.find((t) => t.id === mainThreadId)?.remoteId;
+      if (draftRemoteId != null && items.some((t) => t.id === draftRemoteId)) {
+        void runtime.threads.switchToThread(draftRemoteId);
+        return;
+      }
+
       // Archive-induced empty state: aui `switchToNewThread()`s off the archived
       // thread, so we land on a fresh draft rather than staying on the (now
       // archived) session. If the real thread we just left is now archived, redirect
@@ -168,7 +181,7 @@ export function useSessionListRouter(): void {
     if (active.remoteId != null && active.remoteId !== mainThreadId) unreadStore.clearUnread(active.remoteId);
     rememberActiveSession(active);
     clearFilterOnCrossProject(active);
-  }, [mainThreadId, items, runtime]);
+  }, [mainThreadId, items, threadItems, runtime]);
 
   // Boot auto-select: open a session once the list first loads, so the app doesn't
   // land on the empty new-thread picker. Prefers the last session open before the


### PR DESCRIPTION
## Problem

Starting a New Session on a project/branch that already has a running preview shows an EMPTY preview surface. After the first send, the user still had to click the new session in the left sidebar before the preview came back (todo #210).

## Root cause (traced through assistant-ui 0.14.14 / core 0.2.10 source)

1. New draft: `switchToNewThread()` mints a `__LOCALID_*` item with `custom: undefined`. No `custom` → `useActiveIdentity` has no projectId → `activeLaunchScope` is `null` → `filterRunByScope` drops every scoped Run tab → empty Run surface while composing (expected: no session exists yet).
2. First send: `adapter.initialize` creates the daemon chat and aui stamps `threadIdMap[remoteId] = __LOCALID_*` on the SAME item — but the `chat.created` WS event triggers `runtime.threads.reload()`, and aui's reload classifies the fresh list into an EMPTY accumulator, then merges with `{...state.threadIdMap, ...fresh.threadIdMap}`. That OVERWRITES `threadIdMap[remoteId]` to point at a brand-new remote entry and rebuilds `threadIds` without the local draft.
3. The selection is now stranded on the orphaned draft: custom-less forever, gone from the sidebar list. So the preview stays empty and the sidebar shows the new session unselected — until the manual click runs `switchToThread(remoteId)`, which resolves the scope and lets `useLaunchConfigs` reconcile the running config into a preview tab.

## Fix

`useSessionListRouter`'s active-thread effect now performs the first-send handoff: when the active thread is a `__LOCALID_*` draft whose raw thread item carries a `remoteId`, and the reloaded list contains that session, it calls `switchToThread(remoteId)` — the exact transition the manual sidebar click performs, automated. Guards:

- fresh drafts (no `remoteId`) never switch — boot draft, deliberate New, unrelated reloads from other windows are unaffected;
- the switch only fires while the user is still ON the draft, so navigating away mid-send is respected;
- the handoff is checked before the archive-redirect fallback in the same branch.

## Tests

- `use-session-list-router.test.tsx`: 3 new cases (handoff fires once the reloaded list carries the created chat; no switch before it lands; no switch for a remoteId-less draft). Watched the positive case fail before implementing (red-green). 33/33 pass.
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean.
- eslint on both changed files — clean.

## Needs live verification

This is state/selection logic verified from source + unit tests; I could not run the live app. Please verify in the running app: start a preview in a session, click New Session on the same project/branch, send a first message — the new session should become selected automatically and the preview should re-attach (via the launch-config reconcile) without a sidebar click. Note the preview surface is still empty DURING draft composition (before the first send) — no session exists yet, so there is no scope to attach; that part is unchanged.

Generated with Claude Code.