### PR TITLE
fix(ui): worktree-join chip icon does not update to the new state (todo #199)

### DIFF
--- a/.changeset/worktree-join-icon-state.md
+++ b/.changeset/worktree-join-icon-state.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix the worktree chip icons staying stale after joining or creating a worktree: the composer config mirror now adopts chat updates that change only worktreePath/branchName, and the shell identity (titlebar branch chip, chat header, branch popover) re-derives custom from the remoteId-keyed thread entry so sessions created in the current app run update too.

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-config.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-config.test.ts
@@ -65,4 +65,42 @@ describe('reduceChatThreadState — chat.config.updated', () => {
     expect(after.messageOrder).toEqual([]);
     expect(after.interactions).toBe(before.interactions);
   });
+
+  it('adopts a chat that differs only in worktreePath/branchName (worktree join)', () => {
+    const joined = {
+      ...chat,
+      worktreePath: '/wt/feature-x',
+      branchName: 'feature-x',
+    } as unknown as Chat;
+
+    const base = createChatThreadState('c1');
+    const withFirst = reduceChatThreadState(base, { type: 'chat.config.updated', chat });
+    const afterJoin = reduceChatThreadState(withFirst, { type: 'chat.config.updated', chat: joined });
+
+    expect(afterJoin.chatConfig).toBe(joined);
+    expect(afterJoin.chatConfig?.worktreePath).toBe('/wt/feature-x');
+    expect(afterJoin.chatConfig?.branchName).toBe('feature-x');
+  });
+
+  it('adopts a chat whose worktree was detached (worktreePath cleared)', () => {
+    const isolated = { ...chat, worktreePath: '/wt/feature-x', branchName: 'feature-x' } as unknown as Chat;
+    const detached = { ...chat, worktreePath: undefined, branchName: undefined } as unknown as Chat;
+
+    const base = createChatThreadState('c1');
+    const withIsolated = reduceChatThreadState(base, { type: 'chat.config.updated', chat: isolated });
+    const afterDetach = reduceChatThreadState(withIsolated, { type: 'chat.config.updated', chat: detached });
+
+    expect(afterDetach.chatConfig).toBe(detached);
+    expect(afterDetach.chatConfig?.worktreePath).toBeUndefined();
+  });
+
+  it('still ignores identity-irrelevant churn (same config object fields)', () => {
+    const churn = { ...chat, totalCost: 42 } as unknown as Chat;
+
+    const base = createChatThreadState('c1');
+    const withFirst = reduceChatThreadState(base, { type: 'chat.config.updated', chat });
+    const afterChurn = reduceChatThreadState(withFirst, { type: 'chat.config.updated', chat: churn });
+
+    expect(afterChurn.chatConfig).toBe(chat);
+  });
 });

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -163,7 +163,9 @@ function sameComposerConfig(a: Chat | null, b: Chat): boolean {
     a.fast === b.fast &&
     a.ultracode === b.ultracode &&
     a.adaptiveThinking === b.adaptiveThinking &&
-    a.worktreeMissing === b.worktreeMissing
+    a.worktreeMissing === b.worktreeMissing &&
+    a.worktreePath === b.worktreePath &&
+    a.branchName === b.branchName
   );
 }
 

--- a/packages/ui/src/features/chat/thread/ChatCardHeader.tsx
+++ b/packages/ui/src/features/chat/thread/ChatCardHeader.tsx
@@ -9,7 +9,7 @@ import {
   MessageSquare,
 } from 'lucide-react';
 import { isSurfaceFloor, layoutCanSplit, useLayoutStore } from '@/store/layout';
-import { sessionCustomOf } from '@/features/sessions/view-model/chat-to-thread-custom';
+import { activeSessionCustom } from '@/features/sessions/view-model/chat-to-thread-custom';
 import { useHost } from '@/lib/host';
 import { emitSurfaceIntent } from '@/store/surface-intents';
 import { Hint } from '@/components/ui/hint';
