### PR TITLE
fix(app-tauri): persist remote-daemon tokens via real keyring backend

### DIFF
--- a/.changeset/fix-remote-token-keyring-backend.md
+++ b/.changeset/fix-remote-token-keyring-backend.md
@@ -3,3 +3,5 @@
 ---
 
 Fix remote-daemon pairing: auth tokens now actually persist. `keyring 3.x` needs an explicit backend feature — without one it silently uses an in-memory mock store, so `daemon_token_get` always returned `None` and the renderer opened the daemon WebSocket with no `?token=`, getting rejected ("invalid or missing token"). The app looked "connected" (HTTP/health work) but never loaded projects/chats. Enable the real OS credential stores (`apple-native`, `windows-native`, `sync-secret-service`). No entitlement change needed — a signed, non-sandboxed macOS app accesses its own login-keychain items without `keychain-access-groups`.
+
+Also make token storage fail loudly: `daemon_token_set` now returns a `Result` instead of swallowing keyring write failures, and the Add-remote dialog surfaces a distinct "couldn't save the credential" error instead of reporting a paired-but-tokenless connection as success.

--- a/.changeset/fix-remote-token-keyring-backend.md
+++ b/.changeset/fix-remote-token-keyring-backend.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-app-tauri": patch
+---
+
+Fix remote-daemon pairing: auth tokens now actually persist. `keyring 3.x` needs an explicit backend feature — without one it silently uses an in-memory mock store, so `daemon_token_get` always returned `None` and the renderer opened the daemon WebSocket with no `?token=`, getting rejected ("invalid or missing token"). The app looked "connected" (HTTP/health work) but never loaded projects/chats. Enable the real OS credential stores (`apple-native`, `windows-native`, `sync-secret-service`). No entitlement change needed — a signed, non-sandboxed macOS app accesses its own login-keychain items without `keychain-access-groups`.

--- a/packages/app-tauri/src-tauri/Cargo.lock
+++ b/packages/app-tauri/src-tauri/Cargo.lock
@@ -559,6 +559,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -580,7 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.12.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -593,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.12.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -728,6 +738,16 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -2072,7 +2092,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -3526,7 +3551,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3544,7 +3569,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -3553,7 +3578,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3659,12 +3684,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.12.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.12.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4173,7 +4211,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.12.1",
  "block2 0.6.2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -6430,6 +6468,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/packages/app-tauri/src-tauri/Cargo.toml
+++ b/packages/app-tauri/src-tauri/Cargo.toml
@@ -33,7 +33,11 @@ dirs = "5"
 which = "6"
 portable-pty = "0.9"
 ureq = { version = "2", default-features = false, features = ["json"] }
-keyring = "3"
+# The platform credential-store backends are opt-in in keyring 3.x. Without an
+# explicit backend feature the crate silently falls back to an in-memory mock
+# store, so remote-daemon tokens never persist and every reconnect authenticates
+# with no token. Enable the real OS stores per platform.
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 # Dev-only: MCP Bridge plugin for the Tauri MCP server (webview screenshots,
 # DOM inspection, IPC). Optional + behind the non-default `mcp-bridge` feature

--- a/packages/app-tauri/src-tauri/src/commands/daemons.rs
+++ b/packages/app-tauri/src-tauri/src/commands/daemons.rs
@@ -132,6 +132,13 @@ pub fn daemons_remove(data_dir: Option<String>, id: String) {
 }
 
 /// Returns the keyring token for a daemon, or `None` if absent or unavailable.
+///
+/// Deliberately lenient (unlike `daemon_token_set`): a read failure logs and
+/// returns `None` rather than propagating, so a transient keyring hiccup on
+/// boot/daemon-switch degrades to a token-less connect (surfaced by the WS
+/// auth reject) instead of hard-blocking the app. The loud path is on write,
+/// where a failure means pairing did not actually persist and must not be
+/// reported as success.
 #[tauri::command]
 pub fn daemon_token_get(id: String) -> Option<String> {
     match keyring::Entry::new(KEYRING_SERVICE, &id) {
@@ -139,30 +146,28 @@ pub fn daemon_token_get(id: String) -> Option<String> {
             Ok(token) => Some(token),
             Err(keyring::Error::NoEntry) => None,
             Err(e) => {
-                tracing::warn!(id = %id, err = %e, "daemon_token_get: keyring read failed");
+                tracing::error!(id = %id, err = %e, "daemon_token_get: keyring read failed");
                 None
             }
         },
         Err(e) => {
-            tracing::warn!(id = %id, err = %e, "daemon_token_get: failed to open keyring entry");
+            tracing::error!(id = %id, err = %e, "daemon_token_get: failed to open keyring entry");
             None
         }
     }
 }
 
