### PR TITLE
fix(context): stop the context meter over-reporting (todo #197)

### DIFF
--- a/.agents/cleanup-test.sh
+++ b/.agents/cleanup-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Kill stale test-worktree dev processes. Protected: production daemon on 31415.
+# Run ONCE per fleet (orchestrator) or once before a single-branch launch.
+set -uo pipefail
+
+PROTECTED_PORT=31415
+
+pids=$(ps ax -o pid,command | grep 'mainframe-core run dev' | grep -v grep | awk '{print $1}')
+for pid in $pids; do
+  if ! lsof -iTCP:$PROTECTED_PORT -sTCP:LISTEN -a -p "$pid" 2>/dev/null | grep -q LISTEN; then
+    pkill -9 -P "$pid" 2>/dev/null
+    kill -9 "$pid" 2>/dev/null
+  fi
+done
+
+pids=$(ps ax -o pid,command | grep 'mainframe-desktop run dev' | grep -v grep | awk '{print $1}')
+for pid in $pids; do
+  pkill -9 -P "$pid" 2>/dev/null
+  kill -9 "$pid" 2>/dev/null
+done
+
+lsof -ti :9222 2>/dev/null | xargs kill -9 2>/dev/null
+
+sleep 2
+
+remaining=$(ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | awk '{print $1}')
+if [ -n "$remaining" ]; then
+  echo "$remaining" | xargs kill -9 2>/dev/null
+  sleep 2
+fi
+
+if ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | grep -q .; then
+  echo "CLEANUP_FAILED: dev processes survived" >&2
+  exit 1
+fi
+
+if lsof -iTCP:$PROTECTED_PORT -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "CLEANUP_OK (production daemon on $PROTECTED_PORT untouched)"
+else
+  echo "CLEANUP_OK (nothing on $PROTECTED_PORT — production app not running)"
+fi

--- a/.agents/launch-test-browser.sh
+++ b/.agents/launch-test-browser.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Launch the BROWSER target for test-worktree: daemon + shared renderer in a
+# plain browser — no Electron, no Rust. For renderer/daemon-only scenario
+# sets (no native shell surfaces). Blocks until ready; prints READY + facts.
+# Typical bring-up: 1-2 minutes. Engine: playwright-cli fresh browser at APP_URL.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$PROJECT_ROOT"
+
+# 1. Isolated ports + install + types build only (no shell builds).
+bash scripts/setup-ports.sh --minimal
+
+# 2. Load the isolated ports.
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+export MAINFRAME_DATA_DIR="${MAINFRAME_DATA_DIR:-$HOME/.mainframe_dev}"
+
+DAEMON_LOG="/tmp/mf-daemon-${DAEMON_PORT}.log"
+UI_LOG="/tmp/mf-ui-${DAEMON_PORT}.log"
+
+# 3. Daemon (from source via tsx).
+DAEMON_PORT="$DAEMON_PORT" \
+MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \
+LOG_LEVEL=debug \
+  pnpm --filter @qlan-ro/mainframe-core run dev > "$DAEMON_LOG" 2>&1 &
+
+# 4. Shared renderer (Vite). Browser dev mode reads VITE_DAEMON_PORT (singular)
+# in fake-adapter.ts — the HTTP/WS pair is the electron/tauri shape and is NOT
+# what a plain-browser renderer uses to find the daemon.
+VITE_PORT="$VITE_PORT" \
+VITE_DAEMON_PORT="$DAEMON_PORT" \
+VITE_DAEMON_HTTP_PORT="$DAEMON_PORT" \
+VITE_DAEMON_WS_PORT="$DAEMON_PORT" \
+MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \
+  pnpm --filter @qlan-ro/mainframe-ui run dev > "$UI_LOG" 2>&1 &
+
+# 5. Block until ready.
+deadline=$((SECONDS + 180))
+until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/projects" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: daemon not ready on :${DAEMON_PORT} — log tail:" >&2
+    tail -40 "$DAEMON_LOG" >&2
+    exit 1
+  fi
+  sleep 2
+done
+deadline=$((SECONDS + 120))
+# localhost, not 127.0.0.1 — Vite 6 binds ::1
+until curl -sf "http://localhost:${VITE_PORT}" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: Vite not ready on :${VITE_PORT} — log tail:" >&2
+    tail -40 "$UI_LOG" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "READY"
+echo "DAEMON_PORT=$DAEMON_PORT"
+echo "VITE_PORT=$VITE_PORT"
+echo "APP_URL=http://localhost:$VITE_PORT"
+echo "DAEMON_LOG=$DAEMON_LOG"
+echo "UI_LOG=$UI_LOG"

--- a/.agents/launch-test-tauri.sh
+++ b/.agents/launch-test-tauri.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Launch the Tauri target for test-worktree: fresh-worktree provisioning,
+# isolated env, background launch, readiness wait. Blocks until ready; prints
+# READY + facts, or exits 1 with the log tail.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$PROJECT_ROOT"
+
+export DAEMON_PORT="${DAEMON_PORT:-31500}"
+export MAINFRAME_DATA_DIR="${MAINFRAME_DATA_DIR:-$HOME/.mainframe_dev}"
+VITE_PORT="${VITE_PORT:-5174}"
+LOG="/tmp/mf-tauri-dev-${DAEMON_PORT}.log"
+
+# Guard: never let the embedded daemon race the production port.
+if [ "$DAEMON_PORT" = "31415" ]; then
+  echo "REFUSED: DAEMON_PORT=31415 is the production daemon" >&2
+  exit 2
+fi
+
+# Fresh-worktree provisioning (idempotent).
+[ -d node_modules ] || pnpm install
+cd packages/app-tauri
+ls src-tauri/binaries/node-* >/dev/null 2>&1 || pnpm run provision:node
+[ -d src-tauri/resources/daemon ] || pnpm run bundle:daemon
+
+# `pnpm tauri:dev` is the whole stack: it compiles+runs the Rust shell, starts
+# Vite (its beforeDevCommand, on VITE_PORT), and the shell spawns the daemon.
+# First cold compile ~10-15 min; a warm per-worktree target links in a couple.
+# nohup + disown so the app survives THIS script exiting — lets the caller run
+# the script synchronously (block until READY, return) without reaping the app.
+nohup pnpm tauri:dev > "$LOG" 2>&1 &
+disown 2>/dev/null || true
+
+# Readiness: Vite answers on localhost (NOT 127.0.0.1 — Vite 6 binds ::1),
+# then the daemon answers on its isolated port.
+deadline=$((SECONDS + 600))
+until curl -sf "http://localhost:${VITE_PORT}" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: Vite not ready on :${VITE_PORT} after 600s — log tail:" >&2
+    tail -40 "$LOG" >&2
+    exit 1
+  fi
+  sleep 3
+done
+deadline=$((SECONDS + 120))
+until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/projects" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: daemon not ready on :${DAEMON_PORT} — log tail:" >&2
+    tail -40 "$LOG" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "READY"
+echo "DAEMON_PORT=$DAEMON_PORT"
+echo "VITE_PORT=$VITE_PORT"
+echo "APP_URL=http://localhost:$VITE_PORT"
+echo "DATA_DIR=$MAINFRAME_DATA_DIR"
+echo "LOG=$LOG"

--- a/.agents/launch-test.sh
+++ b/.agents/launch-test.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # builds all three packages. We then start the daemon and desktop on those
 # isolated ports with CDP + debug logging for the test engines.
 
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 cd "$PROJECT_ROOT"
 
 # 1. Isolated ports + install + full build (idempotent: rewrites .env).
@@ -40,10 +40,42 @@ VITE_PORT="$VITE_PORT" \
 MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \
   pnpm --filter @qlan-ro/mainframe-app-electron run dev > "$DESKTOP_LOG" 2>&1 &
 
-# 5. Surface the facts the readiness report / engines need.
-echo "LAUNCHED"
+# 4b. Shared renderer. Post renderer-extraction, app-electron's dev script
+# builds only main+preload — the renderer lives in packages/ui and must be
+# served separately or the window opens on ERR_CONNECTION_REFUSED.
+UI_LOG="/tmp/mf-ui-${DAEMON_PORT}.log"
+VITE_PORT="$VITE_PORT" \
+VITE_DAEMON_HTTP_PORT="$DAEMON_PORT" \
+VITE_DAEMON_WS_PORT="$DAEMON_PORT" \
+MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \
+  pnpm --filter @qlan-ro/mainframe-ui run dev > "$UI_LOG" 2>&1 &
+
+# 5. Block until ready — daemon HTTP, then Electron CDP. The script owns the
+# wait so no caller ever re-implements (or re-imagines) the readiness loop.
+deadline=$((SECONDS + 180))
+until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/projects" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: daemon not ready on :${DAEMON_PORT} — log tail:" >&2
+    tail -40 "$DAEMON_LOG" >&2
+    exit 1
+  fi
+  sleep 2
+done
+deadline=$((SECONDS + 120))
+until curl -sf "http://localhost:9222/json/version" >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    echo "LAUNCH_FAILED: CDP not ready on :9222 — log tail:" >&2
+    tail -40 "$DESKTOP_LOG" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+# 6. Surface the facts the readiness report / engines need.
+echo "READY"
 echo "DAEMON_PORT=$DAEMON_PORT"
 echo "VITE_PORT=$VITE_PORT"
 echo "CDP_URL=http://localhost:9222"
 echo "DAEMON_LOG=$DAEMON_LOG"
 echo "DESKTOP_LOG=$DESKTOP_LOG"
+echo "UI_LOG=$UI_LOG"

--- a/.agents/stop-test.sh
+++ b/.agents/stop-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Port-scoped teardown of ONE test run (parallel-safe; never touches siblings).
+# Usage: stop-test.sh [port ...]   — defaults to this checkout's .env ports + CDP 9222.
+# Tauri note: killing $DAEMON_PORT also takes the parent app (shared socket) — at
+# teardown that is exactly what we want; never use this mid-run for a "daemon-only" restart.
+#
+# POSIX-clean: no bash arrays / BASH_SOURCE, so it runs identically under bash,
+# zsh, or sh regardless of how it's invoked.
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+PROTECTED_PORT=31415
+
+if [ "$#" -gt 0 ]; then
+  PORTS="$*"
+else
+  # shellcheck disable=SC1091
+  [ -f "$PROJECT_ROOT/.env" ] && . "$PROJECT_ROOT/.env"
+  PORTS="${DAEMON_PORT:-31500} ${VITE_PORT:-5174} 9222"
+fi
+
+for port in $PORTS; do
+  if [ "$port" = "$PROTECTED_PORT" ]; then
+    echo "REFUSED: $PROTECTED_PORT is protected" >&2
+    exit 2
+  fi
+done
+
+for port in $PORTS; do
+  lsof -ti ":$port" 2>/dev/null | xargs kill -9 2>/dev/null
+done
+sleep 2
+
+leftover=0
+for port in $PORTS; do
+  if lsof -ti ":$port" >/dev/null 2>&1; then
+    lsof -ti ":$port" | xargs kill -9 2>/dev/null
+    leftover=1
+  fi
+done
+[ "$leftover" = 1 ] && sleep 1
+
+for port in $PORTS; do
+  if lsof -ti ":$port" >/dev/null 2>&1; then
+    echo "STOP_FAILED: port $port still held" >&2
+    exit 1
+  fi
+done
+echo "STOP_OK: ports $PORTS clear"

--- a/.agents/test-worktree.md
+++ b/.agents/test-worktree.md
@@ -17,17 +17,27 @@ default).
   spawns the daemon itself.
 - Engine: `tauri-mcp` (the WKWebView has no CDP). Dev builds compile the
   bridge in (`pnpm tauri:dev` → `cargo tauri dev --features mcp-bridge`).