@@ -54,7 +54,7 @@ function ChatCardHeaderDraft({ projectId, projectName }: { projectId: string | n
 function ChatCardHeaderReal() {
   const host = useHost();
   const title = useAuiState((s) => s.threadListItem?.title) ?? 'Untitled';
-  const custom = useAuiState((s) => sessionCustomOf(s.threadListItem?.custom));
+  const custom = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems));
   const prs = custom?.detectedPrs ?? [];
   const worktreePath = custom?.worktreePath;
   const splitAvailable = useLayoutStore((s) => layoutCanSplit(s.layout));

--- a/packages/ui/src/features/chat/thread/__tests__/ChatCardHeader.test.tsx
+++ b/packages/ui/src/features/chat/thread/__tests__/ChatCardHeader.test.tsx
@@ -5,7 +5,7 @@ import { FakeHostBridge } from '@/lib/host/fake-adapter';
 
 let fakeState: any = { threadListItem: { title: 'Fixture Chat', custom: { detectedPrs: [] } } };
 vi.mock('@assistant-ui/react', () => ({
-  useAuiState: (sel: (s: any) => unknown) => sel(fakeState),
+  useAuiState: (sel: (s: any) => unknown) => sel({ threads: { threadItems: [] }, ...fakeState }),
 }));
 
 const mockEmit = vi.fn();

--- a/packages/ui/src/features/git/BranchPopover.tsx
+++ b/packages/ui/src/features/git/BranchPopover.tsx
@@ -25,7 +25,7 @@ import { useAuiState } from '@assistant-ui/react';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Hint } from '@/components/ui/hint';
-import { sessionCustomOf } from '../sessions/view-model/chat-to-thread-custom';
+import { activeSessionCustom } from '../sessions/view-model/chat-to-thread-custom';
 import { useBranchActions } from './use-branch-actions';
 import { useWorktreeSession } from './use-worktree-session';
 import { BranchPopoverListPane } from './BranchPopoverListPane';