-/// Stores a token for a daemon in the OS keyring. Logs on failure.
+/// Stores a token for a daemon in the OS keyring.
+///
+/// Returns `Err` on failure so the caller (pairing) fails loudly instead of
+/// reporting a paired-but-tokenless state that silently breaks the WebSocket.
 #[tauri::command]
-pub fn daemon_token_set(id: String, token: String) {
-    match keyring::Entry::new(KEYRING_SERVICE, &id) {
-        Ok(entry) => {
-            if let Err(e) = entry.set_password(&token) {
-                tracing::warn!(id = %id, err = %e, "daemon_token_set: keyring write failed");
-            }
-        }
-        Err(e) => {
-            tracing::warn!(id = %id, err = %e, "daemon_token_set: failed to open keyring entry");
-        }
-    }
+pub fn daemon_token_set(id: String, token: String) -> Result<(), String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, &id)
+        .map_err(|e| format!("open keyring entry: {e}"))?;
+    entry
+        .set_password(&token)
+        .map_err(|e| format!("write token to keyring: {e}"))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/packages/ui/src/features/daemon/AddRemoteDialog.tsx
+++ b/packages/ui/src/features/daemon/AddRemoteDialog.tsx
@@ -221,22 +221,31 @@ export function AddRemoteDialog({ open, mode = 'add', target, onClose, onDone }:
     try {
       const { token } = await confirmPairing(targetUrl, trimmedCode, device.trim() || 'This Mac');
 
+      // Pairing succeeded server-side; a failure below is LOCAL token storage
+      // (the host keyring). Surface it as its own phase instead of reporting
+      // "Paired" — a tokenless entry silently fails the WebSocket auth.
       let addedId: string | undefined;
-      if (mode === 'add') {
-        const host = parseRemoteUrl(targetUrl).host;
-        const label = host.split('.')[0] ?? 'New server';
-        const meta: DaemonMeta = {
-          id: crypto.randomUUID(),
-          kind: 'remote',
-          label,
-          host,
-          device: device.trim() || 'This Mac',
-          paired: 'Just now',
-        };
-        await registry.add(meta, token);
-        addedId = meta.id;
-      } else if (target != null) {
-        await getHost().daemons.setToken(target.id, token);
+      try {
+        if (mode === 'add') {
+          const host = parseRemoteUrl(targetUrl).host;
+          const label = host.split('.')[0] ?? 'New server';
+          const meta: DaemonMeta = {
+            id: crypto.randomUUID(),
+            kind: 'remote',
+            label,
+            host,
+            device: device.trim() || 'This Mac',
+            paired: 'Just now',
+          };
+          await registry.add(meta, token);
+          addedId = meta.id;
+        } else if (target != null) {
+          await getHost().daemons.setToken(target.id, token);
+        }
+      } catch (storageErr) {
+        console.warn('[settings/AddRemoteDialog] token storage failed', storageErr);
+        setStep1Phase('storage');
+        return;
       }
 
       setStep1Phase('done');

--- a/packages/ui/src/features/daemon/__tests__/AddRemoteDialog.test.tsx
+++ b/packages/ui/src/features/daemon/__tests__/AddRemoteDialog.test.tsx
@@ -279,6 +279,32 @@ describe('AddRemoteDialog — invalid code', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Behavior 3b — pairing succeeds server-side but local token storage fails
+// ---------------------------------------------------------------------------
+
+describe('AddRemoteDialog — local storage failure after successful pairing', () => {
+  it('shows the storage error notice and does NOT show the Paired success state', async () => {
+    const user = userEvent.setup();
+    mockAdd.mockRejectedValue(new Error('keychain write failed'));
+
+    const onDone = vi.fn();
+    render(<AddRemoteDialog open mode="add" onClose={vi.fn()} onDone={onDone} />);
+
+    await advanceToStep1(user);
+    await typeCode(user, VALID_CODE);
+
+    await user.click(screen.getByTestId('daemon-add-confirm'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('daemon-add-storage-error')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Paired')).not.toBeInTheDocument();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Behavior 4 — network error (PairingError 'network')
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/src/features/daemon/pairing-steps.tsx
+++ b/packages/ui/src/features/daemon/pairing-steps.tsx
@@ -80,7 +80,7 @@ export function Step0Body({ url, phase, version, onUrlChange, onVerify }: Step0B
 // Step1Body
 // ---------------------------------------------------------------------------
 
-export type Step1Phase = 'idle' | 'confirming' | 'invalid' | 'done' | 'unreachable';
+export type Step1Phase = 'idle' | 'confirming' | 'invalid' | 'done' | 'unreachable' | 'storage';
 
 export interface Step1BodyProps {
   lockedUrl: string;
@@ -122,6 +122,13 @@ export function Step1Body({
       {isInvalid && (
         <NoticeCard kind="error" testId="daemon-add-error">
           That code didn&apos;t work
+        </NoticeCard>
+      )}
+
+      {phase === 'storage' && (
+        <NoticeCard kind="error" testId="daemon-add-storage-error">
+          Paired, but couldn&apos;t save the credential to this device&apos;s keychain. The connection won&apos;t
+          persist — check Keychain access and try again.
         </NoticeCard>
       )}
 


### PR DESCRIPTION
## Problem

Pairing a remote daemon in the Tauri app "succeeds" (device row created server-side, dialog shows *Paired*) but projects/chats never load — the app looks connected (health/HTTP work) while the daemon logs repeated `ws upgrade rejected: invalid or missing token`.

## Root cause

`keyring 3.x` makes the OS credential-store backends **opt-in via features**. The dependency was declared as `keyring = "3"` with **no backend feature**, so the crate silently falls back to an **in-memory mock store**:
- `daemon_token_set` writes to a throwaway `Entry` that is dropped when the command returns.
- `daemon_token_get` opens a fresh `Entry`, gets `NoEntry` → returns `None`.

So `getToken` **always** returns `None`. `buildRemoteTarget` then sets `token: null`, and `ws-client.ts` opens `wss://host` with **no `?token=`** → the daemon's WS auth rejects it. This failed on **every platform and build regardless of signing** — the Keychain backend was never compiled in (`Cargo.lock`: `keyring 3.6.3` depended only on `log` + `zeroize`, no `security-framework`).

## Fix

**1. Compile the real credential stores.**
```toml
keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
```
No entitlement change needed — a signed, non-sandboxed macOS app reads/writes its own login-keychain generic passwords without `keychain-access-groups`.

**2. Fail loudly instead of swallowing storage errors.** `daemon_token_set` was fire-and-forget (only logged a warning), which is exactly why this went undiagnosed — pairing reported success while the token was never stored. It now returns a `Result`; the Add-remote dialog surfaces a distinct *"couldn't save the credential to this device's keychain"* error (new `storage` phase, `data-testid="daemon-add-storage-error"`) and no longer reports `done`. `daemon_token_get` stays lenient on read (logs at `error`, returns `None`) so a transient hiccup on boot/switch degrades to a token-less connect rather than hard-blocking the app.

## Verification

- `cargo check` passes on macOS (~47s); Linux/Windows backends stay internally `cfg`-gated so `dbus-secret-service` doesn't break the mac build.
- `Cargo.lock` now links the Keychain backend: `keyring` depends on `security-framework` (was `[log, zeroize]` only).
- UI typecheck green; daemon test suites pass. Added a regression test (`AddRemoteDialog`): a successful pairing whose local token-store rejects shows `daemon-add-storage-error` and does **not** report Paired — verified it fails without the fix and passes with it.
- Server side independently confirmed healthy: a freshly-minted token authenticates over HTTP (`/api/projects` → 200) and WS (`101 Switching Protocols`); DB and 3 projects intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)