### PR TITLE
fix(ui): make the chat thread the single vertical-scroll owner for tool cards

### DIFF
--- a/.changeset/double-scrollbar.md
+++ b/.changeset/double-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix the double vertical scrollbar on chat tool cards: Bash, Read, Edit, Write, Plan, Search, Skill, and Schedule cards no longer nest their own `overflow-y-auto` region inside the thread viewport, so only the thread scrolls vertically while wide code and terminal lines still scroll horizontally.

--- a/packages/ui/src/features/chat/tools/cards/BashCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/BashCard.tsx
@@ -63,10 +63,7 @@ function TerminalBody({ command, resultText, isError, chatId, toolCallId, trunca
       {truncated && chatId && toolCallId ? (
         <ToolResultExpand chatId={chatId} toolUseId={toolCallId} truncatedContent={resultText} fullBytes={fullBytes} />
       ) : (
-        <pre
-          data-testid="chat-bash-output"
-          className="font-mono text-caption overflow-x-auto whitespace-pre-wrap max-h-[400px] overflow-y-auto"
-        >
+        <pre data-testid="chat-bash-output" className="font-mono text-caption overflow-x-auto whitespace-pre-wrap">
           <span className="text-mf-term-green">$ </span>
           <span className="text-mf-term-fg">{command}</span>
           {'\n'}

--- a/packages/ui/src/features/chat/tools/cards/EditFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/EditFileCard.tsx
@@ -103,13 +103,11 @@ function EditCardBody({
 }: EditCardBodyProps) {
   return (
     <div className="border-t border-border">
-      <div className="max-h-[300px] overflow-y-auto">
-        {displayHunks ? (
-          <DiffFromPatch hunks={displayHunks} />
-        ) : (
-          <DiffFallback oldStr={oldString} newStr={newString} startLine={null} />
-        )}
-      </div>
+      {displayHunks ? (
+        <DiffFromPatch hunks={displayHunks} />
+      ) : (
+        <DiffFallback oldStr={oldString} newStr={newString} startLine={null} />
+      )}
       {hasError && (
         <div className="border-t border-border px-3 py-1.5 bg-mf-diff-del-bg">
           {showExpand ? (

--- a/packages/ui/src/features/chat/tools/cards/PlanCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/PlanCard.tsx
@@ -76,7 +76,7 @@ export const PlanCard: ToolCallMessagePartComponent = (part) => {
             <div className="ml-5 border-l border-border py-1">
               <pre
                 data-testid="chat-plan-body"
-                className="text-caption font-mono text-muted-foreground whitespace-pre-wrap px-3 max-h-[200px] overflow-y-auto"
+                className="text-caption font-mono text-muted-foreground whitespace-pre-wrap px-3"
               >
                 {resultText}
               </pre>

--- a/packages/ui/src/features/chat/tools/cards/ReadFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/ReadFileCard.tsx
@@ -47,7 +47,7 @@ function CodePreview({ text }: CodePreviewProps) {
   return (
     <pre
       data-testid="read-card-code-preview"
-      className="bg-mf-code-bg font-mono text-caption leading-normal text-mf-code-fg overflow-auto max-h-[300px] whitespace-pre px-3 py-2"
+      className="bg-mf-code-bg font-mono text-caption leading-normal text-mf-code-fg overflow-x-auto whitespace-pre px-3 py-2"
     >
       {text}
     </pre>

--- a/packages/ui/src/features/chat/tools/cards/SchedulePillCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SchedulePillCard.tsx
@@ -126,7 +126,7 @@ function buildBody(kind: ScheduleKind, parsed: unknown, text: string): React.Rea
     const jobs = Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : [];
     if (jobs.length === 0) return null;
     return (
-      <div className="flex flex-col gap-1.5 font-mono text-caption text-mf-text-3 max-h-72 overflow-y-auto">
+      <div className="flex flex-col gap-1.5 font-mono text-caption text-mf-text-3">
         {jobs.map((j) => (
           <div key={String(j['id'] ?? '')}>
             <div>

--- a/packages/ui/src/features/chat/tools/cards/SearchCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SearchCard.tsx
@@ -43,7 +43,7 @@ function PlainBody({ resultText }: { resultText: string }) {
   return (
     <pre
       data-testid="search-card-plain-body"
-      className="font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 max-h-[300px] overflow-y-auto text-muted-foreground"
+      className="font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 text-muted-foreground"
     >
       {resultText}
     </pre>

--- a/packages/ui/src/features/chat/tools/cards/SkillLoadedCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SkillLoadedCard.tsx
@@ -59,9 +59,7 @@ export function SkillLoadedCard({ skillName, path = '', content = '' }: SkillLoa
       )}
       {open && expandable && (
         <MarkerBody>
-          <div className="max-h-[360px] overflow-y-auto">
-            <MarkerPre muted>{content}</MarkerPre>
-          </div>
+          <MarkerPre muted>{content}</MarkerPre>
         </MarkerBody>
       )}
     </MarkerWrap>

--- a/packages/ui/src/features/chat/tools/cards/WriteFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/WriteFileCard.tsx
@@ -75,9 +75,7 @@ function WriteCardBody({
 }: WriteCardBodyProps) {
   return (
     <div className="border-t border-border">
-      <div className="max-h-[300px] overflow-y-auto">
-        {hunks ? <DiffFromPatch hunks={hunks} /> : <AllAddLines content={content} />}
-      </div>
+      {hunks ? <DiffFromPatch hunks={hunks} /> : <AllAddLines content={content} />}
       {hasError && (
         <div className="border-t border-border px-3 py-1.5 bg-mf-diff-del-bg">
           {showExpand ? (

--- a/packages/ui/src/features/chat/tools/cards/__tests__/BashCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/BashCard.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/features/chat/tools/ToolResultExpand', () => ({
 // ---------------------------------------------------------------------------
 
 import { BashCard } from '../BashCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -165,6 +166,12 @@ describe('BashCard', () => {
     fireEvent.click(trigger);
     const output = screen.getByTestId('chat-bash-output');
     expect(output).toHaveTextContent('hello');
+  });
+
+  it('does not nest a vertical scroll container in the terminal body (single overflow owner)', () => {
+    renderCard(makePart({ args: { command: 'echo hi' }, result: 'hi\nexit 0', isError: false }));
+    fireEvent.click(screen.getByTestId('chat-bash-trigger'));
+    expect(nestedVerticalScrollers(screen.getByTestId('chat-bash-card'))).toHaveLength(0);
   });
 
   it('shows the command as a prompt line inside the output body', () => {

--- a/packages/ui/src/features/chat/tools/cards/__tests__/EditFileCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/EditFileCard.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/store/surface-intents', () => ({
 
 import { EditFileCard } from '../EditFileCard';
 import { emitSurfaceIntent } from '@/store/surface-intents';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -286,6 +287,26 @@ describe('EditFileCard', () => {
   it('renders the card root with data-testid="chat-edit-card"', () => {
     renderCard(makePart({ args: { file_path: 'f.ts', old_string: '', new_string: '' } }));
     expect(screen.getByTestId('chat-edit-card')).toBeInTheDocument();
+  });
+
+  // --- Single overflow owner (todo #198: no double scrollbar) ---
+
+  it('does not nest a vertical scroll container in the diff body (single overflow owner)', () => {
+    const structuredResult = {
+      content: 'OK',
+      structuredPatch: [
+        { oldStart: 10, oldLines: 1, newStart: 10, newLines: 1, lines: ['-const x = 1;', '+const x = 42;'] },
+      ],
+    };
+    renderCard(
+      makePart({
+        args: { file_path: 'src/app.ts', old_string: 'const x = 1;', new_string: 'const x = 42;' },
+        result: structuredResult,
+        isError: false,
+      }),
+    );
+    const card = screen.getByTestId('chat-edit-card');
+    expect(nestedVerticalScrollers(card)).toHaveLength(0);
   });
 });
 

--- a/packages/ui/src/features/chat/tools/cards/__tests__/PlanCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/PlanCard.test.tsx
@@ -24,6 +24,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { PlanCard } from '../PlanCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,6 +71,12 @@ describe('PlanCard', () => {
   it('renders the card root with data-testid="chat-plan-card"', () => {
     renderCard(makePart({}));
     expect(screen.getByTestId('chat-plan-card')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the plan body (single overflow owner)', () => {
+    renderCard(makePart({ result: 'Step 1: implement\nStep 2: test', isError: false }));
+    // Body is open by default when a result is present.
+    expect(nestedVerticalScrollers(screen.getByTestId('chat-plan-card'))).toHaveLength(0);
   });
 
   // --- Header label always visible ---

--- a/packages/ui/src/features/chat/tools/cards/__tests__/ReadFileCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/ReadFileCard.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/features/chat/tools/ToolResultExpand', () => ({
 // ---------------------------------------------------------------------------
 
 import { ReadFileCard } from '../ReadFileCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Minimal wrapper so Radix Tooltip doesn't warn
@@ -153,6 +154,21 @@ describe('ReadFileCard — done state', () => {
       </Wrap>,
     );
     expect(screen.getByTestId('read-card-root')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the code preview (single overflow owner)', () => {
+    render(
+      <Wrap>
+        <ReadFileCard
+          {...baseProps}
+          args={{ file_path: '/a/b/c.ts', from: 1 }}
+          result={'alpha\nbeta'}
+          isError={false}
+        />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('read-card-trigger'));
+    expect(nestedVerticalScrollers(screen.getByTestId('read-card-root'))).toHaveLength(0);
   });
 });
 

--- a/packages/ui/src/features/chat/tools/cards/__tests__/SchedulePillCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/SchedulePillCard.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ScheduleWakeupCard, CronCreateCard, CronDeleteCard, CronListCard, MonitorCard } from '../SchedulePillCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 import type { ToolCallMessagePartProps, ToolCallMessagePartStatus } from '@assistant-ui/react';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -271,6 +272,12 @@ describe('CronListCard — done state', () => {
     fireEvent.click(pill);
     expect(screen.getByText('job-1')).toBeInTheDocument();
     expect(screen.getByText('job-2')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the expanded job list (single overflow owner)', () => {
+    const { container } = renderCronList();
+    fireEvent.click(screen.getByTestId('chat-schedule-cronlist-pill'));
+    expect(nestedVerticalScrollers(container)).toHaveLength(0);
   });
 
   it('renders "Listing schedules…" in pending state', () => {

--- a/packages/ui/src/features/chat/tools/cards/__tests__/SearchCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/SearchCard.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/features/chat/tools/ToolResultExpand', () => ({
 // ---------------------------------------------------------------------------
 
 import { SearchCard } from '../SearchCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Wrapper — satisfies Radix Tooltip requirement
@@ -193,6 +194,16 @@ describe('SearchCard — done state (plain body)', () => {
       </Wrap>,
     );
     expect(screen.getByTestId('search-card-root')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the expanded body (single overflow owner)', () => {
+    render(
+      <Wrap>
+        <SearchCard {...baseProps} toolName="Glob" args={{ glob: '*.ts' }} result={'a.ts\nb.ts'} isError={false} />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('search-card-trigger'));
+    expect(nestedVerticalScrollers(screen.getByTestId('search-card-root'))).toHaveLength(0);
   });
 
   it('renders the plain body with the result text', () => {

--- a/packages/ui/src/features/chat/tools/cards/__tests__/SkillLoadedCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/SkillLoadedCard.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { SkillLoadedCard } from '../SkillLoadedCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ── Wrapper ───────────────────────────────────────────────────────────────────
 
@@ -68,6 +69,16 @@ describe('SkillLoadedCard — expandable behavior', () => {
     );
     fireEvent.click(screen.getByTestId('chat-skill-loaded-pill'));
     expect(screen.getByText('skill body text here')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the expanded content (single overflow owner)', () => {
+    const { container } = render(
+      <Wrap>
+        <SkillLoadedCard skillName="test-skill" path="/p" content={'line 1\nline 2\nline 3'} />
+      </Wrap>,
+    );
+    fireEvent.click(screen.getByTestId('chat-skill-loaded-pill'));
+    expect(nestedVerticalScrollers(container)).toHaveLength(0);
   });
 
   it('clicking the pill a second time collapses the content', () => {

--- a/packages/ui/src/features/chat/tools/cards/__tests__/WriteFileCard.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/WriteFileCard.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@assistant-ui/react', () => ({
 }));
 
 import { WriteFileCard } from '../WriteFileCard';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -188,6 +189,18 @@ describe('WriteFileCard', () => {
 
     // AllAddLines renders each content line — 'hello world' is the only line
     expect(screen.getByText('hello world')).toBeInTheDocument();
+  });
+
+  it('does not nest a vertical scroll container in the expanded body (single overflow owner)', async () => {
+    renderCard(
+      makePart({
+        args: { file_path: 'src/new.ts', content: 'hello world' },
+        result: 'OK',
+        isError: false,
+      }),
+    );
+    await userEvent.click(screen.getByTestId('chat-write-trigger'));
+    expect(nestedVerticalScrollers(screen.getByTestId('chat-write-card'))).toHaveLength(0);
   });
 
   it('collapses body again when trigger is clicked a second time', async () => {

--- a/packages/ui/src/features/chat/tools/cards/__tests__/_part-fixture.ts
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/_part-fixture.ts
@@ -22,3 +22,18 @@ export function makeToolPart(overrides: Partial<ToolCallMessagePartProps> = {}):
     ...overrides,
   };
 }
+
+/**
+ * Tool cards must not nest their own vertical scroll region inside the chat
+ * thread viewport — the viewport is the single overflow owner. A nested
+ * vertical scroller paints a second scrollbar beside the thread's (todo #198
+ * "double scrollbar"). Returns every descendant that would own vertical scroll.
+ * Horizontal-only scrollers (`overflow-x-auto`, for wide code lines) are allowed.
+ */
+export function nestedVerticalScrollers(root: HTMLElement): Element[] {
+  return Array.from(
+    root.querySelectorAll(
+      '[class~="overflow-y-auto"],[class~="overflow-y-scroll"],[class~="overflow-auto"],[class~="overflow-scroll"]',
+    ),
+  );
+}

--- a/packages/ui/src/features/chat/tools/cards/__tests__/marker-pill.test.tsx
+++ b/packages/ui/src/features/chat/tools/cards/__tests__/marker-pill.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { MarkerPill, MarkerWrap, MarkerBody, MarkerCapsLabel, MarkerPre } from '../marker-pill';
+import { nestedVerticalScrollers } from './_part-fixture';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -176,5 +177,10 @@ describe('MarkerPre', () => {
   it('renders preformatted content', () => {
     render(<MarkerPre>const x = 1;</MarkerPre>);
     expect(screen.getByText('const x = 1;')).toBeInTheDocument();
+  });
+
+  it('is not its own vertical scroll container (single overflow owner — todo #198)', () => {
+    const { container } = render(<MarkerPre>{'line 1\nline 2'}</MarkerPre>);
+    expect(nestedVerticalScrollers(container)).toHaveLength(0);
   });
 });

--- a/packages/ui/src/features/chat/tools/cards/marker-pill.tsx
+++ b/packages/ui/src/features/chat/tools/cards/marker-pill.tsx
@@ -121,7 +121,6 @@ export function MarkerPre({ children, muted = false }: { children: React.ReactNo
     <pre
       className={cn(
         'font-mono text-caption whitespace-pre-wrap break-words leading-snug',
-        'max-h-80 overflow-y-auto',
         muted ? 'text-mf-text-3' : 'text-foreground',
       )}
     >

--- a/packages/ui/src/features/chat/tools/shared/card-shell.tsx
+++ b/packages/ui/src/features/chat/tools/shared/card-shell.tsx
@@ -62,7 +62,7 @@ export function ErrorBody({ text, testId }: ErrorBodyProps) {
       <div className="absolute inset-0 bg-destructive opacity-10 pointer-events-none" aria-hidden />
       <pre
         data-testid={testId}
-        className="relative font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 max-h-[300px] overflow-y-auto text-destructive"
+        className="relative font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 text-destructive"
       >
         {text}
       </pre>


### PR DESCRIPTION
## Summary

Fixes todo #198 — double vertical scrollbar on chat tool cards

Tool card bodies each nested their own `max-height` + `overflow-y-auto` region inside the `ThreadPrimitive.Viewport` (itself `overflow-y-auto`). When a card's content and the thread both overflowed, two vertical scrollbars painted side by side on the right edge. This drops the inner vertical scroll containers so the viewport is the single vertical-scroll owner.

Affected cards: Bash, Read, Edit, Write, Plan, Search, Skill (loaded), Schedule list, and the shared marker/error primitives.

## Root cause

Each card wrapped its body in a `max-h-[Npx] overflow-y-auto` container (or applied those classes directly to a `<pre>`). Nested inside the already-scrollable thread viewport, an overflowing card rendered its own scrollbar in addition to the viewport's — the classic nested-scroll "double scrollbar". Horizontal overflow was legitimately needed for wide code/terminal lines, but vertical overflow duplicated the viewport's job.

Fix: remove the inner vertical scrollers (`max-h-*` + `overflow-y-auto`), keeping `overflow-x-auto` where wide content needs it (Bash terminal output, Read code preview). Cards still collapse via their header trigger, so no scroll-hiding hack is required.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — pass
- Changed test files, each in its own vitest process — all pass:
  - `BashCard.test.tsx` (19), `EditFileCard.test.tsx` (19), `PlanCard.test.tsx` (20), `ReadFileCard.test.tsx` (17), `SchedulePillCard.test.tsx` (26), `SearchCard.test.tsx` (19), `SkillLoadedCard.test.tsx` (10), `WriteFileCard.test.tsx` (19), `marker-pill.test.tsx` (17)
  - New `nestedVerticalScrollers()` helper asserts each card owns no nested vertical scroller.

## Needs live verification

The regression tests assert the DOM no longer contains nested vertical scrollers, but the original symptom (two scrollbars painting side by side) is visual. Recommend a quick live check in the running app: open a chat with long Bash/Read/Edit output and confirm only the thread scrolls vertically while wide lines still scroll horizontally within the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)