@@ -72,7 +72,7 @@ export function BranchPopover({
 }: BranchPopoverProps) {
   // Resolve adapterId from the active thread's custom — falls back to 'claude'.
   const adapterId = useAuiState((s) => {
-    const custom = sessionCustomOf(s.threadListItem?.custom);
+    const custom = activeSessionCustom(s.threadListItem, s.threads.threadItems);
     return custom?.adapterId ?? DEFAULT_ADAPTER_ID;
   });
 

--- a/packages/ui/src/features/git/__tests__/BranchPopover.test.tsx
+++ b/packages/ui/src/features/git/__tests__/BranchPopover.test.tsx
@@ -29,7 +29,8 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 // ---------------------------------------------------------------------------
 
 vi.mock('@assistant-ui/react', () => ({
-  useAuiState: (selector: (s: { threadListItem: null }) => unknown) => selector({ threadListItem: null }),
+  useAuiState: (selector: (s: { threadListItem: null; threads: { threadItems: [] } }) => unknown) =>
+    selector({ threadListItem: null, threads: { threadItems: [] } }),
   useAssistantRuntime: () => ({
     threads: {
       reload: vi.fn().mockResolvedValue(undefined),
@@ -47,11 +48,11 @@ vi.mock('../use-worktree-session', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Mock sessionCustomOf — returns null so adapterId falls back to 'claude'
+// Mock activeSessionCustom — returns null so adapterId falls back to 'claude'
 // ---------------------------------------------------------------------------
 
 vi.mock('@/features/sessions/view-model/chat-to-thread-custom', () => ({
-  sessionCustomOf: () => null,
+  activeSessionCustom: () => null,
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/features/git/use-worktree-session.ts
+++ b/packages/ui/src/features/git/use-worktree-session.ts
@@ -3,7 +3,7 @@
  * switches the sessions runtime to it.
  *
  * The caller resolves `adapterId` from the active thread's `custom.adapterId`
- * (via sessionCustomOf) with `'claude'` as the fallback — it is REQUIRED by
+ * (via activeSessionCustom) with `'claude'` as the fallback — it is REQUIRED by
  * createChat's CreateChatBody. Passed as an arg rather than read here so the
  * hook remains runtime-provider-free (simpler to test).
  */

--- a/packages/ui/src/features/sessions/use-active-identity.ts
+++ b/packages/ui/src/features/sessions/use-active-identity.ts
@@ -1,15 +1,15 @@
 /**
  * useActiveIdentity — the active session's project name + worktree branch for the
- * shell MainToolbar. Reads the active thread-list item's `custom` (narrowed once
- * via sessionCustomOf) for projectId + branchName, and resolves the project name
- * from the loaded project list. Runs inside the assistant-ui runtime provider.
+ * shell MainToolbar. Reads the active thread-list item's freshest `custom`
+ * (via activeSessionCustom) for projectId + branchName, and resolves the project
+ * name from the loaded project list. Runs inside the assistant-ui runtime provider.
  *
  * Also exposes `worktreePath` and `projectPath` so callers (AppShell) can push
  * the canonical bases into `useActiveBasesStore` for the intent subscriber (F1 fix).
  */
 import { useAuiState } from '@assistant-ui/react';
 import { useProjects } from './use-projects';
-import { sessionCustomOf } from './view-model/chat-to-thread-custom';
+import { activeSessionCustom } from './view-model/chat-to-thread-custom';
 
 export interface ActiveIdentity {
   projectName: string;
@@ -27,7 +27,10 @@ export interface ActiveIdentity {
 }
 
 export function useActiveIdentity(): ActiveIdentity {
-  const custom = useAuiState((s) => sessionCustomOf(s.threadListItem?.custom));
+  // activeSessionCustom prefers the remoteId-keyed list entry (refreshed by every
+  // threads.reload()) over the active item's own custom, which goes permanently
+  // stale on __LOCALID_* threads (returned refs are store-stable, Object.is-safe).
+  const custom = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems));
   const chatId = useAuiState((s) => s.threadListItem?.remoteId ?? undefined);
   const { projects } = useProjects();
   const project = custom?.projectId ? projects.find((p) => p.id === custom.projectId) : undefined;

--- a/packages/ui/src/features/sessions/view-model/__tests__/chat-to-thread-custom.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/chat-to-thread-custom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Chat } from '@qlan-ro/mainframe-types';
-import { chatToThreadCustom } from '../chat-to-thread-custom';
+import { activeSessionCustom, chatToThreadCustom } from '../chat-to-thread-custom';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -261,5 +261,46 @@ describe('chatToThreadCustom — custom.branchName', () => {
 
   it('is undefined when chat.branchName is absent', () => {
     expect(chatToThreadCustom(makeChat()).custom.branchName).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activeSessionCustom — freshest custom for the ACTIVE thread-list item
+// ---------------------------------------------------------------------------
+
+describe('activeSessionCustom', () => {
+  const staleCustom = { ...chatToThreadCustom(makeChat()).custom };
+  const freshCustom = {
+    ...chatToThreadCustom(makeChat({ worktreePath: '/wt/feature-x', branchName: 'feature-x' })).custom,
+  };
+
+  it('returns undefined for no active item', () => {
+    expect(activeSessionCustom(undefined, [])).toBeUndefined();
+  });
+
+  it('returns the item custom when the item is keyed by its remoteId', () => {
+    const item = { id: 'chat-1', remoteId: 'chat-1', status: 'regular', custom: freshCustom };
+    expect(activeSessionCustom(item, [item])).toBe(freshCustom);
+  });
+
+  it('prefers the remoteId-keyed list entry over a stale __LOCALID_* item custom', () => {
+    // A thread created this app-run keeps its __LOCALID_* mapping id; reload()
+    // re-derives custom only under a NEW remoteId-keyed entry, so the active
+    // item's own custom goes permanently stale (worktree join never shows).
+    const localItem = { id: '__LOCALID_abc', remoteId: 'chat-1', status: 'regular', custom: staleCustom };
+    const freshEntry = { id: 'chat-1', remoteId: 'chat-1', status: 'regular', custom: freshCustom };
+    const result = activeSessionCustom(localItem, [localItem, freshEntry]);
+    expect(result).toBe(freshCustom);
+    expect(result?.worktreePath).toBe('/wt/feature-x');
+  });
+
+  it('falls back to the item custom when no remoteId-keyed entry exists yet', () => {
+    const localItem = { id: '__LOCALID_abc', remoteId: 'chat-1', status: 'regular', custom: staleCustom };
+    expect(activeSessionCustom(localItem, [localItem])).toBe(staleCustom);
+  });
+
+  it('returns undefined for a custom-less draft item', () => {
+    const draft = { id: '__LOCALID_new', status: 'new' };
+    expect(activeSessionCustom(draft, [draft])).toBeUndefined();
   });
 });

--- a/packages/ui/src/features/sessions/view-model/chat-to-thread-custom.ts
+++ b/packages/ui/src/features/sessions/view-model/chat-to-thread-custom.ts
@@ -122,12 +122,31 @@ function narrowSessionCustom(custom: Record<string, unknown>): SessionCustom {
 }
 
 /**
- * Narrow the active thread-list item's boundary `custom` to SessionCustom, or
- * undefined for the custom-less new/draft thread. The single safe read of an
- * active item's custom (e.g. the shell identity), keeping the narrowing here.
+ * Narrow a thread-list item's boundary `custom` to SessionCustom, or undefined
+ * for the custom-less new/draft thread. Internal — active-item reads go through
+ * activeSessionCustom below, which also resolves the freshest entry.
  */
-export function sessionCustomOf(custom: Record<string, unknown> | undefined): SessionCustom | undefined {
+function sessionCustomOf(custom: Record<string, unknown> | undefined): SessionCustom | undefined {
   return custom == null ? undefined : narrowSessionCustom(custom);
+}
+
+/**
+ * Freshest custom for the ACTIVE thread-list item.
+ *
+ * A thread created this app-run keeps its `__LOCALID_*` mapping id for life
+ * (no id-flip), but aui's `threads.reload()` re-derives custom only under a
+ * NEW entry keyed by the remoteId — the `__LOCALID_*` entry's custom is never
+ * written again. Reading `s.threadListItem.custom` alone therefore goes
+ * permanently stale on such threads (e.g. a worktree join never reaches the
+ * toolbar). Prefer the remoteId-keyed list entry, which every reload refreshes.
+ */
+export function activeSessionCustom(
+  item: ThreadListEntry | undefined,
+  threadItems: readonly ThreadListEntry[],
+): SessionCustom | undefined {
+  if (!item) return undefined;
+  const fresh = item.remoteId == null ? undefined : threadItems.find((t) => t.id === item.remoteId);
+  return sessionCustomOf(fresh?.custom ?? item.custom);
 }
 
 /** A thread entry that carries a materialized `custom` (i.e. a real session). */


### PR DESCRIPTION
## Problem

Joining an existing worktree (composer WorktreePopover → Existing) moves the session correctly, but the worktree chip icon never updates to the isolated state. (Todo #199.)

## Root cause (two layers, both from source)

1. **Composer icon (the reported bug).** `sameComposerConfig` in `chat-thread-state.ts` decides whether the controller adopts a `chat.updated` into `state.chatConfig` — the WorktreePopover's state source. It compared adapter/model/permission/plan/effort/features/`worktreeMissing` but **not `worktreePath` or `branchName`**. A worktree join/create/detach changes only those two fields, so the mirror kept the pre-join chat and `isIsolated` never flipped.

2. **Titlebar chip / chat header (same staleness class).** A thread created in the current app run keeps its `__LOCALID_*` mapping id for life (deliberate no-id-flip). assistant-ui's `threads.reload()` re-derives `custom` only under a **new remoteId-keyed entry** (`classifyThreads` runs with an empty accumulator; the merge never rewrites the `__LOCALID_*` entry, and `initialize` never sets `custom` on it). Every consumer of `s.threadListItem.custom` — the titlebar branch chip identity, `ChatCardHeader`, `BranchPopover` — therefore reads permanently stale custom on such sessions.

## Fix

- Add `worktreePath` + `branchName` to `sameComposerConfig` so the mirror adopts worktree transitions (join, create, detach).
- New `activeSessionCustom(item, threadItems)` in the view-model: prefers the remoteId-keyed list entry (refreshed by every reload) and falls back to the item's own custom. `useActiveIdentity`, `ChatCardHeader`, and `BranchPopover` now use it. Returned references are store-stable, so `useAuiState`'s `Object.is` guard is safe.

## Tests

- `chat-thread-state-config.test.ts`: adopts worktree join, adopts detach, still ignores cost/token churn (watched fail before the fix — the reducer kept the stale object).
- `chat-to-thread-custom.test.ts`: `activeSessionCustom` remoteId-preference, `__LOCALID_*` fallback, draft handling.
- Red-green verified by stashing the fixes (suite fails) and restoring (44/44 pass); affected suites (MainToolbar, BranchPopover, ChatCardHeader, WorktreePopover, ComposerToolbar, sessions ws/view-model) all green; UI typecheck clean.

## Needs live verification

I could not run the app. Please verify in the live app:
1. Join an **existing** worktree from the composer popover → the GitFork trigger should turn green/isolated immediately and the popover should show the frozen "Isolated in worktree" panel.
2. On a session **created in the same app run**, join a worktree → the titlebar branch chip should switch to the accent GitFork + "WT" badge (previously stale forever).
3. Detach/disable a worktree → both revert.

Generated with Claude Code.