-- Launch (inline):
-  `cd packages/app-tauri && pnpm tauri:dev > /tmp/mf-tauri-dev.log 2>&1 &`
-  (background; first run compiles Rust — allow up to 10 minutes).
-- Wait-for-Ready: Vite responds at `http://localhost:${VITE_PORT:-5174}`
-  (use `localhost`, NOT `127.0.0.1` — Vite binds IPv6 `::1`), then the app
-  appears in the bridge's `list_devices`. On timeout read
-  `/tmp/mf-tauri-dev.log`.
+- Launch: `script: .agents/launch-test-tauri.sh` — run it EXACTLY ONCE. It
+  owns fresh-worktree provisioning (provision:node / bundle:daemon), the
+  isolated env (`DAEMON_PORT=31500`, `MAINFRAME_DATA_DIR=~/.mainframe_dev`;
+  refuses 31415), the background `tauri:dev` (first run compiles Rust, up to
+  10 min), and the readiness wait. It blocks until ready and prints `READY` +
+  facts (ports, APP_URL, LOG), or exits 1 with the log tail — do not
+  re-launch on failure, read the printed tail.
+- After READY: confirm the app appears in the bridge's `list_devices`.
 - Diff paths: `packages/app-tauri/`, `packages/ui/`.
-- Gotcha: dev launch configs may pin `DAEMON_PORT=31500` and
-  `MAINFRAME_DATA_DIR=~/.mainframe_dev` — a separate daemon from the
-  production one on 31415.
+- Bridge quirks (verified 2026-07-09): selector-based tools
+  (`webview_find_element`, selector-mode `webview_interact`,
+  `webview_keyboard`, `webview_wait_for`) can throw
+  `window.__MCP__.resolveRef is not a function` — fall back to
+  `webview_execute_js` for lookups/typing (native value setter +
+  `dispatchEvent('input')`) and coordinate `webview_interact` clicks.
+  `webview_dom_snapshot` selectors must resolve to a single small container
+  (broad multi-match selectors blow the token limit). `webview_wait_for`
+  cannot evaluate `:not()` compound selectors.
+- The in-app project picker is unrelated to which worktree's binary runs —
+  a target project sitting on a different git branch is NOT a wrong-build
+  signal; the shell/daemon code is built from this worktree regardless.
 
 ### Target: electron
 
@@ -35,6 +45,50 @@ default).
   backed by the local Node daemon. Everything below (Environment, Cleanup,
   Launch script, Wait-for-Ready, Engines) belongs to this target.
 - Diff paths: `packages/app-electron/`, `packages/ui/`.
