### PR TITLE
fix(ui): batch of small chat and editor fixes

### DIFF
--- a/.changeset/ui-small-fixes.md
+++ b/.changeset/ui-small-fixes.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Batch of chat and editor fixes: make console log output selectable, keep the thinking indicator inline after the last message, allow expanding in-progress bash tool cards, prefill the composer when running a todo in a session, and add an agent-annotation comment gutter to the diff viewer.

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -88,6 +88,9 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
               <DegradedChatCard />
               {messageCount === 0 && emptyState != null ? emptyState : null}
               <ThreadPrimitive.Messages components={boundedMessageComponents} />
+              {/* Inline "thinking/working" indicator — sits after the last message,
+                  not pinned above the composer (#214). */}
+              <GeneratingIndicator />
               <ChatGateMount />
             </div>
 
@@ -105,7 +108,6 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
 
               <div className="mx-auto w-full max-w-3xl px-5 pb-4">
                 <BackgroundActivityBar />
-                <GeneratingIndicator />
                 <Composer />
               </div>
             </ThreadPrimitive.ViewportFooter>

--- a/packages/ui/src/features/chat/thread/__tests__/ChatThread.test.tsx
+++ b/packages/ui/src/features/chat/thread/__tests__/ChatThread.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * ChatThread — placement test for the "thinking/working" indicator.
+ *
+ * The indicator must render INLINE after the last message (inside the scrolling
+ * messages column), NOT pinned inside the sticky ViewportFooter above the
+ * composer (#214). We mock the assistant-ui primitives + heavy children down to
+ * identifiable stubs so we can assert the DOM region the indicator lands in.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+// ── assistant-ui primitives → identifiable stub wrappers ─────────────────────
+vi.mock('@assistant-ui/react', () => {
+  return {
+    ThreadPrimitive: {
+      Root: ({ children }: { children?: ReactNode }) => <div data-testid="tp-root">{children}</div>,
+      Viewport: ({ children }: { children?: ReactNode }) => <div data-testid="tp-viewport">{children}</div>,
+      ViewportFooter: ({ children }: { children?: ReactNode }) => (
+        <div data-testid="tp-viewport-footer">{children}</div>
+      ),
+      ScrollToBottom: ({ children }: { children?: ReactNode }) => <>{children}</>,
+      Messages: () => <div data-testid="tp-messages" />,
+    },
+    // isRunning selector → true; messages.length selector → 1.
+    useAuiState: (sel: (s: { thread: { isRunning: boolean; messages: unknown[] } }) => unknown) =>
+      sel({ thread: { isRunning: true, messages: [{}] } }),
+  };
+});
+
+// ── Heavy children → stubs ───────────────────────────────────────────────────
+vi.mock('../../messages/bounded-messages', () => ({ boundedMessageComponents: {} }));
+vi.mock('../../composer/Composer', () => ({ Composer: () => <div data-testid="composer-stub" /> }));
+vi.mock('../../composer/BackgroundActivityBar', () => ({ BackgroundActivityBar: () => null }));
+vi.mock('@/components/ui/assistant-ui/quote', () => ({ SelectionToolbar: () => null }));
+vi.mock('../../composer/edit/composer-edit-context', () => ({
+  ComposerEditProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../gates/ChatGateMount', () => ({ ChatGateMount: () => <div data-testid="gate-mount-stub" /> }));
+vi.mock('../DegradedChatCard', () => ({ DegradedChatCard: () => null }));
+vi.mock('../../runtime/use-chat-thread-runtime', () => ({ useChatExtras: () => undefined }));
+vi.mock('../use-rotating-phrase', () => ({ useRotatingPhrase: () => 'Thinking…' }));
+vi.mock('@/features/skills/use-chat-skills', () => ({
+  SkillsProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../find/FindBar', () => ({ FindBar: () => null }));
+vi.mock('../../find/use-find-hotkey', () => ({ useFindHotkey: () => {} }));
+vi.mock('../../tools/register-cards', () => ({}));
+
+import { ChatThread } from '../ChatThread';
+
+describe('ChatThread — thinking indicator placement (#214)', () => {
+  it('renders the running indicator while a run is active', () => {
+    render(<ChatThread />);
+    expect(screen.getByTestId('chat-thread-running')).toBeInTheDocument();
+  });
+
+  it('places the running indicator OUTSIDE the sticky ViewportFooter', () => {
+    render(<ChatThread />);
+    const footer = screen.getByTestId('tp-viewport-footer');
+    expect(within(footer).queryByTestId('chat-thread-running')).toBeNull();
+  });
+
+  it('places the running indicator immediately after the last message', () => {
+    render(<ChatThread />);
+    const messages = screen.getByTestId('tp-messages');
+    const running = screen.getByTestId('chat-thread-running');
+    // Same parent (the messages column) and the indicator follows the messages.
+    expect(running.parentElement).toBe(messages.parentElement);
+    expect(messages.compareDocumentPosition(running) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/packages/ui/src/features/chat/tools/cards/BashCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/BashCard.tsx
@@ -106,17 +106,22 @@ export const BashCard: ToolCallMessagePartComponent = (part) => {
 
   const { text: resultText, fullBytes } = resolveResultText(result);
   const hasOutput = Boolean(resultText);
+  // A running command (no result yet) is expandable too, so the streaming
+  // output — and the full command — are visible mid-run, not only once it
+  // finishes (#208).
+  const isRunning = result === undefined;
+  const canExpand = hasOutput || isRunning;
 
   return (
     <Collapsible data-testid="chat-bash-card" defaultOpen={false}>
       <div className={cn(cardStyle(result, isError))}>
         <CollapsibleTrigger
           data-testid="chat-bash-trigger"
-          disabled={!hasOutput}
+          disabled={!canExpand}
           className={cn(
             'flex w-full items-center gap-2 px-3 py-[7px] text-left',
             'hover:bg-accent transition-colors',
-            !hasOutput && 'cursor-default',
+            !canExpand && 'cursor-default',
           )}
         >
           <FamilyTile color="var(--mf-tool-bash)" bg="var(--mf-tool-bash-tint)">
@@ -154,7 +159,7 @@ export const BashCard: ToolCallMessagePartComponent = (part) => {
           </Tooltip>
         )}
 
-        {hasOutput && (
+        {canExpand && (
           <CollapsibleContent>
             <TerminalBody
               command={command}

--- a/packages/ui/src/features/chat/tools/cards/__tests__/BashCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/BashCard.test.tsx
@@ -139,11 +139,23 @@ describe('BashCard', () => {
     expect(screen.getByTestId('chat-bash-trigger')).toBeInTheDocument();
   });
 
-  it('trigger is disabled when there is no result', () => {
-    renderCard(makePart({ args: { command: 'ls' }, result: undefined }));
-    // CollapsibleTrigger receives disabled={true} → Radix renders a disabled button
+  it('trigger is disabled when the command finished with no output', () => {
+    // result === '' → completed, but nothing to show and no longer running.
+    renderCard(makePart({ args: { command: 'touch f' }, result: '' }));
     const trigger = screen.getByTestId('chat-bash-trigger');
     expect(trigger).toBeDisabled();
+  });
+
+  it('trigger is ENABLED while the command is still running (result === undefined) (#208)', () => {
+    renderCard(makePart({ args: { command: 'sleep 1' }, result: undefined }));
+    const trigger = screen.getByTestId('chat-bash-trigger');
+    expect(trigger).not.toBeDisabled();
+  });
+
+  it('expands to show the running command in the output body while result is pending (#208)', () => {
+    renderCard(makePart({ args: { command: 'pnpm build' }, result: undefined }));
+    fireEvent.click(screen.getByTestId('chat-bash-trigger'));
+    expect(screen.getByTestId('chat-bash-output')).toHaveTextContent('pnpm build');
   });
 
   // --- Output body content ---

--- a/packages/ui/src/features/editor/CmDiffEditor.tsx
+++ b/packages/ui/src/features/editor/CmDiffEditor.tsx
@@ -15,7 +15,7 @@
  * (nextChange / prevChange in diff-nav.ts) always hold the live MergeView.
  */
 import { useEffect, useRef } from 'react';
-import { EditorState } from '@codemirror/state';
+import { EditorState, type Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { MergeView } from '@codemirror/merge';
 import type { LangPackId } from '@/lib/editor/file-types';
@@ -90,6 +90,19 @@ export interface CmDiffEditorProps {
    * behaviour is completely unchanged.
    */
   onLineSelect?: (sel: LineSelection) => void;
+  /**
+   * Optional extra CM6 extensions installed on the MODIFIED (right / b) pane —
+   * e.g. the inline-comment annotation gutter. Threaded through the MergeView's
+   * `config.b.extensions` (NOT a pre-built EditorState, which silently drops
+   * them) so the diff viewer can host the same gutter as the editor.
+   */
+  extraExtensions?: Extension[];
+  /**
+   * Called with the modified (b) pane's live EditorView once the MergeView
+   * mounts. Lets a parent (e.g. the comment-gutter host) dispatch effects and
+   * read state fields on the pane that carries `extraExtensions`.
+   */
+  onViewReady?: (view: EditorView) => void;
 }
 
 export function CmDiffEditor({
@@ -100,13 +113,21 @@ export function CmDiffEditor({
   onChunksChange,
   onStats,
   onLineSelect,
+  extraExtensions,
+  onViewReady,
 }: CmDiffEditorProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const mergeViewRef = useRef<MergeView | null>(null);
-  // Stable ref so the mount-only effect can always read the latest callback
-  // without needing to re-run (which would destroy/recreate the MergeView).
+  // Stable refs so the mount-only effect can always read the latest callback /
+  // extensions without needing to re-run (which would destroy/recreate the
+  // MergeView). extraExtensions is stable in practice (memoised by the comment
+  // gutter host), so it is applied once at mount like the base extensions.
   const onLineSelectRef = useRef(onLineSelect);
   onLineSelectRef.current = onLineSelect;
+  const onViewReadyRef = useRef(onViewReady);
+  onViewReadyRef.current = onViewReady;
+  const extraExtensionsRef = useRef(extraExtensions);
+  extraExtensionsRef.current = extraExtensions;
 
   // Drives both panes' theme compartment dark flag; re-renders on a mode flip.
   const mode = useTheme((s) => s.mode);
@@ -169,6 +190,8 @@ export function CmDiffEditor({
           bLang.of(langExt),
           bRo.of(EditorState.readOnly.of(readOnly)),
           bClickExt,
+          // Annotation gutter etc. — installed on the modified pane only (#213).
+          ...(extraExtensionsRef.current ?? []),
         ],
       },
       parent: hostRef.current,
@@ -196,6 +219,10 @@ export function CmDiffEditor({
     // The mv object itself is long-lived; diff-nav reads mv.chunks at call time,
     // so registering once at mount is sufficient.
     setActiveMergeView(mv);
+    // Hand the modified pane's live view to any host (e.g. the comment gutter)
+    // so it can dispatch effects / read state fields on the pane carrying
+    // extraExtensions.
+    onViewReadyRef.current?.(mv.b);
     // Report the initial chunk count synchronously after construction so that
     // parent controls (DiffHeader) can display an accurate count without
     // polling the global singleton or using a timer.

--- a/packages/ui/src/features/editor/DiffTab.tsx
+++ b/packages/ui/src/features/editor/DiffTab.tsx
@@ -16,7 +16,7 @@ import { inferLanguage } from '@/lib/editor/file-types';
 import { getWorkingDiff } from '@/lib/api/git';
 import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
 import { useActiveIdentity } from '@/features/sessions/use-active-identity';
-import { CmDiffEditor } from './CmDiffEditor';
+import { CmDiffEditorWithComments } from './inline-comments/CmDiffEditorWithComments';
 import { DiffHeader } from './DiffHeader';
 import { nextChange, prevChange } from './diff-nav';
 
@@ -121,12 +121,13 @@ export function DiffTab({ path, original: origProp, modified: modProp }: DiffTab
         onPrev={prevChange}
         onNext={nextChange}
       />
-      <CmDiffEditor
+      <CmDiffEditorWithComments
         key={`${original}\x00${modified}`}
         original={original}
         modified={modified}
         language={language}
         path={path}
+        filePath={path}
         onChunksChange={handleChunksChange}
       />
     </div>

--- a/packages/ui/src/features/editor/__tests__/CmDiffEditor.test.tsx
+++ b/packages/ui/src/features/editor/__tests__/CmDiffEditor.test.tsx
@@ -11,7 +11,9 @@
  */
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import type { EditorView } from '@codemirror/view';
 import { CmDiffEditor } from '../CmDiffEditor';
+import { buildCommentGutter } from '../inline-comments/comment-gutter';
 
 describe('CmDiffEditor', () => {
   it('renders the editor-diff root with .mf-editor-selectable', () => {
@@ -131,5 +133,41 @@ describe('CmDiffEditor', () => {
     const root = screen.getByTestId('editor-diff');
     // Both .cm-editor nodes must be present (one per pane)
     expect(root.querySelectorAll('.cm-editor').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls onViewReady with the modified pane EditorView (#213)', () => {
+    let view: EditorView | undefined;
+    render(
+      <CmDiffEditor
+        original={'a\n'}
+        modified={'b\n'}
+        language="plaintext"
+        path="/test/onviewready.txt"
+        onViewReady={(v) => {
+          view = v;
+        }}
+      />,
+    );
+    expect(view).toBeTruthy();
+    expect(typeof view!.dispatch).toBe('function');
+  });
+
+  it('installs extraExtensions on the modified pane — the annotation gutter reaches the MergeView (#213)', () => {
+    // Regression guard: MergeView builds each pane from `config.a/b.extensions`.
+    // The annotation gutter must be threaded through so the diff viewer gets the
+    // same gutter as the editor (not silently dropped like a pre-built state).
+    const gutterExt = buildCommentGutter({ onAddComment: () => {}, onOpenComment: () => {} });
+    render(
+      <CmDiffEditor
+        original={'a\nb\n'}
+        modified={'a\nB\n'}
+        language="plaintext"
+        path="/test/gutter-ext.txt"
+        extraExtensions={[gutterExt]}
+      />,
+    );
+    const root = screen.getByTestId('editor-diff');
+    // One comment gutter — installed only on the modified (b) pane.
+    expect(root.querySelectorAll('.cm-comment-gutter').length).toBe(1);
   });
 });

--- a/packages/ui/src/features/editor/inline-comments/CmDiffEditorWithComments.tsx
+++ b/packages/ui/src/features/editor/inline-comments/CmDiffEditorWithComments.tsx
@@ -1,0 +1,50 @@
+/**
+ * CmDiffEditorWithComments — CmDiffEditor + the inline comment gutter + portals.
+ *
+ * The diff twin of CmEditorWithComments: it binds the shared `useCommentGutter`
+ * concern to the diff's MODIFIED (right) pane so a reviewer can add the same
+ * agent annotations on a diff that they can in the plain editor (#213). The
+ * gutter extensions ride in via `extraExtensions` (threaded through the
+ * MergeView's `config.b.extensions`, not a pre-built state) and the modified
+ * pane's live view arrives via `onViewReady`.
+ */
+import type { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import type { CmDiffEditorProps } from '../CmDiffEditor';
+import { CmDiffEditor } from '../CmDiffEditor';
+import { useCommentGutter } from './use-comment-gutter';
+
+type CmDiffEditorWithCommentsProps = Omit<CmDiffEditorProps, 'extraExtensions' | 'onViewReady'> & {
+  enableComments?: boolean;
+  /** Additional CM6 extensions merged with the comment-gutter extensions. */
+  extraExtensions?: Extension[];
+  /** Called with the modified pane's live EditorView once mounted. */
+  onViewReady?: (view: EditorView) => void;
+  /**
+   * File path for the review send; if absent, submit is a no-op with a warning.
+   */
+  filePath?: string;
+};
+
+export function CmDiffEditorWithComments({
+  enableComments = true,
+  extraExtensions,
+  onViewReady,
+  filePath,
+  ...diffProps
+}: CmDiffEditorWithCommentsProps) {
+  const { commentExtensions, handleViewReady, submitBar, portals } = useCommentGutter({
+    enableComments,
+    extraExtensions,
+    onViewReady,
+    filePath,
+  });
+
+  return (
+    <>
+      {submitBar}
+      <CmDiffEditor {...diffProps} extraExtensions={commentExtensions} onViewReady={handleViewReady} />
+      {portals}
+    </>
+  );
+}

--- a/packages/ui/src/features/editor/inline-comments/CmEditorWithComments.tsx
+++ b/packages/ui/src/features/editor/inline-comments/CmEditorWithComments.tsx
@@ -1,43 +1,20 @@
 /**
- * CmEditorWithComments — CmEditor + the comment gutter + React portals.
+ * CmEditorWithComments — CmEditor + the inline comment gutter + React portals.
  *
- * Composes three concerns:
- *   1. useInlineComments — comment data model (add/edit/delete/query)
- *   2. buildCommentGutter — CM6 gutter extension with click-to-add / click-to-open
- *   3. Per-comment portal — rendered into stable host <div>s that CM6 block
- *      widget decorations inject below each commented line.
+ * A thin composition over `useCommentGutter` (which owns the editor-agnostic
+ * comment concern: data model, gutter extension, portals, submit/send). This
+ * component only binds that concern to a code `CmEditor`:
+ * - the gutter extensions are merged into the editor via `extraExtensions`.
+ * - the live EditorView is forwarded via `onViewReady` (also passed through to
+ *   the parent for context-menu use).
  *
- * Block widgets (not hand-inserted DOM) are used so CM6 owns widget
- * placement and lifecycle.  The widget's toDOM() returns a stable host element;
- * this component portals InlineCommentWidget into it.  When a widget is
- * removed (deleteCommentEffect) its WidgetType.destroy() fires and the portal
- * is cleaned up.
- *
- * Props extend CmEditorProps (re-adding extraExtensions and onViewReady as
- * passthroughs) with an optional `enableComments` flag (default true).
- * - extraExtensions: merged with the comment-gutter extensions so LSP and the
- *   gutter coexist in one editor (required by A3).
- * - onViewReady: forwarded alongside the internal viewRef assignment so the
- *   parent context-menu can resolve the live EditorView (required by A1/A3).
- *
- * Submit-review bar:
- *   When any comments have non-empty text, a 30px bar appears below the header
- *   (above the editor) with a count and a "Submit review (N)" button.
+ * The diff viewer shares the same hook via CmDiffEditorWithComments.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { EditorView } from '@codemirror/view';
 import type { Extension } from '@codemirror/state';
-import { MessageSquare } from 'lucide-react';
 import type { CmEditorProps } from '../CmEditor';
 import { CmEditor } from '../CmEditor';
-import { addCommentEffect, buildCommentGutter, commentField, type CommentBlockWidget } from './comment-gutter';
-import { useInlineComments } from './use-inline-comments';
-import { InlineCommentWidget } from './InlineCommentWidget';
-import { resolveCommentRange } from './resolve-comment-range';
-import { useReviewActions } from './use-review-actions';
-
-// ── Types ────────────────────────────────────────────────────────────────────
+import { useCommentGutter } from './use-comment-gutter';
 
 type CmEditorWithCommentsProps = Omit<CmEditorProps, 'extraExtensions' | 'onViewReady'> & {
   enableComments?: boolean;
@@ -52,46 +29,6 @@ type CmEditorWithCommentsProps = Omit<CmEditorProps, 'extraExtensions' | 'onView
   filePath?: string;
 };
 
-/** Portal descriptor: the comment id + the host element from the block widget. */
-interface WidgetPortal {
-  commentId: string;
-  hostElement: HTMLDivElement;
-}
-
-// ── SubmitReviewBar ──────────────────────────────────────────────────────────
-
-interface SubmitReviewBarProps {
-  count: number;
-  filledCount: number;
-  onSubmit: () => void;
-}
-
-function SubmitReviewBar({ count, filledCount, onSubmit }: SubmitReviewBarProps) {
-  return (
-    <div
-      data-testid="editor-submit-review"
-      className="flex h-[30px] shrink-0 items-center gap-2 bg-mf-content2 px-3 [border-bottom:0.5px_solid_var(--border)]"
-    >
-      <MessageSquare size={11} className="shrink-0 text-primary" aria-hidden />
-      <span className="text-caption text-muted-foreground">
-        {count} agent {count === 1 ? 'note' : 'notes'}
-      </span>
-      <div className="flex-1" />
-      <button
-        data-testid="editor-submit-review-btn"
-        type="button"
-        onClick={onSubmit}
-        disabled={filledCount === 0}
-        className="inline-flex h-[22px] items-center gap-1.5 rounded-[6px] border-none bg-primary/10 px-[9px] text-caption font-semibold text-primary disabled:cursor-default disabled:opacity-40 transition-opacity"
-      >
-        Submit review ({count})
-      </button>
-    </div>
-  );
-}
-
-// ── Component ────────────────────────────────────────────────────────────────
-
 export function CmEditorWithComments({
   enableComments = true,
   extraExtensions,
@@ -99,183 +36,18 @@ export function CmEditorWithComments({
   filePath,
   ...editorProps
 }: CmEditorWithCommentsProps) {
-  const viewRef = useRef<EditorView | null>(null);
-  const { comments, addComment, editComment, deleteComment } = useInlineComments();
-
-  // Active portals: each entry corresponds to an open (visible) comment widget.
-  const [portals, setPortals] = useState<WidgetPortal[]>([]);
-  const portalsRef = useRef<WidgetPortal[]>([]);
-
-  // Per-portal draft text state.
-  const [draftTexts, setDraftTexts] = useState<Record<string, string>>({});
-
-  const { handleSubmitReview, handleSendOne, removeComment } = useReviewActions({
+  const { commentExtensions, handleViewReady, submitBar, portals } = useCommentGutter({
+    enableComments,
+    extraExtensions,
+    onViewReady,
     filePath,
-    comments,
-    draftTexts,
-    deleteComment,
-    setPortals,
-    portalsRef,
-    setDraftTexts,
-    viewRef,
   });
-
-  // ── Portal management helpers ────────────────────────────────────────────
-
-  /** Open a portal into the block widget host for `commentId` (if not already open). */
-  const openPortalForWidget = useCallback((commentId: string, widget: CommentBlockWidget) => {
-    if (portalsRef.current.some((p) => p.commentId === commentId)) return;
-
-    // Register a destroy callback on the widget so we clean up if CM6 removes it.
-    widget.setDestroyCallback(() => {
-      portalsRef.current = portalsRef.current.filter((p) => p.commentId !== commentId);
-      setPortals((prev) => prev.filter((p) => p.commentId !== commentId));
-    });
-
-    const entry: WidgetPortal = { commentId, hostElement: widget.hostElement };
-    portalsRef.current = [...portalsRef.current, entry];
-    setPortals((prev) => [...prev, entry]);
-  }, []);
-
-  /** Close (unmount) a portal without deleting the comment data. */
-  const closePortal = useCallback((commentId: string) => {
-    portalsRef.current = portalsRef.current.filter((p) => p.commentId !== commentId);
-    setPortals((prev) => prev.filter((p) => p.commentId !== commentId));
-  }, []);
-
-  // ── Gutter callbacks ─────────────────────────────────────────────────────
-
-  const onAddComment = useCallback(
-    (line: number) => {
-      const view = viewRef.current;
-      if (!view) return;
-
-      // When there is an active selection the comment captures the full range;
-      // otherwise only the clicked line is used.
-      const { startLine, endLine, lineContent } = resolveCommentRange(view.state, line);
-
-      const id = addComment({ startLine, endLine, lineContent });
-
-      // Anchor the block widget BELOW endLine so it appears after the last
-      // selected line (not after the first).
-      view.dispatch({ effects: [addCommentEffect.of({ id, line: endLine, text: '' })] });
-
-      // Open the portal using the widget that was just created.
-      const widget = view.state.field(commentField).widgets.get(id);
-      if (widget) {
-        openPortalForWidget(id, widget);
-      }
-    },
-    [addComment, openPortalForWidget],
-  );
-
-  const onOpenComment = useCallback(
-    (id: string) => {
-      const view = viewRef.current;
-      if (!view) return;
-      const widget = view.state.field(commentField).widgets.get(id);
-      if (widget) {
-        openPortalForWidget(id, widget);
-      }
-    },
-    [openPortalForWidget],
-  );
-
-  // ── Gutter extension (stable reference) ─────────────────────────────────
-
-  const onAddRef = useRef(onAddComment);
-  onAddRef.current = onAddComment;
-  const onOpenRef = useRef(onOpenComment);
-  onOpenRef.current = onOpenComment;
-
-  // Merge caller-provided extensions (e.g. LSP) with the comment gutter so
-  // both coexist in one editor. extraExtensions comes first so the gutter
-  // appears after other gutters in left-to-right order.
-  const commentExtensions = useMemo<Extension[]>(() => {
-    const gutterExt = enableComments
-      ? [
-          buildCommentGutter({
-            onAddComment: (line) => onAddRef.current(line),
-            onOpenComment: (id) => onOpenRef.current(id),
-          }),
-        ]
-      : [];
-    return [...(extraExtensions ?? []), ...gutterExt];
-  }, [enableComments, extraExtensions]);
-
-  // ── Widget save / delete handlers ────────────────────────────────────────
-
-  const handleSave = useCallback(
-    (commentId: string, text: string) => {
-      editComment(commentId, text);
-      closePortal(commentId);
-    },
-    [editComment, closePortal],
-  );
-
-  const handleTextChange = useCallback((commentId: string, text: string) => {
-    setDraftTexts((prev) => ({ ...prev, [commentId]: text }));
-  }, []);
-
-  // Count of comments that have any text (draft or saved).
-  const filledCount = comments.filter((c) => {
-    const draft = draftTexts[c.id];
-    const text = draft !== undefined ? draft : c.text;
-    return text.trim().length > 0;
-  }).length;
-
-  const showSubmitBar = enableComments && comments.length > 0;
-
-  // ── Cleanup portals on unmount ───────────────────────────────────────────
-
-  useEffect(() => {
-    return () => {
-      portalsRef.current = [];
-    };
-  }, []);
-
-  // ── View ready callback ──────────────────────────────────────────────────
-
-  // Stable ref so the onViewReady passthrough is always up-to-date without
-  // re-creating handleViewReady (which would re-mount the editor).
-  const onViewReadyRef = useRef(onViewReady);
-  onViewReadyRef.current = onViewReady;
-
-  const handleViewReady = useCallback((view: EditorView) => {
-    viewRef.current = view;
-    // Forward to the parent so the EditorContextMenu's viewRef resolves.
-    onViewReadyRef.current?.(view);
-  }, []);
-
-  // ── Render ───────────────────────────────────────────────────────────────
 
   return (
     <>
-      {showSubmitBar && (
-        <SubmitReviewBar count={comments.length} filledCount={filledCount} onSubmit={handleSubmitReview} />
-      )}
+      {submitBar}
       <CmEditor {...editorProps} extraExtensions={commentExtensions} onViewReady={handleViewReady} />
-      {portals.map((portal) => {
-        const comment = comments.find((c) => c.id === portal.commentId);
-        const text = draftTexts[portal.commentId] ?? comment?.text ?? '';
-        // Derive 1-based line number from the comment's anchor position.
-        const lineNumber = comment?.startLine;
-        return createPortal(
-          <InlineCommentWidget
-            key={portal.commentId}
-            text={text}
-            lineNumber={lineNumber}
-            endLine={comment?.endLine}
-            lineContent={comment?.lineContent}
-            onTextChange={(t) => handleTextChange(portal.commentId, t)}
-            onSave={() => handleSave(portal.commentId, text)}
-            onClose={() => closePortal(portal.commentId)}
-            onDelete={() => removeComment(portal.commentId)}
-            onSend={() => handleSendOne(portal.commentId)}
-          />,
-          portal.hostElement,
-        );
-      })}
+      {portals}
     </>
   );
 }

--- a/packages/ui/src/features/editor/inline-comments/__tests__/CmDiffEditorWithComments.test.tsx
+++ b/packages/ui/src/features/editor/inline-comments/__tests__/CmDiffEditorWithComments.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * CmDiffEditorWithComments — end-to-end wiring test.
+ *
+ * Renders the real component (real CM6 MergeView, real comment-gutter hook) and
+ * asserts the annotation gutter is installed on the modified pane — the same
+ * gutter the plain editor shows (#213). Only the daemon-backed review send is
+ * mocked (it needs the Tauri/daemon bridge); the gutter wiring is exercised for
+ * real.
+ *
+ * jsdom stubs for CM6 Range measurement live in src/__tests__/setup.ts.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../use-send-review', () => ({
+  useSendReview: () => vi.fn().mockResolvedValue(undefined),
+}));
+
+import { CmDiffEditorWithComments } from '../CmDiffEditorWithComments';
+
+describe('CmDiffEditorWithComments (#213)', () => {
+  it('mounts the diff MergeView', () => {
+    render(
+      <CmDiffEditorWithComments
+        original={'a\nb\n'}
+        modified={'a\nB\n'}
+        language="plaintext"
+        path="/t.txt"
+        filePath="t.txt"
+      />,
+    );
+    const root = screen.getByTestId('editor-diff');
+    expect(root.querySelector('.cm-mergeView')).toBeTruthy();
+  });
+
+  it('installs exactly one annotation gutter, on the modified pane', () => {
+    render(
+      <CmDiffEditorWithComments
+        original={'a\nb\nc\n'}
+        modified={'a\nB\nc\n'}
+        language="plaintext"
+        path="/t.txt"
+        filePath="t.txt"
+      />,
+    );
+    const root = screen.getByTestId('editor-diff');
+    expect(root.querySelectorAll('.cm-comment-gutter').length).toBe(1);
+  });
+
+  it('does not install the gutter when comments are disabled', () => {
+    render(
+      <CmDiffEditorWithComments
+        original={'a\n'}
+        modified={'b\n'}
+        language="plaintext"
+        path="/t.txt"
+        filePath="t.txt"
+        enableComments={false}
+      />,
+    );
+    const root = screen.getByTestId('editor-diff');
+    expect(root.querySelector('.cm-comment-gutter')).toBeNull();
+  });
+});

--- a/packages/ui/src/features/editor/inline-comments/use-comment-gutter.tsx
+++ b/packages/ui/src/features/editor/inline-comments/use-comment-gutter.tsx
@@ -1,0 +1,274 @@
+/**
+ * useCommentGutter — editor-agnostic inline-comment orchestration.
+ *
+ * Owns the whole comment concern independent of WHICH CodeMirror view hosts it:
+ *   1. useInlineComments — comment data model (add/edit/delete/query)
+ *   2. buildCommentGutter — CM6 gutter extension with click-to-add / click-to-open
+ *   3. Per-comment portal — rendered into stable host <div>s that CM6 block
+ *      widget decorations inject below each commented line.
+ *
+ * The consumer wires the returned `commentExtensions` into a view (the code
+ * editor's compartment, or the diff editor's modified pane) and forwards
+ * `handleViewReady` so the gutter callbacks can resolve the live EditorView. It
+ * then renders `submitBar` above the view and `portals` alongside it. This lets
+ * both CmEditorWithComments and CmDiffEditorWithComments share one implementation.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import type { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import { MessageSquare } from 'lucide-react';
+import { addCommentEffect, buildCommentGutter, commentField, type CommentBlockWidget } from './comment-gutter';
+import { useInlineComments } from './use-inline-comments';
+import { InlineCommentWidget } from './InlineCommentWidget';
+import { resolveCommentRange } from './resolve-comment-range';
+import { useReviewActions } from './use-review-actions';
+
+// ── SubmitReviewBar ──────────────────────────────────────────────────────────
+
+interface SubmitReviewBarProps {
+  count: number;
+  filledCount: number;
+  onSubmit: () => void;
+}
+
+function SubmitReviewBar({ count, filledCount, onSubmit }: SubmitReviewBarProps) {
+  return (
+    <div
+      data-testid="editor-submit-review"
+      className="flex h-[30px] shrink-0 items-center gap-2 bg-mf-content2 px-3 [border-bottom:0.5px_solid_var(--border)]"
+    >
+      <MessageSquare size={11} className="shrink-0 text-primary" aria-hidden />
+      <span className="text-caption text-muted-foreground">
+        {count} agent {count === 1 ? 'note' : 'notes'}
+      </span>
+      <div className="flex-1" />
+      <button
+        data-testid="editor-submit-review-btn"
+        type="button"
+        onClick={onSubmit}
+        disabled={filledCount === 0}
+        className="inline-flex h-[22px] items-center gap-1.5 rounded-[6px] border-none bg-primary/10 px-[9px] text-caption font-semibold text-primary disabled:cursor-default disabled:opacity-40 transition-opacity"
+      >
+        Submit review ({count})
+      </button>
+    </div>
+  );
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface UseCommentGutterOptions {
+  /** When false, no gutter is installed and no submit bar renders. Default true. */
+  enableComments?: boolean;
+  /** Additional CM6 extensions merged BEFORE the comment gutter (e.g. LSP). */
+  extraExtensions?: Extension[];
+  /** Forwarded to the parent once the hosting EditorView mounts. */
+  onViewReady?: (view: EditorView) => void;
+  /** File path for the review send; when absent, submit is a no-op with a warning. */
+  filePath?: string;
+}
+
+export interface UseCommentGutterResult {
+  /** Extensions to install on the hosting view (LSP + comment gutter). */
+  commentExtensions: Extension[];
+  /** Pass to the host view's `onViewReady` so gutter callbacks resolve the view. */
+  handleViewReady: (view: EditorView) => void;
+  /** The "Submit review" bar (or null when there are no comments). */
+  submitBar: ReactNode;
+  /** The open per-comment widget portals. */
+  portals: ReactNode;
+}
+
+/** Portal descriptor: the comment id + the host element from the block widget. */
+interface WidgetPortal {
+  commentId: string;
+  hostElement: HTMLDivElement;
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useCommentGutter({
+  enableComments = true,
+  extraExtensions,
+  onViewReady,
+  filePath,
+}: UseCommentGutterOptions): UseCommentGutterResult {
+  const viewRef = useRef<EditorView | null>(null);
+  const { comments, addComment, editComment, deleteComment } = useInlineComments();
+
+  // Active portals: each entry corresponds to an open (visible) comment widget.
+  const [portalEntries, setPortalEntries] = useState<WidgetPortal[]>([]);
+  const portalsRef = useRef<WidgetPortal[]>([]);
+
+  // Per-portal draft text state.
+  const [draftTexts, setDraftTexts] = useState<Record<string, string>>({});
+
+  const { handleSubmitReview, handleSendOne, removeComment } = useReviewActions({
+    filePath,
+    comments,
+    draftTexts,
+    deleteComment,
+    setPortals: setPortalEntries,
+    portalsRef,
+    setDraftTexts,
+    viewRef,
+  });
+
+  // ── Portal management helpers ──────────────────────────────────────────────
+
+  /** Open a portal into the block widget host for `commentId` (if not already open). */
+  const openPortalForWidget = useCallback((commentId: string, widget: CommentBlockWidget) => {
+    if (portalsRef.current.some((p) => p.commentId === commentId)) return;
+
+    // Register a destroy callback on the widget so we clean up if CM6 removes it.
+    widget.setDestroyCallback(() => {
+      portalsRef.current = portalsRef.current.filter((p) => p.commentId !== commentId);
+      setPortalEntries((prev) => prev.filter((p) => p.commentId !== commentId));
+    });
+
+    const entry: WidgetPortal = { commentId, hostElement: widget.hostElement };
+    portalsRef.current = [...portalsRef.current, entry];
+    setPortalEntries((prev) => [...prev, entry]);
+  }, []);
+
+  /** Close (unmount) a portal without deleting the comment data. */
+  const closePortal = useCallback((commentId: string) => {
+    portalsRef.current = portalsRef.current.filter((p) => p.commentId !== commentId);
+    setPortalEntries((prev) => prev.filter((p) => p.commentId !== commentId));
+  }, []);
+
+  // ── Gutter callbacks ───────────────────────────────────────────────────────
+
+  const onAddComment = useCallback(
+    (line: number) => {
+      const view = viewRef.current;
+      if (!view) return;
+
+      // When there is an active selection the comment captures the full range;
+      // otherwise only the clicked line is used.
+      const { startLine, endLine, lineContent } = resolveCommentRange(view.state, line);
+
+      const id = addComment({ startLine, endLine, lineContent });
+
+      // Anchor the block widget BELOW endLine so it appears after the last
+      // selected line (not after the first).
+      view.dispatch({ effects: [addCommentEffect.of({ id, line: endLine, text: '' })] });
+
+      // Open the portal using the widget that was just created.
+      const widget = view.state.field(commentField).widgets.get(id);
+      if (widget) {
+        openPortalForWidget(id, widget);
+      }
+    },
+    [addComment, openPortalForWidget],
+  );
+
+  const onOpenComment = useCallback(
+    (id: string) => {
+      const view = viewRef.current;
+      if (!view) return;
+      const widget = view.state.field(commentField).widgets.get(id);
+      if (widget) {
+        openPortalForWidget(id, widget);
+      }
+    },
+    [openPortalForWidget],
+  );
+
+  // ── Gutter extension (stable reference) ────────────────────────────────────
+
+  const onAddRef = useRef(onAddComment);
+  onAddRef.current = onAddComment;
+  const onOpenRef = useRef(onOpenComment);
+  onOpenRef.current = onOpenComment;
+
+  // Merge caller-provided extensions (e.g. LSP) with the comment gutter so both
+  // coexist in one view. extraExtensions comes first so the gutter appears after
+  // other gutters in left-to-right order.
+  const commentExtensions = useMemo<Extension[]>(() => {
+    const gutterExt = enableComments
+      ? [
+          buildCommentGutter({
+            onAddComment: (line) => onAddRef.current(line),
+            onOpenComment: (id) => onOpenRef.current(id),
+          }),
+        ]
+      : [];
+    return [...(extraExtensions ?? []), ...gutterExt];
+  }, [enableComments, extraExtensions]);
+
+  // ── Widget save / delete handlers ──────────────────────────────────────────
+
+  const handleSave = useCallback(
+    (commentId: string, text: string) => {
+      editComment(commentId, text);
+      closePortal(commentId);
+    },
+    [editComment, closePortal],
+  );
+
+  const handleTextChange = useCallback((commentId: string, text: string) => {
+    setDraftTexts((prev) => ({ ...prev, [commentId]: text }));
+  }, []);
+
+  // Count of comments that have any text (draft or saved).
+  const filledCount = comments.filter((c) => {
+    const draft = draftTexts[c.id];
+    const text = draft !== undefined ? draft : c.text;
+    return text.trim().length > 0;
+  }).length;
+
+  const showSubmitBar = enableComments && comments.length > 0;
+
+  // ── Cleanup portals on unmount ─────────────────────────────────────────────
+
+  useEffect(() => {
+    return () => {
+      portalsRef.current = [];
+    };
+  }, []);
+
+  // ── View ready callback ────────────────────────────────────────────────────
+
+  // Stable ref so the onViewReady passthrough is always up-to-date without
+  // re-creating handleViewReady (which would re-mount the editor).
+  const onViewReadyRef = useRef(onViewReady);
+  onViewReadyRef.current = onViewReady;
+
+  const handleViewReady = useCallback((view: EditorView) => {
+    viewRef.current = view;
+    // Forward to the parent so an EditorContextMenu's viewRef resolves.
+    onViewReadyRef.current?.(view);
+  }, []);
+
+  const submitBar = showSubmitBar ? (
+    <SubmitReviewBar count={comments.length} filledCount={filledCount} onSubmit={handleSubmitReview} />
+  ) : null;
+
+  const portals = (
+    <>
+      {portalEntries.map((portal) => {
+        const comment = comments.find((c) => c.id === portal.commentId);
+        const text = draftTexts[portal.commentId] ?? comment?.text ?? '';
+        return createPortal(
+          <InlineCommentWidget
+            key={portal.commentId}
+            text={text}
+            lineNumber={comment?.startLine}
+            endLine={comment?.endLine}
+            lineContent={comment?.lineContent}
+            onTextChange={(t) => handleTextChange(portal.commentId, t)}
+            onSave={() => handleSave(portal.commentId, text)}
+            onClose={() => closePortal(portal.commentId)}
+            onDelete={() => removeComment(portal.commentId)}
+            onSend={() => handleSendOne(portal.commentId)}
+          />,
+          portal.hostElement,
+        );
+      })}
+    </>
+  );
+
+  return { commentExtensions, handleViewReady, submitBar, portals };
+}

--- a/packages/ui/src/features/run/ConsolePane.tsx
+++ b/packages/ui/src/features/run/ConsolePane.tsx
@@ -95,7 +95,8 @@ function LogLines({ entries, scrollRef }: { entries: LogEntry[]; scrollRef: Reac
   return (
     <div
       ref={scrollRef}
-      className="min-h-0 flex-1 overflow-y-auto pl-[12px] pr-[12px] pt-0 pb-[10px] font-mono text-caption leading-relaxed"
+      data-testid="run-console-log-lines"
+      className="mf-editor-selectable min-h-0 flex-1 overflow-y-auto pl-[12px] pr-[12px] pt-0 pb-[10px] font-mono text-caption leading-relaxed"
     >
       {entries.length === 0 ? (
         <span className="text-muted-foreground">No output yet.</span>

--- a/packages/ui/src/features/run/__tests__/ConsolePane.test.tsx
+++ b/packages/ui/src/features/run/__tests__/ConsolePane.test.tsx
@@ -70,6 +70,13 @@ describe('ConsolePane', () => {
     fireEvent.click(screen.getByTestId('run-console-clear'));
     expect(clearLogsForProcess).toHaveBeenCalledWith('proj-1:/repo', 'dev');
   });
+
+  it('opts the log output into text selection via the mf-editor-selectable class', async () => {
+    const { ConsolePane } = await import('../ConsolePane');
+    render(<ConsolePane scopeKey="proj-1:/repo" processName="dev" />);
+    const lines = screen.getByTestId('run-console-log-lines');
+    expect(lines.classList.contains('mf-editor-selectable')).toBe(true);
+  });
 });
 
 describe('ConsolePane drawer variant', () => {
@@ -106,6 +113,14 @@ describe('ConsolePane drawer variant', () => {
     render(<ConsolePane scopeKey="proj-1:/repo" processName="dev" variant="drawer" />);
     fireEvent.click(screen.getByTestId('run-console-drawer-toggle'));
     expect(screen.getByText('Starting server…')).toBeInTheDocument();
+  });
+
+  it('opts the expanded drawer log output into text selection', async () => {
+    const { ConsolePane } = await import('../ConsolePane');
+    render(<ConsolePane scopeKey="proj-1:/repo" processName="dev" variant="drawer" />);
+    fireEvent.click(screen.getByTestId('run-console-drawer-toggle'));
+    const lines = screen.getByTestId('run-console-log-lines');
+    expect(lines.classList.contains('mf-editor-selectable')).toBe(true);
   });
 
   it('shows the last log line as tail when collapsed', async () => {

--- a/packages/ui/src/features/tasks/__tests__/use-start-todo-session.test.ts
+++ b/packages/ui/src/features/tasks/__tests__/use-start-todo-session.test.ts
@@ -1,0 +1,91 @@
+/**
+ * useStartTodoSession — behavior tests.
+ *
+ * The daemon's `start-session` creates an EMPTY chat and returns the chatId +
+ * initialMessage separately; the client must switch to the new thread and THEN
+ * prefill its composer. Because `switchToThread` is async (mainThreadId only
+ * catches up when it resolves), the prefill must await the switch — otherwise
+ * `setText` targets the previously-active thread's composer and the new chat
+ * opens blank (#212).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// ── Runtime + composer spies ─────────────────────────────────────────────────
+const reload = vi.fn<() => Promise<void>>();
+const switchToThread = vi.fn<(id: string) => Promise<void>>();
+const setText = vi.fn<(text: string) => void>();
+
+vi.mock('@assistant-ui/react', () => ({
+  useAssistantRuntime: () => ({ threads: { reload, switchToThread } }),
+  useAui: () => ({ composer: () => ({ setText }) }),
+}));
+
+vi.mock('@/lib/api/todos', () => ({
+  startTodoSession: vi.fn(),
+  moveTodo: vi.fn(),
+}));
+
+vi.mock('../use-todos-store', () => ({
+  useTodosStore: { getState: () => ({ load: vi.fn().mockResolvedValue(undefined) }) },
+}));
+
+import { useStartTodoSession } from '../use-start-todo-session';
+import { startTodoSession, moveTodo } from '@/lib/api/todos';
+
+const PORT = 31415;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reload.mockResolvedValue(undefined);
+  switchToThread.mockResolvedValue(undefined);
+  vi.mocked(startTodoSession).mockResolvedValue({ chatId: 'chat-9', initialMessage: 'Implement the thing' });
+});
+
+describe('useStartTodoSession', () => {
+  it('does nothing when there is no active project', async () => {
+    const { result } = renderHook(() => useStartTodoSession(PORT, undefined));
+    await result.current('todo-1');
+    expect(startTodoSession).not.toHaveBeenCalled();
+    expect(switchToThread).not.toHaveBeenCalled();
+  });
+
+  it('reloads the list, switches to the new chat, and prefills the composer', async () => {
+    const { result } = renderHook(() => useStartTodoSession(PORT, 'proj-1'));
+    await result.current('todo-1');
+
+    expect(startTodoSession).toHaveBeenCalledWith(PORT, 'todo-1', 'proj-1');
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(switchToThread).toHaveBeenCalledWith('chat-9');
+    expect(setText).toHaveBeenCalledWith('Implement the thing');
+  });
+
+  it('moves an open todo to in_progress before starting the session', async () => {
+    const { result } = renderHook(() => useStartTodoSession(PORT, 'proj-1'));
+    await result.current('todo-1', 'open');
+    expect(moveTodo).toHaveBeenCalledWith(PORT, 'todo-1', 'in_progress');
+  });
+
+  it('prefills the composer only AFTER the thread switch resolves (no race)', async () => {
+    let resolveSwitch!: () => void;
+    switchToThread.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolveSwitch = () => r();
+        }),
+    );
+
+    const { result } = renderHook(() => useStartTodoSession(PORT, 'proj-1'));
+    const done = result.current('todo-1');
+
+    // Wait until the switch has been requested; the composer must NOT be
+    // prefilled yet because the switch is still pending.
+    await vi.waitFor(() => expect(switchToThread).toHaveBeenCalledWith('chat-9'));
+    expect(setText).not.toHaveBeenCalled();
+
+    resolveSwitch();
+    await done;
+
+    expect(setText).toHaveBeenCalledWith('Implement the thing');
+  });
+});

--- a/packages/ui/src/features/tasks/use-start-todo-session.ts
+++ b/packages/ui/src/features/tasks/use-start-todo-session.ts
@@ -41,7 +41,10 @@ export function useStartTodoSession(
       // Reload the thread list so the new remote chat appears before switching.
       await runtime.threads.reload();
       // chatId IS the remoteId; switchToThread resolves it via threadIdMap.
-      runtime.threads.switchToThread(chatId);
+      // Await it: the switch is async (mainThreadId only catches up when it
+      // resolves), so prefilling before it lands would setText on the previously
+      // active thread's composer and open the new chat blank (#212).
+      await runtime.threads.switchToThread(chatId);
       // Prefill the new chat's composer — NOT auto-sent (parity with desktop).
       aui.composer().setText(initialMessage);
     },


### PR DESCRIPTION
## Summary

Batch of five small UI fixes to chat, editor, and run surfaces.

- Fixes todo #221 — make console log output selectable
- Fixes todo #214 — move chat thinking indicator after the last message
- Fixes todo #208 — allow expanding in-progress bash tool cards
- Fixes todo #212 — prefill composer when running a todo in a session
- Fixes todo #213 — allow agent annotations on the diff viewer

## Root cause

- **#221 (selectable console log):** The app shell sets `user-select: none` on `<body>` for a native-desktop feel; content surfaces opt back in via `.mf-editor-selectable`. The Run console log container never opted in, so its text couldn't be selected or copied. Added the same opt-in used by the editor/markdown surfaces (shared by the full pane and the expanded drawer).
- **#214 (thinking indicator placement):** The "Thinking…/Working…" indicator was pinned inside the sticky `ViewportFooter`, floating above the composer. Moved it into the scrolling messages column so it renders inline after the last message.
- **#208 (expand in-progress bash cards):** Bash cards gated expansion on having a resolved result, so a running command was frozen collapsed with its trigger disabled. A pending run (`result === undefined`) is now treated as expandable; a finished command with no output stays non-expandable.
- **#212 (composer prefill on run-todo):** `switchToThread` is async — `mainThreadId` only catches up once it resolves — but the "Run in session" flow called it fire-and-forget and immediately set the composer text, so the prefill landed on the previously active thread and the new chat opened blank. The switch is now awaited before prefilling.
- **#213 (diff-viewer annotations):** The Files diff viewer had no comment gutter. MergeView builds each pane from `config.a/b.extensions`, so the gutter must be threaded through that shape (a pre-built `EditorState` silently drops it). Added optional `extraExtensions` + `onViewReady` to `CmDiffEditor`, extracted the comment orchestration into a shared `useCommentGutter` hook, and added a `CmDiffEditorWithComments` wrapper that `DiffTab` now renders.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — pass
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run` on the changed/added test files — pass (53 tests, 6 files):
  - `ChatThread.test.tsx`, `BashCard.test.tsx` — 23 passed
  - `CmDiffEditor.test.tsx`, `CmDiffEditorWithComments.test.tsx`, `ConsolePane.test.tsx`, `use-start-todo-session.test.ts` — 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
