### PR TITLE
feat: background activity & working indicator

### DIFF
--- a/.changeset/background-activity-indicator.md
+++ b/.changeset/background-activity-indicator.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-ui': minor
+---
+
+Surface background work (subagents, background bash tasks, workflows) in the working indicator: the tracker registers every CLI task kind, `enrichChat` broadens the sidebar 'working' state and attaches a `backgroundActivity` payload, drain turns re-enter 'working', and a new BackgroundActivityBar chip above the composer lists live tasks.

--- a/packages/core/src/__tests__/bg-task-tracker-cleanup.test.ts
+++ b/packages/core/src/__tests__/bg-task-tracker-cleanup.test.ts
@@ -38,7 +38,7 @@ function seedActiveChat(manager: ChatManager, chatId: string, tracker: Backgroun
   // Plant a task in the tracker so we can confirm it's cleaned up
   tracker.start(
     chatId,
-    { id: 'task-1', toolName: 'Bash', toolUseId: 'tu-1', command: 'sleep 1', description: '' },
+    { id: 'task-1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu-1', command: 'sleep 1', description: '' },
     '/tmp/out',
   );
   // Inject a minimal active chat

--- a/packages/core/src/background-tasks/__tests__/kill-tasks-for-chat.test.ts
+++ b/packages/core/src/background-tasks/__tests__/kill-tasks-for-chat.test.ts
@@ -32,7 +32,11 @@ vi.mock('node:child_process', async () => {
 });
 
 function seed(tracker: BackgroundTaskTracker, chatId: string, id: string, outputPath: string) {
-  tracker.start(chatId, { id, toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' }, outputPath);
+  tracker.start(
+    chatId,
+    { id, kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+    outputPath,
+  );
 }
 
 describe('killTasksForChat (CLI + OS, no sweep)', () => {

--- a/packages/core/src/background-tasks/__tests__/liveness.test.ts
+++ b/packages/core/src/background-tasks/__tests__/liveness.test.ts
@@ -4,7 +4,11 @@ import * as lsofMod from '../lsof.js';
 import { BackgroundTaskTracker } from '../tracker.js';
 
 function seedRunning(tracker: BackgroundTaskTracker, chatId: string, id: string, outputPath: string) {
-  tracker.start(chatId, { id, toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' }, outputPath);
+  tracker.start(
+    chatId,
+    { id, kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+    outputPath,
+  );
 }
 
 describe('runLivenessSweep (one tick)', () => {
@@ -72,6 +76,21 @@ describe('runLivenessSweep (one tick)', () => {
     await runLivenessSweep({ tracker, missMap, now: taskStart + 160_000, forceWake: false });
     expect(getMissCount(missMap, 'c1', 't1')).toBe(0);
     expect(tracker.getPid('c1', 't1')).toBe(555);
+  });
+
+  it('non-bash kinds are exempt: an agent task is never lsof-probed or swept', async () => {
+    tracker.start(
+      'c1',
+      { id: 'a1', kind: 'agent', toolName: 'Bash', toolUseId: 'u', command: '', description: 'subagent' },
+      '/p/a1.out',
+    );
+    const taskStart = tracker.get('c1', 'a1')!.startedAt;
+    const detailed = vi.spyOn(lsofMod, 'lsofWritersDetailed').mockResolvedValue({ ok: true, pids: [] });
+
+    await runLivenessSweep({ tracker, missMap, now: taskStart + 100_000, forceWake: true });
+
+    expect(detailed).not.toHaveBeenCalled();
+    expect(tracker.get('c1', 'a1')!.status).toBe('running');
   });
 });
 

--- a/packages/core/src/background-tasks/__tests__/tracker.test.ts
+++ b/packages/core/src/background-tasks/__tests__/tracker.test.ts
@@ -7,6 +7,7 @@ function makeTask(
 ): Omit<BackgroundTask, 'startedAt' | 'endedAt' | 'status' | 'lastOutputLine' | 'summary' | 'usage' | 'outputPath'> {
   return {
     id: 'task-1',
+    kind: 'bash',
     toolName: 'Bash',
     toolUseId: 'tu-1',
     command: 'pnpm dev',
@@ -91,6 +92,7 @@ describe('BackgroundTaskTracker', () => {
       tracker.on('background_task.ended', () => local.push({ kind: 'ended' }));
       tracker.adopt('chat-a', {
         id: 'rec-1',
+        kind: 'bash',
         toolName: 'Bash',
         toolUseId: '',
         command: '<recovered>',
@@ -113,6 +115,7 @@ describe('BackgroundTaskTracker', () => {
     it('replaces an existing entry on adopt', () => {
       tracker.adopt('chat-a', {
         id: 'rec-1',
+        kind: 'bash',
         toolName: 'Bash',
         toolUseId: '',
         command: 'a',
@@ -128,6 +131,7 @@ describe('BackgroundTaskTracker', () => {
       });
       tracker.adopt('chat-a', {
         id: 'rec-1',
+        kind: 'bash',
         toolName: 'Bash',
         toolUseId: '',
         command: 'b',
@@ -148,9 +152,21 @@ describe('BackgroundTaskTracker', () => {
 
   describe('listAllRunning', () => {
     it('returns every running task across all chats with the chatId attached', () => {
-      tracker.start('chat-a', { id: 't1', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' }, '/p/a-t1');
-      tracker.start('chat-a', { id: 't2', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' }, '/p/a-t2');
-      tracker.start('chat-b', { id: 't1', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' }, '/p/b-t1');
+      tracker.start(
+        'chat-a',
+        { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        '/p/a-t1',
+      );
+      tracker.start(
+        'chat-a',
+        { id: 't2', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        '/p/a-t2',
+      );
+      tracker.start(
+        'chat-b',
+        { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        '/p/b-t1',
+      );
       tracker.end('chat-a', 't2', { status: 'completed', outputPath: '/p/a-t2', summary: '', usage: null });
       const all = tracker
         .listAllRunning()
@@ -164,12 +180,12 @@ describe('BackgroundTaskTracker', () => {
     it('stores and reads pids per (chatId, taskId)', () => {
       tracker.start(
         'chat-a',
-        { id: 't1', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
         '/p/t1.out',
       );
       tracker.start(
         'chat-b',
-        { id: 't1', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
         '/p/t1.out',
       );
       tracker.setPid('chat-a', 't1', 111);
@@ -182,7 +198,7 @@ describe('BackgroundTaskTracker', () => {
     it('removeChat clears the pid map slice for that chat', () => {
       tracker.start(
         'chat-a',
-        { id: 't1', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
+        { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'u', command: 'x', description: '' },
         '/p/t1.out',
       );
       tracker.setPid('chat-a', 't1', 111);
@@ -191,11 +207,76 @@ describe('BackgroundTaskTracker', () => {
     });
   });
 
+  describe('background work kinds + live set', () => {
+    it('stamps the kind from the start seed', () => {
+      tracker.start('chat-a', makeTask({ id: 'a-1', kind: 'agent' }), '/tmp/a-1.output');
+      expect(tracker.get('chat-a', 'a-1')!.kind).toBe('agent');
+    });
+
+    it('listLive returns only running tasks for the chat', () => {
+      tracker.start('chat-a', makeTask({ id: 't1' }), '/p/t1');
+      tracker.start('chat-a', makeTask({ id: 't2', kind: 'agent' }), '/p/t2');
+      tracker.start('chat-b', makeTask({ id: 't3' }), '/p/t3');
+      tracker.end('chat-a', 't1', { status: 'completed', outputPath: '/p/t1', summary: '', usage: null });
+      expect(tracker.listLive('chat-a').map((t) => t.id)).toEqual(['t2']);
+      expect(tracker.listLive('chat-b').map((t) => t.id)).toEqual(['t3']);
+      expect(tracker.listLive('chat-none')).toEqual([]);
+    });
+
+    it('upserts on duplicate start of a running task: no double count, keeps startedAt, emits updated', () => {
+      tracker.start('chat-a', makeTask({ id: 'dup', description: 'first' }), '/p/dup');
+      const startedAt = tracker.get('chat-a', 'dup')!.startedAt;
+      events.length = 0;
+      tracker.on('background_task.updated', (chatId, task) => events.push({ kind: 'updated', chatId, task }));
+
+      tracker.start('chat-a', makeTask({ id: 'dup', description: 'second' }), '/p/dup-again');
+
+      expect(tracker.listLive('chat-a')).toHaveLength(1);
+      const task = tracker.get('chat-a', 'dup')!;
+      expect(task.startedAt).toBe(startedAt);
+      expect(task.description).toBe('second');
+      expect(events.map((e) => e.kind)).toEqual(['updated']);
+    });
+
+    it('re-registers fresh (emits started) when the previous entry with the same id is terminal', () => {
+      tracker.start('chat-a', makeTask({ id: 'reuse' }), '/p/reuse');
+      tracker.end('chat-a', 'reuse', { status: 'stopped', outputPath: '', summary: 'CLI exited', usage: null });
+      events.length = 0;
+
+      tracker.start('chat-a', makeTask({ id: 'reuse' }), '/p/reuse');
+
+      expect(tracker.get('chat-a', 'reuse')!.status).toBe('running');
+      expect(events.map((e) => e.kind)).toEqual(['started']);
+    });
+
+    it('endAllRunning stops every running task, emits ended per task, and skips terminal ones', () => {
+      tracker.start('chat-a', makeTask({ id: 'r1' }), '/p/r1');
+      tracker.start('chat-a', makeTask({ id: 'r2', kind: 'agent' }), '/p/r2');
+      tracker.start('chat-a', makeTask({ id: 'done' }), '/p/done');
+      tracker.end('chat-a', 'done', { status: 'completed', outputPath: '', summary: '', usage: null });
+      events.length = 0;
+
+      const ended = tracker.endAllRunning('chat-a');
+
+      expect(ended).toBe(2);
+      expect(tracker.listLive('chat-a')).toEqual([]);
+      expect(tracker.get('chat-a', 'r1')!.status).toBe('stopped');
+      expect(tracker.get('chat-a', 'r2')!.status).toBe('stopped');
+      expect(tracker.get('chat-a', 'done')!.status).toBe('completed');
+      expect(events.map((e) => `${e.kind}:${e.task.id}`).sort()).toEqual(['ended:r1', 'ended:r2']);
+    });
+
+    it('endAllRunning on an unknown chat is a no-op returning 0', () => {
+      expect(tracker.endAllRunning('chat-ghost')).toBe(0);
+      expect(events).toEqual([]);
+    });
+  });
+
   describe('start(outputPath)', () => {
     it('stamps the deterministic outputPath at start time', () => {
       tracker.start(
         'chat-a',
-        { id: 't9', toolName: 'Bash', toolUseId: 'u9', command: 'pnpm dev', description: 'dev server' },
+        { id: 't9', kind: 'bash', toolName: 'Bash', toolUseId: 'u9', command: 'pnpm dev', description: 'dev server' },
         '/tmp/claude-501/-Users-x-proj/sess/tasks/t9.output',
       );
       expect(tracker.get('chat-a', 't9')!.outputPath).toBe('/tmp/claude-501/-Users-x-proj/sess/tasks/t9.output');

--- a/packages/core/src/background-tasks/liveness.ts
+++ b/packages/core/src/background-tasks/liveness.ts
@@ -56,6 +56,11 @@ export async function runLivenessSweep(args: SweepArgs): Promise<void> {
     }
     set.add(task.id);
 
+    // lsof-writer liveness only holds for bash tasks (the shell keeps the
+    // spool file open). Agents/workflows run inside the CLI and have no
+    // writer — probing them would false-stop live work. They close via
+    // task_notification bookends or endAllRunning on CLI exit.
+    if (task.kind !== 'bash') continue;
     if (now - task.startedAt < GRACE_MS) continue;
     if (!task.outputPath) {
       log.warn({ chatId, taskId: task.id }, 'liveness skip: no outputPath');

--- a/packages/core/src/background-tasks/reconcile.ts
+++ b/packages/core/src/background-tasks/reconcile.ts
@@ -35,6 +35,7 @@ function buildRecoveredSnapshot(taskId: string, fp: string, st: Stats, writers: 
   const running = writers.length > 0;
   return {
     id: taskId,
+    kind: 'bash', // only bash tasks spool to disk, so only they can be recovered
     toolName: 'Bash',
     toolUseId: '',
     command: '<recovered>',

--- a/packages/core/src/background-tasks/tracker.ts
+++ b/packages/core/src/background-tasks/tracker.ts
@@ -22,23 +22,27 @@ export class BackgroundTaskTracker {
 
   start(
     chatId: string,
-    seed: Pick<BackgroundTask, 'id' | 'toolName' | 'toolUseId' | 'command' | 'description'>,
+    seed: Pick<BackgroundTask, 'id' | 'kind' | 'toolName' | 'toolUseId' | 'command' | 'description'>,
     outputPath: string,
   ): BackgroundTask {
+    const chat = this.byChat.get(chatId) ?? new Map<string, BackgroundTask>();
+    const existing = chat.get(seed.id);
+    // Duplicate start of a live task (CLI re-register on resume) → upsert, no
+    // double count: keep the original startedAt and emit updated, not started.
+    const isUpsert = existing !== undefined && existing.status === 'running';
     const task: BackgroundTask = {
       ...seed,
       outputPath,
-      startedAt: Date.now(),
+      startedAt: isUpsert ? existing.startedAt : Date.now(),
       endedAt: null,
       status: 'running',
-      lastOutputLine: null,
+      lastOutputLine: isUpsert ? existing.lastOutputLine : null,
       summary: null,
       usage: null,
     };
-    const chat = this.byChat.get(chatId) ?? new Map<string, BackgroundTask>();
     chat.set(task.id, task);
     this.byChat.set(chatId, chat);
-    this.emitter.emit('background_task.started', chatId, task);
+    this.emitter.emit(isUpsert ? 'background_task.updated' : 'background_task.started', chatId, task);
     return task;
   }
 
@@ -84,6 +88,30 @@ export class BackgroundTaskTracker {
     return chat ? [...chat.values()] : [];
   }
 
+  /** Running tasks only — the chat's live background-activity set. */
+  listLive(chatId: string): BackgroundTask[] {
+    return this.list(chatId).filter((t) => t.status === 'running');
+  }
+
+  /**
+   * Terminal-stop every running task for a chat (CLI process ended — agents and
+   * workflows die with it; orphaned entries must not pin the working indicator).
+   * Emits `ended` per task; returns the number stopped.
+   */
+  endAllRunning(chatId: string): number {
+    let count = 0;
+    for (const task of this.listLive(chatId)) {
+      this.end(chatId, task.id, {
+        status: 'stopped',
+        outputPath: task.outputPath ?? '',
+        summary: 'session ended',
+        usage: null,
+      });
+      count++;
+    }
+    return count;
+  }
+
   /**
    * Cross-chat iterator over running tasks. Returns readonly references so
    * sweep callers (liveness, kill) can't mutate tracker state in place.
@@ -114,7 +142,7 @@ export class BackgroundTaskTracker {
   }
 
   on(
-    event: 'background_task.started' | 'background_task.ended',
+    event: 'background_task.started' | 'background_task.updated' | 'background_task.ended',
     listener: (chatId: string, task: BackgroundTask) => void,
   ): void {
     this.emitter.on(event, listener);

--- a/packages/core/src/chat/__tests__/chat-manager-background-activity.test.ts
+++ b/packages/core/src/chat/__tests__/chat-manager-background-activity.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Chat, ControlRequest } from '@qlan-ro/mainframe-types';
+import type { DatabaseManager } from '../../db/index.js';
+import type { AdapterRegistry } from '../../adapters/index.js';
+import type { PermissionManager } from '../permission-manager.js';
+import { ChatManager } from '../chat-manager.js';
+import { BackgroundTaskTracker } from '../../background-tasks/tracker.js';
+
+function makeDb(chats: Array<Partial<Chat> & { id: string }>): DatabaseManager {
+  const store = new Map<string, Partial<Chat> & { id: string }>(chats.map((c) => [c.id, { ...c }]));
+  return {
+    chats: {
+      get: (id: string) => (store.get(id) ?? null) as Chat | null,
+      listAll: () => [...store.values()] as Chat[],
+      list: vi.fn().mockReturnValue([]),
+      listFiltered: vi.fn().mockReturnValue([]),
+      update: vi.fn(),
+      resetWorkingToIdle: vi.fn().mockReturnValue(0),
+    },
+    projects: { list: vi.fn().mockReturnValue([]), get: vi.fn().mockReturnValue(null) },
+    settings: { get: vi.fn(), getByCategory: vi.fn(), set: vi.fn(), delete: vi.fn() },
+  } as unknown as DatabaseManager;
+}
+
+function makeAdapters(): AdapterRegistry {
+  return {
+    get: vi.fn().mockReturnValue(undefined),
+    all: vi.fn().mockReturnValue([]),
+  } as unknown as AdapterRegistry;
+}
+
+function startTask(
+  tracker: BackgroundTaskTracker,
+  chatId: string,
+  id: string,
+  kind: 'bash' | 'agent' | 'workflow',
+  description = 'work',
+) {
+  tracker.start(chatId, { id, kind, toolName: 'Bash', toolUseId: `tu-${id}`, command: 'cmd', description }, `/p/${id}`);
+}
+
+describe('ChatManager enrichChat — backgroundActivity derivation', () => {
+  let tracker: BackgroundTaskTracker;
+  let manager: ChatManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(5000);
+    tracker = new BackgroundTaskTracker();
+    manager = new ChatManager(
+      makeDb([
+        { id: 'c-idle', projectId: 'p1', processState: 'idle' },
+        { id: 'c-working', projectId: 'p1', processState: 'working' },
+      ]),
+      makeAdapters(),
+      tracker,
+    );
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    vi.useRealTimers();
+  });
+
+  it('main-only: working processState, no background → working, isRunning, no backgroundActivity', () => {
+    const chat = manager.getChat('c-working')!;
+    expect(chat.displayStatus).toBe('working');
+    expect(chat.isRunning).toBe(true);
+    expect(chat.backgroundActivity).toBeUndefined();
+  });
+
+  it('background-only: idle processState + live tasks → working, NOT isRunning, activity payload', () => {
+    startTask(tracker, 'c-idle', 'a-1', 'agent', 'reviewer');
+    startTask(tracker, 'c-idle', 'b-1', 'bash', 'dev server');
+
+    const chat = manager.getChat('c-idle')!;
+    expect(chat.displayStatus).toBe('working');
+    expect(chat.isRunning).toBe(false);
+    expect(chat.backgroundActivity).toEqual({
+      total: 2,
+      byKind: { agent: 1, bash: 1 },
+      tasks: [
+        { id: 'a-1', kind: 'agent', description: 'reviewer', startedAt: 5000 },
+        { id: 'b-1', kind: 'bash', description: 'dev server', startedAt: 5000 },
+      ],
+    });
+  });
+
+  it('both main turn and background → working with activity', () => {
+    startTask(tracker, 'c-working', 'w-1', 'workflow', 'deploy');
+    const chat = manager.getChat('c-working')!;
+    expect(chat.displayStatus).toBe('working');
+    expect(chat.isRunning).toBe(true);
+    expect(chat.backgroundActivity).toEqual({
+      total: 1,
+      byKind: { workflow: 1 },
+      tasks: [{ id: 'w-1', kind: 'workflow', description: 'deploy', startedAt: 5000 }],
+    });
+  });
+
+  it('terminal tasks do not count: idle with only ended tasks → idle, no activity', () => {
+    startTask(tracker, 'c-idle', 'a-2', 'agent');
+    tracker.end('c-idle', 'a-2', { status: 'completed', outputPath: '', summary: '', usage: null });
+
+    const chat = manager.getChat('c-idle')!;
+    expect(chat.displayStatus).toBe('idle');
+    expect(chat.backgroundActivity).toBeUndefined();
+  });
+
+  it('pending permission wins over background activity → waiting', () => {
+    startTask(tracker, 'c-idle', 'a-3', 'agent');
+    const permissions = (manager as unknown as { permissions: PermissionManager }).permissions;
+    permissions.enqueue('c-idle', { requestId: 'r1', toolName: 'Bash', toolUseId: 'tu', input: {} } as ControlRequest);
+
+    const chat = manager.getChat('c-idle')!;
+    expect(chat.displayStatus).toBe('waiting');
+    expect(chat.isRunning).toBe(false);
+    // The chip still shows the live background work while the gate is up.
+    expect(chat.backgroundActivity?.total).toBe(1);
+  });
+});

--- a/packages/core/src/chat/__tests__/event-handler-background-activity.test.ts
+++ b/packages/core/src/chat/__tests__/event-handler-background-activity.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventHandler } from '../event-handler.js';
+import { MessageCache } from '../message-cache.js';
+import { PermissionManager } from '../permission-manager.js';
+import { BackgroundTaskTracker } from '../../background-tasks/tracker.js';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+
+const chatId = 'chat-bg';
+
+describe('EventHandler — background activity lifecycle', () => {
+  let db: any;
+  let messages: MessageCache;
+  let permissions: PermissionManager;
+  let emitEvent: ReturnType<typeof vi.fn<(event: any) => void>>;
+  let activeChats: Map<string, any>;
+  let tracker: BackgroundTaskTracker;
+
+  function makeSink(): SessionSink {
+    const handler = new EventHandler(
+      db,
+      messages,
+      permissions,
+      (id) => activeChats.get(id),
+      emitEvent,
+      () => undefined,
+      () => {},
+      () => {},
+      () => [],
+      tracker,
+    );
+    return handler.buildSink(chatId, vi.fn().mockResolvedValue(undefined));
+  }
+
+  beforeEach(() => {
+    db = {
+      chats: { update: vi.fn(), get: vi.fn(), addSkillFile: vi.fn().mockReturnValue(false) },
+      projects: { get: vi.fn() },
+      settings: { get: vi.fn() },
+    };
+    messages = new MessageCache();
+    permissions = new PermissionManager();
+    emitEvent = vi.fn();
+    activeChats = new Map();
+    tracker = new BackgroundTaskTracker();
+  });
+
+  describe('onExit clears the live background set', () => {
+    it('stops every running task when the CLI process ends', () => {
+      activeChats.set(chatId, {
+        chat: { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'working' },
+        session: null,
+      });
+      tracker.start(
+        chatId,
+        { id: 'a-1', kind: 'agent', toolName: 'Bash', toolUseId: 't1', command: '', description: 'agent' },
+        '/p/a-1',
+      );
+      tracker.start(
+        chatId,
+        { id: 'b-1', kind: 'bash', toolName: 'Bash', toolUseId: 't2', command: 'dev', description: '' },
+        '/p/b-1',
+      );
+
+      makeSink().onExit(0);
+
+      expect(tracker.listLive(chatId)).toEqual([]);
+      expect(tracker.get(chatId, 'a-1')!.status).toBe('stopped');
+      expect(tracker.get(chatId, 'b-1')!.status).toBe('stopped');
+    });
+
+    it('does not touch other chats', () => {
+      activeChats.set(chatId, {
+        chat: { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'working' },
+        session: null,
+      });
+      tracker.start(
+        'other-chat',
+        { id: 'x-1', kind: 'bash', toolName: 'Bash', toolUseId: 't3', command: 'c', description: '' },
+        '/p/x-1',
+      );
+
+      makeSink().onExit(0);
+
+      expect(tracker.listLive('other-chat')).toHaveLength(1);
+    });
+  });
+
+  describe('drain-turn re-entry on onMessage', () => {
+    it('flips a non-working processState back to working and emits chat.updated', () => {
+      const chat = { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'idle' };
+      activeChats.set(chatId, { chat, session: null });
+
+      makeSink().onMessage([{ type: 'text', text: 'drain-turn summary' }]);
+
+      expect(chat.processState).toBe('working');
+      expect(db.chats.update).toHaveBeenCalledWith(chatId, { processState: 'working' });
+      const updated = emitEvent.mock.calls.find(([e]: [any]) => e.type === 'chat.updated');
+      expect(updated).toBeDefined();
+      expect(updated![0].chat.processState).toBe('working');
+    });
+
+    it('does not emit chat.updated when the turn is already working', () => {
+      const chat = { id: chatId, totalCost: 0, totalTokensInput: 0, totalTokensOutput: 0, processState: 'working' };
+      activeChats.set(chatId, { chat, session: null });
+
+      makeSink().onMessage([{ type: 'text', text: 'mid-turn message' }]);
+
+      const updated = emitEvent.mock.calls.find(([e]: [any]) => e.type === 'chat.updated');
+      expect(updated).toBeUndefined();
+      expect(db.chats.update).not.toHaveBeenCalledWith(chatId, { processState: 'working' });
+    });
+  });
+});

--- a/packages/core/src/chat/chat-manager.ts
+++ b/packages/core/src/chat/chat-manager.ts
@@ -14,6 +14,7 @@ import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
 import type { ChatListFilters } from '../db/chats.js';
 import { nanoid } from 'nanoid';
+import { deriveBackgroundActivity, toActivityTask } from '@qlan-ro/mainframe-types';
 import { isWorktreePresent } from '../workspace/worktree.js';
 import { createChildLogger } from '../logger.js';
 import { MessageCache } from './message-cache.js';
@@ -74,6 +75,7 @@ export class ChatManager {
       (chatId, uuid) => this.handleQueuedProcessed(chatId, uuid),
       (chatId) => this.clearAllQueuedForChat(chatId),
       (chatId) => this.getQueuedForChat(chatId),
+      this.tracker,
     );
     this.planMode = new PlanModeHandler({
       permissions: this.permissions,
@@ -752,8 +754,16 @@ export class ChatManager {
 
   private enrichChat(chat: Chat): Chat {
     const hasPending = this.permissions.hasPending(chat.id);
-    chat.displayStatus = hasPending ? 'waiting' : chat.processState === 'working' ? 'working' : 'idle';
+    const liveTasks = this.tracker.listLive(chat.id);
+    // Live background work broadens the sidebar 'working' state, but never
+    // isRunning — the composer/thread indicator stays main-turn-only.
+    chat.displayStatus = hasPending
+      ? 'waiting'
+      : chat.processState === 'working' || liveTasks.length > 0
+        ? 'working'
+        : 'idle';
     chat.isRunning = chat.processState === 'working' && !hasPending;
+    chat.backgroundActivity = deriveBackgroundActivity(liveTasks.map(toActivityTask));
     chat.worktreeMissing = chat.worktreePath ? !isWorktreePresent(chat.worktreePath) : false;
     return chat;
   }

--- a/packages/core/src/chat/event-handler.ts
+++ b/packages/core/src/chat/event-handler.ts
@@ -13,6 +13,7 @@ import type {
   QueuedMessageRef,
 } from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
+import type { BackgroundTaskTracker } from '../background-tasks/tracker.js';
 import type { MessageCache } from './message-cache.js';
 import type { PermissionManager } from './permission-manager.js';
 import type { ActiveChat } from './types.js';
@@ -63,6 +64,7 @@ export class EventHandler {
     private onQueuedProcessed: (chatId: string, uuid: string) => void = () => {},
     private onQueuedCleared: (chatId: string) => void = () => {},
     private getQueuedRefs: (chatId: string) => QueuedMessageRef[] = () => [],
+    private tracker?: BackgroundTaskTracker,
   ) {}
 
   setPushService(service: PushService): void {
@@ -95,6 +97,7 @@ export class EventHandler {
       this.onQueuedCleared,
       this.getQueuedRefs,
       this.pushService,
+      this.tracker,
     );
   }
 
@@ -125,6 +128,7 @@ function buildSessionSink(
   onQueuedClearedCb: (chatId: string) => void,
   getQueuedRefs: (chatId: string) => QueuedMessageRef[],
   pushService?: PushService,
+  tracker?: BackgroundTaskTracker,
 ): SessionSink {
   function emitDisplay(): void {
     const categories = getToolCategories(chatId);
@@ -156,6 +160,21 @@ function buildSessionSink(
 
     onMessage(content: any[], metadata?: MessageMetadata) {
       log.debug({ chatId, blockCount: content.length }, 'assistant message received');
+
+      // Drain-turn re-entry: a background task's completion re-invokes the turn
+      // (task_notification → fresh init → assistant message → second result)
+      // AFTER the first result already set processState to 'idle'. A top-level
+      // assistant event means the main agent is speaking again — flip back to
+      // 'working' so the thread indicator runs; the drain turn's own result
+      // clears it via the normal onResult path. Version-proof: on hold-back
+      // CLIs the state is still 'working' here, so this never fires.
+      const reentryChat = getActiveChat(chatId);
+      if (reentryChat && reentryChat.chat.processState !== 'working') {
+        reentryChat.chat.processState = 'working';
+        db.chats.update(chatId, { processState: 'working' });
+        emitEvent({ type: 'chat.updated', chat: reentryChat.chat });
+      }
+
       const categories = getToolCategories(chatId);
       for (const block of content) {
         if (block.type === 'tool_use' && (block.name === 'Write' || block.name === 'Edit')) {
@@ -466,6 +485,12 @@ function buildSessionSink(
         emitEvent({ type: 'message.queued.cleared', chatId });
       }
       onQueuedClearedCb(chatId);
+
+      // The CLI process owns every live background task (agents, workflows,
+      // bg bash) — none can report completion after it dies. Stop them so
+      // orphaned entries don't pin the sidebar's working indicator; the
+      // tracker emits `ended` per survivor for connected clients.
+      tracker?.endAllRunning(chatId);
 
       if (active) {
         active.chat.processState = null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,9 @@ async function main(): Promise<void> {
   backgroundTasks.on('background_task.started', (chatId, task) => {
     broadcastEvent({ type: 'background_task.started', chatId, task });
   });
+  backgroundTasks.on('background_task.updated', (chatId, task) => {
+    broadcastEvent({ type: 'background_task.updated', chatId, task });
+  });
   backgroundTasks.on('background_task.ended', (chatId, task) => {
     broadcastEvent({ type: 'background_task.ended', chatId, task });
   });

--- a/packages/core/src/plugins/builtin/claude/__tests__/task-events-integration.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/task-events-integration.test.ts
@@ -61,6 +61,41 @@ describe('task event chain — Mainframe chat id is used (not Claude session id)
     expect(tracker.list('claude-session-abc')).toEqual([]);
   });
 
+  it('task_started threads task_type through to the tracked kind', () => {
+    const { session, tracker } = makeSession('mf-chat-7');
+    const sink = makeSink();
+
+    send(session, sink, { type: 'system', subtype: 'init', session_id: 'claude-session-k' });
+    send(session, sink, {
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 'agent-1',
+      tool_use_id: 'tu-a',
+      description: 'reviewer subagent',
+      task_type: 'local_agent',
+    });
+
+    expect(tracker.get('mf-chat-7', 'agent-1')!.kind).toBe('agent');
+  });
+
+  it('task_updated with a terminal status ends the task', () => {
+    const { session, tracker } = makeSession('mf-chat-8');
+    const sink = makeSink();
+
+    send(session, sink, { type: 'system', subtype: 'init', session_id: 'claude-session-u' });
+    send(session, sink, {
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 'task-u',
+      tool_use_id: 'tu-u',
+      description: 'bg agent',
+      task_type: 'local_agent',
+    });
+    send(session, sink, { type: 'system', subtype: 'task_updated', task_id: 'task-u', status: 'failed' });
+
+    expect(tracker.get('mf-chat-8', 'task-u')!.status).toBe('failed');
+  });
+
   it('tracker.list(mainframeChatId) reflects completion after task_notification arrives', () => {
     const { session, tracker } = makeSession('mf-chat-99');
     const sink = makeSink();

--- a/packages/core/src/plugins/builtin/claude/__tests__/task-events.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/task-events.test.ts
@@ -105,6 +105,65 @@ describe('ClaudeTaskEvents', () => {
     expect(tracker.get('chat-a', 't-6')!.status).toBe('stopped');
   });
 
+  describe('background work kind mapping', () => {
+    it('maps local_bash → bash', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'b1', description: 'x', task_type: 'local_bash' }, CTX);
+      expect(tracker.get('chat-a', 'b1')!.kind).toBe('bash');
+    });
+
+    it('maps local_agent → agent', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'a1', description: 'x', task_type: 'local_agent' }, CTX);
+      expect(tracker.get('chat-a', 'a1')!.kind).toBe('agent');
+    });
+
+    it('maps remote agents and teammates → agent', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'a2', description: 'x', task_type: 'remote_agent' }, CTX);
+      te.handleTaskStarted('chat-a', { task_id: 'a3', description: 'x', task_type: 'teammate' }, CTX);
+      expect(tracker.get('chat-a', 'a2')!.kind).toBe('agent');
+      expect(tracker.get('chat-a', 'a3')!.kind).toBe('agent');
+    });
+
+    it('maps local_workflow → workflow', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'w1', description: 'x', task_type: 'local_workflow' }, CTX);
+      expect(tracker.get('chat-a', 'w1')!.kind).toBe('workflow');
+    });
+
+    it('maps an unknown task_type → other', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'o1', description: 'x', task_type: 'local_quantum' }, CTX);
+      expect(tracker.get('chat-a', 'o1')!.kind).toBe('other');
+    });
+
+    it('falls back to bash when task_type is missing but a Bash tool_use was captured', () => {
+      te.captureToolUse('tu-k', { name: 'Bash', input: { command: 'pnpm dev', run_in_background: true } });
+      te.handleTaskStarted('chat-a', { task_id: 'k1', tool_use_id: 'tu-k', description: 'dev' }, CTX);
+      expect(tracker.get('chat-a', 'k1')!.kind).toBe('bash');
+    });
+
+    it('maps missing task_type with no captured tool_use → other', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'k2', description: 'x' }, CTX);
+      expect(tracker.get('chat-a', 'k2')!.kind).toBe('other');
+    });
+  });
+
+  describe('handleTaskUpdated', () => {
+    it('ends the task on a terminal status', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'u1', description: 'x', task_type: 'local_agent' }, CTX);
+      te.handleTaskUpdated('chat-a', { task_id: 'u1', status: 'completed' });
+      expect(tracker.get('chat-a', 'u1')!.status).toBe('completed');
+    });
+
+    it('ignores a non-terminal status (task stays running)', () => {
+      te.handleTaskStarted('chat-a', { task_id: 'u2', description: 'x', task_type: 'local_agent' }, CTX);
+      te.handleTaskUpdated('chat-a', { task_id: 'u2', status: 'running' });
+      expect(tracker.get('chat-a', 'u2')!.status).toBe('running');
+    });
+
+    it('ignores an unknown task_id', () => {
+      te.handleTaskUpdated('chat-a', { task_id: 'ghost', status: 'completed' });
+      expect(tracker.get('chat-a', 'ghost')).toBeNull();
+    });
+  });
+
   it('threads deterministic outputPath into tracker.start', () => {
     const trackerStart = vi.fn();
     const tracker = { start: trackerStart, end: vi.fn() } as unknown as BackgroundTaskTracker;

--- a/packages/core/src/plugins/builtin/claude/events.ts
+++ b/packages/core/src/plugins/builtin/claude/events.ts
@@ -69,9 +69,17 @@ function handleSystemEvent(session: ClaudeSession, event: Record<string, unknown
           task_id: event.task_id as string,
           tool_use_id: event.tool_use_id as string | undefined,
           description: event.description as string | undefined,
+          task_type: event.task_type as string | undefined,
         },
         { claudeSessionId: session.state.chatId, realCwd: session.state.realProjectPath },
       );
+    }
+  } else if (event.subtype === 'task_updated') {
+    if (session.state.mainframeChatId) {
+      session.state.taskEvents.handleTaskUpdated(session.state.mainframeChatId, {
+        task_id: event.task_id as string,
+        status: event.status as string,
+      });
     }
   } else if (event.subtype === 'task_notification') {
     session.state.activeTasks.delete(event.task_id as string);

--- a/packages/core/src/plugins/builtin/claude/task-events.ts
+++ b/packages/core/src/plugins/builtin/claude/task-events.ts
@@ -1,4 +1,4 @@
-import type { BackgroundTaskStatus, BackgroundTaskToolName } from '@qlan-ro/mainframe-types';
+import type { BackgroundTaskStatus, BackgroundTaskToolName, BackgroundWorkKind } from '@qlan-ro/mainframe-types';
 import { BackgroundTaskTracker } from '../../../background-tasks/tracker.js';
 import { encodeCwdSegment } from '../../../background-tasks/encoding.js';
 import { spoolRoot } from '../../../background-tasks/spool-root.js';
@@ -19,6 +19,12 @@ type TaskStartedPayload = {
   task_id: string;
   tool_use_id?: string;
   description?: string;
+  task_type?: string;
+};
+
+type TaskUpdatedPayload = {
+  task_id: string;
+  status: string;
 };
 
 type TaskNotificationPayload = {
@@ -30,6 +36,19 @@ type TaskNotificationPayload = {
 };
 
 const KNOWN_STATUSES = new Set<BackgroundTaskStatus>(['completed', 'failed', 'stopped']);
+
+/**
+ * CLI `task_type` → client-facing kind. Prefix-tolerant (`local_agent`,
+ * `remote_agent`, teammates → agent) so new CLI variants degrade gracefully;
+ * genuinely unknown types land in 'other', never dropped.
+ */
+export function mapTaskKind(taskType: string | undefined, hasBashMetadata: boolean): BackgroundWorkKind {
+  if (taskType === undefined) return hasBashMetadata ? 'bash' : 'other';
+  if (taskType.includes('bash')) return 'bash';
+  if (taskType.includes('agent') || taskType.includes('teammate')) return 'agent';
+  if (taskType.includes('workflow')) return 'workflow';
+  return 'other';
+}
 
 function mapStatus(s: string): Exclude<BackgroundTaskStatus, 'running'> {
   if (KNOWN_STATUSES.has(s as BackgroundTaskStatus)) {
@@ -72,6 +91,7 @@ export class ClaudeTaskEvents {
       chatId,
       {
         id: payload.task_id,
+        kind: mapTaskKind(payload.task_type, meta !== null),
         toolName: meta?.toolName ?? 'Bash',
         toolUseId: payload.tool_use_id ?? '',
         command: meta?.command ?? payload.description ?? '<unknown>',
@@ -79,6 +99,21 @@ export class ClaudeTaskEvents {
       },
       outputPath,
     );
+  }
+
+  /**
+   * `task_updated` fires alongside `task_notification` (post-leak CLI addition).
+   * Only a terminal status closes the task — the tracker dedups when the
+   * notification already landed; non-terminal updates carry nothing we track.
+   */
+  handleTaskUpdated(chatId: string, payload: TaskUpdatedPayload): void {
+    if (!KNOWN_STATUSES.has(payload.status as BackgroundTaskStatus)) return;
+    this.tracker.end(chatId, payload.task_id, {
+      status: payload.status as Exclude<BackgroundTaskStatus, 'running'>,
+      outputPath: '',
+      summary: '',
+      usage: null,
+    });
   }
 
   handleTaskNotification(chatId: string, payload: TaskNotificationPayload): void {

--- a/packages/core/src/server/routes/__tests__/background-tasks.test.ts
+++ b/packages/core/src/server/routes/__tests__/background-tasks.test.ts
@@ -30,7 +30,7 @@ describe('background-tasks routes', () => {
     const tracker = new BackgroundTaskTracker();
     tracker.start(
       'c1',
-      { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'sleep 5', description: '' },
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'sleep 5', description: '' },
       DUMMY_PATH,
     );
     const res = await request(makeApp({ tracker })).get('/api/chats/c1/background-tasks');
@@ -45,6 +45,7 @@ describe('background-tasks routes', () => {
     // adopt() lets us place a task with outputPath: null (e.g. a recovered entry with no spool file).
     tracker.adopt('c1', {
       id: 't1',
+      kind: 'bash',
       toolName: 'Bash',
       toolUseId: 'tu',
       command: 'x',
@@ -70,7 +71,11 @@ describe('background-tasks routes', () => {
 
   it('GET /output → 409 invalid_path when validator rejects', async () => {
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      DUMMY_PATH,
+    );
     tracker.end('c1', 't1', { status: 'completed', outputPath: '/etc/passwd', summary: '', usage: null });
     const res = await request(makeApp({ tracker, validator: async () => false })).get(
       '/api/chats/c1/background-tasks/t1/output',
@@ -88,7 +93,11 @@ describe('background-tasks routes', () => {
     await writeFile(outPath, 'a\nb\nc\nlast line\n');
 
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, outPath);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      outPath,
+    );
     tracker.end('c1', 't1', { status: 'completed', outputPath: outPath, summary: '', usage: null });
     const res = await request(makeApp({ tracker })).get('/api/chats/c1/background-tasks/t1/output?bytes=64');
     expect(res.status).toBe(200);
@@ -103,7 +112,11 @@ describe('background-tasks routes', () => {
 
   it('POST /kill → 200 on success', async () => {
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      DUMMY_PATH,
+    );
     const session = { stopBackgroundTask: vi.fn().mockResolvedValue({ ok: true }) };
     const killImpl = vi.fn().mockResolvedValue({ ok: true, via: 'stop_task' });
     const res = await request(makeApp({ tracker, sessionForChat: () => session, killImpl })).post(
@@ -115,7 +128,11 @@ describe('background-tasks routes', () => {
 
   it('POST /kill → 502 + error body when kill fails', async () => {
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      DUMMY_PATH,
+    );
     const session = { stopBackgroundTask: vi.fn() };
     const killImpl = vi.fn().mockResolvedValue({ ok: false, error: 'timeout', via: 'none' });
     const res = await request(makeApp({ tracker, sessionForChat: () => session, killImpl })).post(
@@ -137,7 +154,11 @@ describe('background-tasks routes', () => {
 
   it('GET /output → 500 (via error middleware) when the validator rejects, not a hung request', async () => {
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      DUMMY_PATH,
+    );
     tracker.end('c1', 't1', { status: 'completed', outputPath: '/etc/passwd', summary: '', usage: null });
     const res = await request(
       makeAppWithErrorTrap({
@@ -152,7 +173,11 @@ describe('background-tasks routes', () => {
 
   it('POST /kill → 500 (via error middleware) when killImpl rejects, not a hung request', async () => {
     const tracker = new BackgroundTaskTracker();
-    tracker.start('c1', { id: 't1', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' }, DUMMY_PATH);
+    tracker.start(
+      'c1',
+      { id: 't1', kind: 'bash', toolName: 'Bash', toolUseId: 'tu', command: 'x', description: '' },
+      DUMMY_PATH,
+    );
     const killImpl = vi.fn().mockRejectedValue(new Error('kill boom'));
     const res = await request(
       makeAppWithErrorTrap({ tracker, sessionForChat: () => ({ stopBackgroundTask: vi.fn() }), killImpl }),
@@ -164,6 +189,7 @@ describe('background-tasks routes', () => {
     const tracker = new BackgroundTaskTracker();
     tracker.adopt('chat-a', {
       id: 'rec-1',
+      kind: 'bash',
       toolName: 'Bash',
       toolUseId: '',
       command: '<recovered>',

--- a/packages/types/src/__tests__/background-activity.test.ts
+++ b/packages/types/src/__tests__/background-activity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Behavior tests for the background-activity types + helpers.
+ * All expected values are hardcoded — no production logic re-derived here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  BackgroundWorkKindSchema,
+  BackgroundActivitySchema,
+  toActivityTask,
+  deriveBackgroundActivity,
+  type BackgroundTask,
+} from '../index.js';
+
+function makeTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: 'b-1',
+    kind: 'bash',
+    toolName: 'Bash',
+    toolUseId: 'tu-1',
+    command: 'pnpm dev',
+    description: 'dev server',
+    outputPath: '/tmp/b-1.output',
+    startedAt: 1000,
+    endedAt: null,
+    status: 'running',
+    lastOutputLine: null,
+    summary: null,
+    usage: null,
+    ...overrides,
+  };
+}
+
+describe('BackgroundWorkKindSchema', () => {
+  it('accepts the four kinds', () => {
+    for (const kind of ['bash', 'agent', 'workflow', 'other']) {
+      expect(BackgroundWorkKindSchema.parse(kind)).toBe(kind);
+    }
+  });
+
+  it('rejects unknown kinds', () => {
+    expect(() => BackgroundWorkKindSchema.parse('local_bash')).toThrow();
+  });
+});
+
+describe('toActivityTask', () => {
+  it('picks id, kind, description, startedAt', () => {
+    expect(toActivityTask(makeTask())).toEqual({
+      id: 'b-1',
+      kind: 'bash',
+      description: 'dev server',
+      startedAt: 1000,
+    });
+  });
+
+  it('falls back to command when description is empty', () => {
+    expect(toActivityTask(makeTask({ description: '' }))).toEqual({
+      id: 'b-1',
+      kind: 'bash',
+      description: 'pnpm dev',
+      startedAt: 1000,
+    });
+  });
+});
+
+describe('deriveBackgroundActivity', () => {
+  it('returns undefined for an empty list', () => {
+    expect(deriveBackgroundActivity([])).toBeUndefined();
+  });
+
+  it('counts by kind and totals', () => {
+    const activity = deriveBackgroundActivity([
+      toActivityTask(makeTask({ id: 'a-1', kind: 'agent', description: 'reviewer' })),
+      toActivityTask(makeTask({ id: 'a-2', kind: 'agent', description: 'tester' })),
+      toActivityTask(makeTask({ id: 'b-1', kind: 'bash' })),
+      toActivityTask(makeTask({ id: 'w-1', kind: 'workflow', description: 'deploy' })),
+    ]);
+    expect(activity).toEqual({
+      total: 4,
+      byKind: { agent: 2, bash: 1, workflow: 1 },
+      tasks: [
+        { id: 'a-1', kind: 'agent', description: 'reviewer', startedAt: 1000 },
+        { id: 'a-2', kind: 'agent', description: 'tester', startedAt: 1000 },
+        { id: 'b-1', kind: 'bash', description: 'dev server', startedAt: 1000 },
+        { id: 'w-1', kind: 'workflow', description: 'deploy', startedAt: 1000 },
+      ],
+    });
+  });
+
+  it('validates against BackgroundActivitySchema', () => {
+    const activity = deriveBackgroundActivity([toActivityTask(makeTask())]);
+    expect(BackgroundActivitySchema.parse(activity)).toEqual(activity);
+  });
+});

--- a/packages/types/src/background-task.ts
+++ b/packages/types/src/background-task.ts
@@ -1,9 +1,17 @@
+import { z } from 'zod';
+
 export type BackgroundTaskStatus = 'running' | 'completed' | 'failed' | 'stopped';
 
 export type BackgroundTaskToolName = 'Bash' | 'Monitor';
 
+/** What a CLI background task is, mapped from the CLI's `task_type` (`local_bash` → `bash`, agents/teammates → `agent`, …). */
+export type BackgroundWorkKind = 'bash' | 'agent' | 'workflow' | 'other';
+
+export const BackgroundWorkKindSchema = z.enum(['bash', 'agent', 'workflow', 'other']);
+
 export interface BackgroundTask {
   id: string;
+  kind: BackgroundWorkKind;
   toolName: BackgroundTaskToolName;
   toolUseId: string;
   command: string;
@@ -42,3 +50,51 @@ export interface BackgroundTaskEndedEvent {
 }
 
 export type BackgroundTaskEvent = BackgroundTaskStartedEvent | BackgroundTaskUpdatedEvent | BackgroundTaskEndedEvent;
+
+/** One live background task as surfaced to clients (in `Chat.backgroundActivity` and the UI activity bar). */
+export interface BackgroundActivityTask {
+  id: string;
+  kind: BackgroundWorkKind;
+  description: string;
+  startedAt: number;
+}
+
+/** Live background work for a chat — derived from the tracker, never persisted. */
+export interface BackgroundActivity {
+  total: number;
+  byKind: Partial<Record<BackgroundWorkKind, number>>;
+  tasks: BackgroundActivityTask[];
+}
+
+export const BackgroundActivityTaskSchema: z.ZodType<BackgroundActivityTask> = z.object({
+  id: z.string().min(1),
+  kind: BackgroundWorkKindSchema,
+  description: z.string(),
+  startedAt: z.number(),
+});
+
+export const BackgroundActivitySchema: z.ZodType<BackgroundActivity> = z.object({
+  total: z.number().int().nonnegative(),
+  byKind: z.partialRecord(BackgroundWorkKindSchema, z.number().int().positive()),
+  tasks: z.array(BackgroundActivityTaskSchema),
+});
+
+/** Project a tracker task onto its client-facing activity entry (bash tasks often carry the command, not a description). */
+export function toActivityTask(task: BackgroundTask): BackgroundActivityTask {
+  return {
+    id: task.id,
+    kind: task.kind,
+    description: task.description || task.command,
+    startedAt: task.startedAt,
+  };
+}
+
+/** Aggregate live tasks into the `backgroundActivity` payload; undefined when nothing is live. */
+export function deriveBackgroundActivity(tasks: BackgroundActivityTask[]): BackgroundActivity | undefined {
+  if (tasks.length === 0) return undefined;
+  const byKind: Partial<Record<BackgroundWorkKind, number>> = {};
+  for (const task of tasks) {
+    byKind[task.kind] = (byKind[task.kind] ?? 0) + 1;
+  }
+  return { total: tasks.length, byKind, tasks };
+}

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -1,4 +1,5 @@
 import type { SessionMention } from './context.js';
+import type { BackgroundActivity } from './background-task.js';
 import type { DetectedPr, ControlRequest, EffortLevel } from './adapter.js';
 import type { ExecutionMode } from './settings.js';
 import type { LeafContent } from './content.js';
@@ -57,6 +58,8 @@ export interface Chat {
   processState?: 'working' | 'idle' | null;
   displayStatus?: 'idle' | 'working' | 'waiting';
   isRunning?: boolean;
+  /** Live background work (agents/bash/workflows) — derived per response, never persisted. */
+  backgroundActivity?: BackgroundActivity;
   worktreeMissing?: boolean;
   todos?: TodoItem[];
   pinned?: boolean;

--- a/packages/ui/src/features/chat/composer/BackgroundActivityBar.tsx
+++ b/packages/ui/src/features/chat/composer/BackgroundActivityBar.tsx
@@ -1,0 +1,103 @@
+/**
+ * BackgroundActivityBar — compact chip above the composer surfacing live
+ * background work (subagents, background bash tasks, workflows) while the
+ * composer stays fully active. Hidden when the live set is empty; clicking
+ * opens a popover listing each item with its kind icon and elapsed time.
+ *
+ * Data: `extras.state.backgroundTasks`, fed by `background_task.*` events and
+ * resynced from `chat.updated`'s `backgroundActivity` (see chat-thread-state).
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Bot, SquareTerminal, Workflow } from 'lucide-react';
+import type { BackgroundActivityTask, BackgroundWorkKind } from '@qlan-ro/mainframe-types';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useChatExtras } from '../runtime/use-chat-thread-runtime';
+
+const KIND_ICONS: Record<BackgroundWorkKind, typeof Bot> = {
+  agent: Bot,
+  bash: SquareTerminal,
+  workflow: Workflow,
+  other: SquareTerminal,
+};
+
+/** "2 agents · 1 task · 1 workflow" — bash and unknown kinds both read as tasks. */
+export function summarizeByKind(tasks: BackgroundActivityTask[]): string {
+  const counts = { agent: 0, task: 0, workflow: 0 };
+  for (const t of tasks) {
+    if (t.kind === 'agent') counts.agent += 1;
+    else if (t.kind === 'workflow') counts.workflow += 1;
+    else counts.task += 1;
+  }
+  const parts: string[] = [];
+  if (counts.agent > 0) parts.push(`${counts.agent} agent${counts.agent === 1 ? '' : 's'}`);
+  if (counts.task > 0) parts.push(`${counts.task} task${counts.task === 1 ? '' : 's'}`);
+  if (counts.workflow > 0) parts.push(`${counts.workflow} workflow${counts.workflow === 1 ? '' : 's'}`);
+  return parts.join(' · ');
+}
+
+/** "<1m", "5m", "1h 12m" — minute-level is enough for a background chip. */
+export function formatElapsed(startedAt: number, now: number): string {
+  const minutes = Math.floor(Math.max(0, now - startedAt) / 60_000);
+  if (minutes < 1) return '<1m';
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+/** Re-renders every 30s so elapsed times stay fresh while work is live. */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const timer = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(timer);
+  }, [active]);
+  return active ? now : Date.now();
+}
+
+export function BackgroundActivityBar() {
+  const extras = useChatExtras();
+  const backgroundTasks = extras?.state.backgroundTasks;
+  const tasks = useMemo(() => Object.values(backgroundTasks ?? {}), [backgroundTasks]);
+  const now = useNow(tasks.length > 0);
+  if (tasks.length === 0) return null;
+
+  return (
+    <div className="px-1 pb-1.5">
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            data-testid="composer-background-activity"
+            aria-label={`Background activity: ${summarizeByKind(tasks)}`}
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-border bg-card py-0.5 pl-2 pr-2.5 text-caption text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground"
+          >
+            <span className="size-[5px] flex-shrink-0 rounded-full bg-primary motion-safe:animate-pulse" aria-hidden />
+            <span>{summarizeByKind(tasks)}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" className="w-80 p-1">
+          <ul className="flex max-h-56 flex-col gap-px overflow-y-auto">
+            {tasks.map((task) => {
+              const Icon = KIND_ICONS[task.kind] ?? SquareTerminal;
+              return (
+                <li
+                  key={task.id}
+                  data-testid={`composer-background-activity-item-${task.id}`}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5"
+                >
+                  <Icon size={13} className="flex-shrink-0 text-mf-text-3" aria-hidden />
+                  <span className="min-w-0 flex-1 truncate text-caption text-foreground">
+                    {task.description || 'Background task'}
+                  </span>
+                  <span className="flex-shrink-0 font-mono text-micro tabular-nums text-mf-text-3">
+                    {formatElapsed(task.startedAt, now)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/packages/ui/src/features/chat/composer/__tests__/BackgroundActivityBar.test.tsx
+++ b/packages/ui/src/features/chat/composer/__tests__/BackgroundActivityBar.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Behavior tests for BackgroundActivityBar — the chip above the composer that
+ * surfaces live background work (agents / bg bash tasks / workflows).
+ * Hardcoded expected labels; no production logic re-derived.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { BackgroundActivityTask } from '@qlan-ro/mainframe-types';
+
+let __backgroundTasks: Record<string, BackgroundActivityTask> = {};
+
+vi.mock('../../runtime/use-chat-thread-runtime', () => ({
+  useChatExtras: () => ({ state: { backgroundTasks: __backgroundTasks } }),
+}));
+
+import { BackgroundActivityBar } from '../BackgroundActivityBar';
+
+function task(id: string, kind: BackgroundActivityTask['kind'], description: string, startedAt: number) {
+  return { id, kind, description, startedAt };
+}
+
+describe('BackgroundActivityBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(10 * 60_000); // t = 10 minutes
+    __backgroundTasks = {};
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when there is no live background work', () => {
+    render(<BackgroundActivityBar />);
+    expect(screen.queryByTestId('composer-background-activity')).toBeNull();
+  });
+
+  it('shows counts by kind — agents, tasks, workflows', () => {
+    __backgroundTasks = {
+      'a-1': task('a-1', 'agent', 'reviewer', 0),
+      'a-2': task('a-2', 'agent', 'tester', 0),
+      'b-1': task('b-1', 'bash', 'pnpm dev', 0),
+      'w-1': task('w-1', 'workflow', 'deploy', 0),
+    };
+    render(<BackgroundActivityBar />);
+    expect(screen.getByTestId('composer-background-activity').textContent).toContain('2 agents · 1 task · 1 workflow');
+  });
+
+  it('uses singular labels for single items', () => {
+    __backgroundTasks = { 'a-1': task('a-1', 'agent', 'reviewer', 0) };
+    render(<BackgroundActivityBar />);
+    expect(screen.getByTestId('composer-background-activity').textContent).toContain('1 agent');
+  });
+
+  it("counts 'other' kinds as tasks", () => {
+    __backgroundTasks = {
+      'o-1': task('o-1', 'other', 'mystery', 0),
+      'b-1': task('b-1', 'bash', 'pnpm dev', 0),
+    };
+    render(<BackgroundActivityBar />);
+    expect(screen.getByTestId('composer-background-activity').textContent).toContain('2 tasks');
+  });
+
+  it('opens a popover listing each task with description and elapsed time', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    __backgroundTasks = {
+      'a-1': task('a-1', 'agent', 'reviewer subagent', 5 * 60_000), // started 5m ago
+      'b-1': task('b-1', 'bash', 'pnpm dev', 10 * 60_000 - 20_000), // started 20s ago
+    };
+    render(<BackgroundActivityBar />);
+
+    await user.click(screen.getByTestId('composer-background-activity'));
+
+    const agentRow = screen.getByTestId('composer-background-activity-item-a-1');
+    expect(agentRow.textContent).toContain('reviewer subagent');
+    expect(agentRow.textContent).toContain('5m');
+
+    const bashRow = screen.getByTestId('composer-background-activity-item-b-1');
+    expect(bashRow.textContent).toContain('pnpm dev');
+    expect(bashRow.textContent).toContain('<1m');
+  });
+});

--- a/packages/ui/src/features/chat/controller/__tests__/chat-event-router-background-snapshot.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-event-router-background-snapshot.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Behavior tests: routeDaemonEvent mirrors chat.updated's `backgroundActivity`
+ * into a background.snapshot dispatch (reconnect/turn-boundary resync path).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import { routeDaemonEvent, type DaemonEventRouterHost } from '../chat-event-router';
+import { createChatThreadState, type ChatStateEvent } from '../chat-thread-state';
+
+vi.mock('@/lib/toast', () => ({
+  mfToast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn(), permission: vi.fn() },
+}));
+vi.mock('../../../../lib/api/chats', () => ({
+  trustWorkspace: vi.fn(),
+}));
+
+const CHAT_ID = 'chat-abc';
+
+function makeChat(overrides: Partial<Chat> = {}): Chat {
+  return { id: CHAT_ID, adapterId: 'claude', projectId: 'p1', ...overrides } as Chat;
+}
+
+describe('routeDaemonEvent — chat.updated background resync', () => {
+  let dispatched: ChatStateEvent[];
+  let host: DaemonEventRouterHost;
+
+  beforeEach(() => {
+    dispatched = [];
+    host = {
+      getChatId: () => CHAT_ID,
+      getState: () => createChatThreadState(CHAT_ID),
+      dispatch: (e) => dispatched.push(e),
+      refreshInBackground: vi.fn(),
+    };
+  });
+
+  it('dispatches background.snapshot with the tasks from chat.backgroundActivity', () => {
+    const event: DaemonEvent = {
+      type: 'chat.updated',
+      chat: makeChat({
+        backgroundActivity: {
+          total: 1,
+          byKind: { agent: 1 },
+          tasks: [{ id: 'a-1', kind: 'agent', description: 'reviewer', startedAt: 9000 }],
+        },
+      }),
+    };
+
+    routeDaemonEvent(event, host);
+
+    expect(dispatched).toContainEqual({
+      type: 'background.snapshot',
+      tasks: [{ id: 'a-1', kind: 'agent', description: 'reviewer', startedAt: 9000 }],
+    });
+  });
+
+  it('dispatches an empty background.snapshot when backgroundActivity is absent', () => {
+    routeDaemonEvent({ type: 'chat.updated', chat: makeChat() }, host);
+    expect(dispatched).toContainEqual({ type: 'background.snapshot', tasks: [] });
+  });
+
+  it('does not dispatch a snapshot for another chat', () => {
+    routeDaemonEvent({ type: 'chat.updated', chat: makeChat({ id: 'chat-other' }) }, host);
+    expect(dispatched.find((e) => e.type === 'background.snapshot')).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-background.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-background.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Behavior tests for the background-activity slice of the chat-thread reducer.
+ * Fixed input events, hardcoded expected state — no production logic re-derived.
+ */
+import { describe, it, expect } from 'vitest';
+import type { BackgroundActivityTask } from '@qlan-ro/mainframe-types';
+import { createChatThreadState, reduceChatThreadState } from '../chat-thread-state';
+
+const CHAT_ID = 'chat-abc';
+
+function task(id: string, overrides: Partial<BackgroundActivityTask> = {}): BackgroundActivityTask {
+  return { id, kind: 'agent', description: `desc-${id}`, startedAt: 1000, ...overrides };
+}
+
+describe('chat-thread-state — background activity slice', () => {
+  it('starts empty', () => {
+    expect(createChatThreadState(CHAT_ID).backgroundTasks).toEqual({});
+  });
+
+  it('background.upsert adds a task', () => {
+    const s0 = createChatThreadState(CHAT_ID);
+    const s1 = reduceChatThreadState(s0, { type: 'background.upsert', task: task('a-1') });
+    expect(s1.backgroundTasks).toEqual({
+      'a-1': { id: 'a-1', kind: 'agent', description: 'desc-a-1', startedAt: 1000 },
+    });
+  });
+
+  it('background.upsert replaces an existing task by id (no duplicates)', () => {
+    let s = createChatThreadState(CHAT_ID);
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('a-1') });
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('a-1', { description: 'renamed' }) });
+    expect(Object.keys(s.backgroundTasks)).toEqual(['a-1']);
+    expect(s.backgroundTasks['a-1']!.description).toBe('renamed');
+  });
+
+  it('background.ended removes the task', () => {
+    let s = createChatThreadState(CHAT_ID);
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('a-1') });
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('b-1', { kind: 'bash' }) });
+    s = reduceChatThreadState(s, { type: 'background.ended', taskId: 'a-1' });
+    expect(s.backgroundTasks).toEqual({
+      'b-1': { id: 'b-1', kind: 'bash', description: 'desc-b-1', startedAt: 1000 },
+    });
+  });
+
+  it('background.ended for an unknown id returns the same state object', () => {
+    const s0 = createChatThreadState(CHAT_ID);
+    const s1 = reduceChatThreadState(s0, { type: 'background.ended', taskId: 'ghost' });
+    expect(s1).toBe(s0);
+  });
+
+  it('background.snapshot replaces the whole slice', () => {
+    let s = createChatThreadState(CHAT_ID);
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('stale') });
+    s = reduceChatThreadState(s, {
+      type: 'background.snapshot',
+      tasks: [task('a-1'), task('w-1', { kind: 'workflow' })],
+    });
+    expect(s.backgroundTasks).toEqual({
+      'a-1': { id: 'a-1', kind: 'agent', description: 'desc-a-1', startedAt: 1000 },
+      'w-1': { id: 'w-1', kind: 'workflow', description: 'desc-w-1', startedAt: 1000 },
+    });
+  });
+
+  it('background.snapshot with identical content returns the same state object (no churn)', () => {
+    let s = createChatThreadState(CHAT_ID);
+    s = reduceChatThreadState(s, { type: 'background.snapshot', tasks: [task('a-1')] });
+    const s2 = reduceChatThreadState(s, { type: 'background.snapshot', tasks: [task('a-1')] });
+    expect(s2).toBe(s);
+  });
+
+  it('background.snapshot with an empty list clears the slice', () => {
+    let s = createChatThreadState(CHAT_ID);
+    s = reduceChatThreadState(s, { type: 'background.upsert', task: task('a-1') });
+    s = reduceChatThreadState(s, { type: 'background.snapshot', tasks: [] });
+    expect(s.backgroundTasks).toEqual({});
+  });
+});

--- a/packages/ui/src/features/chat/controller/__tests__/handle-daemon-event-background.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/handle-daemon-event-background.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Behavior tests for handleDaemonEvent — background_task.* mapping.
+ * Fixed input events, hardcoded expected HandleResults.
+ */
+import { describe, it, expect } from 'vitest';
+import type { BackgroundTask } from '@qlan-ro/mainframe-types';
+import { handleDaemonEvent } from '../handle-daemon-event';
+
+const CHAT_ID = 'chat-abc';
+const OTHER_CHAT = 'chat-other';
+const EMPTY_MSGS = {} as Readonly<Record<string, unknown>>;
+
+function makeTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: 'a-1',
+    kind: 'agent',
+    toolName: 'Bash',
+    toolUseId: 'tu-1',
+    command: '',
+    description: 'reviewer subagent',
+    outputPath: '/p/a-1',
+    startedAt: 4200,
+    endedAt: null,
+    status: 'running',
+    lastOutputLine: null,
+    summary: null,
+    usage: null,
+    ...overrides,
+  };
+}
+
+describe('handleDaemonEvent — background_task.*', () => {
+  it('started → background.upsert with the projected activity task', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.started', chatId: CHAT_ID, task: makeTask() },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({
+      kind: 'event',
+      event: {
+        type: 'background.upsert',
+        task: { id: 'a-1', kind: 'agent', description: 'reviewer subagent', startedAt: 4200 },
+      },
+    });
+  });
+
+  it('started for another chat → noop', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.started', chatId: OTHER_CHAT, task: makeTask() },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({ kind: 'noop' });
+  });
+
+  it('updated with running status → background.upsert', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.updated', chatId: CHAT_ID, task: makeTask({ description: 'now longer' }) },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({
+      kind: 'event',
+      event: {
+        type: 'background.upsert',
+        task: { id: 'a-1', kind: 'agent', description: 'now longer', startedAt: 4200 },
+      },
+    });
+  });
+
+  it('updated with a terminal status → background.ended', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.updated', chatId: CHAT_ID, task: makeTask({ status: 'completed', endedAt: 5000 }) },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({ kind: 'event', event: { type: 'background.ended', taskId: 'a-1' } });
+  });
+
+  it('ended → background.ended', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.ended', chatId: CHAT_ID, task: makeTask({ status: 'stopped', endedAt: 5000 }) },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({ kind: 'event', event: { type: 'background.ended', taskId: 'a-1' } });
+  });
+
+  it('started with a non-running status (adopt replay of a finished task) → background.ended', () => {
+    const result = handleDaemonEvent(
+      { type: 'background_task.started', chatId: CHAT_ID, task: makeTask({ status: 'failed', endedAt: 5000 }) },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({ kind: 'event', event: { type: 'background.ended', taskId: 'a-1' } });
+  });
+
+  it('bash task with empty description falls back to the command', () => {
+    const result = handleDaemonEvent(
+      {
+        type: 'background_task.started',
+        chatId: CHAT_ID,
+        task: makeTask({ id: 'b-1', kind: 'bash', description: '', command: 'pnpm dev' }),
+      },
+      CHAT_ID,
+      EMPTY_MSGS,
+    );
+    expect(result).toEqual({
+      kind: 'event',
+      event: {
+        type: 'background.upsert',
+        task: { id: 'b-1', kind: 'bash', description: 'pnpm dev', startedAt: 4200 },
+      },
+    });
+  });
+});

--- a/packages/ui/src/features/chat/controller/chat-event-router.ts
+++ b/packages/ui/src/features/chat/controller/chat-event-router.ts
@@ -38,6 +38,10 @@ export function routeDaemonEvent(event: DaemonEvent, host: DaemonEventRouterHost
   // handleDaemonEvent below still maps chat.updated → run.started/stopped.
   if (event.type === 'chat.updated' && event.chat.id === chatId) {
     host.dispatch({ type: 'chat.config.updated', chat: event.chat });
+    // Server-authoritative resync of the live background set: enrichChat stamps
+    // `backgroundActivity` on every broadcast, so a missed background_task.*
+    // event self-heals at the next turn boundary. Absent field = nothing live.
+    host.dispatch({ type: 'background.snapshot', tasks: event.chat.backgroundActivity?.tasks ?? [] });
   }
 
   // Non-fatal: the CLI reported the workspace is untrusted. Surface an actionable

--- a/packages/ui/src/features/chat/controller/chat-thread-controller.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-controller.ts
@@ -195,15 +195,18 @@ export class ChatThreadController {
 
     this.dispatch({ type: 'history.loading' });
 
-    // Seed the composer config from REST so the toolbar isn't empty before the
-    // first chat.updated; thereafter chat.updated keeps state.chatConfig live.
-    if (!this.state.chatConfig) {
-      void getChat(this.port, this.daemonId)
-        .then((chat) => {
-          if (!this.disposed) this.dispatch({ type: 'chat.config.updated', chat });
-        })
-        .catch((err: unknown) => console.warn('[chat-controller] seed chat config failed', err));
-    }
+    // Seed the composer config + live background set from REST so neither is
+    // empty/stale before the first chat.updated. Fetched on every load (not
+    // just the first): a reattach after dormancy may have missed
+    // background_task.* events, and both reducer paths bail identity-stable
+    // when nothing changed.
+    void getChat(this.port, this.daemonId)
+      .then((chat) => {
+        if (this.disposed) return;
+        this.dispatch({ type: 'chat.config.updated', chat });
+        this.dispatch({ type: 'background.snapshot', tasks: chat?.backgroundActivity?.tasks ?? [] });
+      })
+      .catch((err: unknown) => console.warn('[chat-controller] seed chat config failed', err));
 
     const request = getChatMessages(this.port, this.daemonId)
       .then((messages) => {

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -15,7 +15,13 @@
  *  - interactions.queued — from message.queued.* events
  *  - pendingUserMessages — optimistic send, reconciled on echo
  */
-import type { DisplayMessage, ControlRequest, QueuedMessageRef, Chat } from '@qlan-ro/mainframe-types';
+import type {
+  BackgroundActivityTask,
+  Chat,
+  ControlRequest,
+  DisplayMessage,
+  QueuedMessageRef,
+} from '@qlan-ro/mainframe-types';
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -78,6 +84,12 @@ export interface ChatThreadState {
   readonly contextUsage: { percentage: number; totalTokens: number; maxTokens: number } | null;
   /** True between `chat.compacting` and `chat.compactDone` — session-bar status. */
   readonly compacting: boolean;
+  /**
+   * Live background work (agents / bg bash / workflows) keyed by task id — fed
+   * by `background_task.*` events, resynced from `chat.updated`'s
+   * `backgroundActivity` snapshot. Drives the BackgroundActivityBar chip.
+   */
+  readonly backgroundTasks: Readonly<Record<string, BackgroundActivityTask>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,7 +121,10 @@ export type ChatStateEvent =
   | { type: 'chat.id.adopted'; chatId: string }
   | { type: 'context.usage'; percentage: number; totalTokens: number; maxTokens: number }
   | { type: 'compact.started' }
-  | { type: 'compact.done' };
+  | { type: 'compact.done' }
+  | { type: 'background.upsert'; task: BackgroundActivityTask }
+  | { type: 'background.ended'; taskId: string }
+  | { type: 'background.snapshot'; tasks: BackgroundActivityTask[] };
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -130,6 +145,7 @@ export function createChatThreadState(chatId: string): ChatThreadState {
     chatConfig: null,
     contextUsage: null,
     compacting: false,
+    backgroundTasks: {} as Readonly<Record<string, BackgroundActivityTask>>,
   };
 }
 
@@ -165,6 +181,18 @@ function sameComposerConfig(a: Chat | null, b: Chat): boolean {
     a.adaptiveThinking === b.adaptiveThinking &&
     a.worktreeMissing === b.worktreeMissing
   );
+}
+
+/** True when the snapshot lists exactly the tasks already in state (field-equal). */
+function sameBackgroundTasks(
+  current: Readonly<Record<string, BackgroundActivityTask>>,
+  snapshot: BackgroundActivityTask[],
+): boolean {
+  if (Object.keys(current).length !== snapshot.length) return false;
+  return snapshot.every((t) => {
+    const c = current[t.id];
+    return c !== undefined && c.kind === t.kind && c.description === t.description && c.startedAt === t.startedAt;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +338,28 @@ export function reduceChatThreadState(state: ChatThreadState, event: ChatStateEv
 
     case 'compact.done':
       return state.compacting ? { ...state, compacting: false } : state;
+
+    case 'background.upsert':
+      return {
+        ...state,
+        backgroundTasks: { ...state.backgroundTasks, [event.task.id]: event.task },
+      };
+
+    case 'background.ended': {
+      if (!(event.taskId in state.backgroundTasks)) return state;
+      const backgroundTasks = { ...state.backgroundTasks };
+      delete backgroundTasks[event.taskId];
+      return { ...state, backgroundTasks };
+    }
+
+    case 'background.snapshot': {
+      // chat.updated fires on every turn boundary — bail identity-stable when
+      // the snapshot matches so the composer doesn't re-render on churn.
+      if (sameBackgroundTasks(state.backgroundTasks, event.tasks)) return state;
+      const backgroundTasks: Record<string, BackgroundActivityTask> = {};
+      for (const task of event.tasks) backgroundTasks[task.id] = task;
+      return { ...state, backgroundTasks };
+    }
 
     case 'local.message.queued':
       return {

--- a/packages/ui/src/features/chat/controller/handle-daemon-event.ts
+++ b/packages/ui/src/features/chat/controller/handle-daemon-event.ts
@@ -6,7 +6,7 @@
  * The "refetch-on-gap" signal is a special return value so the controller
  * can call refresh() without this module knowing about HTTP.
  */
-import type { DaemonEvent } from '@qlan-ro/mainframe-types';
+import { toActivityTask, type DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { ChatStateEvent } from './chat-thread-state';
 
 export type HandleResult = { kind: 'event'; event: ChatStateEvent } | { kind: 'refresh' } | { kind: 'noop' };
@@ -103,6 +103,20 @@ export function handleDaemonEvent(
           maxTokens: event.maxTokens,
         },
       };
+
+    case 'background_task.started':
+    case 'background_task.updated':
+      if (event.chatId !== chatId) return { kind: 'noop' };
+      // A non-running payload (e.g. an adopt replay of a finished task) means
+      // the task is no longer live — treat it as ended so it can't stick.
+      if (event.task.status !== 'running') {
+        return { kind: 'event', event: { type: 'background.ended', taskId: event.task.id } };
+      }
+      return { kind: 'event', event: { type: 'background.upsert', task: toActivityTask(event.task) } };
+
+    case 'background_task.ended':
+      if (event.chatId !== chatId) return { kind: 'noop' };
+      return { kind: 'event', event: { type: 'background.ended', taskId: event.task.id } };
 
     case 'chat.compacting':
       if (event.chatId !== chatId) return { kind: 'noop' };

--- a/packages/ui/src/features/chat/thread/ChatSessionInline.tsx
+++ b/packages/ui/src/features/chat/thread/ChatSessionInline.tsx
@@ -6,9 +6,9 @@
  * adapter word is dropped — the dot conveys the adapter; the Hint spells both out.
  * `part="status"`: the 8-segment context meter + percentage, in the header's
  * right group. No "Thinking" label/spinner — run state is the thread's own
- * running indicator, not a redundant header label. Background-tasks pill stays
- * deferred (no task feed in app-tauri yet). Renders nothing until the chat
- * config is loaded (drafts / blank surface).
+ * running indicator, not a redundant header label. Background work lives in
+ * the composer's BackgroundActivityBar, not here. Renders nothing until the
+ * chat config is loaded (drafts / blank surface).
  */
 import { cn } from '@/lib/utils';
 import { useChatExtras } from '../runtime/use-chat-thread-runtime';

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -11,6 +11,7 @@ import { ThreadPrimitive, useAuiState } from '@assistant-ui/react';
 import { ArrowDownIcon } from 'lucide-react';
 import { boundedMessageComponents } from '../messages/bounded-messages';
 import { Composer } from '../composer/Composer';
+import { BackgroundActivityBar } from '../composer/BackgroundActivityBar';
 import { SelectionToolbar } from '@/components/ui/assistant-ui/quote';
 import { ComposerEditProvider } from '../composer/edit/composer-edit-context';
 import { ChatGateMount } from '../gates/ChatGateMount';
@@ -101,6 +102,7 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
               </ThreadPrimitive.ScrollToBottom>
 
               <div className="mx-auto w-full max-w-3xl px-5 pb-4">
+                <BackgroundActivityBar />
                 <GeneratingIndicator />
                 <Composer />
               </div>


### PR DESCRIPTION
## Summary

Implements docs/plans/2026-07-08-background-activity-working-indicator.md: background work (subagents, background bash tasks, workflows) now participates in the session working indicator, with a new chip above the composer, while the composer/thread indicator stays main-turn-only.

### Types (`@qlan-ro/mainframe-types`)
- `BackgroundWorkKind` (`bash | agent | workflow | other`) + `kind` on `BackgroundTask`
- `BackgroundActivity` / `BackgroundActivityTask` client payload with Zod schemas, plus shared `toActivityTask` / `deriveBackgroundActivity` helpers
- `Chat.backgroundActivity?` (additive; mobile-safe)

### Core
- **Tracker generalized**: kind-stamped registrations, `listLive`, `endAllRunning`; duplicate `task_started` upserts (keeps `startedAt`, emits `background_task.updated`, no double count)
- **Claude adapter**: `task_type → kind` mapping (prefix-tolerant; unknown → `other`), terminal `task_updated` closes tasks, `task_type` threaded through `events.ts`
- **`enrichChat`**: `displayStatus = waiting | (main-working OR live-background → working) | idle`; `isRunning` unchanged (main-turn-only); attaches `backgroundActivity`
- **Drain-turn re-entry**: a top-level assistant event while `processState !== 'working'` flips back to working (the drain turn's own `result` clears it); never fires on hold-back CLIs
- **CLI exit**: `endAllRunning` in the same path that nulls `processState`, so orphaned entries can't pin the spinner
- **Liveness sweep gated to `kind === 'bash'`** — agents/workflows have no lsof writer on the spool file; probing them would false-stop live work after ~4 min (deviation from the plan text, required for the plan's own bookend accounting to hold)
- Daemon now broadcasts `background_task.updated`

### UI
- `backgroundTasks` slice in chat-thread-state (`upsert` / `ended` / `snapshot` events, identity-stable snapshot bail)
- `handle-daemon-event` maps the three `background_task.*` events (previously dropped)
- Resync: `chat.updated` and the controller's REST chat seed both dispatch a `background.snapshot`
- New `BackgroundActivityBar` above the composer: pulsing dot + counts by kind ("2 agents · 1 task · 1 workflow"), popover listing live items (kind icon, description, elapsed time). Testids: `composer-background-activity`, `composer-background-activity-item-<taskId>`
- Sidebar: zero code change — `working` broadened upstream. The session-title indicator the plan asks to remove does not exist in `packages/ui` (it was never ported); only the stale "deferred" comment in `ChatSessionInline` was updated

## Tests
- types: schema/helper behavior (7)
- core: tracker kinds/live-set/upsert/`endAllRunning`, task-events kind mapping + `task_updated`, integration through `handleStdout`, `enrichChat` derivation matrix (main-only / background-only / both / permission overlay / terminal-only), event-handler drain-turn re-entry + exit clearing, liveness bash-gate
- ui: reducer slice, daemon-event mapping, router/controller snapshot resync, `BackgroundActivityBar` render/counts/popover/elapsed

All affected suites green; `types` build + `core`/`ui` typechecks clean.

## Needs live visual verification
The chip is unit-tested but not visually verified against the running app (app-tauri phantom-token trap): check chip styling above the composer, popover placement (`side=top`), and end-to-end behavior with a real background agent/bash task on CLI v2.1.202.

Generated with Claude Code