+
+### Target: browser (cheapest — use when NO scenario is native-required)
+
+- Type: `web-spa` — the shared `packages/ui` renderer in a plain browser +
+  the daemon from source. No Electron, no Rust: bring-up 1–2 min.
+- Launch: `script: .agents/launch-test-browser.sh` — blocks until ready,
+  prints `READY` + `APP_URL`.
+- Engine: `playwright-cli` fresh browser (`open --headed $APP_URL`) — full
+  selector/ref support, no bridge quirks, no pinned CDP port.
+- Eligibility: chosen by the skill's cheapest-sufficient-target rule — every
+  scenario in the set must be renderer/daemon-only. **Native surfaces that
+  do NOT exist here** (any scenario touching them forces a native target):
+  preview child webviews, PTY terminal, window chrome/traffic lights, native
+  menus/tray/file dialogs, any Tauri-command-backed feature. Runtime-fidelity
+  caveat: this is not the shipped WKWebView/Electron runtime — compositing
+  and shell-specific rendering bugs will not reproduce; run a periodic
+  full-native pass for that.
+
+## Fleet
+
+Limits for multi-branch runs (consumed by the skill's Fleet Mode):
+
+- **Per-target caps: `electron` max 1, `tauri` max 1, `browser` max 4.**
+  Electron's CDP port is pinned to `9222` (not isolated by setup-ports.sh);
+  the tauri-mcp bridge reliably tracks one dev app at a time (and dies while
+  a preview child webview is mounted — see Gotchas). Browser runs have no
+  singleton (fresh browser per run, isolated ports) and are light
+  (daemon + Vite only) — they run genuinely in parallel.
+- **Max parallel runs: 4 total**, but at most one tauri + one electron at a
+  time (their full builds thrash the machine; browser runs are cheap).
+- **Prefer the browser target.** Native builds are slow and heavy; the
+  browser target (vite + daemon, no cargo) is the default path for
+  renderer/daemon-only scenario sets — reserve tauri/electron for genuinely
+  native surfaces.
+- Daemon/Vite ports and `MAINFRAME_DATA_DIR=~/.mainframe_dev` are isolated
+  per run by `scripts/setup-ports.sh`, so parallel runs don't collide there —
+  but they DO share `~/.mainframe_dev`; scenarios that assert on global DB
+  state (project/chat counts) belong in sequential runs.
+- **Process kills in a fleet:** the Cleanup section below matches ANY
+  `mainframe-core/desktop run dev` process — including live test runs — so
+  it runs exactly once (orchestrator, before any env exists). Per-branch
+  teardown uses the Stop / Restart section, which is scoped to that
+  worktree's own `.env` ports and is parallel-safe.
+- Protected port `31415` applies to every run, always.
 
 ## Protected Ports
 
@@ -65,49 +119,14 @@ Production defaults (never used here): `DAEMON_PORT=31415`, `VITE_PORT=5173`,
 
 ## Cleanup (Kill Stale Dev Processes)
 
-Previous sessions leave orphaned pnpm wrappers, daemons, Vite servers, and Electron instances across worktrees. Kill them — but respect the Protected Ports above.
-
-```bash
-# 1. Kill all mainframe-core dev wrappers (skip anything on port 31415)
-pids=$(ps ax -o pid,command | grep 'mainframe-core run dev' | grep -v grep | awk '{print $1}')
-for pid in $pids; do
-  if ! lsof -iTCP:31415 -sTCP:LISTEN -a -p $pid 2>/dev/null | grep -q LISTEN; then
-    pkill -9 -P $pid 2>/dev/null
-    kill -9 $pid 2>/dev/null
-  fi
-done
-
-# 2. Kill mainframe-desktop dev wrappers (Vite + Electron dev instances)
-pids=$(ps ax -o pid,command | grep 'mainframe-desktop run dev' | grep -v grep | awk '{print $1}')
-for pid in $pids; do
-  pkill -9 -P $pid 2>/dev/null
-  kill -9 $pid 2>/dev/null
-done
-
-# 3. Kill CDP port 9222 (dev Electron)
-lsof -ti :9222 2>/dev/null | xargs kill -9 2>/dev/null
-
-sleep 2
-
-# 4. Retry if anything survived
-remaining=$(ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | awk '{print $1}')
-if [ -n "$remaining" ]; then
-  echo "WARNING: processes still alive after kill: $remaining — retrying"
-  echo "$remaining" | xargs kill -9 2>/dev/null
-  sleep 2
-fi
-
-if lsof -ti :9222 2>/dev/null; then
-  echo "WARNING: port 9222 still held — force killing"
-  lsof -ti :9222 | xargs kill -9 2>/dev/null
-  sleep 1
-fi
-
-# Final check — fail loudly if still occupied
-if ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | grep -q .; then
-  echo "ERROR: could not kill all dev processes — manual intervention needed"
-fi
 ```
+script: .agents/cleanup-test.sh
+```
+
+Run the script exactly as-is — it kills stale `run dev` wrappers and CDP
+9222 while skipping anything on the protected port 31415, retries once, and
+exits nonzero if processes survive. Fleet runs execute it exactly once
+(orchestrator), never per-branch.
 
 **Never use `pkill -f "mainframe"` unfiltered** — it can hit the production app. The commands above specifically target `run dev` processes and skip anything on port 31415.
 
@@ -117,48 +136,28 @@ fi
 script: .agents/launch-test.sh
 ```
 
-Run the script EXACTLY ONCE. On readiness-poll timeout, read the log file — do
-not re-launch.
+Run the script EXACTLY ONCE. It owns the full electron bring-up: isolated
+ports via `scripts/setup-ports.sh` (never the protected prod `31415`),
+`pnpm install` + full build, daemon (`LOG_LEVEL=debug`), desktop (Vite +
+Electron, CDP on `9222`), the shared `packages/ui` renderer dev server, and
+the readiness wait. It **blocks until ready** and prints `READY` + facts
+(ports, CDP_URL, log paths), or exits 1 with the failing component's log
+tail — do not re-launch on failure, read the printed tail.
 
-`launch-test.sh` owns the full project bring-up and is the place to tweak how
-the app starts for testing. It:
-
-1. runs `scripts/setup-ports.sh` — allocates **isolated** free ports (daemon
-   `31416–32416`, Vite `5174–6174`, never the protected prod port `31415`),
-   writes `.env` with the `VITE_DAEMON_*` mirrors (without which the renderer
-   falls back to the prod daemon), then `pnpm install` + full build of all
-   three packages;
-2. sources the isolated `.env`;
-3. starts the daemon (`LOG_LEVEL=debug`, log → `/tmp/mf-daemon-<port>.log`);
-4. starts desktop (Vite + Electron with CDP on `9222`, log →
-   `/tmp/mf-desktop-<port>.log`);
-5. prints `DAEMON_PORT` / `VITE_PORT` / `CDP_URL` / log paths for the readiness
-   report.
-
-Because step 1 already does a full install + build, the dispatching
+Because the script already does a full install + build, the dispatching
 `prepare-worktree` subagent does **not** need a separate build step for this
-project — the script is authoritative. Default ports (`31415`/`5173`) are never
-used; isolation here is what prevents the production-daemon / sibling-worktree
-port clashes that otherwise derail the start.
+project — the script is authoritative.
 
 ## Wait for Ready
 
-```bash
-# Daemon
-for i in $(seq 1 20); do
-  curl -s http://127.0.0.1:$DAEMON_PORT/api/projects > /dev/null 2>&1 && break
-  sleep 0.5
-done
+The launch scripts own the readiness wait — a caller never re-implements it.
+Declarative facts the engines need after `READY`:
 
-# Electron CDP
-for i in $(seq 1 30); do
-  curl -s http://localhost:9222/json/version > /dev/null 2>&1 && break
-  sleep 0.5
-done
-curl -s http://localhost:9222/json/version
-```
-
-Daemon ready when `/api/projects` responds. App ready when `/json/version` returns JSON containing `webSocketDebuggerUrl`.
+- Daemon HTTP: `http://127.0.0.1:$DAEMON_PORT/api/projects` responds.
+- Electron CDP: `http://localhost:9222/json/version` returns JSON with
+  `webSocketDebuggerUrl`.
+- Tauri: Vite at `http://localhost:$VITE_PORT` (`localhost`, not
+  `127.0.0.1`), app present in the bridge's `list_devices`.
 
 ## Test Engines
 
@@ -176,23 +175,69 @@ CDP endpoint: `http://localhost:9222`
 - Run command: `cd packages/e2e && npx playwright test tests/99-adhoc-*.spec.ts --workers=1 --reporter=list`
 - Throwaway — delete the file after reporting results, never commit.
 
+## Seeding & Fixtures
+
+**Hand-authored replay fixtures (preferred for rendering/derived-state
+scenarios).** The e2e mock-cli plugin (`packages/e2e/plugins/mock-cli`, see
+its `DESIGN.md`) replays an NDJSON event fixture through a real adapter —
+full live event path (all SessionSink callbacks incl. `onSubagentChild`), no
+API calls, fully deterministic. **Write fixtures by hand — no LLM run
+needed:**
+
+- Format (one JSON per line): `{"dir":"in","method":"sendMessage","args":["<text>"]}`
+  marks a user send (positional — reply N answers send N);
+  `{"dir":"out","method":"<sink method>","args":[<verbatim sink-signature args>],"delayMs":N}`
+  is what the fake CLI emits; `"fx"` lines apply file effects.
+- Authoring guards: start from an existing fixture in
+  `packages/e2e/fixtures/recordings/` (permissions, compaction, attachments,
+  bash exit codes, …) and take payload shapes from
+  `docs/adapters/claude/PROTOCOL_REVERSED.md` or `packages/core`'s own test
+  fixtures — never invent event shapes; a fixture the daemon would never
+  receive proves nothing.
+- Replay wiring: build the plugin (esbuild, per
+  `packages/e2e/fixtures/daemon.ts`), copy it into
+  `<data-dir>/plugins/mock-cli`, run the daemon with `E2E_MODE=mock
+  E2E_RECORDINGS_DIR=<dir with your fixture>`, create the chat with the mock
+  adapterId.
+- `E2E_MODE=record` also exists (tees a real CLI session to a fixture) but is
+  a shape-sampling aid, not the default path — it reintroduces live-LLM cost
+  and nondeterminism.
+
+Rules learned from live runs (2026-07-09 fleet):
+
+- **Never use `/tmp` as a throwaway project path** for transcript/session-path
+  scenarios on macOS — the CLI encodes the `/private` realpath while the
+  daemon stores the symlinked path, and they never match. Use `~/Projects/...`.
+- **Seed session state through the running app, not SQLite.** Writing
+  `claude_session_id`/`transcript_missing` directly to the DB is invisible to
+  the daemon's in-memory `activeChats` cache — send a real message instead.
+- **File-watch/external-edit fixtures** must live outside any dev server's
+  watched root (use repo-root docs, not `packages/*/src`) or HMR of the app
+  under test confounds the check.
+- **Register the worktree as a project first** (`POST /api/projects
+  {"path": "<worktree>"}`) before any file-surface testing — the pre-existing
+  "mainframe" project points at the main checkout, and file edits through it
+  silently target the wrong filesystem path.
+- `~/.mainframe_dev` accumulates real project registrations across runs;
+  non-mainframe launch configs failing to start (`command not found`) is a
+  PATH/env artifact, not a bug — the config's presence in the picker is the
+  signal, not whether its process binds.
+
 ## Stop / Restart
 
-Kill by port. **Never kill just Electron** — that leaves the daemon and Vite dangling.
-
-```bash
-source .env
-lsof -ti :$DAEMON_PORT :$VITE_PORT :9222 2>/dev/null | xargs kill -9 2>/dev/null
-
-sleep 2
-for port in $DAEMON_PORT $VITE_PORT 9222; do
-  if lsof -ti :$port 2>/dev/null; then
-    echo "Port $port still held — retrying kill"
-    lsof -ti :$port | xargs kill -9 2>/dev/null
-  fi
-done
-sleep 1
 ```
+script: .agents/stop-test.sh [port ...]
+```
+
+Port-scoped, parallel-safe teardown of one run — defaults to this checkout's
+`.env` ports + CDP 9222; pass explicit ports to override. Refuses the
+protected port 31415; exits nonzero if a port stays held. Never kill just
+Electron — the script kills the full port set for exactly this run.
+
+**Tauri caveat:** killing `$DAEMON_PORT` also takes the parent `app-tauri`
+process (shared socket). At teardown that is intended; never use this
+mid-run hoping for a daemon-only restart — relaunch the app properly
+instead.
 
 Then re-run the **Launch** section.
 

--- a/.agents/ui-selectors.md
+++ b/.agents/ui-selectors.md
@@ -1,17 +1,40 @@
 # UI Selector Catalog
-Resolved selectors for test-worktree. Each row is re-verified on use.
+
+Resolved selectors for test-worktree. Entries are HINTS for the cascade's
+step-2 matching — every entry still passes step-3 DOM-verify on use; a stale
+entry found wrong is corrected here in the same run.
+
+Refreshed 2026-07-09 from a 7-branch fleet run (tauri build). The pre-refresh
+catalog was electron-era and most rows no longer existed.
 
 | NL target | Selector | Source | Confidence | Last verified |
 |---|---|---|---|---|
-| files panel › file entry | `[data-testid="right-top"]` >> `getByText("<filename>", { exact: true })` | dom-verify | 0.80 | 2026-05-17 |
-| files panel › monaco editor | `.monaco-editor` (single code-editor instance; assertion target) | dom-verify | 0.80 | 2026-05-17 |
-| chat › composer input | `[data-testid="center"] textarea` (only textarea in chat zone) | dom-verify | 0.80 | 2026-05-17 |
-| sessions › new session (mainframe-web) | `button[aria-label="New session in mainframe-web"]` (reveal-on-hover; dispatch click via DOM) | dom-verify | 0.80 | 2026-05-17 |
-| sessions › project group (mainframe-web) | `[data-testid^="project-group-"]` filtered by text `mainframe-web` | dom-verify | 0.80 | 2026-05-17 |
-| sessions › chat list item | `[data-testid="chat-list-item"]` | catalog | 0.95 | 2026-05-17 |
-| sessions › archive session action | chat-list-item >> `button[aria-label="Archive session"]` | dom-verify | 0.80 | 2026-05-17 |
-| left rail › preview toggle | `button[title="Preview"]` (left icon rail) | dom-verify | 0.80 | 2026-05-17 |
-| launch bar › start button | `[data-testid="launch-start-btn"]` | catalog | 0.95 | 2026-05-17 |
-| launch bar › config selector | `[data-testid="launch-config-selector"]` | catalog | 0.95 | 2026-05-17 |
-| chat › shiki code block | `[data-testid="center"] pre.shiki` (kept-language highlight path) | dom-verify | 0.80 | 2026-05-17 |
-| chat › fallback code block | `[data-testid="center"] code.block` (dropped-language plain path) | dom-verify | 0.80 | 2026-05-17 |
+| chat › composer input | `[data-testid="chat-composer-input"]` | dom-verify | 0.95 | 2026-07-09 |
+| chat › composer send button | `[data-testid="chat-composer-send"]` | dom-verify | 0.95 | 2026-07-09 |
+| chat › context percentage | `[data-testid="chat-header-context-pct"]` | dom-verify | 0.95 | 2026-07-09 |
+| sessions › session row | `[data-testid="sessions-row"]` | dom-verify | 0.95 | 2026-07-09 |
+| sessions › archive row action | `sessions-row` node → `.querySelector('[data-testid="sessions-row-action-archive"]')` (no aria-label) | dom-verify | 0.95 | 2026-07-09 |
+| sessions › degraded marker | `[data-testid="sessions-row-meta-degraded"]` (aria-label names the cause) | dom-verify | 0.95 | 2026-07-09 |
+| titlebar › branch chip | `[data-testid="main-toolbar-branch"]` (`data-worktree` reflects isolation; `main-toolbar-branch-wt` = "wt" badge) | dom-verify | 0.95 | 2026-07-09 |
+| composer › worktree trigger | `[data-testid="composer-worktree-trigger"]` | dom-verify | 0.95 | 2026-07-09 |
+| composer › background-activity chip | `[data-testid="composer-background-activity"]`; popover rows `composer-background-activity-item-<taskId>` | dom-verify | 0.95 | 2026-07-09 |
+| chat › degraded card | `[data-testid="chat-degraded-card"]` (+ `chat-degraded-continue/-delete/-project-root/-error`) | dom-verify | 0.95 | 2026-07-09 |
+| surface rail › run toggle | `[data-testid="surface-rail-run"]` | dom-verify | 0.90 | 2026-07-09 |
+
+## Interaction techniques (this app, tauri build)
+
+- **Hover-revealed row actions** (archive, rename, tags): the button has a
+  zero-size rect until real CSS `:hover`; synthetic hovers don't reveal it.
+  Click via `row.querySelector('[data-testid="..."]').click()` scoped to the
+  specific row's DOM node — never by screen coordinates.
+- **Session-row navigation**: text-strategy clicks and bare JS `.click()`
+  don't fire the SPA router — use a real pointer event at the
+  `getBoundingClientRect()` center, re-read the rect immediately before each
+  click (coordinates drift as the chat streams).
+- **Text-strategy clicks match substrings** ("mainframe" hits
+  "mainframe-web") — prefer `data-testid` lookups via `webview_execute_js`.
+- **New-session draft slot**: a draft's project cannot be reassigned via the
+  project picker once the draft exists — select the project (filter pill or
+  project group) BEFORE clicking "+". If a picker item click doesn't switch
+  the active thread after 2 attempts, fall back to an existing idle session
+  row instead of retrying.

--- a/.changeset/fix-context-meter-overreport.md
+++ b/.changeset/fix-context-meter-overreport.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix the context meter over-reporting (stuck near 100%): persist the CLI-reported context totals on the chat row and prefer them over the catalog-window estimate; resolve probed model windows via each entry's own resolvedModel; stop subagent, synthetic zero-usage, and cumulative result usage from corrupting the stored context size.

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ docs/CODE-ANALYSIS*
 
 /packages/e2e/playwright-report/
 packages/e2e/plugins/mock-cli/index.js
+.playwright-cli/

--- a/packages/core/src/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/__tests__/adapter-registry.test.ts
@@ -36,9 +36,10 @@ describe('ClaudeAdapter.listModels', () => {
   it('returns the hardcoded Claude model catalog', async () => {
     const adapter = new ClaudeAdapter();
     const models = await adapter.listModels();
-    expect(models.length).toBe(14);
+    expect(models.length).toBe(15);
     const ids = models.map((m) => m.id);
     expect(ids).toContain('default');
+    expect(ids).toContain('claude-sonnet-5');
     expect(ids).toContain('claude-opus-4-6');
     expect(ids).toContain('opus[1m]');
     expect(ids).toContain('claude-sonnet-4-6');

--- a/packages/core/src/__tests__/claude-events.test.ts
+++ b/packages/core/src/__tests__/claude-events.test.ts
@@ -650,6 +650,76 @@ describe('handleStderr', () => {
   });
 });
 
+describe('handleStdout — context-token capture (#197)', () => {
+  function sendAssistant(session: ClaudeSession, sink: SessionSink, event: Record<string, unknown>) {
+    handleStdout(session, Buffer.from(JSON.stringify({ type: 'assistant', ...event }) + '\n'), sink);
+  }
+  function sendResult(session: ClaudeSession, sink: SessionSink, event: Record<string, unknown> = {}) {
+    handleStdout(session, Buffer.from(JSON.stringify({ type: 'result', subtype: 'success', ...event }) + '\n'), sink);
+  }
+
+  it('reports contextTokens from the last parent assistant usage (input + cache tokens)', () => {
+    const session = createSession();
+    const sink = createSink();
+    sendAssistant(session, sink, {
+      message: {
+        content: [{ type: 'text', text: 'hi' }],
+        usage: { input_tokens: 1, output_tokens: 9, cache_creation_input_tokens: 2, cache_read_input_tokens: 3 },
+      },
+    });
+    sendResult(session, sink);
+    expect(sink.onResult).toHaveBeenCalledWith(expect.objectContaining({ contextTokens: 6 }));
+  });
+
+  it('ignores subagent assistant usage (parent_tool_use_id) for context tokens', () => {
+    const session = createSession();
+    const sink = createSink();
+    sendAssistant(session, sink, {
+      parent_tool_use_id: 'toolu_task_1',
+      message: {
+        content: [{ type: 'text', text: 'subagent' }],
+        usage: { input_tokens: 50_000, output_tokens: 10, cache_read_input_tokens: 100_000 },
+      },
+    });
+    sendResult(session, sink);
+    expect(sink.onResult).toHaveBeenCalledWith(expect.objectContaining({ contextTokens: null }));
+  });
+
+  it('does not let a synthetic zero-usage assistant message clobber the captured usage', () => {
+    const session = createSession();
+    const sink = createSink();
+    sendAssistant(session, sink, {
+      message: {
+        content: [{ type: 'text', text: 'real' }],
+        usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 300 },
+      },
+    });
+    sendAssistant(session, sink, {
+      message: {
+        model: '<synthetic>',
+        content: [{ type: 'text', text: 'synthetic' }],
+        usage: { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      },
+    });
+    sendResult(session, sink);
+    expect(sink.onResult).toHaveBeenCalledWith(expect.objectContaining({ contextTokens: 400 }));
+  });
+
+  it('never uses the result event cumulative usage as a context size', () => {
+    const session = createSession();
+    const sink = createSink();
+    // No assistant usage captured this turn — the result's own `usage` is the
+    // QueryEngine total across ALL API calls, not a context size.
+    sendResult(session, sink, { usage: { input_tokens: 500, output_tokens: 200, cache_read_input_tokens: 900_000 } });
+    expect(sink.onResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextTokens: null,
+        usage: expect.objectContaining({ output_tokens: 200 }),
+      }),
+    );
+  });
+});
+
 describe('handleStdout — subagent result isolation (#141)', () => {
   it('does not call onResult for a result event with parent_tool_use_id (subagent turn)', () => {
     const session = createSession();

--- a/packages/core/src/__tests__/event-handler.test.ts
+++ b/packages/core/src/__tests__/event-handler.test.ts
@@ -65,6 +65,100 @@ describe('EventHandler token accumulation', () => {
   });
 });
 
+describe('EventHandler context-size persistence (#197)', () => {
+  let db: any;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+
+  const chatId = 'chat-ctx';
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    messages = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    activeChats = new Map();
+    activeChats.set(chatId, {
+      chat: {
+        id: chatId,
+        totalCost: 0,
+        totalTokensInput: 0,
+        totalTokensOutput: 0,
+        lastContextTokensInput: 347_000,
+        processState: 'working',
+      },
+      session: null,
+    });
+  });
+
+  function makeSink(): SessionSink {
+    const handler = new EventHandler(db, messages, permissions, (id) => activeChats.get(id), emitEvent);
+    return handler.buildSink(chatId, createRespondToPermission());
+  }
+
+  it('uses contextTokens (not the cumulative usage) for lastContextTokensInput', () => {
+    const sink = makeSink();
+    sink.onResult({
+      total_cost_usd: 0,
+      usage: { input_tokens: 900_000, output_tokens: 10 },
+      contextTokens: 150_000,
+    });
+    expect(activeChats.get(chatId)!.chat.lastContextTokensInput).toBe(150_000);
+    expect(db.chats.update).toHaveBeenCalledWith(chatId, expect.objectContaining({ lastContextTokensInput: 150_000 }));
+  });
+
+  it('preserves the stored context size when contextTokens is null (unknown this turn)', () => {
+    const sink = makeSink();
+    sink.onResult({ total_cost_usd: 0, usage: { input_tokens: 0, output_tokens: 0 }, contextTokens: null });
+    expect(activeChats.get(chatId)!.chat.lastContextTokensInput).toBe(347_000);
+    const updateArg = db.chats.update.mock.calls.find(([id]: [string]) => id === chatId)?.[1];
+    expect(updateArg).not.toHaveProperty('lastContextTokensInput');
+  });
+
+  it('falls back to usage input_tokens for adapters that do not report contextTokens', () => {
+    const sink = makeSink();
+    sink.onResult({ total_cost_usd: 0, usage: { input_tokens: 1_000 } });
+    expect(activeChats.get(chatId)!.chat.lastContextTokensInput).toBe(1_000);
+  });
+
+  it('does not clobber the stored context size with a zero legacy usage', () => {
+    const sink = makeSink();
+    sink.onResult({ total_cost_usd: 0, usage: { input_tokens: 0, output_tokens: 0 } });
+    expect(activeChats.get(chatId)!.chat.lastContextTokensInput).toBe(347_000);
+  });
+
+  it('persists live totals from onContextUsage and re-broadcasts the chat', () => {
+    const sink = makeSink();
+    sink.onContextUsage({ totalTokens: 151_000, maxTokens: 967_000, percentage: 16 });
+
+    expect(db.chats.update).toHaveBeenCalledWith(
+      chatId,
+      expect.objectContaining({ lastContextTotalTokens: 151_000, lastContextMaxTokens: 967_000 }),
+    );
+    const chat = activeChats.get(chatId)!.chat;
+    expect(chat.lastContextTotalTokens).toBe(151_000);
+    expect(chat.lastContextMaxTokens).toBe(967_000);
+
+    const types = emitEvent.mock.calls.map(([e]: [any]) => e.type);
+    expect(types).toContain('chat.contextUsage');
+    expect(types).toContain('chat.updated');
+  });
+
+  it('does not persist an onContextUsage report without a usable maxTokens', () => {
+    const sink = makeSink();
+    sink.onContextUsage({ totalTokens: 1_000, maxTokens: 0, percentage: 0 });
+    expect(db.chats.update).not.toHaveBeenCalled();
+    const types = emitEvent.mock.calls.map(([e]: [any]) => e.type);
+    expect(types).toContain('chat.contextUsage');
+  });
+});
+
 describe('EventHandler adapterId stamping', () => {
   let db: any;
   let messages: MessageCache;

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -340,18 +340,27 @@ function buildSessionSink(
       const queueRemaining = refsAfter.length;
       const nextProcessState: 'idle' | 'working' = queueRemaining > 0 ? 'working' : 'idle';
 
+      // Context size: prefer the adapter's explicit per-turn report
+      // (`contextTokens`; null = "unknown this turn — keep the stored value").
+      // Legacy adapters without the field fall back to the turn's usage, but a
+      // zero must never clobber a real stored size (synthetic/EMPTY_USAGE turns).
+      const contextTokens = data.contextTokens === undefined ? tokensInput : data.contextTokens;
+      const contextUpdate = contextTokens != null && contextTokens > 0 ? { lastContextTokensInput: contextTokens } : {};
+
       db.chats.update(chatId, {
         totalCost: newCost,
         totalTokensInput: newInput,
         totalTokensOutput: newOutput,
-        lastContextTokensInput: tokensInput,
+        ...contextUpdate,
         processState: nextProcessState,
         updatedAt: now,
       });
       active.chat.totalCost = newCost;
       active.chat.totalTokensInput = newInput;
       active.chat.totalTokensOutput = newOutput;
-      active.chat.lastContextTokensInput = tokensInput;
+      if (contextUpdate.lastContextTokensInput != null) {
+        active.chat.lastContextTokensInput = contextUpdate.lastContextTokensInput;
+      }
       active.chat.processState = nextProcessState;
       active.chat.updatedAt = now;
 
@@ -488,6 +497,22 @@ function buildSessionSink(
     },
 
     onContextUsage(usage: ContextUsage) {
+      // Persist the CLI's own totals so the meter survives reloads and
+      // dormant-chat turns instead of regressing to a catalog-window guess
+      // (#197). `chat.updated` is broadcast ungated (unlike chat.contextUsage,
+      // which only reaches subscribers), so unsubscribed clients converge too.
+      if (usage.maxTokens > 0) {
+        db.chats.update(chatId, {
+          lastContextTotalTokens: usage.totalTokens,
+          lastContextMaxTokens: usage.maxTokens,
+        });
+        const active = getActiveChat(chatId);
+        if (active) {
+          active.chat.lastContextTotalTokens = usage.totalTokens;
+          active.chat.lastContextMaxTokens = usage.maxTokens;
+          emitEvent({ type: 'chat.updated', chat: active.chat });
+        }
+      }
       emitEvent({ type: 'chat.contextUsage', chatId, ...usage });
     },
 

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -16,8 +16,12 @@ type RawChatRow = Omit<
   | 'fast'
   | 'ultracode'
   | 'adaptiveThinking'
+  | 'lastContextTotalTokens'
+  | 'lastContextMaxTokens'
 > & {
   mentions: string;
+  lastContextTotalTokens: number | null;
+  lastContextMaxTokens: number | null;
   modifiedFiles: string;
   todos: string;
   pinned: number;
@@ -36,6 +40,7 @@ const CHAT_SELECT_FIELDS = `
   created_at as createdAt, updated_at as updatedAt,
   total_cost as totalCost, total_tokens_input as totalTokensInput,
   total_tokens_output as totalTokensOutput, last_context_tokens_input as lastContextTokensInput,
+  last_context_total_tokens as lastContextTotalTokens, last_context_max_tokens as lastContextMaxTokens,
   mentions, modified_files as modifiedFiles,
   worktree_path as worktreePath, branch_name as branchName,
   process_state as processState, todos, pinned, effort,
@@ -171,6 +176,8 @@ export class ChatsRepository {
     totalTokensInput: { column: 'total_tokens_input' },
     totalTokensOutput: { column: 'total_tokens_output' },
     lastContextTokensInput: { column: 'last_context_tokens_input' },
+    lastContextTotalTokens: { column: 'last_context_total_tokens' },
+    lastContextMaxTokens: { column: 'last_context_max_tokens' },
     title: { column: 'title' },
     permissionMode: { column: 'permission_mode' },
     worktreePath: { column: 'worktree_path', transform: (v) => v ?? null },
@@ -338,6 +345,8 @@ export class ChatsRepository {
   private mapRow(row: RawChatRow): Chat {
     return {
       ...row,
+      lastContextTotalTokens: row.lastContextTotalTokens ?? undefined,
+      lastContextMaxTokens: row.lastContextMaxTokens ?? undefined,
       mentions: parseJsonColumn(row.mentions, []),
       modifiedFiles: parseJsonColumn(row.modifiedFiles, []),
       worktreePath: row.worktreePath || undefined,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -103,6 +103,12 @@ export function initializeSchema(db: Database.Database): void {
   if (!cols.some((c) => c.name === 'last_context_tokens_input')) {
     db.exec('ALTER TABLE chats ADD COLUMN last_context_tokens_input INTEGER DEFAULT 0');
   }
+  if (!cols.some((c) => c.name === 'last_context_total_tokens')) {
+    db.exec('ALTER TABLE chats ADD COLUMN last_context_total_tokens INTEGER');
+  }
+  if (!cols.some((c) => c.name === 'last_context_max_tokens')) {
+    db.exec('ALTER TABLE chats ADD COLUMN last_context_max_tokens INTEGER');
+  }
   if (!cols.some((c) => c.name === 'todos')) {
     db.exec('ALTER TABLE chats ADD COLUMN todos TEXT');
   }
@@ -114,7 +120,8 @@ export function initializeSchema(db: Database.Database): void {
   }
   if (!cols.some((c) => c.name === 'fast')) db.exec('ALTER TABLE chats ADD COLUMN fast INTEGER');
   if (!cols.some((c) => c.name === 'ultracode')) db.exec('ALTER TABLE chats ADD COLUMN ultracode INTEGER');
-  if (!cols.some((c) => c.name === 'adaptive_thinking')) db.exec('ALTER TABLE chats ADD COLUMN adaptive_thinking INTEGER');
+  if (!cols.some((c) => c.name === 'adaptive_thinking'))
+    db.exec('ALTER TABLE chats ADD COLUMN adaptive_thinking INTEGER');
   if (!cols.some((c) => c.name === 'detected_prs')) {
     db.exec("ALTER TABLE chats ADD COLUMN detected_prs TEXT DEFAULT '[]'");
   }

--- a/packages/core/src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts
@@ -15,4 +15,39 @@ describe('enrichWithContextWindow', () => {
     const probed: AdapterModel[] = [{ id: 'default', label: 'Default', description: 'Fable 5' }];
     expect(enrichWithContextWindow(probed, 'claude-fable-5[1m]')[0]!.contextWindow).toBe(1_000_000);
   });
+
+  // Live-probed CLI shapes (2026-07-09): each entry carries its own resolvedModel,
+  // e.g. { value: 'opus[1m]', resolvedModel: 'claude-opus-4-8[1m]' },
+  // { value: 'haiku', resolvedModel: 'claude-haiku-4-5-20251001' },
+  // { value: 'claude-fable-5[1m]', resolvedModel: 'claude-fable-5' } (suffix on id only).
+  it('infers 1M from a non-default entry whose own resolvedModel carries [1m]', () => {
+    const probed: AdapterModel[] = [
+      { id: 'opus[1m]', label: 'Opus', description: 'Opus 4.8 with 1M context', resolvedModel: 'claude-opus-4-8[1m]' },
+      { id: 'my-alias', label: 'Aliased', description: 'Some model', resolvedModel: 'claude-something-9[1m]' },
+    ];
+    const enriched = enrichWithContextWindow(probed);
+    expect(enriched[0]!.contextWindow).toBe(1_000_000);
+    expect(enriched[1]!.contextWindow).toBe(1_000_000);
+  });
+
+  it('keeps the [1m] id suffix authoritative even when resolvedModel drops it', () => {
+    const probed: AdapterModel[] = [
+      { id: 'claude-fable-5[1m]', label: 'Fable 5', description: 'Fable 5', resolvedModel: 'claude-fable-5' },
+    ];
+    expect(enrichWithContextWindow(probed)[0]!.contextWindow).toBe(1_000_000);
+  });
+
+  it('resolves the static-catalog window via the entry resolvedModel for alias ids', () => {
+    const probed: AdapterModel[] = [
+      { id: 'haiku', label: 'Haiku 4.5', description: 'Fastest', resolvedModel: 'claude-haiku-4-5-20251001' },
+    ];
+    expect(enrichWithContextWindow(probed)[0]!.contextWindow).toBe(200_000);
+  });
+
+  it('gives claude-sonnet-5 the extended window from the static catalog (live-verified 1M)', () => {
+    const probed: AdapterModel[] = [
+      { id: 'sonnet', label: 'Sonnet 5', description: 'Efficient for routine tasks', resolvedModel: 'claude-sonnet-5' },
+    ];
+    expect(enrichWithContextWindow(probed)[0]!.contextWindow).toBe(1_000_000);
+  });
 });

--- a/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
@@ -31,4 +31,21 @@ describe('extractProbePayload', () => {
     };
     expect(extractProbePayload(event)?.resolvedModel).toBeUndefined();
   });
+
+  it('carries each entry own resolvedModel onto the mapped model', () => {
+    const event = {
+      type: 'control_response',
+      response: {
+        response: {
+          models: [
+            { value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' },
+            { value: 'claude-sonnet-5', displayName: 'Sonnet 5' },
+          ],
+        },
+      },
+    };
+    const out = extractProbePayload(event);
+    expect(out?.models[0]?.resolvedModel).toBe('claude-sonnet-5');
+    expect(out?.models[1]?.resolvedModel).toBeUndefined();
+  });
 });

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -111,6 +111,9 @@ const CLAUDE_MODELS: AdapterModel[] = [
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     supportedEfforts: ['low', 'medium', 'high', 'max'],
   },
+  // Window live-verified 2026-07-07: the CLI's get_context_usage reports
+  // maxTokens 967,000 for claude-sonnet-5 (1M minus the CLI's reserve).
+  { id: 'claude-sonnet-5', label: 'Sonnet 5', contextWindow: EXTENDED_CONTEXT_WINDOW },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
   { id: 'claude-3-5-sonnet-20241022', label: 'Sonnet 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
   { id: 'claude-3-5-haiku-20241022', label: 'Haiku 3.5', contextWindow: DEFAULT_CONTEXT_WINDOW },
@@ -123,16 +126,21 @@ function hasExtendedWindowSuffix(id: string): boolean {
 // The CLI's model probe doesn't expose context window size — only a marketing
 // description like "Opus 4.7 with 1M context". Reconcile probed entries with
 // the static catalog so known IDs retain their authoritative window, unknown
-// IDs ending in "[1m]" (or resolving to one via `resolvedModel`) get the
-// extended window, and everything else falls back to a description sniff
-// before the 200k default.
-export function enrichWithContextWindow(probed: AdapterModel[], resolvedModel?: string): AdapterModel[] {
+// IDs ending in "[1m]" (on the entry id OR its own `resolvedModel` — the CLI
+// puts the suffix on either side, e.g. `claude-fable-5[1m]` resolves to a
+// bare `claude-fable-5`) get the extended window, and everything else falls
+// back to a description sniff before the 200k default. `defaultResolvedModel`
+// is kept for callers probing legacy payloads where only the "default" entry
+// carried a resolution.
+export function enrichWithContextWindow(probed: AdapterModel[], defaultResolvedModel?: string): AdapterModel[] {
   const staticById = new Map(CLAUDE_MODELS.map((m) => [m.id, m]));
   return probed.map((model) => {
     if (model.contextWindow) return model;
-    const effectiveId = model.id === 'default' && resolvedModel ? resolvedModel : model.id;
-    if (hasExtendedWindowSuffix(effectiveId)) return { ...model, contextWindow: EXTENDED_CONTEXT_WINDOW };
-    const fromStatic = staticById.get(model.id)?.contextWindow;
+    const resolved = model.resolvedModel ?? (model.id === 'default' ? defaultResolvedModel : undefined);
+    if (hasExtendedWindowSuffix(model.id) || (resolved && hasExtendedWindowSuffix(resolved))) {
+      return { ...model, contextWindow: EXTENDED_CONTEXT_WINDOW };
+    }
+    const fromStatic = staticById.get(model.id)?.contextWindow ?? (resolved && staticById.get(resolved)?.contextWindow);
     if (fromStatic) return { ...model, contextWindow: fromStatic };
     const window = /\b1m\b|1m context/i.test(model.description ?? '')
       ? EXTENDED_CONTEXT_WINDOW

--- a/packages/core/src/plugins/builtin/claude/assistant-event.ts
+++ b/packages/core/src/plugins/builtin/claude/assistant-event.ts
@@ -4,6 +4,20 @@ import type { ClaudeSession } from './session.js';
 import { isPrCreateCommand, isPrMutationCommand, parsePrIdentifierFromArgs } from './pr-detection.js';
 import { normalizeTodos } from '../../../todos/normalize.js';
 
+// `<synthetic>` assistant messages and error turns carry all-zero usage;
+// letting them through would clobber the real captured context size (#197).
+function hasNonZeroUsage(usage: NonNullable<ClaudeSessionUsage>): boolean {
+  return (
+    (usage.input_tokens ?? 0) +
+      (usage.output_tokens ?? 0) +
+      (usage.cache_creation_input_tokens ?? 0) +
+      (usage.cache_read_input_tokens ?? 0) >
+    0
+  );
+}
+
+type ClaudeSessionUsage = ClaudeSession['state']['lastAssistantUsage'];
+
 export function handleAssistantEvent(session: ClaudeSession, event: Record<string, unknown>, sink: SessionSink): void {
   const message = event.message as {
     model?: string;
@@ -15,12 +29,10 @@ export function handleAssistantEvent(session: ClaudeSession, event: Record<strin
       cache_read_input_tokens?: number;
     };
   };
-  if (message?.usage) {
-    session.state.lastAssistantUsage = message.usage;
-  }
-  if (!message?.content) return;
-
   if (typeof event.parent_tool_use_id === 'string' && event.parent_tool_use_id) {
+    // Subagent turn: its usage reflects the SUBAGENT's context, not this
+    // chat's — never capture it as lastAssistantUsage (#197).
+    if (!message?.content) return;
     const parentToolUseId = event.parent_tool_use_id;
     const tagged = message.content.map((b) => ({
       ...b,
@@ -29,6 +41,11 @@ export function handleAssistantEvent(session: ClaudeSession, event: Record<strin
     sink.onSubagentChild(parentToolUseId, tagged);
     return;
   }
+
+  if (message?.usage && hasNonZeroUsage(message.usage)) {
+    session.state.lastAssistantUsage = message.usage;
+  }
+  if (!message?.content) return;
 
   for (const block of message.content) {
     if (block.type === 'tool_use') {

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -162,6 +162,15 @@ function handleResultEvent(session: ClaudeSession, event: Record<string, unknown
   const tokensInput =
     (usage?.input_tokens || 0) + (usage?.cache_creation_input_tokens || 0) + (usage?.cache_read_input_tokens || 0);
   const tokensOutput = usage?.output_tokens || 0;
+  // Context size comes ONLY from the last parent assistant usage. The result
+  // event's own `usage` is the QueryEngine total accumulated across every API
+  // call in the turn (cache reads summed N times) — fine for cost accounting,
+  // wrong as a context size (#197). `null` tells the sink "unknown this turn".
+  const contextTokens = lastUsage
+    ? (lastUsage.input_tokens || 0) +
+      (lastUsage.cache_creation_input_tokens || 0) +
+      (lastUsage.cache_read_input_tokens || 0)
+    : null;
   session.state.lastAssistantUsage = undefined;
   session.clearInterruptTimer();
 
@@ -180,6 +189,7 @@ function handleResultEvent(session: ClaudeSession, event: Record<string, unknown
           cache_read_input_tokens: usage.cache_read_input_tokens,
         }
       : undefined,
+    contextTokens,
     subtype: event.subtype as string | undefined,
     is_error: event.is_error as boolean | undefined,
   });

--- a/packages/core/src/plugins/builtin/claude/probe-models.ts
+++ b/packages/core/src/plugins/builtin/claude/probe-models.ts
@@ -38,6 +38,7 @@ export function mapModelInfo(info: CliModelInfo): AdapterModel {
   }
   const model: AdapterModel = { id: info.value, label };
   if (info.description) model.description = info.description;
+  if (typeof info.resolvedModel === 'string') model.resolvedModel = info.resolvedModel;
   if (info.supportedEffortLevels?.length) {
     model.supportedEfforts = info.supportedEffortLevels;
     if (info.supportedEffortLevels.includes('xhigh')) model.supportsUltracode = true;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -18,6 +18,15 @@ export interface SessionResult {
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
   };
+  /**
+   * Tokens occupying the context window at the turn's last model call
+   * (input + cache tokens of the final parent assistant message).
+   * `null` = the adapter knows the size is unknown this turn (e.g. error
+   * turn with no assistant usage) — do NOT estimate it from `usage`, which
+   * may be a cumulative multi-call total. Absent (undefined) = legacy
+   * adapter; `usage` remains the best available approximation.
+   */
+  contextTokens?: number | null;
   subtype?: string;
   result?: string;
   is_error?: boolean;
@@ -218,6 +227,8 @@ export interface AdapterModel {
   id: string;
   label: string;
   description?: string;
+  /** Concrete model id an alias entry currently resolves to (CLI probe, per-entry). */
+  resolvedModel?: string;
   contextWindow?: number;
   isDefault?: boolean;
   /** Dynamic, per-model. Empty/absent → model has no effort control. */

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -49,6 +49,14 @@ export interface Chat {
   totalTokensInput: number;
   totalTokensOutput: number;
   lastContextTokensInput: number;
+  /**
+   * Last CLI-reported context usage (`get_context_usage` after each turn):
+   * tokens in the window / usable window size. This is the authoritative pair
+   * for the context meter when no live report is in memory — unlike
+   * `lastContextTokensInput` ÷ a catalog window, which is a guess.
+   */
+  lastContextTotalTokens?: number;
+  lastContextMaxTokens?: number;
   contextFiles?: string[];
   mentions?: SessionMention[];
   modifiedFiles?: string[];

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-session-bar.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-session-bar.test.ts
@@ -5,6 +5,7 @@
  * All expected values are hardcoded. No reducer logic is re-derived here.
  */
 import { describe, it, expect } from 'vitest';
+import type { Chat } from '@qlan-ro/mainframe-types';
 import { createChatThreadState, reduceChatThreadState } from '../chat-thread-state';
 
 const CHAT_ID = 'c1';
@@ -78,6 +79,75 @@ describe('reduceChatThreadState — context.usage', () => {
     expect(after.runState).toEqual({ type: 'idle' });
     expect(after.compacting).toBe(false);
     expect(after.interactions).toBe(before.interactions);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chat.config.updated — persisted context adoption (#197)
+// ---------------------------------------------------------------------------
+
+describe('reduceChatThreadState — chat.config.updated adopts persisted context usage', () => {
+  const persistedChat = {
+    id: CHAT_ID,
+    adapterId: 'claude',
+    lastContextTokensInput: 151_000,
+    lastContextTotalTokens: 151_000,
+    lastContextMaxTokens: 967_000,
+  } as unknown as Chat;
+
+  it('seeds contextUsage from the chat persisted totals when none is in memory', () => {
+    const before = createChatThreadState(CHAT_ID);
+    const after = reduceChatThreadState(before, { type: 'chat.config.updated', chat: persistedChat });
+
+    expect(after.contextUsage).toEqual({
+      percentage: (151_000 / 967_000) * 100,
+      totalTokens: 151_000,
+      maxTokens: 967_000,
+    });
+  });
+
+  it('updates a stale in-memory contextUsage when newer persisted totals arrive (dormant-chat turn)', () => {
+    const base = createChatThreadState(CHAT_ID);
+    const withLive = reduceChatThreadState(base, {
+      type: 'context.usage',
+      percentage: 5,
+      totalTokens: 50_000,
+      maxTokens: 967_000,
+    });
+    const after = reduceChatThreadState(withLive, { type: 'chat.config.updated', chat: persistedChat });
+
+    expect(after.contextUsage?.totalTokens).toBe(151_000);
+    expect(after.contextUsage?.maxTokens).toBe(967_000);
+  });
+
+  it('keeps the live contextUsage object when the persisted totals match it', () => {
+    const base = createChatThreadState(CHAT_ID);
+    const withLive = reduceChatThreadState(base, {
+      type: 'context.usage',
+      percentage: 15.6,
+      totalTokens: 151_000,
+      maxTokens: 967_000,
+    });
+    const after = reduceChatThreadState(withLive, { type: 'chat.config.updated', chat: persistedChat });
+
+    expect(after.contextUsage).toBe(withLive.contextUsage);
+  });
+
+  it('leaves contextUsage untouched when the chat has no persisted totals', () => {
+    const chatWithout = { id: CHAT_ID, adapterId: 'claude', lastContextTokensInput: 10_000 } as unknown as Chat;
+    const base = createChatThreadState(CHAT_ID);
+    const after = reduceChatThreadState(base, { type: 'chat.config.updated', chat: chatWithout });
+
+    expect(after.contextUsage).toBeNull();
+    expect(after.chatConfig).toBe(chatWithout);
+  });
+
+  it('returns the SAME state reference when neither config nor persisted totals changed', () => {
+    const base = createChatThreadState(CHAT_ID);
+    const first = reduceChatThreadState(base, { type: 'chat.config.updated', chat: persistedChat });
+    const again = reduceChatThreadState(first, { type: 'chat.config.updated', chat: { ...persistedChat } });
+
+    expect(again).toBe(first);
   });
 });
 

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -151,6 +151,17 @@ function removePending(state: ChatThreadState, clientId: string): ChatThreadStat
   return { ...state, pendingUserMessages };
 }
 
+/**
+ * The chat row's persisted CLI-reported context usage (daemon persists it from
+ * `get_context_usage` after each turn), mapped to the contextUsage slice shape.
+ * Null when the chat has never reported (legacy rows, codex).
+ */
+function persistedContextUsage(chat: Chat): ChatThreadState['contextUsage'] {
+  const { lastContextTotalTokens: total, lastContextMaxTokens: max } = chat;
+  if (total == null || max == null || max <= 0) return null;
+  return { percentage: (total / max) * 100, totalTokens: total, maxTokens: max };
+}
+
 /** True when every composer-toolbar field of two chats is equal (ignores cost/token/updatedAt churn). */
 function sameComposerConfig(a: Chat | null, b: Chat): boolean {
   return (
@@ -209,11 +220,27 @@ export function reduceChatThreadState(state: ChatThreadState, event: ChatStateEv
     case 'chat.id.adopted':
       return state.chatId === event.chatId ? state : { ...state, chatId: event.chatId };
 
-    case 'chat.config.updated':
+    case 'chat.config.updated': {
       // chat.updated also fires for cost/token/updatedAt churn during a run.
       // Only adopt a new identity when a composer-relevant field actually changed,
-      // so the toolbar doesn't re-render on every broadcast.
-      return sameComposerConfig(state.chatConfig, event.chat) ? state : { ...state, chatConfig: event.chat };
+      // so the toolbar doesn't re-render on every broadcast. The persisted
+      // context totals are adopted separately: they keep the meter truthful on
+      // controller seed and after turns completed while this chat was dormant
+      // (chat.contextUsage only reaches subscribers; chat.updated is ungated).
+      const persisted = persistedContextUsage(event.chat);
+      const sameUsage =
+        persisted == null ||
+        (state.contextUsage != null &&
+          state.contextUsage.totalTokens === persisted.totalTokens &&
+          state.contextUsage.maxTokens === persisted.maxTokens);
+      const sameConfig = sameComposerConfig(state.chatConfig, event.chat);
+      if (sameConfig && sameUsage) return state;
+      return {
+        ...state,
+        chatConfig: sameConfig ? state.chatConfig : event.chat,
+        contextUsage: sameUsage ? state.contextUsage : persisted,
+      };
+    }
 
     case 'message.added':
       return upsertMessage(state, event.message);

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -156,7 +156,8 @@ function removePending(state: ChatThreadState, clientId: string): ChatThreadStat
  * `get_context_usage` after each turn), mapped to the contextUsage slice shape.
  * Null when the chat has never reported (legacy rows, codex).
  */
-function persistedContextUsage(chat: Chat): ChatThreadState['contextUsage'] {
+function persistedContextUsage(chat: Chat | null): ChatThreadState['contextUsage'] {
+  if (chat == null) return null;
   const { lastContextTotalTokens: total, lastContextMaxTokens: max } = chat;
   if (total == null || max == null || max <= 0) return null;
   return { percentage: (total / max) * 100, totalTokens: total, maxTokens: max };

--- a/packages/ui/src/features/chat/thread/__tests__/session-bar-status.test.ts
+++ b/packages/ui/src/features/chat/thread/__tests__/session-bar-status.test.ts
@@ -114,6 +114,35 @@ describe('deriveContextPct — token-based fallback', () => {
 });
 
 // ---------------------------------------------------------------------------
+// deriveContextPct — persisted CLI truth beats the catalog guess (#197)
+// ---------------------------------------------------------------------------
+
+describe('deriveContextPct — persisted CLI totals (via chat.config.updated)', () => {
+  it('uses persistedTotal/persistedMax, not lastContextTokensInput/catalog window', () => {
+    // The stuck-at-100% bug: 151k real tokens, catalog window wrongly 200k
+    // (real claude-sonnet-5 window is ~967k usable). The persisted CLI totals
+    // must win: 151_000 / 967_000 ≈ 16%, not min(100, 151/200) = 76%.
+    const state = reduceChatThreadState(createChatThreadState('c1'), {
+      type: 'chat.config.updated',
+      chat: makeChat({
+        lastContextTokensInput: 151_000,
+        lastContextTotalTokens: 151_000,
+        lastContextMaxTokens: 967_000,
+      }),
+    });
+    expect(deriveContextPct(state, 200_000)).toBe(16);
+  });
+
+  it('still falls back to the catalog estimate when the chat has no persisted totals', () => {
+    const state = reduceChatThreadState(createChatThreadState('c1'), {
+      type: 'chat.config.updated',
+      chat: makeChat({ lastContextTokensInput: 50_000 }),
+    });
+    expect(deriveContextPct(state, 200_000)).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deriveContextPct — null when no data
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/src/features/review/__tests__/ReviewDiffView.test.tsx
+++ b/packages/ui/src/features/review/__tests__/ReviewDiffView.test.tsx
@@ -104,7 +104,7 @@ describe('ReviewDiffView', () => {
     mockGetWorkingDiff.mockResolvedValue({ original: 'old', modified: 'new', diff: '', source: 'git' });
     render(<ReviewDiffView port={31415} projectId="proj-1" chatId="chat-1" file="src/a.ts" onAppend={vi.fn()} />);
 
-    await waitFor(() => screen.queryByTestId('cm-diff-editor-stub'));
+    await screen.findByTestId('cm-diff-editor-stub');
 
     const submit = screen.getByTestId('review-comment-submit');
     expect((submit as HTMLButtonElement).disabled).toBe(true);
@@ -114,7 +114,7 @@ describe('ReviewDiffView', () => {
     mockGetWorkingDiff.mockResolvedValue({ original: 'old', modified: 'new', diff: '', source: 'git' });
     render(<ReviewDiffView port={31415} projectId="proj-1" chatId="chat-1" file="src/a.ts" onAppend={vi.fn()} />);
 
-    await waitFor(() => screen.queryByTestId('cm-diff-editor-stub'));
+    await screen.findByTestId('cm-diff-editor-stub');
 
     // Simulate a line click in CmDiffEditor
     capturedOnLineSelect?.({ line: 3, text: 'const x = 1;' });
@@ -127,7 +127,7 @@ describe('ReviewDiffView', () => {
     mockGetWorkingDiff.mockResolvedValue({ original: 'old', modified: 'new', diff: '', source: 'git' });
     render(<ReviewDiffView port={31415} projectId="proj-1" chatId="chat-1" file="src/a.ts" onAppend={vi.fn()} />);
 
-    await waitFor(() => screen.queryByTestId('cm-diff-editor-stub'));
+    await screen.findByTestId('cm-diff-editor-stub');
 
     capturedOnLineSelect?.({ line: 3, text: 'const x = 1;' });
 
@@ -142,7 +142,7 @@ describe('ReviewDiffView', () => {
     const onAppend = vi.fn();
     render(<ReviewDiffView port={31415} projectId="proj-1" chatId="chat-1" file="src/a.ts" onAppend={onAppend} />);
 
-    await waitFor(() => screen.queryByTestId('cm-diff-editor-stub'));
+    await screen.findByTestId('cm-diff-editor-stub');
 
     // Simulate clicking line 3 in CmDiffEditor
     capturedOnLineSelect?.({ line: 3, text: 'const x = 1;' });

--- a/scripts/setup-ports.sh
+++ b/scripts/setup-ports.sh
@@ -36,6 +36,7 @@ MAINFRAME_DATA_DIR=$MAINFRAME_DATA_DIR
 
 # Vite-prefixed mirrors so import.meta.env exposes them to the renderer.
 # Without these the renderer falls back to the production daemon port (31415).
+VITE_DAEMON_PORT=$DAEMON_PORT
 VITE_DAEMON_HTTP_PORT=$DAEMON_PORT
 VITE_DAEMON_WS_PORT=$DAEMON_PORT
 EOF
@@ -52,6 +53,14 @@ echo "Installing dependencies…"
 echo ""
 echo "Building @qlan-ro/mainframe-types…"
 (cd "$PROJECT_ROOT" && pnpm --filter @qlan-ro/mainframe-types build)
+
+# --minimal: browser-mode test runs need only ports + install + types
+# (daemon runs from source via tsx; Vite serves the renderer from source).
+if [ "${1:-}" = "--minimal" ]; then
+  echo ""
+  echo "Minimal setup complete (skipped core/electron builds)."
+  exit 0
+fi
 
 echo ""
 echo "Building @qlan-ro/mainframe-core…"


### PR DESCRIPTION
## Problem (todo #197)

The context meter sat near 100% and never showed compaction. A prior debugging session (INVESTIGATION-197 / memory `context-indicator-bugs-2026-07-07`) traced it: the live path (`result` → `get_context_usage` → `chat.contextUsage`) is healthy — the wrong number is the **fallback estimate** (`lastContextTokensInput ÷ catalog contextWindow`) computed against a wrong window (catalog guessed 200k for `claude-sonnet-5`; the CLI reports 967k usable), and the estimate was never reconciled because `chat.contextUsage` was ephemeral.

## Fixes

1. **Persist the CLI truth** — `onContextUsage` now writes `last_context_total_tokens` / `last_context_max_tokens` on the chat row and re-broadcasts `chat.updated` (ungated, unlike the subscriber-gated `chat.contextUsage`). The UI reducer adopts the persisted totals into `contextUsage` on `chat.config.updated`, so reloads and dormant-chat turns show the CLI's own ratio instead of a catalog guess. The catalog estimate survives only for chats that never reported (codex, legacy rows).
2. **Per-entry `resolvedModel` in catalog enrichment** — the probe keeps each entry's own `resolvedModel`; `[1m]` is honored on either the id or the resolution (live-probed: `claude-fable-5[1m]` resolves to a bare `claude-fable-5`), and the static catalog is also consulted by resolution (`haiku` → `claude-haiku-4-5-20251001`). Added `claude-sonnet-5` (1M) to the static catalog — live-verified via `get_context_usage` (`maxTokens: 967000` = 1M minus the CLI reserve).
3. **Subagent usage no longer pollutes the estimate** — the `parent_tool_use_id` early-return now runs before usage capture in `assistant-event.ts`.
4. **Zero-usage guard** — `<synthetic>` all-zero assistant messages no longer clobber `lastAssistantUsage`, and a zero/unknown turn (`EMPTY_USAGE`, error results) no longer resets the stored context size to 0.
5. **Cumulative usage is not a context size** — the claude adapter reports `contextTokens` (last parent assistant usage) separately; the result event's QueryEngine multi-call total is used only for cost/token accounting. Codex keeps its existing `usage.input_tokens` fallback.

`SessionResult.contextTokens`, `AdapterModel.resolvedModel`, and the two `Chat` fields are additive (mobile-safe); DB migration is additive `ALTER TABLE`.

## Tests

TDD red→green throughout: `adapter-enrich` (+5), `probe-models` (+1), `claude-events` (+4), `event-handler` (+6), `chat-thread-state-session-bar` (+5), `session-bar-status` (+2). Verified: 77 core + 209 UI tests pass in the affected files, full core suite green (title-generation is a real-CLI integration test, flaky only under full-suite load), UI+core typecheck clean, 0 lint errors.

## Needs live verification (not addressed here by design)

- **Compacting label**: `state.compacting` is tracked but no component renders it — the textual status labels were deleted with the ChatSessionBar in the 2026-07-02 density pass. Re-adding a "Compacting…" indicator is a design decision for the header; flagging instead of guessing.
- **Fix 6 (display)**: the `Math.min(100, …)` clamp and a live-vs-estimate visual distinction are left as-is — with the persisted-truth path the >100% "wrong denominator" signal should no longer occur, and the visual treatment needs the live app to judge.
- End-to-end behavior of the persisted fallback (open app → meter shows CLI ratio before any turn) needs a live daemon+UI run.

Generated with Claude Code.