### PR TITLE
feat: missing-transcript detection + unified degraded-chat recovery

### DIFF
--- a/.changeset/degraded-chat-recovery.md
+++ b/.changeset/degraded-chat-recovery.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-ui': minor
+---
+
+Detect deleted CLI transcripts and unify degraded-chat recovery: a persisted `transcriptMissing` flag (new `transcript_missing` column) reconciled on history load and on the periodic scan, a typed `{ messages, transcriptMissing }` history payload, recovery routes (recreate-worktree, continue-here, continue-in-project-root), and one degraded-chat card in the thread replacing the composer worktree banner, with a unified sidebar marker.

--- a/packages/core/src/__tests__/daemon-restart-messages.test.ts
+++ b/packages/core/src/__tests__/daemon-restart-messages.test.ts
@@ -239,9 +239,9 @@ describe('message resilience across daemon restart', () => {
 
     expect(json.success).toBe(true);
 
-    // REST now returns DisplayMessage[] which groups consecutive assistant turns.
-    // All 10 text blocks should be present (merged into grouped turns).
-    const allTexts = json.data.flatMap((m: any) =>
+    // REST now returns { messages, transcriptMissing }; messages groups
+    // consecutive assistant turns. All 10 text blocks should be present.
+    const allTexts = json.data.messages.flatMap((m: any) =>
       m.content.filter((c: any) => c.type === 'text').map((c: any) => c.text),
     );
     for (let i = 1; i <= 10; i++) {

--- a/packages/core/src/chat/__tests__/chat-manager-degraded.test.ts
+++ b/packages/core/src/chat/__tests__/chat-manager-degraded.test.ts
@@ -1,0 +1,103 @@
+import Database from 'better-sqlite3';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatMessage, DaemonEvent } from '@qlan-ro/mainframe-types';
+import { ChatsRepository } from '../../db/chats.js';
+import { ProjectsRepository } from '../../db/projects.js';
+import { initializeSchema } from '../../db/schema.js';
+import { ChatManager } from '../chat-manager.js';
+import { BackgroundTaskTracker } from '../../background-tasks/tracker.js';
+
+const HISTORY_MESSAGE: ChatMessage = {
+  id: 'm1',
+  chatId: 'sess-1',
+  type: 'assistant',
+  content: [{ type: 'text', text: 'hello from history' }],
+  timestamp: '2026-07-08T00:00:00.000Z',
+};
+
+describe('ChatManager — degraded transcript handling', () => {
+  let chats: ChatsRepository;
+  let projects: ProjectsRepository;
+  let events: DaemonEvent[];
+  let mgr: ChatManager;
+  let transcriptPresent: boolean;
+  let history: ChatMessage[];
+  let projectId: string;
+  let chatId: string;
+
+  beforeEach(() => {
+    const sqlite = new Database(':memory:');
+    initializeSchema(sqlite);
+    chats = new ChatsRepository(sqlite);
+    projects = new ProjectsRepository(sqlite);
+    events = [];
+    transcriptPresent = true;
+    history = [];
+
+    const adapter = {
+      isTranscriptPresent: vi.fn(async () => transcriptPresent),
+      createSession: vi.fn(() => ({ loadHistory: vi.fn(async () => history) })),
+    };
+    const db: any = { chats, projects, settings: { get: vi.fn() } };
+    const adapters: any = { get: vi.fn(() => adapter), getAll: vi.fn(() => []), list: vi.fn(() => []) };
+    mgr = new ChatManager(db, adapters, new BackgroundTaskTracker(), undefined, (e) => events.push(e));
+
+    projectId = projects.create('/project/degraded').id;
+    const chat = chats.create(projectId, 'claude');
+    chatId = chat.id;
+    chats.update(chatId, { claudeSessionId: 'sess-1' });
+  });
+
+  it('getDisplayMessages reports transcriptMissing:true, persists the flag, and emits chat.updated', async () => {
+    transcriptPresent = false;
+    const result = await mgr.getDisplayMessages(chatId);
+
+    expect(result.messages).toEqual([]);
+    expect(result.transcriptMissing).toBe(true);
+    expect(chats.get(chatId)?.transcriptMissing).toBe(true);
+    expect(events.some((e) => e.type === 'chat.updated' && e.chat.transcriptMissing === true)).toBe(true);
+  });
+
+  it('getDisplayMessages returns history with transcriptMissing:false and self-heals a stale flag', async () => {
+    chats.update(chatId, { transcriptMissing: true });
+    transcriptPresent = true;
+    history = [HISTORY_MESSAGE];
+
+    const result = await mgr.getDisplayMessages(chatId);
+
+    expect(result.transcriptMissing).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(chats.get(chatId)?.transcriptMissing).toBe(false);
+  });
+
+  it('sendMessage with the flag set clears the dead session identity and spawns fresh', async () => {
+    chats.update(chatId, {
+      transcriptMissing: true,
+      sessionFilePath: '/home/u/.claude/projects/x/sess-1.jsonl',
+    });
+
+    const session = {
+      isSpawned: true,
+      supportsReplayAck: true,
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const startChat = vi.fn().mockImplementation(async () => {
+      (mgr as any).activeChats.set(chatId, { chat: chats.get(chatId), session });
+    });
+    (mgr as any).lifecycle = {
+      waitForInterrupt: vi.fn().mockResolvedValue(undefined),
+      startChat,
+      doGenerateTitle: vi.fn().mockResolvedValue(undefined),
+      getLoadingChats: () => new Map(),
+    };
+
+    await mgr.sendMessage(chatId, 'continue after transcript loss');
+
+    const row = chats.get(chatId);
+    expect(row?.claudeSessionId).toBeNull();
+    expect(row?.sessionFilePath).toBeNull();
+    expect(row?.transcriptMissing).toBe(false);
+    expect(startChat).toHaveBeenCalledWith(chatId);
+    expect(session.sendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/chat/__tests__/degraded-recovery.test.ts
+++ b/packages/core/src/chat/__tests__/degraded-recovery.test.ts
@@ -1,0 +1,139 @@
+import Database from 'better-sqlite3';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Chat } from '@qlan-ro/mainframe-types';
+import { ChatsRepository } from '../../db/chats.js';
+import { ProjectsRepository } from '../../db/projects.js';
+import { initializeSchema } from '../../db/schema.js';
+import {
+  continueHere,
+  continueInProjectRoot,
+  recreateChatWorktree,
+  type DegradedRecoveryDeps,
+} from '../degraded-recovery.js';
+
+describe('degraded-recovery', () => {
+  let chats: ChatsRepository;
+  let projects: ProjectsRepository;
+  let projectId: string;
+  let chatId: string;
+  let synced: Array<{ chatId: string; partial: Partial<Chat> }>;
+  let updatedIds: string[];
+  let clearedMessageIds: string[];
+  let killedSessions: number;
+  let activeSession: { isSpawned: boolean; kill: () => Promise<void> } | null;
+  let branchExists: ReturnType<typeof vi.fn<(projectPath: string, branchName: string) => Promise<boolean>>>;
+  let addWorktree: ReturnType<
+    typeof vi.fn<(projectPath: string, worktreePath: string, branchName: string) => Promise<void>>
+  >;
+
+  function makeDeps(): DegradedRecoveryDeps {
+    return {
+      db: { chats, projects } as unknown as DegradedRecoveryDeps['db'],
+      getActiveChat: (id) =>
+        id === chatId && activeSession ? ({ chat: chats.get(chatId)!, session: activeSession } as never) : undefined,
+      syncChatFields: (id, partial) => synced.push({ chatId: id, partial }),
+      emitChatUpdated: (id) => updatedIds.push(id),
+      clearMessages: (id) => clearedMessageIds.push(id),
+      git: { branchExists, addWorktree },
+    };
+  }
+
+  beforeEach(() => {
+    const sqlite = new Database(':memory:');
+    initializeSchema(sqlite);
+    chats = new ChatsRepository(sqlite);
+    projects = new ProjectsRepository(sqlite);
+    projectId = projects.create('/project/rec').id;
+    chatId = chats.create(projectId, 'claude').id;
+    synced = [];
+    updatedIds = [];
+    clearedMessageIds = [];
+    killedSessions = 0;
+    activeSession = null;
+    branchExists = vi.fn(async () => true);
+    addWorktree = vi.fn(async () => undefined);
+  });
+
+  describe('continueHere', () => {
+    it('clears the dead session identity, drops cached messages, and broadcasts', async () => {
+      chats.update(chatId, {
+        claudeSessionId: 'dead-sess',
+        sessionFilePath: '/x/dead-sess.jsonl',
+        transcriptMissing: true,
+      });
+
+      await continueHere(makeDeps(), chatId);
+
+      const row = chats.get(chatId);
+      expect(row?.claudeSessionId).toBeNull();
+      expect(row?.sessionFilePath).toBeNull();
+      expect(row?.transcriptMissing).toBe(false);
+      expect(clearedMessageIds).toEqual([chatId]);
+      expect(updatedIds).toEqual([chatId]);
+      expect(synced).toEqual([
+        { chatId, partial: { claudeSessionId: undefined, sessionFilePath: undefined, transcriptMissing: false } },
+      ]);
+    });
+
+    it('kills a spawned session so the next send starts fresh', async () => {
+      chats.update(chatId, { claudeSessionId: 'dead-sess', transcriptMissing: true });
+      activeSession = {
+        isSpawned: true,
+        kill: async () => {
+          killedSessions += 1;
+        },
+      };
+
+      await continueHere(makeDeps(), chatId);
+      expect(killedSessions).toBe(1);
+    });
+
+    it('rejects for an unknown chat', async () => {
+      await expect(continueHere(makeDeps(), 'nope')).rejects.toThrow(/not found/i);
+    });
+  });
+
+  describe('continueInProjectRoot', () => {
+    it('detaches the chat from its deleted worktree and broadcasts', async () => {
+      chats.update(chatId, { worktreePath: '/project/rec/.worktrees/feat-x', branchName: 'feat-x' });
+
+      await continueInProjectRoot(makeDeps(), chatId);
+
+      const row = chats.get(chatId);
+      expect(row?.worktreePath).toBeUndefined();
+      expect(row?.branchName).toBeUndefined();
+      expect(updatedIds).toEqual([chatId]);
+      expect(synced).toEqual([{ chatId, partial: { worktreePath: undefined, branchName: undefined } }]);
+    });
+
+    it('rejects when the chat has no worktree', async () => {
+      await expect(continueInProjectRoot(makeDeps(), chatId)).rejects.toThrow(/no worktree/i);
+    });
+  });
+
+  describe('recreateChatWorktree', () => {
+    it('recreates the worktree at the stored path from the stored branch and broadcasts', async () => {
+      chats.update(chatId, { worktreePath: '/project/rec/.worktrees/feat-x', branchName: 'feat-x' });
+
+      await recreateChatWorktree(makeDeps(), chatId);
+
+      expect(addWorktree).toHaveBeenCalledWith('/project/rec', '/project/rec/.worktrees/feat-x', 'feat-x');
+      expect(updatedIds).toEqual([chatId]);
+    });
+
+    it('fails with a 409 and a clear message when the branch no longer exists', async () => {
+      chats.update(chatId, { worktreePath: '/project/rec/.worktrees/feat-x', branchName: 'feat-x' });
+      branchExists.mockResolvedValue(false);
+
+      await expect(recreateChatWorktree(makeDeps(), chatId)).rejects.toMatchObject({
+        message: expect.stringMatching(/branch "feat-x" no longer exists/i),
+        statusCode: 409,
+      });
+      expect(addWorktree).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the chat has no stored worktree/branch', async () => {
+      await expect(recreateChatWorktree(makeDeps(), chatId)).rejects.toThrow(/no worktree/i);
+    });
+  });
+});

--- a/packages/core/src/chat/__tests__/external-session-sweep.test.ts
+++ b/packages/core/src/chat/__tests__/external-session-sweep.test.ts
@@ -1,0 +1,47 @@
+import Database from 'better-sqlite3';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Chat } from '@qlan-ro/mainframe-types';
+import { ChatsRepository } from '../../db/chats.js';
+import { ProjectsRepository } from '../../db/projects.js';
+import { initializeSchema } from '../../db/schema.js';
+import { ExternalSessionService } from '../external-session-service.js';
+
+describe('ExternalSessionService.sweepTranscriptPresence', () => {
+  let chats: ChatsRepository;
+  let projects: ProjectsRepository;
+  let projectId: string;
+  let reconcile: ReturnType<typeof vi.fn<(chat: Chat) => Promise<boolean>>>;
+  let service: ExternalSessionService;
+
+  beforeEach(() => {
+    const sqlite = new Database(':memory:');
+    initializeSchema(sqlite);
+    chats = new ChatsRepository(sqlite);
+    projects = new ProjectsRepository(sqlite);
+    projectId = projects.create('/project/sweep').id;
+    reconcile = vi.fn().mockResolvedValue(false);
+    const db: any = { chats, projects, settings: { get: vi.fn() } };
+    const adapters: any = { getAll: vi.fn(() => []) };
+    service = new ExternalSessionService(db, adapters, () => {}, reconcile);
+  });
+
+  it('reconciles every non-archived chat with a CLI session id', async () => {
+    const withSession = chats.create(projectId, 'claude');
+    chats.update(withSession.id, { claudeSessionId: 'sess-a' });
+    const draft = chats.create(projectId, 'claude'); // no session id — skipped
+    const archived = chats.create(projectId, 'claude');
+    chats.update(archived.id, { claudeSessionId: 'sess-b', status: 'archived' });
+
+    await service.sweepTranscriptPresence(projectId);
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile.mock.calls[0][0]).toMatchObject({ id: withSession.id });
+    expect(reconcile.mock.calls.every(([chat]) => chat.id !== draft.id && chat.id !== archived.id)).toBe(true);
+  });
+
+  it('is a no-op when no reconcile callback was provided', async () => {
+    const db: any = { chats, projects, settings: { get: vi.fn() } };
+    const bare = new ExternalSessionService(db, { getAll: () => [] } as any, () => {});
+    await expect(bare.sweepTranscriptPresence(projectId)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/chat/__tests__/transcript-presence.test.ts
+++ b/packages/core/src/chat/__tests__/transcript-presence.test.ts
@@ -1,0 +1,117 @@
+import Database from 'better-sqlite3';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import { ChatsRepository } from '../../db/chats.js';
+import { ProjectsRepository } from '../../db/projects.js';
+import { initializeSchema } from '../../db/schema.js';
+import { reconcileTranscriptPresence, type TranscriptPresenceDeps } from '../transcript-presence.js';
+
+describe('reconcileTranscriptPresence', () => {
+  let chats: ChatsRepository;
+  let projects: ProjectsRepository;
+  let projectId: string;
+  let events: DaemonEvent[];
+  let synced: Array<{ chatId: string; partial: Partial<Chat> }>;
+  let presence: boolean | null;
+
+  function makeDeps(adapterHasPredicate = true): TranscriptPresenceDeps {
+    const adapter = adapterHasPredicate ? { isTranscriptPresent: vi.fn(async () => presence) } : {};
+    return {
+      db: { chats, projects } as unknown as TranscriptPresenceDeps['db'],
+      adapters: { get: () => adapter } as unknown as TranscriptPresenceDeps['adapters'],
+      emitEvent: (e) => events.push(e),
+      syncChatFields: (chatId, partial) => synced.push({ chatId, partial }),
+    };
+  }
+
+  function makeChat(overrides: Partial<Chat> = {}): Chat {
+    const chat = chats.create(projectId, 'claude');
+    const updates: Partial<Chat> = { claudeSessionId: 'sess-1', ...overrides };
+    chats.update(chat.id, updates);
+    return chats.get(chat.id)!;
+  }
+
+  beforeEach(() => {
+    const db = new Database(':memory:');
+    initializeSchema(db);
+    chats = new ChatsRepository(db);
+    projects = new ProjectsRepository(db);
+    projectId = projects.create('/project/p1').id;
+    events = [];
+    synced = [];
+    presence = true;
+  });
+
+  it('sets the flag, persists it, syncs memory, and emits chat.updated when the transcript is gone', async () => {
+    presence = false;
+    const chat = makeChat();
+    const result = await reconcileTranscriptPresence(makeDeps(), chat);
+
+    expect(result).toBe(true);
+    expect(chat.transcriptMissing).toBe(true);
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(true);
+    expect(synced).toEqual([{ chatId: chat.id, partial: { transcriptMissing: true } }]);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'chat.updated', chat: { id: chat.id, transcriptMissing: true } });
+  });
+
+  it('clears the flag when the transcript reappears (self-healing)', async () => {
+    presence = true;
+    const chat = makeChat({ transcriptMissing: true });
+    const result = await reconcileTranscriptPresence(makeDeps(), chat);
+
+    expect(result).toBe(false);
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'chat.updated', chat: { id: chat.id, transcriptMissing: false } });
+  });
+
+  it('does not re-persist or re-emit when the state is unchanged (idempotent)', async () => {
+    presence = false;
+    const chat = makeChat({ transcriptMissing: true });
+    const result = await reconcileTranscriptPresence(makeDeps(), chat);
+
+    expect(result).toBe(true);
+    expect(events).toHaveLength(0);
+    expect(synced).toHaveLength(0);
+  });
+
+  it('skips chats with an active run (CLI owns the file mid-session)', async () => {
+    presence = false;
+    const chat = makeChat({ processState: 'working' });
+    const result = await reconcileTranscriptPresence(makeDeps(), chat);
+
+    expect(result).toBe(false);
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(false);
+    expect(events).toHaveLength(0);
+  });
+
+  it('treats a chat without a session id as new, and clears a stale flag on it', async () => {
+    const chat = chats.create(projectId, 'claude');
+    chats.update(chat.id, { transcriptMissing: true });
+    const loaded = chats.get(chat.id)!;
+
+    const result = await reconcileTranscriptPresence(makeDeps(), loaded);
+    expect(result).toBe(false);
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(false);
+  });
+
+  it('skips adapters that do not implement the predicate', async () => {
+    presence = false;
+    const chat = makeChat();
+    const result = await reconcileTranscriptPresence(makeDeps(false), chat);
+
+    expect(result).toBe(false);
+    expect(events).toHaveLength(0);
+  });
+
+  it('skips when presence cannot be determined (predicate returns null)', async () => {
+    presence = null;
+    const chat = makeChat({ transcriptMissing: true });
+    const result = await reconcileTranscriptPresence(makeDeps(), chat);
+
+    expect(result).toBe(true);
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(true);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -1,5 +1,6 @@
 import type {
   Chat,
+  ChatHistoryPayload,
   ChatMessage,
   ControlRequest,
   ControlResponse,
@@ -36,6 +37,13 @@ import { findMainframeCommand } from '../commands/registry.js';
 import { prepareMessagesForClient } from '../messages/display-pipeline.js';
 import { resolveTuningForChat } from './resolve-tuning-for-chat.js';
 import { writeWorkspaceTrust } from '../plugins/builtin/claude/trust-store.js';
+import { reconcileTranscriptPresence } from './transcript-presence.js';
+import {
+  continueHere,
+  continueInProjectRoot,
+  recreateChatWorktree,
+  type DegradedRecoveryDeps,
+} from './degraded-recovery.js';
 
 const logger = createChildLogger('chat:manager');
 
@@ -120,7 +128,12 @@ export class ChatManager {
       emitEvent: (event) => this.emitEvent(event),
       applyTuning: (chatId) => this.applyTuning(chatId),
     });
-    this.externalSessions = new ExternalSessionService(this.db, this.adapters, (e) => this.emitEvent(e));
+    this.externalSessions = new ExternalSessionService(
+      this.db,
+      this.adapters,
+      (e) => this.emitEvent(e),
+      (chat) => this.reconcileTranscript(chat),
+    );
     this.idleScanner = new IdleSessionScanner(this.activeChats);
     this.idleScanner.start();
   }
@@ -259,6 +272,12 @@ export class ChatManager {
       this.emitEvent({ type: 'message.added', chatId, message: errorMsg });
       this.eventHandler.emitDisplay(chatId);
       return;
+    }
+
+    // Transcript gone + no live CLI: `--resume` would target a dead session id.
+    // Apply the same reset as the card's "Continue here" so this send spawns fresh.
+    if (chat?.transcriptMissing && !this.activeChats.get(chatId)?.session?.isSpawned) {
+      await this.continueHere(chatId);
     }
 
     // Wait for any in-flight interrupt to finish before checking spawn state.
@@ -695,12 +714,59 @@ export class ChatManager {
     }
   }
 
-  async getDisplayMessages(chatId: string): Promise<DisplayMessage[]> {
+  /**
+   * Display history + transcript presence in one typed result, so the REST
+   * route (and the UI) can tell an empty thread from a deleted transcript.
+   * Reconciling here persists flag flips and broadcasts `chat.updated`.
+   */
+  async getDisplayMessages(chatId: string): Promise<ChatHistoryPayload> {
     const raw = await this.getMessages(chatId);
     const chat = this.getChat(chatId);
     const adapter = chat ? this.adapters.get(chat.adapterId) : undefined;
     const categories = adapter?.getToolCategories?.();
-    return prepareMessagesForClient(raw, categories);
+    const transcriptMissing = chat ? await this.reconcileTranscript(chat) : false;
+    return { messages: prepareMessagesForClient(raw, categories), transcriptMissing };
+  }
+
+  /** Reconcile the persisted transcriptMissing flag against the transcript file on disk. */
+  async reconcileTranscript(chat: Chat): Promise<boolean> {
+    return reconcileTranscriptPresence(
+      {
+        db: this.db,
+        adapters: this.adapters,
+        emitEvent: (e) => this.emitEvent(e),
+        syncChatFields: (id, partial) => this.syncChatFields(id, partial),
+      },
+      chat,
+    );
+  }
+
+  private recoveryDeps(): DegradedRecoveryDeps {
+    return {
+      db: this.db,
+      getActiveChat: (id) => this.activeChats.get(id),
+      syncChatFields: (id, partial) => this.syncChatFields(id, partial),
+      emitChatUpdated: (id) => this.emitChatUpdated(id),
+      clearMessages: (id) => {
+        this.messages.delete(id);
+        this.eventHandler.clearDisplayCache(id);
+      },
+    };
+  }
+
+  /** Forget the dead CLI session so the next send spawns fresh in the same chat row. */
+  async continueHere(chatId: string): Promise<void> {
+    return continueHere(this.recoveryDeps(), chatId);
+  }
+
+  /** Detach the chat from its deleted worktree and rebind it to the project root. */
+  async continueInProjectRoot(chatId: string): Promise<void> {
+    return continueInProjectRoot(this.recoveryDeps(), chatId);
+  }
+
+  /** Re-add the deleted worktree at its stored path from the stored branch (409 when branch gone). */
+  async recreateWorktree(chatId: string): Promise<void> {
+    return recreateChatWorktree(this.recoveryDeps(), chatId);
   }
 
   isChatRunning(chatId: string): boolean {

--- a/packages/core/src/chat/degraded-recovery.ts
+++ b/packages/core/src/chat/degraded-recovery.ts
@@ -1,0 +1,85 @@
+/**
+ * Degraded-chat recovery actions (missing transcript / missing worktree).
+ *
+ * Backs the daemon recovery routes and the degraded-chat UI card:
+ * - `continueHere` — forget the dead CLI session so the next send spawns fresh
+ *   in the same chat row (title/branch/worktree/project metadata carry over).
+ * - `continueInProjectRoot` — detach a chat from its deleted worktree and
+ *   rebind it to the main checkout.
+ * - `recreateChatWorktree` — re-add the worktree at its stored path from the
+ *   stored branch; fails clearly (409) when the branch is gone.
+ */
+import type { Chat } from '@qlan-ro/mainframe-types';
+import type { ChatsRepository } from '../db/chats.js';
+import type { ProjectsRepository } from '../db/projects.js';
+import type { ActiveChat } from './types.js';
+import { branchExists, addWorktreeForBranch } from '../workspace/worktree.js';
+
+export interface DegradedRecoveryGit {
+  branchExists(projectPath: string, branchName: string): Promise<boolean>;
+  addWorktree(projectPath: string, worktreePath: string, branchName: string): Promise<void>;
+}
+
+export interface DegradedRecoveryDeps {
+  db: { chats: ChatsRepository; projects: ProjectsRepository };
+  getActiveChat(chatId: string): ActiveChat | undefined;
+  syncChatFields(chatId: string, partial: Partial<Chat>): void;
+  emitChatUpdated(chatId: string): void;
+  /** Drop the in-memory message + display caches (the history is gone for good). */
+  clearMessages(chatId: string): void;
+  /** Injectable for tests; defaults to the real git worktree ops. */
+  git?: DegradedRecoveryGit;
+}
+
+const defaultGit: DegradedRecoveryGit = { branchExists, addWorktree: addWorktreeForBranch };
+
+function requireChat(deps: DegradedRecoveryDeps, chatId: string): Chat {
+  const chat = deps.db.chats.get(chatId);
+  if (!chat) throw new Error(`Chat ${chatId} not found`);
+  return chat;
+}
+
+/** Kill a spawned CLI session so the next send respawns with the recovered config. */
+async function killSpawnedSession(deps: DegradedRecoveryDeps, chatId: string): Promise<void> {
+  const active = deps.getActiveChat(chatId);
+  if (active?.session?.isSpawned) {
+    await active.session.kill();
+    active.session = null;
+  }
+}
+
+export async function continueHere(deps: DegradedRecoveryDeps, chatId: string): Promise<void> {
+  requireChat(deps, chatId);
+  await killSpawnedSession(deps, chatId);
+  deps.db.chats.clearSession(chatId);
+  deps.syncChatFields(chatId, { claudeSessionId: undefined, sessionFilePath: undefined, transcriptMissing: false });
+  deps.clearMessages(chatId);
+  deps.emitChatUpdated(chatId);
+}
+
+export async function continueInProjectRoot(deps: DegradedRecoveryDeps, chatId: string): Promise<void> {
+  const chat = requireChat(deps, chatId);
+  if (!chat.worktreePath) throw new Error('Chat has no worktree');
+  await killSpawnedSession(deps, chatId);
+  deps.db.chats.clearWorktree(chatId);
+  deps.syncChatFields(chatId, { worktreePath: undefined, branchName: undefined });
+  deps.emitChatUpdated(chatId);
+}
+
+export async function recreateChatWorktree(deps: DegradedRecoveryDeps, chatId: string): Promise<void> {
+  const chat = requireChat(deps, chatId);
+  if (!chat.worktreePath || !chat.branchName) throw new Error('Chat has no worktree to recreate');
+  const project = deps.db.projects.get(chat.projectId);
+  if (!project) throw new Error(`Project ${chat.projectId} not found`);
+
+  const git = deps.git ?? defaultGit;
+  if (!(await git.branchExists(project.path, chat.branchName))) {
+    throw Object.assign(
+      new Error(`Branch "${chat.branchName}" no longer exists — continue in the project root instead`),
+      { statusCode: 409 },
+    );
+  }
+  await git.addWorktree(project.path, chat.worktreePath, chat.branchName);
+  // enrichChat recomputes worktreeMissing from disk on read, so a plain re-emit clears the flag.
+  deps.emitChatUpdated(chatId);
+}

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -16,7 +16,26 @@ export class ExternalSessionService {
     private db: DatabaseManager,
     private adapters: AdapterRegistry,
     private emitEvent: (event: DaemonEvent) => void,
+    /** ChatManager.reconcileTranscript — flags chats whose transcript vanished (degraded-chat sweep). */
+    private reconcileTranscript?: (chat: Chat) => Promise<boolean>,
   ) {}
+
+  /**
+   * Reconcile transcript presence for every non-archived chat of the project
+   * that has a CLI session id, so the sidebar degraded marker appears without
+   * the chat being opened. Runs on the same cadence as the auto-scan.
+   */
+  async sweepTranscriptPresence(projectId: string): Promise<void> {
+    if (!this.reconcileTranscript) return;
+    const candidates = this.db.chats.list(projectId).filter((c) => c.status !== 'archived' && c.claudeSessionId);
+    for (const chat of candidates) {
+      try {
+        await this.reconcileTranscript(chat);
+      } catch (err) {
+        logger.warn({ err, chatId: chat.id }, 'transcript presence sweep failed');
+      }
+    }
+  }
 
   /** Page of importable external sessions merged and sorted across all adapters for a project. */
   async scanPage(projectId: string, offset: number, limit: number): Promise<ExternalSessionPage> {
@@ -121,11 +140,13 @@ export class ExternalSessionService {
     this.stopAutoScan(projectId);
 
     this.emitCount(projectId).catch((err) => logger.warn({ err, projectId }, 'Initial external session scan failed'));
+    void this.sweepTranscriptPresence(projectId);
 
     const interval = setInterval(() => {
       this.emitCount(projectId).catch((err) =>
         logger.warn({ err, projectId }, 'Periodic external session scan failed'),
       );
+      void this.sweepTranscriptPresence(projectId);
     }, SCAN_INTERVAL_MS);
 
     this.scanIntervals.set(projectId, interval);

--- a/packages/core/src/chat/transcript-presence.ts
+++ b/packages/core/src/chat/transcript-presence.ts
@@ -1,0 +1,77 @@
+/**
+ * Transcript-presence reconciliation (degraded-chat detection).
+ *
+ * The CLI owns the transcript file (Claude `~/.claude/projects/...jsonl`,
+ * Codex `~/.codex/sessions/...`); retention cleanup or manual deletion leaves
+ * the Mainframe chat row behind with a dead `--resume` target. This helper
+ * stats the transcript via the adapter predicate and keeps the persisted
+ * `transcript_missing` flag in sync — set when the file is gone, cleared when
+ * it reappears (self-healing). Runs on history load and on the periodic
+ * external-session sweep; idempotent, so scan/load races are harmless.
+ */
+import type { Adapter, Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { ChatsRepository } from '../db/chats.js';
+import type { ProjectsRepository } from '../db/projects.js';
+import { createChildLogger } from '../logger.js';
+
+const log = createChildLogger('chat:transcript-presence');
+
+export interface TranscriptPresenceDeps {
+  db: { chats: ChatsRepository; projects: ProjectsRepository };
+  adapters: { get(adapterId: string): Adapter | undefined };
+  emitEvent: (event: DaemonEvent) => void;
+  /** Mirror the flag into the in-memory active-chat cache (ChatManager.syncChatFields). */
+  syncChatFields: (chatId: string, partial: Partial<Chat>) => void;
+}
+
+/**
+ * Reconcile the persisted `transcriptMissing` flag against the transcript file
+ * on disk. Returns the current missing-state after reconciliation.
+ *
+ * Skips (returns the existing flag unchanged) when:
+ * - the chat has an active run — the CLI owns the file mid-session;
+ * - the adapter has no `isTranscriptPresent` predicate;
+ * - presence cannot be determined (predicate returns `null` or throws).
+ */
+export async function reconcileTranscriptPresence(deps: TranscriptPresenceDeps, chat: Chat): Promise<boolean> {
+  const current = chat.transcriptMissing ?? false;
+
+  if (chat.processState === 'working') return current;
+
+  // A chat that never spawned a CLI session is new, not degraded — clear any stale flag.
+  if (!chat.claudeSessionId) {
+    if (current) applyFlag(deps, chat, false);
+    return false;
+  }
+
+  const adapter = deps.adapters.get(chat.adapterId);
+  if (!adapter?.isTranscriptPresent) return current;
+
+  const project = deps.db.projects.get(chat.projectId);
+  if (!project) return current;
+
+  let present: boolean | null;
+  try {
+    present = await adapter.isTranscriptPresent(
+      chat.claudeSessionId,
+      chat.worktreePath ?? project.path,
+      chat.sessionFilePath ?? null,
+    );
+  } catch (err) {
+    log.warn({ err, chatId: chat.id, adapterId: chat.adapterId }, 'isTranscriptPresent failed');
+    return current;
+  }
+  if (present === null) return current;
+
+  const missing = !present;
+  if (missing !== current) applyFlag(deps, chat, missing);
+  return missing;
+}
+
+/** Persist the flipped flag, mirror it in memory, and broadcast chat.updated. */
+function applyFlag(deps: TranscriptPresenceDeps, chat: Chat, missing: boolean): void {
+  deps.db.chats.update(chat.id, { transcriptMissing: missing });
+  chat.transcriptMissing = missing;
+  deps.syncChatFields(chat.id, { transcriptMissing: missing });
+  deps.emitEvent({ type: 'chat.updated', chat });
+}

--- a/packages/core/src/db/__tests__/transcript-missing.test.ts
+++ b/packages/core/src/db/__tests__/transcript-missing.test.ts
@@ -1,0 +1,83 @@
+import Database from 'better-sqlite3';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChatsRepository } from '../chats.js';
+import { ProjectsRepository } from '../projects.js';
+import { initializeSchema } from '../schema.js';
+
+describe('chats.transcript_missing column', () => {
+  let db: Database.Database;
+  let chats: ChatsRepository;
+  let projects: ProjectsRepository;
+  let projectId: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    initializeSchema(db);
+    chats = new ChatsRepository(db);
+    projects = new ProjectsRepository(db);
+    projectId = projects.create('/project/transcripts').id;
+  });
+
+  it('migration adds the column to a pre-existing chats table', () => {
+    const legacy = new Database(':memory:');
+    legacy.exec(`
+      CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, path TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL, last_opened_at TEXT NOT NULL);
+      CREATE TABLE chats (id TEXT PRIMARY KEY, adapter_id TEXT NOT NULL, project_id TEXT NOT NULL,
+        title TEXT, claude_session_id TEXT, model TEXT, status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL, total_cost REAL DEFAULT 0,
+        total_tokens_input INTEGER DEFAULT 0, total_tokens_output INTEGER DEFAULT 0);
+    `);
+    initializeSchema(legacy);
+    const cols = legacy.pragma('table_info(chats)') as { name: string }[];
+    expect(cols.some((c) => c.name === 'transcript_missing')).toBe(true);
+    legacy.close();
+  });
+
+  it('defaults to false on new chats', () => {
+    const chat = chats.create(projectId, 'claude');
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(false);
+  });
+
+  it('persists transcriptMissing through update() and maps it back as a boolean', () => {
+    const chat = chats.create(projectId, 'claude');
+    chats.update(chat.id, { transcriptMissing: true });
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(true);
+    chats.update(chat.id, { transcriptMissing: false });
+    expect(chats.get(chat.id)?.transcriptMissing).toBe(false);
+  });
+
+  it('includes transcriptMissing in list() results', () => {
+    const chat = chats.create(projectId, 'claude');
+    chats.update(chat.id, { transcriptMissing: true });
+    const listed = chats.list(projectId).find((c) => c.id === chat.id);
+    expect(listed?.transcriptMissing).toBe(true);
+  });
+
+  describe('clearSession', () => {
+    it('clears session identity and resets the transcript flag', () => {
+      const chat = chats.create(projectId, 'claude');
+      chats.update(chat.id, {
+        claudeSessionId: 'dead-session',
+        sessionFilePath: '/home/u/.claude/projects/x/dead-session.jsonl',
+        transcriptMissing: true,
+      });
+      chats.clearSession(chat.id);
+      const loaded = chats.get(chat.id);
+      expect(loaded?.claudeSessionId).toBeNull();
+      expect(loaded?.sessionFilePath).toBeNull();
+      expect(loaded?.transcriptMissing).toBe(false);
+    });
+  });
+
+  describe('clearWorktree', () => {
+    it('clears worktree binding so the chat rebinds to the project root', () => {
+      const chat = chats.create(projectId, 'claude');
+      chats.update(chat.id, { worktreePath: '/project/.worktrees/feat-x', branchName: 'feat-x' });
+      chats.clearWorktree(chat.id);
+      const loaded = chats.get(chat.id);
+      expect(loaded?.worktreePath).toBeUndefined();
+      expect(loaded?.branchName).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/db/chats.ts
+++ b/packages/core/src/db/chats.ts
@@ -16,6 +16,7 @@ type RawChatRow = Omit<
   | 'fast'
   | 'ultracode'
   | 'adaptiveThinking'
+  | 'transcriptMissing'
 > & {
   mentions: string;
   modifiedFiles: string;
@@ -27,6 +28,7 @@ type RawChatRow = Omit<
   fast: number | null;
   ultracode: number | null;
   adaptive_thinking: number | null;
+  transcriptMissing: number;
 };
 
 const CHAT_SELECT_FIELDS = `
@@ -41,6 +43,7 @@ const CHAT_SELECT_FIELDS = `
   process_state as processState, todos, pinned, effort,
   plan_mode as planMode, detected_prs as detectedPrs,
   session_file_path as sessionFilePath,
+  transcript_missing as transcriptMissing,
   fast, ultracode, adaptive_thinking
 `.trim();
 
@@ -185,6 +188,7 @@ export class ChatsRepository {
     ultracode: { column: 'ultracode', transform: (v) => (v == null ? null : v ? 1 : 0) },
     adaptiveThinking: { column: 'adaptive_thinking', transform: (v) => (v == null ? null : v ? 1 : 0) },
     planMode: { column: 'plan_mode', transform: (v) => (v ? 1 : 0) },
+    transcriptMissing: { column: 'transcript_missing', transform: (v) => (v ? 1 : 0) },
   };
 
   update(id: string, updates: Partial<Chat>): void {
@@ -308,6 +312,24 @@ export class ChatsRepository {
   }
 
   /**
+   * Forget the CLI session bound to this chat: the next send spawns a fresh
+   * session instead of `--resume`ing a dead id. Used by degraded-chat recovery
+   * ("Continue here") after the CLI's transcript file was deleted.
+   */
+  clearSession(id: string): void {
+    this.db
+      .prepare(
+        'UPDATE chats SET claude_session_id = NULL, session_file_path = NULL, transcript_missing = 0 WHERE id = ?',
+      )
+      .run(id);
+  }
+
+  /** Detach the chat from its (deleted) worktree so it rebinds to the project root. */
+  clearWorktree(id: string): void {
+    this.db.prepare('UPDATE chats SET worktree_path = NULL, branch_name = NULL WHERE id = ?').run(id);
+  }
+
+  /**
    * Bulk-reset every chat whose process_state is 'working' to 'idle'.
    * Returns the number of rows affected.
    */
@@ -351,6 +373,7 @@ export class ChatsRepository {
       adaptiveThinking: parseNullableBool(row.adaptive_thinking),
       planMode: Boolean(row.planMode),
       detectedPrs: parseJsonColumn<DetectedPr[]>(row.detectedPrs, []),
+      transcriptMissing: Boolean(row.transcriptMissing),
     };
   }
 

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -114,7 +114,8 @@ export function initializeSchema(db: Database.Database): void {
   }
   if (!cols.some((c) => c.name === 'fast')) db.exec('ALTER TABLE chats ADD COLUMN fast INTEGER');
   if (!cols.some((c) => c.name === 'ultracode')) db.exec('ALTER TABLE chats ADD COLUMN ultracode INTEGER');
-  if (!cols.some((c) => c.name === 'adaptive_thinking')) db.exec('ALTER TABLE chats ADD COLUMN adaptive_thinking INTEGER');
+  if (!cols.some((c) => c.name === 'adaptive_thinking'))
+    db.exec('ALTER TABLE chats ADD COLUMN adaptive_thinking INTEGER');
   if (!cols.some((c) => c.name === 'detected_prs')) {
     db.exec("ALTER TABLE chats ADD COLUMN detected_prs TEXT DEFAULT '[]'");
   }
@@ -124,6 +125,9 @@ export function initializeSchema(db: Database.Database): void {
   }
   if (!cols.some((c) => c.name === 'session_file_path')) {
     db.exec('ALTER TABLE chats ADD COLUMN session_file_path TEXT');
+  }
+  if (!cols.some((c) => c.name === 'transcript_missing')) {
+    db.exec('ALTER TABLE chats ADD COLUMN transcript_missing INTEGER DEFAULT 0');
   }
 
   const sdkChats = db.prepare("SELECT COUNT(*) as n FROM chats WHERE adapter_id = 'claude-sdk'").get() as { n: number };

--- a/packages/core/src/plugins/builtin/claude/__tests__/transcript.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/transcript.test.ts
@@ -1,0 +1,34 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { isClaudeTranscriptPresent } from '../transcript.js';
+
+describe('isClaudeTranscriptPresent', () => {
+  let dir: string;
+  let existingJsonl: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'mf-claude-transcript-'));
+    existingJsonl = path.join(dir, 'session-1.jsonl');
+    await writeFile(existingJsonl, '{"type":"user"}\n');
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns true when the stored sessionFilePath exists', async () => {
+    await expect(isClaudeTranscriptPresent('session-1', '/nonexistent/project', existingJsonl)).resolves.toBe(true);
+  });
+
+  it('returns false when neither the stored path nor the derived path exists', async () => {
+    await expect(
+      isClaudeTranscriptPresent('no-such-session', '/nonexistent/project', path.join(dir, 'gone.jsonl')),
+    ).resolves.toBe(false);
+  });
+
+  it('returns false when no stored path is given and the derived path does not exist', async () => {
+    await expect(isClaudeTranscriptPresent('no-such-session', '/nonexistent/project')).resolves.toBe(false);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -16,6 +16,7 @@ import { BackgroundTaskTracker } from '../../../background-tasks/tracker.js';
 import { probeModels as doProbeModels } from './probe-models.js';
 import * as skills from './skills.js';
 import { listExternalSessions } from './external-sessions.js';
+import { isClaudeTranscriptPresent } from './transcript.js';
 import { ClaudePlanModeHandler } from './plan-mode-handler.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import { createChildLogger } from '../../../logger.js';
@@ -277,5 +278,13 @@ export class ClaudeAdapter implements Adapter {
     opts?: { offset?: number; limit?: number },
   ): Promise<ExternalSessionPage> {
     return listExternalSessions(projectPath, excludeSessionIds, opts);
+  }
+
+  async isTranscriptPresent(
+    sessionId: string,
+    projectPath: string,
+    sessionFilePath?: string | null,
+  ): Promise<boolean | null> {
+    return isClaudeTranscriptPresent(sessionId, projectPath, sessionFilePath);
   }
 }

--- a/packages/core/src/plugins/builtin/claude/history.ts
+++ b/packages/core/src/plugins/builtin/claude/history.ts
@@ -1,9 +1,9 @@
 import { createReadStream } from 'node:fs';
 import { access, constants, readdir } from 'node:fs/promises';
 import { createInterface } from 'node:readline';
-import { homedir } from 'node:os';
 import path from 'node:path';
 import type { ChatMessage, MessageContent, SkillFileEntry } from '@qlan-ro/mainframe-types';
+import { getSessionJsonlPath } from './transcript.js';
 import { resolveSkillPath } from './skill-path.js';
 import { createChildLogger } from '../../../logger.js';
 import {
@@ -21,12 +21,6 @@ import {
 } from './history-subagents.js';
 
 const log = createChildLogger('claude:history');
-
-function getSessionJsonlPath(sessionId: string, projectPath: string): { jsonlPath: string; projectDir: string } {
-  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
-  const projectDir = path.join(homedir(), '.claude', 'projects', encodedPath);
-  return { jsonlPath: path.join(projectDir, sessionId + '.jsonl'), projectDir };
-}
 
 export async function discoverSessionJsonlFiles(
   sessionId: string,

--- a/packages/core/src/plugins/builtin/claude/transcript.ts
+++ b/packages/core/src/plugins/builtin/claude/transcript.ts
@@ -1,0 +1,34 @@
+import { access, constants } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+/** Canonical `~/.claude/projects/<encoded>/<sessionId>.jsonl` path for a session. */
+export function getSessionJsonlPath(sessionId: string, projectPath: string): { jsonlPath: string; projectDir: string } {
+  const encodedPath = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+  const projectDir = path.join(homedir(), '.claude', 'projects', encodedPath);
+  return { jsonlPath: path.join(projectDir, sessionId + '.jsonl'), projectDir };
+}
+
+/**
+ * Whether the CLI transcript for `sessionId` still exists on disk. Checks the
+ * stored `session_file_path` first (authoritative — survives worktree moves),
+ * then the path derived from the project path.
+ */
+export async function isClaudeTranscriptPresent(
+  sessionId: string,
+  projectPath: string,
+  sessionFilePath?: string | null,
+): Promise<boolean> {
+  const candidates = [sessionFilePath, getSessionJsonlPath(sessionId, projectPath).jsonlPath].filter(
+    (p): p is string => typeof p === 'string' && p.length > 0,
+  );
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.R_OK);
+      return true;
+    } catch {
+      /* expected: candidate missing, try the next one */
+    }
+  }
+  return false;
+}

--- a/packages/core/src/plugins/builtin/codex/__tests__/transcript.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/transcript.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { isCodexTranscriptPresent } from '../transcript.js';
+import type { AgentMetadata } from '../thread-registry.js';
+
+const THREAD_ID = 'thread-abc';
+
+function lookupWith(rolloutPath: string | null): (ids: readonly string[]) => Map<string, AgentMetadata> {
+  return () => new Map([[THREAD_ID, { nickname: null, role: null, rolloutPath }]]);
+}
+
+describe('isCodexTranscriptPresent', () => {
+  let sessionsRoot: string;
+  let rolloutFile: string;
+
+  beforeAll(async () => {
+    sessionsRoot = await mkdtemp(path.join(tmpdir(), 'mf-codex-sessions-'));
+    const dayDir = path.join(sessionsRoot, '2026', '07', '08');
+    await mkdir(dayDir, { recursive: true });
+    rolloutFile = path.join(dayDir, `rollout-2026-07-08-${THREAD_ID}.jsonl`);
+    await writeFile(rolloutFile, '{"type":"response_item"}\n');
+  });
+
+  afterAll(async () => {
+    await rm(sessionsRoot, { recursive: true, force: true });
+  });
+
+  it('returns true when the registry rollout file exists inside the sessions root', async () => {
+    await expect(isCodexTranscriptPresent(THREAD_ID, { lookup: lookupWith(rolloutFile), sessionsRoot })).resolves.toBe(
+      true,
+    );
+  });
+
+  it('returns false when the rollout file was deleted', async () => {
+    const gone = path.join(sessionsRoot, '2026', '07', '08', `rollout-gone-${THREAD_ID}.jsonl`);
+    await expect(isCodexTranscriptPresent(THREAD_ID, { lookup: lookupWith(gone), sessionsRoot })).resolves.toBe(false);
+  });
+
+  it('returns null when the registry has no row for the thread (cannot determine)', async () => {
+    await expect(isCodexTranscriptPresent(THREAD_ID, { lookup: () => new Map(), sessionsRoot })).resolves.toBeNull();
+  });
+
+  it('returns null when the registry row has no rollout path', async () => {
+    await expect(isCodexTranscriptPresent(THREAD_ID, { lookup: lookupWith(null), sessionsRoot })).resolves.toBeNull();
+  });
+
+  it('returns null when the rollout path resolves outside the sessions root (untrusted)', async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), 'mf-codex-outside-'));
+    const outsideFile = path.join(outside, 'rollout-x.jsonl');
+    await writeFile(outsideFile, 'x\n');
+    await expect(
+      isCodexTranscriptPresent(THREAD_ID, { lookup: lookupWith(outsideFile), sessionsRoot }),
+    ).resolves.toBeNull();
+    await rm(outside, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -10,6 +10,7 @@ import type {
 } from '@qlan-ro/mainframe-types';
 import { CodexSession } from './session.js';
 import { CodexPlanModeHandler } from './plan-mode-handler.js';
+import { isCodexTranscriptPresent } from './transcript.js';
 import { JsonRpcClient } from './jsonrpc.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
 import type { InitializeResult, ModelInfo, ModelListResult, ThreadListResult } from './types.js';
@@ -162,6 +163,10 @@ export class CodexAdapter implements Adapter {
     } finally {
       client?.close();
     }
+  }
+
+  async isTranscriptPresent(sessionId: string): Promise<boolean | null> {
+    return isCodexTranscriptPresent(sessionId);
   }
 
   private async spawnTempAppServer(): Promise<JsonRpcClient> {

--- a/packages/core/src/plugins/builtin/codex/transcript.ts
+++ b/packages/core/src/plugins/builtin/codex/transcript.ts
@@ -1,0 +1,41 @@
+import { realpath } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
+import { lookupAgentMetadata, type AgentMetadata } from './thread-registry.js';
+
+interface CodexTranscriptDeps {
+  /** Registry lookup — injectable for tests; defaults to Codex's state DB. */
+  lookup?: (threadIds: readonly string[]) => Map<string, AgentMetadata>;
+  /** Sessions root the rollout must live under — injectable for tests. */
+  sessionsRoot?: string;
+}
+
+/**
+ * Whether the Codex rollout transcript for `threadId` still exists on disk.
+ * Returns `null` (cannot determine — don't flag) when the state DB has no row,
+ * the row carries no rollout path, or the path escapes `~/.codex/sessions`
+ * (untrusted input, mirrors rollout-reader.ts containment).
+ */
+export async function isCodexTranscriptPresent(threadId: string, deps?: CodexTranscriptDeps): Promise<boolean | null> {
+  const lookup = deps?.lookup ?? lookupAgentMetadata;
+  const rolloutPath = lookup([threadId]).get(threadId)?.rolloutPath;
+  if (!rolloutPath) return null;
+
+  let resolved: string;
+  try {
+    resolved = await realpath(rolloutPath);
+  } catch {
+    /* expected: rollout file deleted */
+    return false;
+  }
+
+  const rootBase = deps?.sessionsRoot ?? join(homedir(), '.codex', 'sessions');
+  let rootResolved = rootBase;
+  try {
+    rootResolved = await realpath(rootBase);
+  } catch {
+    /* expected: root may not exist yet — compare against the literal path */
+  }
+  if (!resolved.startsWith(rootResolved + sep)) return null;
+  return true;
+}

--- a/packages/core/src/server/http.ts
+++ b/packages/core/src/server/http.ts
@@ -25,6 +25,7 @@ import {
   contentSearchRoutes,
   lspRoutes,
   worktreeRoutes,
+  chatRecoveryRoutes,
   tagRoutes,
   workflowRoutes,
   suggestionRoutes,
@@ -145,6 +146,7 @@ export function createHttpServer(deps: HttpServerDeps): { app: Express; pushServ
   app.use(launchRoutes(ctx));
   app.use(externalSessionRoutes(ctx));
   app.use(worktreeRoutes(ctx));
+  app.use(chatRecoveryRoutes(ctx));
   app.use(tagRoutes(ctx));
   app.use(workflowRoutes(ctx));
   app.use(workflowAdminRoutes(ctx));

--- a/packages/core/src/server/routes/__tests__/chat-recovery.test.ts
+++ b/packages/core/src/server/routes/__tests__/chat-recovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { chatRecoveryRoutes } from '../chat-recovery.js';
+
+function makeCtx() {
+  return {
+    chats: {
+      getChat: vi.fn(() => ({ id: 'c1' })),
+      continueHere: vi.fn().mockResolvedValue(undefined),
+      continueInProjectRoot: vi.fn().mockResolvedValue(undefined),
+      recreateWorktree: vi.fn().mockResolvedValue(undefined),
+    },
+  } as any;
+}
+
+function makeApp(ctx = makeCtx()) {
+  const app = express();
+  app.use(express.json());
+  app.use(chatRecoveryRoutes(ctx));
+  return app;
+}
+
+describe('chat recovery routes', () => {
+  let ctx: ReturnType<typeof makeCtx>;
+
+  beforeEach(() => {
+    ctx = makeCtx();
+  });
+
+  describe('POST /api/chats/:id/recreate-worktree', () => {
+    it('recreates and returns success', async () => {
+      const res = await request(makeApp(ctx)).post('/api/chats/c1/recreate-worktree');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ctx.chats.recreateWorktree).toHaveBeenCalledWith('c1');
+    });
+
+    it('maps a branch-gone failure to its statusCode and message', async () => {
+      ctx.chats.recreateWorktree.mockRejectedValue(
+        Object.assign(new Error('Branch "feat-x" no longer exists'), { statusCode: 409 }),
+      );
+      const res = await request(makeApp(ctx)).post('/api/chats/c1/recreate-worktree');
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ success: false, error: 'Branch "feat-x" no longer exists' });
+    });
+
+    it('404s for an unknown chat', async () => {
+      ctx.chats.getChat.mockReturnValue(null);
+      const res = await request(makeApp(ctx)).post('/api/chats/nope/recreate-worktree');
+      expect(res.status).toBe(404);
+      expect(ctx.chats.recreateWorktree).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/chats/:id/continue-here', () => {
+    it('resets the session identity and returns success', async () => {
+      const res = await request(makeApp(ctx)).post('/api/chats/c1/continue-here');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ctx.chats.continueHere).toHaveBeenCalledWith('c1');
+    });
+
+    it('404s for an unknown chat', async () => {
+      ctx.chats.getChat.mockReturnValue(null);
+      const res = await request(makeApp(ctx)).post('/api/chats/nope/continue-here');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/chats/:id/continue-in-project-root', () => {
+    it('detaches the worktree and returns success', async () => {
+      const res = await request(makeApp(ctx)).post('/api/chats/c1/continue-in-project-root');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ctx.chats.continueInProjectRoot).toHaveBeenCalledWith('c1');
+    });
+
+    it('maps failures to 400 with the error message', async () => {
+      ctx.chats.continueInProjectRoot.mockRejectedValue(new Error('Chat has no worktree'));
+      const res = await request(makeApp(ctx)).post('/api/chats/c1/continue-in-project-root');
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ success: false, error: 'Chat has no worktree' });
+    });
+  });
+});

--- a/packages/core/src/server/routes/__tests__/chats-messages.test.ts
+++ b/packages/core/src/server/routes/__tests__/chats-messages.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { chatRoutes } from '../chats.js';
+
+describe('GET /api/chats/:id/messages', () => {
+  it('returns the typed { messages, transcriptMissing } envelope', async () => {
+    const messages = [{ id: 'm1', type: 'assistant' }];
+    const ctx = {
+      chats: {
+        getDisplayMessages: vi.fn().mockResolvedValue({ messages, transcriptMissing: true }),
+      },
+      db: {},
+    } as any;
+    const app = express();
+    app.use(express.json());
+    app.use(chatRoutes(ctx));
+
+    const res = await request(app).get('/api/chats/c1/messages');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      data: { messages, transcriptMissing: true },
+    });
+    expect(ctx.chats.getDisplayMessages).toHaveBeenCalledWith('c1');
+  });
+});

--- a/packages/core/src/server/routes/chat-recovery.ts
+++ b/packages/core/src/server/routes/chat-recovery.ts
@@ -1,0 +1,52 @@
+/**
+ * Degraded-chat recovery routes — the actions behind the unified degraded-chat
+ * card (missing transcript / missing worktree). All three re-emit an enriched
+ * `chat.updated` via the ChatManager so clients clear the card live.
+ */
+import { Router } from 'express';
+import { z } from 'zod';
+import type { RouteContext } from './types.js';
+import { asyncHandler } from './async-handler.js';
+import { okEmpty, fail } from './respond.js';
+import { createChildLogger } from '../../logger.js';
+
+const log = createChildLogger('routes:chat-recovery');
+
+const Params = z.object({ id: z.string().min(1) });
+
+export function chatRecoveryRoutes(ctx: RouteContext): Router {
+  const router = Router();
+
+  const post = (path: string, run: (chatId: string) => Promise<void>, label: string): void => {
+    router.post(
+      `/api/chats/:id/${path}`,
+      asyncHandler(async (req, res) => {
+        const parsed = Params.safeParse(req.params);
+        if (!parsed.success) {
+          fail(res, 400, parsed.error.issues[0]?.message ?? 'Invalid input');
+          return;
+        }
+        const chatId = parsed.data.id;
+        if (!ctx.chats.getChat(chatId)) {
+          fail(res, 404, 'Chat not found');
+          return;
+        }
+        try {
+          await run(chatId);
+          okEmpty(res);
+        } catch (err) {
+          const statusCode = (err as Error & { statusCode?: number }).statusCode ?? 400;
+          const message = err instanceof Error ? err.message : `Failed to ${label}`;
+          log.warn({ err, chatId }, `${label} failed`);
+          fail(res, statusCode, message);
+        }
+      }),
+    );
+  };
+
+  post('recreate-worktree', (id) => ctx.chats.recreateWorktree(id), 'recreate worktree');
+  post('continue-here', (id) => ctx.chats.continueHere(id), 'continue here');
+  post('continue-in-project-root', (id) => ctx.chats.continueInProjectRoot(id), 'continue in project root');
+
+  return router;
+}

--- a/packages/core/src/server/routes/chats.ts
+++ b/packages/core/src/server/routes/chats.ts
@@ -95,8 +95,8 @@ export function chatRoutes(ctx: RouteContext): Router {
   router.get(
     '/api/chats/:id/messages',
     asyncHandler(async (req: Request, res: Response) => {
-      const messages = await ctx.chats.getDisplayMessages(param(req, 'id'));
-      res.json({ success: true, data: messages });
+      const history = await ctx.chats.getDisplayMessages(param(req, 'id'));
+      res.json({ success: true, data: history });
     }),
   );
 

--- a/packages/core/src/server/routes/index.ts
+++ b/packages/core/src/server/routes/index.ts
@@ -15,6 +15,7 @@ export { tunnelRoutes } from './tunnel.js';
 export { contentSearchRoutes } from './search.js';
 export { lspRoutes } from './lsp-routes.js';
 export { worktreeRoutes } from './worktree.js';
+export { chatRecoveryRoutes } from './chat-recovery.js';
 export { deviceRoutes } from './device.js';
 export { tagRoutes } from './tags.js';
 export { workflowRoutes } from './workflows.js';

--- a/packages/core/src/workspace/worktree.ts
+++ b/packages/core/src/workspace/worktree.ts
@@ -101,6 +101,32 @@ export async function backfillWorktreeRelationships(projects: ProjectsRepository
   }
 }
 
+export async function branchExists(projectPath: string, branchName: string): Promise<boolean> {
+  try {
+    await execGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branchName}`], projectPath);
+    return true;
+  } catch {
+    /* expected: branch missing */
+    return false;
+  }
+}
+
+/** Re-add a previously deleted worktree at its original path, checking out an existing branch. */
+export async function addWorktreeForBranch(
+  projectPath: string,
+  worktreePath: string,
+  branchName: string,
+): Promise<void> {
+  try {
+    // Drop the stale registration git still holds for the deleted directory.
+    await execGit(['worktree', 'prune'], projectPath);
+  } catch {
+    /* best-effort */
+  }
+  // No timeout: checkout of a large tree can exceed the default cap (see createWorktree).
+  await execGit(['worktree', 'add', worktreePath, branchName], projectPath, { timeout: 0 });
+}
+
 export async function removeWorktree(projectPath: string, worktreePath: string, branchName: string): Promise<void> {
   try {
     await execGit(['worktree', 'remove', worktreePath, '--force'], projectPath);

--- a/packages/e2e/tests-tauri/composer.spec.ts
+++ b/packages/e2e/tests-tauri/composer.spec.ts
@@ -391,8 +391,8 @@ test.describe('§composer provider locked after first message', () => {
   });
 });
 
-// ─── Worktree-missing banner (§9c) ─────────────────────────────────────────────
-test.describe('§composer worktree-missing banner', () => {
+// ─── Worktree-missing → degraded card locks composer (§9c) ────────────────────
+test.describe('§composer worktree-missing degraded card', () => {
   let app: TauriAppFixture;
   let project: TauriProject;
   let chatId: string;
@@ -432,12 +432,18 @@ test.describe('§composer worktree-missing banner', () => {
     await closeTauriApp(app);
   });
 
-  test('shows the worktree-missing banner and locks the input + send button', async () => {
+  test('shows the degraded-chat card with recovery actions and locks the input + send button', async () => {
     const { page } = app;
-    const banner = page.getByTestId('chat-composer-worktree-missing');
-    await expect(banner).toBeVisible({ timeout: 10_000 });
-    await expect(banner).toContainText('The worktree for this session was deleted');
-    await expect(banner).toContainText(worktreePath);
+    // The old chat-composer-worktree-missing banner was replaced by the
+    // thread-level DegradedChatCard (unified transcript/worktree recovery).
+    const card = page.getByTestId('chat-degraded-card');
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText('Worktree deleted');
+    await expect(card).toContainText(worktreePath);
+    await expect(page.getByTestId('chat-degraded-recreate-worktree')).toBeVisible();
+    await expect(page.getByTestId('chat-degraded-project-root')).toBeVisible();
+    await expect(page.getByTestId('chat-degraded-delete')).toBeVisible();
+    await expect(page.getByTestId('chat-composer-worktree-missing')).toHaveCount(0);
 
     await expect(page.getByTestId('chat-composer-input')).toBeDisabled();
     await expect(page.getByTestId('chat-composer-send')).toBeDisabled();

--- a/packages/e2e/tests-tauri/sessions-rows.spec.ts
+++ b/packages/e2e/tests-tauri/sessions-rows.spec.ts
@@ -13,12 +13,12 @@
  *   SessionRowMeta.tsx    — project chip / worktree pill / PR link / tag dots
  *   SessionContextMenu.tsx — right-click menu (Pin/Unpin, Rename, Tags, Archive, Copy Session ID)
  *   SessionGroupHeader.tsx — group header, incl. the 'Pinned' group's pin glyph
- *   view-model/session-status.ts — deriveSessionBadge (worktree-missing > working > waiting > idle)
+ *   view-model/session-status.ts — deriveSessionBadge (worktree-missing > transcript-missing > working > waiting > idle)
  *
  * Testid reference (all verified against source above):
  *   sessions-row                     — row root (data-chat-id, data-active)
  *   sessions-row-status-dot          — StatusDot; aria-label = badge.base
- *                                       ('idle'|'working'|'waiting'|'worktree-missing')
+ *                                       ('idle'|'working'|'waiting'|'worktree-missing'|'transcript-missing')
  *   sessions-row-relative-time       — time label, hidden on row hover
  *   sessions-row-action-tags/-rename/-archive — hover-action buttons (hidden until row hover)
  *   sessions-ctx-pin/-rename/-tags/-archive/-copy-id — context-menu items
@@ -26,7 +26,7 @@
  *   sessions-group-pin-glyph         — pin glyph on the Pinned group header (see NOTE below)
  *   sessions-row-meta-project        — project chip (All view only)
  *   sessions-row-meta-worktree       — worktree pill (text-destructive when missing)
- *   sessions-row-meta-worktree-missing — empty marker span, present only when worktreeMissing
+ *   sessions-row-meta-degraded       — unified degraded marker (muted icon); aria-label names the cause(s)
  *   sessions-row-meta-tag-dot-<name> — applied-tag dot cluster
  *
  * NOTE on the pin glyph: SessionRow.tsx also renders a PER-ROW
@@ -253,7 +253,7 @@ test.describe('§sessions-rows Worktree meta pill + missing state', () => {
     const pill = row.getByTestId('sessions-row-meta-worktree');
     await expect(pill).toBeVisible({ timeout: 15_000 });
     await expect(pill).not.toHaveClass(/text-destructive/);
-    await expect(row.getByTestId('sessions-row-meta-worktree-missing')).toHaveCount(0);
+    await expect(row.getByTestId('sessions-row-meta-degraded')).toHaveCount(0);
     await expect(dot).toHaveAttribute('aria-label', 'idle');
 
     const chatRes = await page.request.get(`${DAEMON_BASE}/api/chats/${chatId}`);
@@ -269,8 +269,10 @@ test.describe('§sessions-rows Worktree meta pill + missing state', () => {
 
     await expect(dot).toHaveAttribute('aria-label', 'worktree-missing', { timeout: 15_000 });
     await expect(pill).toHaveClass(/text-destructive/);
-    // Present-but-empty marker span — assert attachment, not visibility (it has no box).
-    await expect(row.getByTestId('sessions-row-meta-worktree-missing')).toHaveCount(1);
+    // Unified degraded marker — aria-label names the cause.
+    const marker = row.getByTestId('sessions-row-meta-degraded');
+    await expect(marker).toHaveCount(1);
+    await expect(marker).toHaveAttribute('aria-label', 'Worktree missing');
   });
 });
 

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -353,6 +353,17 @@ export interface Adapter {
   ): Promise<ExternalSessionPage>;
 
   /**
+   * Whether the CLI's transcript for `sessionId` still exists on disk.
+   * Returns `null` when presence cannot be determined (e.g. the adapter's own
+   * registry is unreadable) — callers must treat `null` as "don't flag".
+   */
+  isTranscriptPresent?(
+    sessionId: string,
+    projectPath: string,
+    sessionFilePath?: string | null,
+  ): Promise<boolean | null>;
+
+  /**
    * Factory for an adapter-specific plan-mode action handler.
    *
    * Returns `unknown` here to avoid a core→types dependency cycle — core casts

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -58,6 +58,8 @@ export interface Chat {
   displayStatus?: 'idle' | 'working' | 'waiting';
   isRunning?: boolean;
   worktreeMissing?: boolean;
+  /** True when the CLI's transcript file for this session was deleted from disk (persisted flag). */
+  transcriptMissing?: boolean;
   todos?: TodoItem[];
   pinned?: boolean;
   effort?: EffortLevel | null;

--- a/packages/types/src/display.ts
+++ b/packages/types/src/display.ts
@@ -68,3 +68,12 @@ export interface DisplayMessage {
   timestamp: string;
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * GET /api/chats/:id/messages payload — `transcriptMissing` distinguishes a
+ * genuinely empty thread from one whose CLI transcript was deleted from disk.
+ */
+export interface ChatHistoryPayload {
+  messages: DisplayMessage[];
+  transcriptMissing: boolean;
+}

--- a/packages/ui/src/features/chat/composer/Composer.tsx
+++ b/packages/ui/src/features/chat/composer/Composer.tsx
@@ -13,7 +13,7 @@
  */
 import { useCallback } from 'react';
 import { ComposerPrimitive, useAui, useAuiState } from '@assistant-ui/react';
-import { AlertTriangleIcon, ArrowUpIcon, SquareIcon } from 'lucide-react';
+import { ArrowUpIcon, SquareIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ComposerToolbar } from './config-toolbar/ComposerToolbar';
 import { ComposerEditMode } from './edit/ComposerEditMode';
@@ -53,29 +53,6 @@ function SendOrCancelButton({ sendDisabled }: { sendDisabled?: boolean }) {
     >
       <ArrowUpIcon className="size-3.5" />
     </ComposerPrimitive.Send>
-  );
-}
-
-/** Shown when the session's worktree was deleted out from under it — input is locked until it's restored or the chat archived. */
-function WorktreeMissingBanner({ worktreePath }: { worktreePath?: string }) {
-  return (
-    <div
-      data-testid="chat-composer-worktree-missing"
-      className="mx-3 mt-2 flex items-center gap-2 rounded-md bg-mf-destructive-tint px-3 py-2 text-caption text-destructive"
-    >
-      <AlertTriangleIcon className="size-3.5 shrink-0" />
-      <span>
-        The worktree for this session was deleted. Archive this session or recreate the worktree
-        {worktreePath ? (
-          <>
-            {' '}
-            at <code className="font-mono">{worktreePath}</code>.
-          </>
-        ) : (
-          '.'
-        )}
-      </span>
-    </div>
   );
 }
 
@@ -125,8 +102,6 @@ export function Composer() {
             '[&[data-dragging]]:bg-mf-selection',
           )}
         >
-          {worktreeMissing && <WorktreeMissingBanner worktreePath={chat?.worktreePath} />}
-
           {/* Quote pill — renders only when a quote is set (select-to-quote). */}
           <ComposerQuotePreview />
 

--- a/packages/ui/src/features/chat/composer/__tests__/Composer.test.tsx
+++ b/packages/ui/src/features/chat/composer/__tests__/Composer.test.tsx
@@ -18,9 +18,8 @@
  *  - All assertions use hardcoded expected values.
  *
  * Behaviors covered:
- *  1. worktreeMissing=true, worktreePath='/tmp/wt'
- *       → banner present (data-testid="chat-composer-worktree-missing")
- *       → banner text contains '/tmp/wt' inside a <code>
+ *  1. worktreeMissing=true
+ *       → NO composer banner (recovery lives in the thread-level DegradedChatCard)
  *       → input has the `disabled` attribute
  *       → send button has the `disabled` attribute
  *  2. worktreeMissing=false
@@ -149,28 +148,18 @@ function renderComposer() {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Composer — worktreeMissing=true shows banner and disables input/send', () => {
+describe('Composer — worktreeMissing=true disables input/send (banner replaced by the degraded card)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     __isRunning = false;
     __sendSpy = vi.fn();
   });
 
-  it('renders the worktree-missing banner', () => {
+  it('does NOT render the old worktree-missing banner (the thread-level DegradedChatCard owns recovery)', () => {
     __extrasReturn = { worktreeMissing: true, worktreePath: '/tmp/wt' };
     renderComposer();
 
-    expect(screen.getByTestId('chat-composer-worktree-missing')).toBeInTheDocument();
-  });
-
-  it('banner text contains the worktreePath inside a <code> element', () => {
-    __extrasReturn = { worktreeMissing: true, worktreePath: '/tmp/wt' };
-    renderComposer();
-
-    const banner = screen.getByTestId('chat-composer-worktree-missing');
-    const code = banner.querySelector('code');
-    expect(code).not.toBeNull();
-    expect(code!.textContent).toBe('/tmp/wt');
+    expect(screen.queryByTestId('chat-composer-worktree-missing')).not.toBeInTheDocument();
   });
 
   it('input (chat-composer-input) has the disabled attribute', () => {

--- a/packages/ui/src/features/chat/controller/__tests__/chat-event-router-error-toast.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-event-router-error-toast.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
   interruptChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-ack.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-ack.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
   interruptChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-dormancy.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-dormancy.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
   interruptChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-initial-subscribe-refresh.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-initial-subscribe-refresh.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue({ id: 'chat', adapterId: 'claude' }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
@@ -119,7 +119,10 @@ afterEach(() => {
 describe('reactivation after dormancy — re-seeds on the reattach ack', () => {
   it('refreshes history when a warm controller re-attaches, even with no pending send', async () => {
     // First activation: the chat already holds one message; the mount load() seeds it.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-1', 'first')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-1', 'first')],
+      transcriptMissing: false,
+    });
 
     const { fakeClient, pushEvent } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -139,10 +142,10 @@ describe('reactivation after dormancy — re-seeds on the reattach ack', () => {
 
     // While dormant, the daemon appended a message. It is persisted (REST now
     // returns it) but was never delivered live — the controller had no sub.
-    vi.mocked(getChatMessages).mockResolvedValue([
-      userDisplayMsg('srv-1', 'first'),
-      userDisplayMsg('srv-2', 'arrived while backgrounded'),
-    ]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-1', 'first'), userDisplayMsg('srv-2', 'arrived while backgrounded')],
+      transcriptMissing: false,
+    });
 
     // Switch back — a fresh sub attaches. The user was only reading, so there is
     // NO unreconciled pending; only the reattach signal can trigger the catch-up.
@@ -158,7 +161,7 @@ describe('reactivation after dormancy — re-seeds on the reattach ack', () => {
 describe('initial subscribe:ack — recovers a missed handoff event', () => {
   it('refreshes history on the first ack so the optimistic pending is reconciled', async () => {
     // The just-created chat is empty when the first load + send happen.
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient, pushEvent } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -173,7 +176,10 @@ describe('initial subscribe:ack — recovers a missed handoff event', () => {
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(1);
 
     // The daemon now holds the user message; a refresh would reconcile the pending.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-1', 'which model are you?')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-1', 'which model are you?')],
+      transcriptMissing: false,
+    });
 
     // The subscription finally attaches and acks (initial, not a reconnect).
     pushEvent({ type: 'subscribe:ack', chatId: CHAT_ID });

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-load.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-load.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue(null),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
@@ -116,7 +116,7 @@ describe('ChatThreadController.refresh — recovers from a prior failure', () =>
     // First call rejects (the failure).
     vi.mocked(getChatMessages).mockRejectedValueOnce(new Error('transient'));
     // Second call (refresh) resolves with an empty history.
-    vi.mocked(getChatMessages).mockResolvedValueOnce([]);
+    vi.mocked(getChatMessages).mockResolvedValueOnce({ messages: [], transcriptMissing: false });
 
     const ctrl = new ChatThreadController(CHAT_ID, PORT, makeFakeWs());
     ctrl.subscribeLive();
@@ -137,7 +137,7 @@ describe('ChatThreadController.refresh — recovers from a prior failure', () =>
 
 describe('ChatThreadController.load — getChatMessages resolves', () => {
   it('sets loadState.type to "ready" when getChatMessages resolves with an empty array', async () => {
-    vi.mocked(getChatMessages).mockResolvedValueOnce([]);
+    vi.mocked(getChatMessages).mockResolvedValueOnce({ messages: [], transcriptMissing: false });
 
     const ctrl = new ChatThreadController(CHAT_ID, PORT, makeFakeWs());
     ctrl.subscribeLive();

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-local-load.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-local-load.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue(null),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-reconcile.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-reconcile.test.ts
@@ -31,7 +31,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue(null),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-restore.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-restore.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue({ id: 'chat', adapterId: 'claude' }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
@@ -244,7 +244,7 @@ describe('restorePendingPermission — duplicate guard', () => {
 describe('reconcilePendingAgainstHistory — matching text', () => {
   it('removes an optimistic pending whose text matches a user message in the re-fetched history', async () => {
     // getChatMessages returns empty on the initial load triggered by subscribe.
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -256,7 +256,10 @@ describe('reconcilePendingAgainstHistory — matching text', () => {
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(1);
 
     // On refresh the history now contains the server echo of the same message.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-1', 'hello reconnect')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-1', 'hello reconnect')],
+      transcriptMissing: false,
+    });
 
     await ctrl.refresh();
 
@@ -271,7 +274,7 @@ describe('reconcilePendingAgainstHistory — matching text', () => {
 
 describe('reconcilePendingAgainstHistory — non-matching text', () => {
   it('does NOT remove a pending whose text differs from every user message in history', async () => {
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -282,7 +285,10 @@ describe('reconcilePendingAgainstHistory — non-matching text', () => {
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(1);
 
     // History contains a user message with completely different text.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-2', 'a completely different message')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-2', 'a completely different message')],
+      transcriptMissing: false,
+    });
 
     await ctrl.refresh();
 
@@ -305,7 +311,7 @@ describe('reconcilePendingAgainstHistory — non-matching text', () => {
 
 describe('reconcilePendingAgainstHistory — count-aware (identical text)', () => {
   it('reconciles exactly one pending when two identical sends have only one server echo', async () => {
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -317,14 +323,17 @@ describe('reconcilePendingAgainstHistory — count-aware (identical text)', () =
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(2);
 
     // Server history has the message exactly once → only one pending reconciles.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-dbl-1', 'ask me two questions')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-dbl-1', 'ask me two questions')],
+      transcriptMissing: false,
+    });
     await ctrl.refresh();
 
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(1);
   });
 
   it('reconciles both pendings when two identical sends have two server echoes', async () => {
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -335,10 +344,13 @@ describe('reconcilePendingAgainstHistory — count-aware (identical text)', () =
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(2);
 
     // Two legitimate sends → two server copies → both reconcile.
-    vi.mocked(getChatMessages).mockResolvedValue([
-      userDisplayMsg('srv-dbl-1', 'ask me two questions'),
-      userDisplayMsg('srv-dbl-2', 'ask me two questions'),
-    ]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [
+        userDisplayMsg('srv-dbl-1', 'ask me two questions'),
+        userDisplayMsg('srv-dbl-2', 'ask me two questions'),
+      ],
+      transcriptMissing: false,
+    });
     await ctrl.refresh();
 
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(0);
@@ -352,7 +364,7 @@ describe('reconcilePendingAgainstHistory — count-aware (identical text)', () =
 
 describe('reconcilePendingAgainstHistory — partial match: one cleared, one retained', () => {
   it('removes only the pending whose text is in history, leaving the other intact', async () => {
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -364,7 +376,10 @@ describe('reconcilePendingAgainstHistory — partial match: one cleared, one ret
     expect(Object.keys(ctrl.getState().pendingUserMessages)).toHaveLength(2);
 
     // History only contains the first message — second has not echoed yet.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-p1', 'first question')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-p1', 'first question')],
+      transcriptMissing: false,
+    });
 
     await ctrl.refresh();
 
@@ -387,7 +402,7 @@ describe('reconcilePendingAgainstHistory — partial match: one cleared, one ret
 
 describe('reconcilePendingAgainstHistory — delayed echo past the live match window', () => {
   it('reconciles a pending older than 10 minutes when history contains the matching text', async () => {
-    vi.mocked(getChatMessages).mockResolvedValue([]);
+    vi.mocked(getChatMessages).mockResolvedValue({ messages: [], transcriptMissing: false });
 
     const { fakeClient } = makeFakeWs();
     const ctrl = new ChatThreadController(CHAT_ID, PORT, fakeClient);
@@ -403,7 +418,10 @@ describe('reconcilePendingAgainstHistory — delayed echo past the live match wi
     vi.advanceTimersByTime(11 * 60 * 1000);
 
     // History now contains the server echo.
-    vi.mocked(getChatMessages).mockResolvedValue([userDisplayMsg('srv-late-1', 'delayed echo message')]);
+    vi.mocked(getChatMessages).mockResolvedValue({
+      messages: [userDisplayMsg('srv-late-1', 'delayed echo message')],
+      transcriptMissing: false,
+    });
 
     await ctrl.refresh();
 

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-retry.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-retry.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue(null),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-send.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-send.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getChat: vi.fn().mockResolvedValue(null),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-trust-required.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-controller-trust-required.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../../../lib/api/attachments', () => ({
 }));
 
 vi.mock('../../../../lib/api/chats', () => ({
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
   interruptChat: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-transcript.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-transcript.test.ts
@@ -1,0 +1,70 @@
+/**
+ * chat-thread-state — transcriptMissing plumbing.
+ *
+ * `history.loaded` carries the typed daemon payload's transcriptMissing flag;
+ * the reducer mirrors it into chatConfig (when seeded) so the degraded card
+ * reacts to a load-time detection without waiting for a chat.updated. A
+ * chat.updated differing ONLY in transcriptMissing must also refresh
+ * chatConfig (sameComposerConfig must not swallow it).
+ */
+import { describe, it, expect } from 'vitest';
+import type { Chat } from '@qlan-ro/mainframe-types';
+import { createChatThreadState, reduceChatThreadState } from '../chat-thread-state';
+
+const chatFixture = {
+  id: 'c1',
+  adapterId: 'claude',
+  projectId: 'p1',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  totalCost: 0,
+  totalTokensInput: 0,
+  totalTokensOutput: 0,
+  lastContextTokensInput: 0,
+  transcriptMissing: false,
+} as Chat;
+
+describe('history.loaded — transcriptMissing mirror', () => {
+  it('sets chatConfig.transcriptMissing when chatConfig is seeded', () => {
+    let state = createChatThreadState('c1');
+    state = reduceChatThreadState(state, { type: 'chat.config.updated', chat: chatFixture });
+
+    state = reduceChatThreadState(state, { type: 'history.loaded', messages: [], transcriptMissing: true });
+
+    expect(state.loadState).toEqual({ type: 'ready' });
+    expect(state.chatConfig?.transcriptMissing).toBe(true);
+  });
+
+  it('leaves a null chatConfig alone (REST seed carries the flag later)', () => {
+    let state = createChatThreadState('c1');
+    state = reduceChatThreadState(state, { type: 'history.loaded', messages: [], transcriptMissing: true });
+    expect(state.chatConfig).toBeNull();
+  });
+
+  it('clears a previously-set flag when the payload reports the transcript back', () => {
+    let state = createChatThreadState('c1');
+    state = reduceChatThreadState(state, {
+      type: 'chat.config.updated',
+      chat: { ...chatFixture, transcriptMissing: true },
+    });
+
+    state = reduceChatThreadState(state, { type: 'history.loaded', messages: [], transcriptMissing: false });
+
+    expect(state.chatConfig?.transcriptMissing).toBe(false);
+  });
+});
+
+describe('chat.config.updated — transcriptMissing is composer-relevant', () => {
+  it('adopts a chat.updated that differs only in transcriptMissing', () => {
+    let state = createChatThreadState('c1');
+    state = reduceChatThreadState(state, { type: 'chat.config.updated', chat: chatFixture });
+
+    state = reduceChatThreadState(state, {
+      type: 'chat.config.updated',
+      chat: { ...chatFixture, transcriptMissing: true },
+    });
+
+    expect(state.chatConfig?.transcriptMissing).toBe(true);
+  });
+});

--- a/packages/ui/src/features/chat/controller/__tests__/chat-ws-subscription.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-ws-subscription.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../../lib/api/chats', () => ({
   getPendingPermission: vi.fn().mockResolvedValue(null),
   resumeChat: vi.fn().mockResolvedValue(undefined),
   // stubs for imports other modules in the same tree pull in
-  getChatMessages: vi.fn().mockResolvedValue([]),
+  getChatMessages: vi.fn().mockResolvedValue({ messages: [], transcriptMissing: false }),
   interruptChat: vi.fn().mockResolvedValue(undefined),
   cancelQueuedMessage: vi.fn().mockResolvedValue(undefined),
   editQueuedMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/ui/src/features/chat/controller/chat-thread-controller.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-controller.ts
@@ -206,9 +206,9 @@ export class ChatThreadController {
     }
 
     const request = getChatMessages(this.port, this.daemonId)
-      .then((messages) => {
+      .then(({ messages, transcriptMissing }) => {
         if (this.loadPromise !== request) return;
-        this.dispatch({ type: 'history.loaded', messages });
+        this.dispatch({ type: 'history.loaded', messages, transcriptMissing });
         this.reconcilePendingAgainstHistory(messages);
       })
       .catch((error: unknown) => {

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -86,7 +86,7 @@ export interface ChatThreadState {
 
 export type ChatStateEvent =
   | { type: 'history.loading' }
-  | { type: 'history.loaded'; messages: DisplayMessage[] }
+  | { type: 'history.loaded'; messages: DisplayMessage[]; transcriptMissing?: boolean }
   | { type: 'history.failed'; error: unknown }
   | { type: 'run.started' }
   | { type: 'run.cancelling' }
@@ -163,7 +163,8 @@ function sameComposerConfig(a: Chat | null, b: Chat): boolean {
     a.fast === b.fast &&
     a.ultracode === b.ultracode &&
     a.adaptiveThinking === b.adaptiveThinking &&
-    a.worktreeMissing === b.worktreeMissing
+    a.worktreeMissing === b.worktreeMissing &&
+    a.transcriptMissing === b.transcriptMissing
   );
 }
 
@@ -183,11 +184,20 @@ export function reduceChatThreadState(state: ChatThreadState, event: ChatStateEv
         messagesById[msg.id] = msg;
         messageOrder.push(msg.id);
       }
+      // Mirror the load-time transcript detection into chatConfig so the
+      // degraded card reacts without waiting for the chat.updated broadcast.
+      const chatConfig =
+        event.transcriptMissing !== undefined &&
+        state.chatConfig !== null &&
+        state.chatConfig.transcriptMissing !== event.transcriptMissing
+          ? { ...state.chatConfig, transcriptMissing: event.transcriptMissing }
+          : state.chatConfig;
       return {
         ...state,
         loadState: { type: 'ready' },
         messagesById,
         messageOrder,
+        chatConfig,
       };
     }
 

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -14,6 +14,7 @@ import { Composer } from '../composer/Composer';
 import { SelectionToolbar } from '@/components/ui/assistant-ui/quote';
 import { ComposerEditProvider } from '../composer/edit/composer-edit-context';
 import { ChatGateMount } from '../gates/ChatGateMount';
+import { DegradedChatCard } from './DegradedChatCard';
 import { useChatExtras } from '../runtime/use-chat-thread-runtime';
 import { useRotatingPhrase } from './use-rotating-phrase';
 import { SkillsProvider } from '@/features/skills/use-chat-skills';
@@ -83,6 +84,7 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
           >
             <div className="mx-auto w-full max-w-3xl flex-1 px-5 py-4">
               <LoadErrorBanner />
+              <DegradedChatCard />
               {messageCount === 0 && emptyState != null ? emptyState : null}
               <ThreadPrimitive.Messages components={boundedMessageComponents} />
               <ChatGateMount />

--- a/packages/ui/src/features/chat/thread/DegradedChatCard.tsx
+++ b/packages/ui/src/features/chat/thread/DegradedChatCard.tsx
@@ -1,0 +1,130 @@
+/**
+ * DegradedChatCard — unified recovery card for a degraded chat, rendered in
+ * the thread area. Replaces both the silent empty thread (transcript deleted
+ * from disk) and the old composer worktree banner. One section per cause; a
+ * chat can have both, in which case the transcript's "Continue here" merges
+ * into whichever worktree action is chosen (fresh session after recovery).
+ */
+import { useState } from 'react';
+import { AlertTriangleIcon } from 'lucide-react';
+import { useChatExtras } from '../runtime/use-chat-thread-runtime';
+import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
+import { archiveChat, continueChatHere, continueChatInProjectRoot, recreateChatWorktree } from '@/lib/api/chats';
+
+const ACTION_BUTTON =
+  'rounded-md border border-border px-3 py-1.5 text-caption text-foreground transition-colors hover:bg-accent disabled:opacity-50';
+
+function CauseSection({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex flex-col gap-1 text-left">
+      <p className="flex items-center gap-1.5 text-body font-medium text-foreground">
+        <AlertTriangleIcon className="size-3.5 shrink-0 text-destructive" />
+        {title}
+      </p>
+      <p className="text-caption text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+export function DegradedChatCard() {
+  const extras = useChatExtras();
+  const port = useDaemonPort();
+  const [busy, setBusy] = useState(false);
+  const [recreateError, setRecreateError] = useState<string | null>(null);
+
+  const chat = extras?.state.chatConfig ?? null;
+  const worktreeMissing = chat?.worktreeMissing ?? false;
+  const transcriptMissing = chat?.transcriptMissing ?? false;
+  if (!chat || (!worktreeMissing && !transcriptMissing)) return null;
+  const chatId = chat.id;
+
+  const run = (action: () => Promise<void>) => {
+    setBusy(true);
+    void action()
+      .catch((err: unknown) => {
+        // Recovery failures surface in the card; the daemon's chat.updated clears it on success.
+        setRecreateError(err instanceof Error ? err.message : 'Recovery failed');
+      })
+      .finally(() => setBusy(false));
+  };
+
+  return (
+    <div
+      data-testid="chat-degraded-card"
+      className="mx-auto my-8 flex w-full max-w-md flex-col gap-4 rounded-lg border border-border bg-card px-5 py-5"
+    >
+      {transcriptMissing && (
+        <CauseSection
+          title="Transcript deleted"
+          body={
+            worktreeMissing
+              ? 'This session’s transcript was deleted from disk by the CLI’s cleanup. Its history can’t be recovered — recover the working directory below and the next message starts a fresh session there.'
+              : 'This session’s transcript was deleted from disk by the CLI’s cleanup. Its history can’t be recovered, but you can continue in this chat with a fresh session.'
+          }
+        />
+      )}
+      {worktreeMissing && (
+        <CauseSection
+          title="Worktree deleted"
+          body={
+            chat.worktreePath
+              ? `The worktree for this session (${chat.worktreePath}) was deleted.`
+              : 'The worktree for this session was deleted.'
+          }
+        />
+      )}
+
+      {recreateError != null && (
+        <p data-testid="chat-degraded-error" className="text-caption text-destructive">
+          {recreateError}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {transcriptMissing && !worktreeMissing && (
+          <button
+            data-testid="chat-degraded-continue"
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => continueChatHere(port, chatId))}
+            className={ACTION_BUTTON}
+          >
+            Continue here
+          </button>
+        )}
+        {worktreeMissing && recreateError == null && (
+          <button
+            data-testid="chat-degraded-recreate-worktree"
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => recreateChatWorktree(port, chatId))}
+            className={ACTION_BUTTON}
+          >
+            Recreate worktree
+          </button>
+        )}
+        {worktreeMissing && (
+          <button
+            data-testid="chat-degraded-project-root"
+            type="button"
+            disabled={busy}
+            onClick={() => run(() => continueChatInProjectRoot(port, chatId))}
+            className={ACTION_BUTTON}
+            title="The agent will run in the main checkout; uncommitted worktree work is not recovered."
+          >
+            Continue in project root
+          </button>
+        )}
+        <button
+          data-testid="chat-degraded-delete"
+          type="button"
+          disabled={busy}
+          onClick={() => run(() => archiveChat(port, chatId, true))}
+          className={`${ACTION_BUTTON} text-destructive`}
+        >
+          Delete chat
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/features/chat/thread/__tests__/DegradedChatCard.test.tsx
+++ b/packages/ui/src/features/chat/thread/__tests__/DegradedChatCard.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * DegradedChatCard — behavior tests.
+ *
+ * The unified degraded-chat card renders in the thread area when the chat's
+ * transcript file was deleted (`transcriptMissing`) and/or its worktree is gone
+ * (`worktreeMissing`), one section per cause, each with its recovery actions:
+ *  - transcript: Continue here (chat-degraded-continue) — hidden when the
+ *    worktree is ALSO missing (recovery merges into the worktree actions);
+ *  - worktree: Recreate worktree (chat-degraded-recreate-worktree) +
+ *    Continue in project root (chat-degraded-project-root);
+ *  - always: Delete chat (chat-degraded-delete).
+ * A failed recreate shows the error and falls back to project-root only.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Chat } from '@qlan-ro/mainframe-types';
+
+let __chatConfig: Partial<Chat> | null = null;
+
+vi.mock('../../runtime/use-chat-thread-runtime', () => ({
+  useChatExtras: () => (__chatConfig === null ? undefined : { state: { chatConfig: __chatConfig } }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31415,
+}));
+
+vi.mock('@/lib/api/chats', () => ({
+  continueChatHere: vi.fn().mockResolvedValue(undefined),
+  recreateChatWorktree: vi.fn().mockResolvedValue(undefined),
+  continueChatInProjectRoot: vi.fn().mockResolvedValue(undefined),
+  archiveChat: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { continueChatHere, recreateChatWorktree, continueChatInProjectRoot, archiveChat } from '@/lib/api/chats';
+import { DegradedChatCard } from '../DegradedChatCard';
+
+function chat(overrides: Partial<Chat>): Partial<Chat> {
+  return { id: 'chat-9', worktreeMissing: false, transcriptMissing: false, ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __chatConfig = null;
+});
+
+describe('DegradedChatCard — visibility', () => {
+  it('renders nothing when neither flag is set', () => {
+    __chatConfig = chat({});
+    render(<DegradedChatCard />);
+    expect(screen.queryByTestId('chat-degraded-card')).toBeNull();
+  });
+
+  it('renders nothing when extras are unavailable', () => {
+    __chatConfig = null;
+    render(<DegradedChatCard />);
+    expect(screen.queryByTestId('chat-degraded-card')).toBeNull();
+  });
+});
+
+describe('DegradedChatCard — transcript missing only', () => {
+  beforeEach(() => {
+    __chatConfig = chat({ transcriptMissing: true });
+  });
+
+  it('shows the card with Continue here + Delete chat, and no worktree actions', () => {
+    render(<DegradedChatCard />);
+    expect(screen.getByTestId('chat-degraded-card')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-continue')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-delete')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-degraded-recreate-worktree')).toBeNull();
+    expect(screen.queryByTestId('chat-degraded-project-root')).toBeNull();
+  });
+
+  it('Continue here POSTs the continue-here reset for this chat', async () => {
+    render(<DegradedChatCard />);
+    fireEvent.click(screen.getByTestId('chat-degraded-continue'));
+    await waitFor(() => expect(continueChatHere).toHaveBeenCalledWith(31415, 'chat-9'));
+  });
+
+  it('Delete chat archives the chat', async () => {
+    render(<DegradedChatCard />);
+    fireEvent.click(screen.getByTestId('chat-degraded-delete'));
+    await waitFor(() => expect(archiveChat).toHaveBeenCalledWith(31415, 'chat-9', true));
+  });
+});
+
+describe('DegradedChatCard — worktree missing only', () => {
+  beforeEach(() => {
+    __chatConfig = chat({ worktreeMissing: true, worktreePath: '/repo/.worktrees/feat-x', branchName: 'feat-x' });
+  });
+
+  it('shows Recreate worktree + Continue in project root + Delete, and no Continue here', () => {
+    render(<DegradedChatCard />);
+    expect(screen.getByTestId('chat-degraded-card')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-recreate-worktree')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-project-root')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-delete')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-degraded-continue')).toBeNull();
+  });
+
+  it('Recreate worktree POSTs the recreate route', async () => {
+    render(<DegradedChatCard />);
+    fireEvent.click(screen.getByTestId('chat-degraded-recreate-worktree'));
+    await waitFor(() => expect(recreateChatWorktree).toHaveBeenCalledWith(31415, 'chat-9'));
+  });
+
+  it('Continue in project root POSTs the detach route', async () => {
+    render(<DegradedChatCard />);
+    fireEvent.click(screen.getByTestId('chat-degraded-project-root'));
+    await waitFor(() => expect(continueChatInProjectRoot).toHaveBeenCalledWith(31415, 'chat-9'));
+  });
+
+  it('a failed recreate shows the error and falls back to project-root only', async () => {
+    vi.mocked(recreateChatWorktree).mockRejectedValueOnce(new Error('Branch "feat-x" no longer exists'));
+    render(<DegradedChatCard />);
+    fireEvent.click(screen.getByTestId('chat-degraded-recreate-worktree'));
+
+    await waitFor(() => expect(screen.getByTestId('chat-degraded-error')).toBeInTheDocument());
+    expect(screen.getByTestId('chat-degraded-error').textContent).toContain('Branch "feat-x" no longer exists');
+    expect(screen.queryByTestId('chat-degraded-recreate-worktree')).toBeNull();
+    expect(screen.getByTestId('chat-degraded-project-root')).toBeInTheDocument();
+  });
+});
+
+describe('DegradedChatCard — both causes', () => {
+  beforeEach(() => {
+    __chatConfig = chat({
+      transcriptMissing: true,
+      worktreeMissing: true,
+      worktreePath: '/repo/.worktrees/feat-x',
+      branchName: 'feat-x',
+    });
+  });
+
+  it('lists both causes but merges Continue here into the worktree actions', () => {
+    render(<DegradedChatCard />);
+    expect(screen.getByTestId('chat-degraded-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-degraded-continue')).toBeNull();
+    expect(screen.getByTestId('chat-degraded-recreate-worktree')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-project-root')).toBeInTheDocument();
+    expect(screen.getByTestId('chat-degraded-delete')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/features/sessions/filter/__tests__/apply-session-filters.test.ts
+++ b/packages/ui/src/features/sessions/filter/__tests__/apply-session-filters.test.ts
@@ -27,6 +27,7 @@ function item(
       hasPending: false,
       detectedPrs,
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: 1748779200000,
       worktreePath,
     },

--- a/packages/ui/src/features/sessions/filter/__tests__/tags-in-use.test.ts
+++ b/packages/ui/src/features/sessions/filter/__tests__/tags-in-use.test.ts
@@ -27,6 +27,7 @@ function item(
       hasPending: false,
       detectedPrs,
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: 1748779200000,
       worktreePath,
     },

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-create-once.test.tsx
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-create-once.test.tsx
@@ -39,7 +39,7 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FC } from 'react';
-import type { Chat, ClientEvent, DisplayMessage } from '@qlan-ro/mainframe-types';
+import type { Chat, ChatHistoryPayload, ClientEvent } from '@qlan-ro/mainframe-types';
 import type { AssistantRuntime } from '@assistant-ui/react';
 
 // ---------------------------------------------------------------------------
@@ -60,7 +60,7 @@ vi.mock('../../../../lib/api/chats', () => ({
   }),
   // Benign reads the controller does on load/seed.
   getChat: vi.fn(async (_port: number, chatId: string): Promise<Chat> => ({ id: chatId }) as Chat),
-  getChatMessages: vi.fn(async (): Promise<DisplayMessage[]> => []),
+  getChatMessages: vi.fn(async (): Promise<ChatHistoryPayload> => ({ messages: [], transcriptMissing: false })),
   listChats: vi.fn(async (): Promise<Chat[]> => []),
 }));
 

--- a/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
@@ -48,6 +48,7 @@ function statusLogoClass(badge: SessionBadge, adapterId: string): string {
   const visual = badge.unread || active ? 'text-primary' : 'text-mf-text-4 opacity-50';
   switch (badge.base) {
     case 'worktree-missing':
+    case 'transcript-missing':
       return `${base} ${visual}`;
     case 'working':
       return `${base} ${visual} ${workingLogoAnimation(adapterId)}`;
@@ -63,6 +64,8 @@ function dotLabel(badge: SessionBadge): string {
   switch (badge.base) {
     case 'worktree-missing':
       return 'Worktree missing';
+    case 'transcript-missing':
+      return 'Transcript missing';
     case 'working':
       return 'Working';
     case 'waiting':
@@ -285,6 +288,7 @@ function SessionRowInner({
                 <SessionRowMeta
                   worktreePath={custom.worktreePath}
                   worktreeMissing={custom.worktreeMissing}
+                  transcriptMissing={custom.transcriptMissing}
                   detectedPrs={custom.detectedPrs}
                   tags={custom.tags}
                   colorOf={colorOf}

--- a/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
@@ -8,7 +8,7 @@
  * density pass) — no text pill here, so worktree + PR keep the room.
  */
 
-import { GitFork } from 'lucide-react';
+import { AlertTriangle, GitFork } from 'lucide-react';
 import type { TagColor } from '@qlan-ro/mainframe-types';
 import type { DetectedPr } from '@qlan-ro/mainframe-types';
 import { TAG_DOT_STYLE } from '../tags/tag-colors';
@@ -19,6 +19,8 @@ import { TruncatedWithTooltip } from '@/components/ui/truncated-with-tooltip';
 interface SessionRowMetaProps {
   worktreePath?: string;
   worktreeMissing: boolean;
+  /** True when the CLI's transcript file for this session was deleted from disk. */
+  transcriptMissing?: boolean;
   detectedPrs: DetectedPr[];
   tags?: string[];
   colorOf?: (name: string) => TagColor;
@@ -33,9 +35,26 @@ function worktreeBasename(path: string): string {
   return parts[parts.length - 1] ?? path;
 }
 
+/** Unified degraded marker — one muted icon, tooltip + aria-label name the cause(s). */
+function DegradedMarker({ causes }: { causes: string[] }) {
+  const label = causes.join(' · ');
+  return (
+    <Hint label={label}>
+      <span
+        data-testid="sessions-row-meta-degraded"
+        aria-label={label}
+        className="inline-flex flex-shrink-0 items-center text-mf-text-3"
+      >
+        <AlertTriangle size={9} aria-hidden />
+      </span>
+    </Hint>
+  );
+}
+
 export function SessionRowMeta({
   worktreePath,
   worktreeMissing,
+  transcriptMissing = false,
   detectedPrs,
   tags,
   colorOf,
@@ -44,6 +63,10 @@ export function SessionRowMeta({
 }: SessionRowMetaProps) {
   const visibleTags = tags != null && tags.length > 0 ? tags.slice(0, 4) : [];
   const chipColor = projectId != null ? projectColor(projectId) : undefined;
+  const degradedCauses = [
+    ...(worktreeMissing ? ['Worktree missing'] : []),
+    ...(transcriptMissing ? ['Transcript missing'] : []),
+  ];
 
   return (
     <div className="flex min-w-0 items-center gap-[8px] text-micro tracking-normal text-mf-text-3">
@@ -64,6 +87,7 @@ export function SessionRowMeta({
           <TruncatedWithTooltip text={projectName} className="min-w-0" />
         </span>
       )}
+      {degradedCauses.length > 0 && <DegradedMarker causes={degradedCauses} />}
       {worktreePath != null && (
         <Hint label={worktreePath}>
           <span
@@ -73,7 +97,6 @@ export function SessionRowMeta({
               worktreeMissing ? 'text-destructive' : 'text-muted-foreground',
             ].join(' ')}
           >
-            {worktreeMissing && <span data-testid="sessions-row-meta-worktree-missing" aria-label="worktree missing" />}
             <GitFork size={9} className="flex-shrink-0 text-mf-text-3" aria-hidden />
             <span className="max-w-[8rem] truncate">{worktreeBasename(worktreePath)}</span>
           </span>

--- a/packages/ui/src/features/sessions/sidebar/__tests__/ArchivedSessionsDialog.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/ArchivedSessionsDialog.test.tsx
@@ -95,6 +95,7 @@ function makeCustom(projectId: string, updatedAt: number, status: 'active' | 'ar
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt,
   };
 }

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
@@ -71,6 +71,7 @@ function makeCustom(): SessionCustom {
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt: 1749284160000,
   };
 }

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
@@ -156,6 +156,7 @@ function makeItem(overrides?: Partial<SessionCustom>): SessionItem {
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt: 1749284160000,
     ...overrides,
   };

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.unread-store.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.unread-store.test.tsx
@@ -65,6 +65,7 @@ function makeItem(overrides: Partial<SessionItem> = {}): SessionItem {
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt: 1749284160000,
   };
   return {

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRowMeta.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRowMeta.test.tsx
@@ -7,8 +7,8 @@
  *  - projectId + projectName → a colored project chip renders (only in "All" view).
  *  - worktreePath="/repos/mf/.git/worktrees/feat-x" and worktreeMissing=false →
  *    data-testid="sessions-row-meta-worktree" is present and contains text "feat-x".
- *  - worktreePath="/repos/mf/.git/worktrees/feat-x" and worktreeMissing=true →
- *    data-testid="sessions-row-meta-worktree-missing" is present in the DOM.
+ *  - worktreeMissing/transcriptMissing → the unified
+ *    data-testid="sessions-row-meta-degraded" marker, aria-label naming the cause(s).
  *  - detectedPrs=[{ number: 42, url: "https://github.com/org/r/pull/42" }] →
  *    data-testid="sessions-row-meta-pr" renders text "#42".
  *  - detectedPrs=[] and no worktreePath → neither worktree nor PR elements appear.

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRowMeta.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRowMeta.test.tsx
@@ -87,14 +87,45 @@ describe('SessionRowMeta — worktree pill (not missing)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. Worktree missing indicator is present when worktreeMissing=true
+// 3. Unified degraded marker (cause-agnostic, aria-label names the cause)
 // ---------------------------------------------------------------------------
 
-describe('SessionRowMeta — worktree missing indicator', () => {
-  it('renders data-testid="sessions-row-meta-worktree-missing" when worktreeMissing=true', () => {
+describe('SessionRowMeta — unified degraded marker', () => {
+  it('renders sessions-row-meta-degraded labelled "Worktree missing" when worktreeMissing=true', () => {
     render(<SessionRowMeta worktreePath="/repos/mf/.git/worktrees/feat-x" worktreeMissing={true} detectedPrs={[]} />);
     expect(screen.getByTestId('sessions-row-meta-worktree')).toBeTruthy();
-    expect(screen.getByTestId('sessions-row-meta-worktree-missing')).toBeTruthy();
+    const marker = screen.getByTestId('sessions-row-meta-degraded');
+    expect(marker.getAttribute('aria-label')).toBe('Worktree missing');
+  });
+
+  it('renders the marker labelled "Transcript missing" when transcriptMissing=true', () => {
+    render(<SessionRowMeta worktreeMissing={false} transcriptMissing={true} detectedPrs={[]} />);
+    const marker = screen.getByTestId('sessions-row-meta-degraded');
+    expect(marker.getAttribute('aria-label')).toBe('Transcript missing');
+  });
+
+  it('names both causes when both flags are set', () => {
+    render(
+      <SessionRowMeta
+        worktreePath="/repos/mf/.git/worktrees/feat-x"
+        worktreeMissing={true}
+        transcriptMissing={true}
+        detectedPrs={[]}
+      />,
+    );
+    const marker = screen.getByTestId('sessions-row-meta-degraded');
+    expect(marker.getAttribute('aria-label')).toBe('Worktree missing · Transcript missing');
+  });
+
+  it('renders no marker (and never the old worktree-missing testid) when healthy', () => {
+    render(<SessionRowMeta worktreePath="/repos/mf/.git/worktrees/feat-x" worktreeMissing={false} detectedPrs={[]} />);
+    expect(screen.queryByTestId('sessions-row-meta-degraded')).toBeNull();
+    expect(screen.queryByTestId('sessions-row-meta-worktree-missing')).toBeNull();
+  });
+
+  it('the old sessions-row-meta-worktree-missing testid is gone even when degraded', () => {
+    render(<SessionRowMeta worktreePath="/repos/mf/.git/worktrees/feat-x" worktreeMissing={true} detectedPrs={[]} />);
+    expect(screen.queryByTestId('sessions-row-meta-worktree-missing')).toBeNull();
   });
 });
 
@@ -144,7 +175,9 @@ describe('SessionRowMeta — answer pill removed', () => {
       <SessionRowMeta
         worktreePath="/repos/mf/.git/worktrees/feat-x"
         worktreeMissing={false}
-        detectedPrs={[{ number: 42, url: 'https://github.com/org/r/pull/42', owner: 'org', repo: 'r', source: 'created' }]}
+        detectedPrs={[
+          { number: 42, url: 'https://github.com/org/r/pull/42', owner: 'org', repo: 'r', source: 'created' },
+        ]}
         tags={['alpha']}
         colorOf={() => 'blue'}
         projectId="p1"

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
@@ -270,6 +270,7 @@ function makeCustom(overrides?: Partial<SessionCustom>): SessionCustom {
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt: 1749284160000,
     ...overrides,
   };

--- a/packages/ui/src/features/sessions/view-model/__tests__/archived-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/archived-sessions.test.ts
@@ -25,6 +25,7 @@ function item(
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt,
     ...overrides,
   };

--- a/packages/ui/src/features/sessions/view-model/__tests__/attention-counts.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/attention-counts.test.ts
@@ -20,6 +20,7 @@ function item(id: string, projectId: string, hasPending = false): SessionItem {
       hasPending,
       detectedPrs: [],
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: 1748779200000,
     },
   };

--- a/packages/ui/src/features/sessions/view-model/__tests__/chat-to-thread-custom.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/chat-to-thread-custom.test.ts
@@ -263,3 +263,17 @@ describe('chatToThreadCustom — custom.branchName', () => {
     expect(chatToThreadCustom(makeChat()).custom.branchName).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// custom.transcriptMissing
+// ---------------------------------------------------------------------------
+
+describe('chatToThreadCustom — custom.transcriptMissing', () => {
+  it('is false when chat.transcriptMissing is absent', () => {
+    expect(chatToThreadCustom(makeChat()).custom.transcriptMissing).toBe(false);
+  });
+
+  it('is true when chat.transcriptMissing is true', () => {
+    expect(chatToThreadCustom(makeChat({ transcriptMissing: true })).custom.transcriptMissing).toBe(true);
+  });
+});

--- a/packages/ui/src/features/sessions/view-model/__tests__/count-by-base-status.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/count-by-base-status.test.ts
@@ -34,6 +34,7 @@ it('buckets sessions by base status (unread does not bucket)', () => {
   const unread = new Set<string>(['d']);
   expect(countByBaseStatus(items, unread)).toEqual({
     'worktree-missing': 1,
+    'transcript-missing': 0,
     working: 1,
     waiting: 1,
     idle: 2,

--- a/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
@@ -30,6 +30,7 @@ function item(id: string, overrides: Partial<SessionCustom> & { title?: string }
       hasPending: false,
       detectedPrs: [],
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: TODAY_1100,
       ...custom,
     },

--- a/packages/ui/src/features/sessions/view-model/__tests__/initial-session.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/initial-session.test.ts
@@ -26,6 +26,7 @@ function item(
       hasPending: false,
       detectedPrs: [],
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: 1000,
       ...customOverrides,
     },

--- a/packages/ui/src/features/sessions/view-model/__tests__/project-activity.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/project-activity.test.ts
@@ -34,6 +34,7 @@ function item(id: string, projectId: string, updatedAt: number): SessionItem {
       hasPending: false,
       detectedPrs: [],
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt,
     },
   };

--- a/packages/ui/src/features/sessions/view-model/__tests__/session-status.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/session-status.test.ts
@@ -38,3 +38,24 @@ describe('deriveSessionBadge', () => {
     expect(deriveSessionBadge(base(), false)).toEqual({ base: 'idle', unread: false });
   });
 });
+
+describe('deriveSessionBadge — transcript-missing', () => {
+  it('transcript-missing outranks working', () => {
+    expect(deriveSessionBadge(base({ transcriptMissing: true, displayStatus: 'working' }), false)).toEqual({
+      base: 'transcript-missing',
+      unread: false,
+    });
+  });
+  it('worktree-missing stays highest precedence when both flags are set', () => {
+    expect(deriveSessionBadge(base({ worktreeMissing: true, transcriptMissing: true }), false)).toEqual({
+      base: 'worktree-missing',
+      unread: false,
+    });
+  });
+  it('transcript-missing outranks waiting; unread rides alongside', () => {
+    expect(deriveSessionBadge(base({ transcriptMissing: true, hasPending: true }), true)).toEqual({
+      base: 'transcript-missing',
+      unread: true,
+    });
+  });
+});

--- a/packages/ui/src/features/sessions/view-model/__tests__/session-unread.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/session-unread.test.ts
@@ -18,6 +18,7 @@ function item(id: string, remoteId?: string): SessionItem {
       hasPending: false,
       detectedPrs: [],
       worktreeMissing: false,
+      transcriptMissing: false,
       updatedAt: 0,
     },
   };

--- a/packages/ui/src/features/sessions/view-model/__tests__/thread-list-projection.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/thread-list-projection.test.ts
@@ -33,6 +33,7 @@ function makeCustom(): SessionCustom {
     hasPending: false,
     detectedPrs: [],
     worktreeMissing: false,
+    transcriptMissing: false,
     updatedAt: 1749284160000,
   };
 }

--- a/packages/ui/src/features/sessions/view-model/chat-to-thread-custom.ts
+++ b/packages/ui/src/features/sessions/view-model/chat-to-thread-custom.ts
@@ -29,6 +29,8 @@ export interface SessionCustom {
   detectedPrs: NonNullable<Chat['detectedPrs']>;
   worktreePath?: string;
   worktreeMissing: boolean;
+  /** True when the CLI's transcript file for this session was deleted from disk. */
+  transcriptMissing: boolean;
   /** Worktree branch — read by the shell MainToolbar identity (additive). */
   branchName?: string;
   updatedAt: number;
@@ -65,6 +67,7 @@ export function chatToThreadCustom(chat: Chat): ThreadCustomResult {
     detectedPrs: chat.detectedPrs ?? [],
     worktreePath: chat.worktreePath,
     worktreeMissing: chat.worktreeMissing ?? false,
+    transcriptMissing: chat.transcriptMissing ?? false,
     branchName: chat.branchName,
     updatedAt: new Date(chat.updatedAt).getTime(),
   };

--- a/packages/ui/src/features/sessions/view-model/count-by-base-status.ts
+++ b/packages/ui/src/features/sessions/view-model/count-by-base-status.ts
@@ -5,7 +5,13 @@ import { isSessionUnread } from './session-unread';
 export type BaseStatusCounts = Record<SessionBase, number>;
 
 export function countByBaseStatus(items: SessionItem[], unread: Set<string>): BaseStatusCounts {
-  const counts: BaseStatusCounts = { 'worktree-missing': 0, working: 0, waiting: 0, idle: 0 };
+  const counts: BaseStatusCounts = {
+    'worktree-missing': 0,
+    'transcript-missing': 0,
+    working: 0,
+    waiting: 0,
+    idle: 0,
+  };
   for (const item of items) {
     const { base } = deriveSessionBadge(item.custom, isSessionUnread(item, unread));
     counts[base] += 1;

--- a/packages/ui/src/features/sessions/view-model/session-status.ts
+++ b/packages/ui/src/features/sessions/view-model/session-status.ts
@@ -2,13 +2,14 @@
  * Pure badge-state derivation from SessionCustom + client unread flag.
  *
  * `base` is the dominant lifecycle status (precedence: worktree-missing >
- * working > waiting > idle). `unread` is a MODIFIER carried alongside it — the
- * row tints idle / adds the answer-ready treatment to waiting based on it.
- * unread is NOT a field of SessionCustom; callers inject it from the client store.
+ * transcript-missing > working > waiting > idle). `unread` is a MODIFIER
+ * carried alongside it — the row tints idle / adds the answer-ready treatment
+ * to waiting based on it. unread is NOT a field of SessionCustom; callers
+ * inject it from the client store.
  */
 import type { SessionCustom } from './chat-to-thread-custom';
 
-export type SessionBase = 'worktree-missing' | 'working' | 'waiting' | 'idle';
+export type SessionBase = 'worktree-missing' | 'transcript-missing' | 'working' | 'waiting' | 'idle';
 
 export interface SessionBadge {
   base: SessionBase;
@@ -17,6 +18,7 @@ export interface SessionBadge {
 
 export function deriveSessionBadge(custom: SessionCustom, unread: boolean): SessionBadge {
   if (custom.worktreeMissing) return { base: 'worktree-missing', unread };
+  if (custom.transcriptMissing) return { base: 'transcript-missing', unread };
   if (custom.displayStatus === 'working') return { base: 'working', unread };
   if (custom.hasPending) return { base: 'waiting', unread };
   return { base: 'idle', unread };

--- a/packages/ui/src/layout/__tests__/SidebarFooter.test.tsx
+++ b/packages/ui/src/layout/__tests__/SidebarFooter.test.tsx
@@ -83,9 +83,12 @@ function Wrapper({ children }: { children: ReactNode }) {
 // ---------------------------------------------------------------------------
 
 it('renders the daemon-footer-trigger and per-status counts', () => {
-  render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 2, waiting: 1, idle: 3 }} />, {
-    wrapper: Wrapper,
-  });
+  render(
+    <SidebarFooterView counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 2, waiting: 1, idle: 3 }} />,
+    {
+      wrapper: Wrapper,
+    },
+  );
   expect(screen.getByTestId('daemon-footer-trigger')).toBeInTheDocument();
   expect(screen.getByTestId('sidebar-footer-count-working')).toHaveTextContent('2');
   expect(screen.getByTestId('sidebar-footer-count-waiting')).toHaveTextContent('1');
@@ -93,18 +96,28 @@ it('renders the daemon-footer-trigger and per-status counts', () => {
 
 describe('SidebarFooter — design-parity (Phase-3)', () => {
   it('root element has h-[25px] class (artboard specifies height: 25)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 0, waiting: 0, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 0, waiting: 0, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const footer = screen.getByTestId('sidebar-footer');
     expect(footer.className).toContain('h-[25px]');
     expect(footer.className).not.toContain('h-7');
   });
 
   it('working-count dot has animate-pulse class (artboard shows tw-pulse animation)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 1, waiting: 0, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 1, waiting: 0, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const workingCount = screen.getByTestId('sidebar-footer-count-working');
     const dot = workingCount.querySelector('.animate-pulse');
     expect(dot).toBeTruthy();
@@ -113,53 +126,83 @@ describe('SidebarFooter — design-parity (Phase-3)', () => {
 
 describe('SidebarFooter — design-parity findings 1.7/1.10/1.11/1.12', () => {
   it('root element uses px-[12px] horizontal padding (finding 1.7 — design wants 12px, px-3 compresses to 6px)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 0, waiting: 0, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 0, waiting: 0, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const footer = screen.getByTestId('sidebar-footer');
     expect(footer.className).toContain('px-[12px]');
     expect(footer.className).not.toContain('px-3');
   });
 
   it('count-cluster wrapper uses gap-[9px] between working/waiting/idle groups (finding 1.10)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 1, waiting: 1, idle: 1 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 1, waiting: 1, idle: 1 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const clusterWrap = screen.getByTestId('sidebar-footer-counts');
     expect(clusterWrap.className).toContain('gap-[9px]');
   });
 
   it('each count span uses gap-[4px] between dot and digit (finding 1.11 — gap-1 compresses to 2px)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 1, waiting: 0, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 1, waiting: 0, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const workingCount = screen.getByTestId('sidebar-footer-count-working');
     expect(workingCount.className).toContain('gap-[4px]');
     expect(workingCount.className).not.toContain('gap-1 ');
   });
 
   it('working count digit carries text-primary + font-semibold (finding 1.12)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 1, waiting: 0, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 1, waiting: 0, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const workingCount = screen.getByTestId('sidebar-footer-count-working');
     expect(workingCount.className).toContain('text-primary');
     expect(workingCount.className).toContain('font-semibold');
   });
 
   it('waiting count digit carries text-mf-warning + font-semibold (finding 1.12)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 0, waiting: 1, idle: 0 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 0, waiting: 1, idle: 0 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const waitingCount = screen.getByTestId('sidebar-footer-count-waiting');
     expect(waitingCount.className).toContain('text-mf-warning');
     expect(waitingCount.className).toContain('font-semibold');
   });
 
   it('idle count digit carries text-mf-text-3 + font-semibold (finding 1.12)', () => {
-    render(<SidebarFooterView counts={{ 'worktree-missing': 0, working: 0, waiting: 0, idle: 1 }} />, {
-      wrapper: Wrapper,
-    });
+    render(
+      <SidebarFooterView
+        counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 0, waiting: 0, idle: 1 }}
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const idleCount = screen.getByTestId('sidebar-footer-count-idle');
     expect(idleCount.className).toContain('text-mf-text-3');
     expect(idleCount.className).toContain('font-semibold');

--- a/packages/ui/src/lib/api/chats.ts
+++ b/packages/ui/src/lib/api/chats.ts
@@ -4,8 +4,8 @@
  * isLocalhost() bypass confirmed in packages/core/src/server/middleware/auth.ts).
  */
 import type {
-  DisplayMessage,
   Chat,
+  ChatHistoryPayload,
   SessionTuning,
   ExecutionMode,
   PermissionMode,
@@ -29,8 +29,23 @@ export interface ChatConfigPatch {
 export const setChatConfig = (port: number, chatId: string, body: ChatConfigPatch): Promise<Chat> =>
   request<Chat>('PATCH', `${apiBase(port)}/api/chats/${chatId}/config`, body);
 
-export const getChatMessages = (port: number, chatId: string): Promise<DisplayMessage[]> =>
-  request<DisplayMessage[]>('GET', `${apiBase(port)}/api/chats/${chatId}/messages`);
+/** History + transcript presence — `transcriptMissing` tells an empty thread from a deleted transcript. */
+export const getChatMessages = (port: number, chatId: string): Promise<ChatHistoryPayload> =>
+  request<ChatHistoryPayload>('GET', `${apiBase(port)}/api/chats/${chatId}/messages`);
+
+// ── Degraded-chat recovery (missing transcript / missing worktree) ──────────
+
+/** Forget the dead CLI session; the next send spawns fresh in the same chat row. */
+export const continueChatHere = (port: number, chatId: string): Promise<void> =>
+  requestEmpty('POST', `${apiBase(port)}/api/chats/${chatId}/continue-here`);
+
+/** Re-add the deleted worktree at its stored path from the stored branch (409 when the branch is gone). */
+export const recreateChatWorktree = (port: number, chatId: string): Promise<void> =>
+  requestEmpty('POST', `${apiBase(port)}/api/chats/${chatId}/recreate-worktree`);
+
+/** Detach the chat from its deleted worktree and rebind it to the project root. */
+export const continueChatInProjectRoot = (port: number, chatId: string): Promise<void> =>
+  requestEmpty('POST', `${apiBase(port)}/api/chats/${chatId}/continue-in-project-root`);
 
 /** The chat record (model, effort, planMode, permissionMode, adapterId, isRunning, …). */
 export const getChat = (port: number, chatId: string): Promise<Chat> =>


### PR DESCRIPTION
Implements the approved design in `docs/plans/2026-07-08-missing-transcript-worktree-recovery-design.md`.

## Problem
When the CLI deletes a session transcript (retention cleanup, manual deletion), the chat rendered as a silent empty thread and the next send died against a dead `--resume` id. A deleted worktree had detection but only a hard-locking composer banner with no recovery.

## Detection (core)
- Adapter predicate `isTranscriptPresent`: Claude stats the stored `session_file_path` / derived `~/.claude/projects/<encoded>/<id>.jsonl`; Codex checks the registry rollout path with `~/.codex/sessions` containment (null = cannot determine, never flag).
- New `transcript_missing` column (+ idempotent migration) exposed as `chat.transcriptMissing`.
- `reconcileTranscriptPresence`: self-healing, skips running chats and draft chats, persists flips, broadcasts enriched `chat.updated`. Runs on history load and on the 5-minute external-session sweep so the sidebar marker appears without opening the chat.

## Daemon API
- `GET /api/chats/:id/messages` now returns `{ messages, transcriptMissing }` (typed `ChatHistoryPayload`). **Note:** shape change also affects the mobile submodule — needs its own follow-up PR there.
- `POST /api/chats/:id/recreate-worktree` — re-adds the worktree at the stored path from the stored branch; 409 with a clear message when the branch is gone.
- `POST /api/chats/:id/continue-here` — forgets the dead CLI session (id + file path + flag), kills any spawned session, clears message caches. Sending with the flag set applies the same reset automatically.
- `POST /api/chats/:id/continue-in-project-root` — detaches the chat from the deleted worktree.

## UI
- `DegradedChatCard` in the thread replaces the composer `WorktreeMissingBanner`: one section per cause, actions `chat-degraded-continue` / `chat-degraded-recreate-worktree` / `chat-degraded-project-root` / `chat-degraded-delete`; failed recreate shows the error and falls back to project-root only; with both causes, Continue-here merges into the worktree actions.
- Composer stays locked only for a missing worktree; a missing transcript keeps it usable.
- Sidebar: unified `sessions-row-meta-degraded` marker (aria-label names the cause), `deriveSessionBadge` gains `transcript-missing` just below `worktree-missing`.
- Controller mirrors the load-time flag into `chatConfig`.

## Tests
- Core: `reconcileTranscriptPresence` (7), adapter predicates (8), DB column/migration/clearSession/clearWorktree (6), ChatManager degraded handling incl. send-reset (3), degraded-recovery ops (8), recovery routes (7), typed messages route (1), external-session sweep (2) — 42 new tests, all green.
- UI: DegradedChatCard (10), badge precedence, projection, reducer transcript plumbing, SessionRowMeta marker, composer banner removal — all green; full UI/core/e2e typecheck clean.
- E2E: `composer.spec.ts` + `sessions-rows.spec.ts` updated to the new testids (not executed here — needs the built app).

## Needs live verification
UI card and sidebar marker need a visual pass in the running app (app-tauri phantom-token trap means classes can silently render unstyled), plus a manual run of the two updated E2E specs.

Generated with Claude Code.