### PR TITLE
feat(codex): adapter-aware titles and disk-based session import

### DIFF
--- a/.changeset/codex-titles-import.md
+++ b/.changeset/codex-titles-import.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+---
+
+Make chat title generation adapter-aware and import Codex sessions from disk. Title generation now runs behind an optional `Adapter.generateTitle` (Claude implements it; Codex keeps its deterministic first-message title instead of cross-spawning the `claude` binary). Codex external-session import scans the rollout JSONL files under `~/.codex/sessions` — matching a session to a project by its recorded `cwd` — so sessions started outside Mainframe show up too.

--- a/packages/core/src/__tests__/title-dispatch.test.ts
+++ b/packages/core/src/__tests__/title-dispatch.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AdapterSession, ChatMessage, SessionOptions } from '@qlan-ro/mainframe-types';
+import { ChatManager } from '../chat/index.js';
+import { AdapterRegistry } from '../adapters/index.js';
+import { BackgroundTaskTracker } from '../background-tasks/tracker.js';
+import { MockBaseAdapter } from './helpers/mock-adapter.js';
+import { MockBaseSession } from './helpers/mock-session.js';
+
+// Adapter-aware title generation: the LLM refine step must route through the
+// chat's own adapter (`adapter.generateTitle`), never cross-spawn another
+// vendor's CLI. Adapters that omit the method keep the deterministic title.
+
+class MockSession extends MockBaseSession {
+  constructor(adapterId: string, projectPath: string) {
+    super('proc-1', adapterId, projectPath);
+  }
+  override async loadHistory(): Promise<ChatMessage[]> {
+    return [];
+  }
+}
+
+class TitleAdapter extends MockBaseAdapter {
+  override id = 'mock';
+  override name = 'Mock';
+  generateTitleFn?: (content: string, binary: string) => Promise<string | null>;
+
+  override createSession(options: SessionOptions): AdapterSession {
+    return new MockSession(this.id, options.projectPath);
+  }
+
+  generateTitle(content: string, binary: string): Promise<string | null> {
+    if (!this.generateTitleFn) throw new Error('generateTitleFn not set');
+    return this.generateTitleFn(content, binary);
+  }
+}
+
+const chatId = 'test-chat';
+const testProject = { id: 'proj-1', name: 'Test', path: '/tmp/test' };
+
+function freshChat() {
+  return {
+    id: chatId,
+    adapterId: 'mock',
+    projectId: 'proj-1',
+    claudeSessionId: 'session-1',
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    totalCost: 0,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+  };
+}
+
+function createMockDb(settingsGetFn?: (...args: unknown[]) => unknown) {
+  return {
+    chats: {
+      get: vi.fn().mockImplementation(() => freshChat()),
+      update: vi.fn(),
+      addPlanFile: vi.fn().mockReturnValue(false),
+      addSkillFile: vi.fn().mockReturnValue(false),
+      addMention: vi.fn().mockReturnValue(false),
+    },
+    projects: { get: vi.fn().mockReturnValue(testProject) },
+    settings: { get: settingsGetFn ?? vi.fn().mockReturnValue(null) },
+  };
+}
+
+function titleUpdates(db: ReturnType<typeof createMockDb>): string[] {
+  return db.chats.update.mock.calls
+    .filter((call) => 'title' in (call[1] as Record<string, unknown>))
+    .map((call) => (call[1] as { title: string }).title);
+}
+
+describe('title generation dispatch (adapter-aware)', () => {
+  let adapter: TitleAdapter;
+  let registry: AdapterRegistry;
+
+  beforeEach(() => {
+    adapter = new TitleAdapter();
+    registry = new AdapterRegistry();
+    registry.register(adapter);
+  });
+
+  it("routes the LLM refine through the chat's own adapter.generateTitle", async () => {
+    adapter.generateTitleFn = vi.fn().mockResolvedValue('Refined Title');
+    const db = createMockDb();
+    const manager = new ChatManager(db as never, registry, new BackgroundTaskTracker());
+
+    await manager.sendMessage(chatId, 'Refactor the authentication module to use JWT tokens');
+
+    await vi.waitFor(() => expect(titleUpdates(db).length).toBeGreaterThanOrEqual(2), { timeout: 2000 });
+
+    expect(adapter.generateTitleFn).toHaveBeenCalledWith(
+      'Refactor the authentication module to use JWT tokens',
+      'claude',
+    );
+    const titles = titleUpdates(db);
+    expect(titles[titles.length - 1]).toBe('Refined Title');
+  });
+
+  it('resolves the binary from the <adapterId>.titleBinary setting', async () => {
+    adapter.generateTitleFn = vi.fn().mockResolvedValue('X');
+    const settingsGet = vi.fn().mockImplementation((category: string, key: string) => {
+      if (category === 'provider' && key === 'mock.titleBinary') return '/custom/bin';
+      return null;
+    });
+    const db = createMockDb(settingsGet);
+    const manager = new ChatManager(db as never, registry, new BackgroundTaskTracker());
+
+    await manager.sendMessage(chatId, 'do a thing');
+
+    await vi.waitFor(() => expect(adapter.generateTitleFn).toHaveBeenCalled(), { timeout: 2000 });
+    expect(adapter.generateTitleFn).toHaveBeenCalledWith('do a thing', '/custom/bin');
+  });
+
+  it('keeps the deterministic title when the adapter omits generateTitle', async () => {
+    const plain = new MockBaseAdapter((o) => new MockSession('plain', o.projectPath));
+    plain.id = 'mock';
+    const registry2 = new AdapterRegistry();
+    registry2.register(plain);
+    const db = createMockDb();
+    const manager = new ChatManager(db as never, registry2, new BackgroundTaskTracker());
+
+    await manager.sendMessage(chatId, 'Fix the login bug on mobile Safari');
+    await new Promise((r) => setTimeout(r, 200));
+
+    const titles = titleUpdates(db);
+    expect(titles).toHaveLength(1);
+    expect(titles[0]).toMatch(/^Fix the login bug/);
+  });
+});

--- a/packages/core/src/__tests__/title-generation.test.ts
+++ b/packages/core/src/__tests__/title-generation.test.ts
@@ -4,6 +4,7 @@ import { ChatManager } from '../chat/index.js';
 import { AdapterRegistry } from '../adapters/index.js';
 import { MockBaseAdapter } from './helpers/mock-adapter.js';
 import { MockBaseSession } from './helpers/mock-session.js';
+import { generateClaudeTitle } from '../plugins/builtin/claude/title-generator.js';
 import type { ChatMessage, AdapterSession, SessionOptions, DaemonEvent } from '@qlan-ro/mainframe-types';
 
 // ── Mock adapter & DB (infrastructure, not what we're testing) ──────
@@ -26,6 +27,12 @@ class MockAdapter extends MockBaseAdapter {
   override createSession(options: SessionOptions): AdapterSession {
     this.currentSession = new MockSession(this.id, options.projectPath);
     return this.currentSession;
+  }
+
+  // These are integration tests of the real Claude CLI title path, exercised
+  // through the adapter dispatch — delegate to the same spawn the claude adapter uses.
+  generateTitle(content: string, binary: string): Promise<string | null> {
+    return generateClaudeTitle(content, binary);
   }
 }
 

--- a/packages/core/src/__tests__/title-generator-args.test.ts
+++ b/packages/core/src/__tests__/title-generator-args.test.ts
@@ -11,9 +11,9 @@ vi.mock('node:child_process', () => ({
 }));
 
 // Import AFTER the mock is registered so the module picks up the stub.
-const { generateTitle } = await import('../chat/title-generator.js');
+const { generateClaudeTitle } = await import('../plugins/builtin/claude/title-generator.js');
 
-describe('generateTitle — CLI args contract', () => {
+describe('generateClaudeTitle — CLI args contract', () => {
   it('passes --no-session-persistence to execFile so throwaway prompts are never persisted', async () => {
     execFileMock.mockImplementation(
       (_bin: string, _args: string[], _opts: unknown, callback: (err: null, stdout: string) => void) => {
@@ -22,7 +22,7 @@ describe('generateTitle — CLI args contract', () => {
       },
     );
 
-    const result = await generateTitle('some message', 'claude');
+    const result = await generateClaudeTitle('some message', 'claude');
 
     // Verify execFile was invoked exactly once.
     expect(execFileMock).toHaveBeenCalledTimes(1);

--- a/packages/core/src/chat/external-session-service.ts
+++ b/packages/core/src/chat/external-session-service.ts
@@ -2,7 +2,7 @@ import type { Chat, DaemonEvent, ExternalSession, ExternalSessionPage } from '@q
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import { createChildLogger } from '../logger.js';
-import { deriveTitleFromMessage, generateTitle } from './title-generator.js';
+import { deriveTitleFromMessage } from './title-generator.js';
 
 const logger = createChildLogger('chat:external-sessions');
 
@@ -126,8 +126,11 @@ export class ExternalSessionService {
     const disabled = this.db.settings.get('general', 'titleGeneration.disabled');
     if (disabled === 'true') return;
 
+    const adapter = this.adapters.get(adapterId);
+    if (!adapter?.generateTitle) return; // deterministic title (set at import time) stands
+
     const binary = this.db.settings.get('provider', `${adapterId}.titleBinary`) || 'claude';
-    const title = await generateTitle(content, binary);
+    const title = await adapter.generateTitle(content, binary);
     if (!title) return;
 
     chat.title = title;

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -11,7 +11,6 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFileCb);
 import { createChildLogger } from '../logger.js';
-import { generateTitle } from './title-generator.js';
 import { extractMentionsFromText } from './context-tracker.js';
 import { extractPrFromToolResult, PR_CREATE_COMMANDS } from '../plugins/builtin/claude/pr-detection.js';
 import type { MessageCache } from './message-cache.js';
@@ -345,10 +344,13 @@ export class ChatLifecycleManager {
     if (disabled === 'true') return;
 
     const adapterId = active.chat.adapterId;
+    const adapter = this.deps.adapters.get(adapterId);
+    if (!adapter?.generateTitle) return; // deterministic title (set on first message) stands
+
     const binary = this.deps.db.settings.get('provider', `${adapterId}.titleBinary`) || 'claude';
 
     try {
-      const title = await generateTitle(content, binary);
+      const title = await adapter.generateTitle(content, binary);
       if (title) {
         active.chat.title = title;
         this.deps.db.chats.update(chatId, { title });

--- a/packages/core/src/chat/title-generator.ts
+++ b/packages/core/src/chat/title-generator.ts
@@ -1,55 +1,8 @@
-import { execFile } from 'node:child_process';
-
-function execFileNoStdin(
-  bin: string,
-  args: string[],
-  opts: { timeout?: number; maxBuffer?: number; env?: NodeJS.ProcessEnv },
-): Promise<{ stdout: string }> {
-  return new Promise((resolve, reject) => {
-    const cp = execFile(bin, args, { ...opts, encoding: 'utf-8' }, (error, stdout) => {
-      if (error) reject(error);
-      else resolve({ stdout: stdout as string });
-    });
-    cp.stdin?.end();
-  });
-}
-
+/** Deterministic fallback title: the first user message, cleaned and truncated at a word boundary. */
 export function deriveTitleFromMessage(content: string): string {
   const cleaned = content.replace(/\s+/g, ' ').trim();
   if (cleaned.length <= 50) return cleaned;
   const truncated = cleaned.slice(0, 50);
   const lastSpace = truncated.lastIndexOf(' ');
   return (lastSpace > 20 ? truncated.slice(0, lastSpace) : truncated) + '…';
-}
-
-export async function generateTitle(content: string, binary: string): Promise<string | null> {
-  const message = content.slice(0, 500);
-  const prompt = `Generate a short title (2-5 words) for a coding chat that starts with this message.\nRules: Title case. No quotes. No punctuation. Be specific about the task.\nExamples: Auth Refactor, Fix Login Bug, Add Dark Mode Toggle, Optimize DB Queries\n\nMessage: ${message}\n\nTitle:`;
-
-  const { stdout } = await execFileNoStdin(
-    binary,
-    [
-      '-p',
-      prompt,
-      // Don't persist this throwaway prompt as a resumable session on disk —
-      // otherwise it pollutes the CLI's session list (and our external-sessions
-      // scan) as a "Generate a short title…" ghost. The CLI's own title gen
-      // avoids this by calling the API directly; we shell out, so we opt out here.
-      '--no-session-persistence',
-      '--output-format',
-      'text',
-      '--model',
-      'claude-haiku-4-5-20251001',
-      '--max-turns',
-      '1',
-    ],
-    { timeout: 30_000, maxBuffer: 8192, env: { ...process.env, NO_COLOR: '1' } },
-  );
-
-  const title = stdout
-    .trim()
-    .replace(/^["']|["']$/g, '')
-    .trim();
-  if (title && title.length >= 2 && title.length <= 80) return title;
-  return null;
 }

--- a/packages/core/src/plugins/builtin/claude/adapter.ts
+++ b/packages/core/src/plugins/builtin/claude/adapter.ts
@@ -16,6 +16,7 @@ import { BackgroundTaskTracker } from '../../../background-tasks/tracker.js';
 import { probeModels as doProbeModels } from './probe-models.js';
 import * as skills from './skills.js';
 import { listExternalSessions } from './external-sessions.js';
+import { generateClaudeTitle } from './title-generator.js';
 import { isClaudeTranscriptPresent } from './transcript.js';
 import { ClaudePlanModeHandler } from './plan-mode-handler.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
@@ -240,6 +241,10 @@ export class ClaudeAdapter implements Adapter {
       session.kill().catch((err) => log.warn({ err }, 'failed to kill claude session during killAll'));
     }
     this.sessions.clear();
+  }
+
+  generateTitle(content: string, binary: string): Promise<string | null> {
+    return generateClaudeTitle(content, binary);
   }
 
   async listSkills(projectPath: string): Promise<Skill[]> {

--- a/packages/core/src/plugins/builtin/claude/title-generator.ts
+++ b/packages/core/src/plugins/builtin/claude/title-generator.ts
@@ -1,0 +1,48 @@
+import { execFile } from 'node:child_process';
+
+function execFileNoStdin(
+  bin: string,
+  args: string[],
+  opts: { timeout?: number; maxBuffer?: number; env?: NodeJS.ProcessEnv },
+): Promise<{ stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const cp = execFile(bin, args, { ...opts, encoding: 'utf-8' }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string });
+    });
+    cp.stdin?.end();
+  });
+}
+
+/** One-shot Haiku call over the Claude CLI that turns a first message into a short title. */
+export async function generateClaudeTitle(content: string, binary: string): Promise<string | null> {
+  const message = content.slice(0, 500);
+  const prompt = `Generate a short title (2-5 words) for a coding chat that starts with this message.\nRules: Title case. No quotes. No punctuation. Be specific about the task.\nExamples: Auth Refactor, Fix Login Bug, Add Dark Mode Toggle, Optimize DB Queries\n\nMessage: ${message}\n\nTitle:`;
+
+  const { stdout } = await execFileNoStdin(
+    binary,
+    [
+      '-p',
+      prompt,
+      // Don't persist this throwaway prompt as a resumable session on disk —
+      // otherwise it pollutes the CLI's session list (and our external-sessions
+      // scan) as a "Generate a short title…" ghost. The CLI's own title gen
+      // avoids this by calling the API directly; we shell out, so we opt out here.
+      '--no-session-persistence',
+      '--output-format',
+      'text',
+      '--model',
+      'claude-haiku-4-5-20251001',
+      '--max-turns',
+      '1',
+    ],
+    { timeout: 30_000, maxBuffer: 8192, env: { ...process.env, NO_COLOR: '1' } },
+  );
+
+  const title = stdout
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .trim();
+  if (title && title.length >= 2 && title.length <= 80) return title;
+  return null;
+}

--- a/packages/core/src/plugins/builtin/codex/__tests__/external-sessions.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/external-sessions.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, utimes, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { listExternalSessions, clearCodexExternalSessionCache } from '../external-sessions.js';
+
+interface RolloutSpec {
+  id: string;
+  cwd: string;
+  branch?: string;
+  createdAt?: string;
+  /** User-message texts, in order (one input_text block each). */
+  userMessages?: string[];
+  /** User messages with multiple input_text blocks each (mirrors Codex's bundled first message). */
+  userBlockMessages?: string[][];
+  /** Extra malformed/truncated lines appended verbatim. */
+  rawTrailing?: string[];
+  mtime?: Date;
+}
+
+async function writeRollout(root: string, spec: RolloutSpec): Promise<string> {
+  const dir = join(root, '2026', '05', '01');
+  await mkdir(dir, { recursive: true });
+  const ts = spec.createdAt ?? '2026-05-01T02:00:47.000Z';
+  const meta = {
+    timestamp: ts,
+    type: 'session_meta',
+    payload: {
+      id: spec.id,
+      timestamp: ts,
+      cwd: spec.cwd,
+      originator: 'mainframe',
+      ...(spec.branch ? { git: { branch: spec.branch } } : {}),
+    },
+  };
+  const lines = [JSON.stringify(meta)];
+  const messages: string[][] = [...(spec.userBlockMessages ?? []), ...(spec.userMessages ?? []).map((text) => [text])];
+  for (const blocks of messages) {
+    lines.push(
+      JSON.stringify({
+        timestamp: ts,
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: blocks.map((text) => ({ type: 'input_text', text })),
+        },
+      }),
+    );
+  }
+  for (const raw of spec.rawTrailing ?? []) lines.push(raw);
+
+  const filePath = join(dir, `rollout-2026-05-01T02-00-47-${spec.id}.jsonl`);
+  await writeFile(filePath, lines.join('\n') + '\n', 'utf8');
+  if (spec.mtime) await utimes(filePath, spec.mtime, spec.mtime);
+  return filePath;
+}
+
+const PROJECT = '/Users/dev/projects/app';
+const uuid = (n: number) => `019de09f-93b4-7832-b2aa-c6b3dae2${n.toString().padStart(4, '0')}`;
+
+describe('codex listExternalSessions (rollout scan)', () => {
+  let root: string;
+  beforeEach(async () => {
+    clearCodexExternalSessionCache();
+    root = await mkdtemp(join(tmpdir(), 'codex-rollouts-'));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('includes sessions whose meta cwd matches the project (equal or nested), excludes others', async () => {
+    await writeRollout(root, { id: uuid(1), cwd: PROJECT, userMessages: ['Fix the login bug'] });
+    await writeRollout(root, { id: uuid(2), cwd: join(PROJECT, 'packages/ui'), userMessages: ['Nested worktree'] });
+    await writeRollout(root, { id: uuid(3), cwd: '/Users/dev/projects/other', userMessages: ['Different project'] });
+
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+
+    const ids = page.sessions.map((s) => s.sessionId).sort();
+    expect(ids).toEqual([uuid(1), uuid(2)]);
+    expect(page.total).toBe(2);
+    expect(page.sessions.every((s) => s.adapterId === 'codex')).toBe(true);
+  });
+
+  it('derives firstPrompt from the first non-preamble user message', async () => {
+    await writeRollout(root, {
+      id: uuid(1),
+      cwd: PROJECT,
+      userMessages: [
+        '<environment_context>\n  <cwd>/x</cwd>\n</environment_context>',
+        '# AGENTS.md instructions for /Users/dev/projects/app\n<INSTRUCTIONS>do things</INSTRUCTIONS>',
+        '<image name=[Image #1]></image>Add a dark mode toggle to settings',
+      ],
+    });
+
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+
+    expect(page.sessions).toHaveLength(1);
+    expect(page.sessions[0]!.firstPrompt).toBe('Add a dark mode toggle to settings');
+    expect(page.sessions[0]!.title).toBe('Add a dark mode toggle to settings');
+  });
+
+  it('skips every injected block of the bundled first message, then finds the real prompt', async () => {
+    await writeRollout(root, {
+      id: uuid(1),
+      cwd: PROJECT,
+      userBlockMessages: [
+        [
+          '<recommended_plugins>\nplugins here\n</recommended_plugins>',
+          '# AGENTS.md instructions for /app\n<INSTRUCTIONS>x</INSTRUCTIONS>',
+          '<environment_context>\n<cwd>/app</cwd>\n</environment_context>',
+        ],
+      ],
+      userMessages: ['Wire up the settings page'],
+    });
+
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+    expect(page.sessions[0]!.firstPrompt).toBe('Wire up the settings page');
+  });
+
+  it('falls back to a synthetic title when only preamble messages exist', async () => {
+    await writeRollout(root, {
+      id: uuid(1),
+      cwd: PROJECT,
+      userMessages: ['<environment_context>\n  <cwd>/x</cwd>\n</environment_context>'],
+    });
+
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+    expect(page.sessions[0]!.firstPrompt).toBeUndefined();
+    expect(page.sessions[0]!.title).toBe('(session)');
+  });
+
+  it('excludes already-imported session ids', async () => {
+    await writeRollout(root, { id: uuid(1), cwd: PROJECT, userMessages: ['one'] });
+    await writeRollout(root, { id: uuid(2), cwd: PROJECT, userMessages: ['two'] });
+
+    const page = await listExternalSessions(PROJECT, [uuid(1)], undefined, { sessionsRoot: root });
+    expect(page.sessions.map((s) => s.sessionId)).toEqual([uuid(2)]);
+    expect(page.total).toBe(1);
+  });
+
+  it('sorts by modification time descending', async () => {
+    await writeRollout(root, {
+      id: uuid(1),
+      cwd: PROJECT,
+      userMessages: ['old'],
+      mtime: new Date('2026-05-01T00:00:00Z'),
+    });
+    await writeRollout(root, {
+      id: uuid(2),
+      cwd: PROJECT,
+      userMessages: ['new'],
+      mtime: new Date('2026-05-02T00:00:00Z'),
+    });
+
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+    expect(page.sessions.map((s) => s.sessionId)).toEqual([uuid(2), uuid(1)]);
+  });
+
+  it('paginates with total and nextOffset', async () => {
+    for (let i = 1; i <= 3; i++) {
+      await writeRollout(root, {
+        id: uuid(i),
+        cwd: PROJECT,
+        userMessages: [`msg ${i}`],
+        mtime: new Date(`2026-05-0${i}T00:00:00Z`),
+      });
+    }
+
+    const page = await listExternalSessions(PROJECT, [], { offset: 0, limit: 2 }, { sessionsRoot: root });
+    expect(page.total).toBe(3);
+    expect(page.sessions).toHaveLength(2);
+    expect(page.nextOffset).toBe(2);
+
+    const page2 = await listExternalSessions(PROJECT, [], { offset: 2, limit: 2 }, { sessionsRoot: root });
+    expect(page2.sessions).toHaveLength(1);
+    expect(page2.nextOffset).toBeNull();
+  });
+
+  it('count-only (limit<=0) returns total without enriched sessions', async () => {
+    await writeRollout(root, { id: uuid(1), cwd: PROJECT, userMessages: ['a'] });
+    await writeRollout(root, { id: uuid(2), cwd: PROJECT, userMessages: ['b'] });
+
+    const page = await listExternalSessions(PROJECT, [], { offset: 0, limit: 0 }, { sessionsRoot: root });
+    expect(page.total).toBe(2);
+    expect(page.sessions).toEqual([]);
+    expect(page.nextOffset).toBeNull();
+  });
+
+  it('captures the git branch from meta', async () => {
+    await writeRollout(root, { id: uuid(1), cwd: PROJECT, branch: 'feat/x', userMessages: ['hi'] });
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+    expect(page.sessions[0]!.gitBranch).toBe('feat/x');
+  });
+
+  it('tolerates malformed/truncated lines without crashing', async () => {
+    await writeRollout(root, {
+      id: uuid(1),
+      cwd: PROJECT,
+      userMessages: ['valid prompt'],
+      rawTrailing: ['{ this is not json', '{"type":"response_item","payload":'],
+    });
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: root });
+    expect(page.sessions).toHaveLength(1);
+    expect(page.sessions[0]!.firstPrompt).toBe('valid prompt');
+  });
+
+  it('returns an empty page when the sessions root does not exist', async () => {
+    const page = await listExternalSessions(PROJECT, [], undefined, { sessionsRoot: join(root, 'nope') });
+    expect(page).toEqual({ sessions: [], total: 0, nextOffset: null });
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -4,16 +4,16 @@ import type {
   Adapter,
   AdapterModel,
   AdapterSession,
-  ExternalSession,
   ExternalSessionPage,
   SessionOptions,
 } from '@qlan-ro/mainframe-types';
 import { CodexSession } from './session.js';
 import { CodexPlanModeHandler } from './plan-mode-handler.js';
 import { isCodexTranscriptPresent } from './transcript.js';
+import { listExternalSessions } from './external-sessions.js';
 import { JsonRpcClient } from './jsonrpc.js';
 import type { ToolCategories } from '../../../messages/tool-categorization.js';
-import type { InitializeResult, ModelInfo, ModelListResult, ThreadListResult } from './types.js';
+import type { InitializeResult, ModelInfo, ModelListResult } from './types.js';
 import { createChildLogger } from '../../../logger.js';
 
 const log = createChildLogger('codex:adapter');
@@ -121,48 +121,7 @@ export class CodexAdapter implements Adapter {
     excludeSessionIds: string[],
     opts?: { offset?: number; limit?: number },
   ): Promise<ExternalSessionPage> {
-    let client: JsonRpcClient | null = null;
-    try {
-      client = await this.spawnTempAppServer();
-      const seen = new Set<string>();
-      const aggregated: ExternalSession[] = [];
-      try {
-        const result = await client.request<ThreadListResult>('thread/list', {
-          cwd: projectPath,
-          archived: false,
-        });
-        for (const t of result.data) {
-          if (seen.has(t.id)) continue;
-          seen.add(t.id);
-          aggregated.push({
-            sessionId: t.id,
-            adapterId: this.id,
-            projectPath,
-            firstPrompt: t.name ?? t.preview,
-            summary: t.name ?? t.preview,
-            createdAt: new Date(t.createdAt).toISOString(),
-            modifiedAt: new Date(t.updatedAt).toISOString(),
-            model: t.model,
-          });
-        }
-      } catch (err) {
-        log.warn({ err, projectPath }, 'codex: failed to list external sessions for path');
-      }
-      const excludeSet = new Set(excludeSessionIds);
-      const filtered = aggregated.filter((s) => !excludeSet.has(s.sessionId));
-      const offset = Math.max(0, opts?.offset ?? 0);
-      const limit = opts?.limit ?? 50;
-      const total = filtered.length;
-      if (limit <= 0) return { sessions: [], total, nextOffset: null };
-      const sessions = filtered.slice(offset, offset + limit);
-      const nextOffset = offset + limit < total ? offset + limit : null;
-      return { sessions, total, nextOffset };
-    } catch (err) {
-      log.warn({ err }, 'codex: failed to list external sessions');
-      return { sessions: [], total: 0, nextOffset: null };
-    } finally {
-      client?.close();
-    }
+    return listExternalSessions(projectPath, excludeSessionIds, opts);
   }
 
   async isTranscriptPresent(sessionId: string): Promise<boolean | null> {

--- a/packages/core/src/plugins/builtin/codex/external-session-parse.ts
+++ b/packages/core/src/plugins/builtin/codex/external-session-parse.ts
@@ -1,0 +1,91 @@
+// Parsing for Codex rollout JSONL heads: session_meta facts and the first real
+// user prompt. Kept separate from the filesystem scan so both stay small.
+
+const CWD_RE = /"cwd"\s*:\s*"((?:[^"\\]|\\.)*)"/;
+// Codex's first user message bundles injected context blocks (plugins, AGENTS.md,
+// environment) before the user's real prompt; each block is a separate
+// `input_text`, so we skip blocks that begin with these markers.
+const PREAMBLE_PREFIXES = [
+  '<recommended_plugins>',
+  '<environment_context>',
+  '<user_instructions>',
+  '<INSTRUCTIONS>',
+  '# AGENTS.md instructions',
+  '# Context from my IDE setup',
+];
+
+/** Project-independent facts from a rollout's session_meta. */
+export interface RolloutMeta {
+  cwd?: string;
+  gitBranch?: string;
+  createdAt?: string;
+}
+
+interface RolloutLine {
+  type?: string;
+  timestamp?: string;
+  payload?: {
+    type?: string;
+    role?: string;
+    timestamp?: string;
+    cwd?: string;
+    git?: { branch?: string };
+    content?: Array<{ type?: string; text?: string }>;
+  };
+}
+
+export function parseLines(chunk: string): RolloutLine[] {
+  const out: RolloutLine[] = [];
+  for (const line of chunk.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      out.push(JSON.parse(t) as RolloutLine);
+    } catch {
+      /* expected: truncated line at the head-byte boundary */
+    }
+  }
+  return out;
+}
+
+/** Each user message holds one or more `input_text` blocks; return them in order. */
+function userTextBlocks(line: RolloutLine): string[] {
+  const p = line.payload;
+  if (line.type !== 'response_item' || p?.type !== 'message' || p.role !== 'user' || !Array.isArray(p.content)) {
+    return [];
+  }
+  return p.content.filter((c) => c?.type === 'input_text' || c?.type === 'text').map((c) => c.text ?? '');
+}
+
+function isPreamble(text: string): boolean {
+  const t = text.trimStart();
+  return PREAMBLE_PREFIXES.some((prefix) => t.startsWith(prefix)) || t.slice(0, 200).includes('<INSTRUCTIONS>');
+}
+
+function cleanPrompt(text: string): string {
+  return text
+    .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** First block, across all user messages, that isn't injected context. */
+export function firstUserPrompt(lines: RolloutLine[]): string | undefined {
+  for (const line of lines) {
+    for (const text of userTextBlocks(line)) {
+      if (!text || isPreamble(text)) continue;
+      const cleaned = cleanPrompt(text);
+      if (cleaned) return cleaned.slice(0, 500);
+    }
+  }
+  return undefined;
+}
+
+export function extractMeta(lines: RolloutLine[], head: string): RolloutMeta {
+  const meta = lines.find((l) => l.type === 'session_meta')?.payload;
+  // Regex fallback covers a session_meta line truncated past the read window; cwd
+  // is an early field so the first match is always the real one.
+  const cwd = meta?.cwd ?? CWD_RE.exec(head)?.[1];
+  return { cwd, gitBranch: meta?.git?.branch || undefined, createdAt: meta?.timestamp };
+}

--- a/packages/core/src/plugins/builtin/codex/external-sessions.ts
+++ b/packages/core/src/plugins/builtin/codex/external-sessions.ts
@@ -1,0 +1,208 @@
+// Discover importable Codex sessions by scanning the rollout JSONL files Codex
+// writes to ~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<threadId>.jsonl.
+// We scan the files directly (not Codex's state DB) so sessions started outside
+// Mainframe are found too — the same reason the Claude scanner reads *.jsonl
+// rather than trusting an index. A session belongs to a project when the `cwd`
+// recorded in its session_meta is the project root or nested under it.
+
+import { open, readdir, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
+import type { ExternalSession, ExternalSessionPage } from '@qlan-ro/mainframe-types';
+import { createChildLogger } from '../../../logger.js';
+import { extractMeta, firstUserPrompt, parseLines, type RolloutMeta } from './external-session-parse.js';
+
+const logger = createChildLogger('codex:external-sessions');
+
+const DEFAULT_LIMIT = 50;
+const SCAN_CONCURRENCY = 8;
+// Small read covers the session_meta line (cwd + git branch) for filtering and
+// counting every candidate. Larger read reaches the first real user prompt,
+// which sits past Codex's bundled preamble (~70KB in); only the enriched page
+// window pays this cost.
+const META_BYTES = 32 * 1024;
+const PROMPT_BYTES = 192 * 1024;
+const WALK_MAX_DEPTH = 4; // sessions/YYYY/MM/DD/rollout-*.jsonl
+const SYNTHETIC_TITLE = '(session)';
+
+const ROLLOUT_RE = /^rollout-.*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
+
+export interface CodexScanDeps {
+  /** Sessions root the rollouts live under — injectable for tests. */
+  sessionsRoot?: string;
+}
+
+interface Candidate {
+  sessionId: string;
+  filePath: string;
+  mtimeMs: number;
+  size: number;
+}
+
+type MatchedSession = RolloutMeta & { candidate: Candidate };
+
+const metaCache = new Map<string, { mtimeMs: number; size: number; meta: RolloutMeta }>();
+const promptCache = new Map<string, { mtimeMs: number; size: number; firstPrompt?: string }>();
+
+export function clearCodexExternalSessionCache(): void {
+  metaCache.clear();
+  promptCache.clear();
+}
+
+export function codexSessionsRoot(): string {
+  return join(homedir(), '.codex', 'sessions');
+}
+
+/** Belongs to this project if cwd equals the root or is nested under it. */
+function cwdBelongsToProject(cwd: string | undefined, projectPath: string): boolean {
+  if (!cwd) return false;
+  if (cwd === projectPath) return true;
+  return cwd.startsWith(projectPath + sep);
+}
+
+async function walkRollouts(dir: string, depth: number, out: Candidate[]): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    /* expected: date dir vanished or root absent */
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (depth < WALK_MAX_DEPTH) await walkRollouts(full, depth + 1, out);
+      continue;
+    }
+    const match = ROLLOUT_RE.exec(entry.name);
+    if (!match) continue;
+    try {
+      const st = await stat(full);
+      out.push({ sessionId: match[1]!, filePath: full, mtimeMs: st.mtimeMs, size: st.size });
+    } catch {
+      /* expected: file deleted mid-scan */
+    }
+  }
+}
+
+async function readHead(filePath: string, bytes: number): Promise<string> {
+  const handle = await open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    const len = Math.min(bytes, size);
+    const buf = Buffer.alloc(len);
+    await handle.read(buf, 0, len, 0);
+    return buf.toString('utf-8');
+  } finally {
+    await handle.close();
+  }
+}
+
+async function loadMeta(candidate: Candidate): Promise<RolloutMeta | null> {
+  const cached = metaCache.get(candidate.sessionId);
+  if (cached && cached.mtimeMs === candidate.mtimeMs && cached.size === candidate.size) return cached.meta;
+
+  let head: string;
+  try {
+    head = await readHead(candidate.filePath, META_BYTES);
+  } catch (err) {
+    logger.warn({ err: String(err), filePath: candidate.filePath }, 'failed to read rollout head');
+    return null;
+  }
+  const meta = extractMeta(parseLines(head), head);
+  metaCache.set(candidate.sessionId, { mtimeMs: candidate.mtimeMs, size: candidate.size, meta });
+  return meta;
+}
+
+async function loadFirstPrompt(candidate: Candidate): Promise<string | undefined> {
+  const cached = promptCache.get(candidate.sessionId);
+  if (cached && cached.mtimeMs === candidate.mtimeMs && cached.size === candidate.size) return cached.firstPrompt;
+
+  let firstPrompt: string | undefined;
+  try {
+    firstPrompt = firstUserPrompt(parseLines(await readHead(candidate.filePath, PROMPT_BYTES)));
+  } catch (err) {
+    logger.warn({ err: String(err), filePath: candidate.filePath }, 'failed to read rollout prompt');
+  }
+  promptCache.set(candidate.sessionId, { mtimeMs: candidate.mtimeMs, size: candidate.size, firstPrompt });
+  return firstPrompt;
+}
+
+/** Map over items with bounded concurrency, preserving order. */
+async function pooled<T, R>(items: T[], fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]!);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(SCAN_CONCURRENCY, items.length) }, worker));
+  return out;
+}
+
+async function collectCandidates(root: string, excludeSet: Set<string>): Promise<Candidate[]> {
+  const collected: Candidate[] = [];
+  await walkRollouts(root, 0, collected);
+
+  const bySession = new Map<string, Candidate>();
+  for (const c of collected) {
+    if (excludeSet.has(c.sessionId)) continue;
+    const prev = bySession.get(c.sessionId);
+    if (!prev || c.mtimeMs > prev.mtimeMs) bySession.set(c.sessionId, c);
+  }
+  return [...bySession.values()].sort((a, b) => b.mtimeMs - a.mtimeMs || (a.sessionId < b.sessionId ? 1 : -1));
+}
+
+function toExternalSession(m: MatchedSession, firstPrompt: string | undefined, projectPath: string): ExternalSession {
+  const modifiedAt = new Date(m.candidate.mtimeMs).toISOString();
+  return {
+    sessionId: m.candidate.sessionId,
+    adapterId: 'codex',
+    projectPath,
+    cwd: m.cwd,
+    firstPrompt,
+    title: firstPrompt ?? SYNTHETIC_TITLE,
+    createdAt: m.createdAt ?? modifiedAt,
+    modifiedAt,
+    gitBranch: m.gitBranch,
+  };
+}
+
+export async function listExternalSessions(
+  projectPath: string,
+  excludeSessionIds: string[],
+  opts?: { offset?: number; limit?: number },
+  deps?: CodexScanDeps,
+): Promise<ExternalSessionPage> {
+  const offset = Math.max(0, opts?.offset ?? 0);
+  const limit = opts?.limit ?? DEFAULT_LIMIT;
+  const root = deps?.sessionsRoot ?? codexSessionsRoot();
+
+  let candidates: Candidate[];
+  try {
+    candidates = await collectCandidates(root, new Set(excludeSessionIds));
+  } catch (err) {
+    logger.warn({ err: String(err), projectPath }, 'codex external-session scan failed');
+    return { sessions: [], total: 0, nextOffset: null };
+  }
+
+  const metas = await pooled(candidates, loadMeta);
+  const matched: MatchedSession[] = candidates
+    .map((candidate, i) => ({ candidate, meta: metas[i] }))
+    .filter(
+      (x): x is { candidate: Candidate; meta: RolloutMeta } => !!x.meta && cwdBelongsToProject(x.meta.cwd, projectPath),
+    )
+    .map((x) => ({ ...x.meta, candidate: x.candidate }));
+
+  const total = matched.length;
+  if (limit <= 0) return { sessions: [], total, nextOffset: null };
+
+  const window = matched.slice(offset, offset + limit);
+  const prompts = await pooled(window, (m) => loadFirstPrompt(m.candidate));
+  const sessions = window.map((m, i) => toExternalSession(m, prompts[i], projectPath));
+  const nextOffset = offset + limit < total ? offset + limit : null;
+  return { sessions, total, nextOffset };
+}

--- a/packages/core/src/plugins/builtin/codex/types.ts
+++ b/packages/core/src/plugins/builtin/codex/types.ts
@@ -100,26 +100,6 @@ export interface ThreadReadResult {
   };
 }
 
-export interface ThreadListParams {
-  cwd?: string;
-  archived?: boolean;
-}
-
-export interface ThreadSummary {
-  id: string;
-  name: string | null;
-  preview: string;
-  cwd: string;
-  modelProvider: string;
-  model: string;
-  createdAt: number;
-  updatedAt: number;
-}
-
-export interface ThreadListResult {
-  data: ThreadSummary[];
-}
-
 // --- Turn ---
 
 export interface TurnStartParams {

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -340,6 +340,15 @@ export interface Adapter {
   killAll(): void;
   getToolCategories?(): import('./display.js').ToolCategories;
 
+  /**
+   * Generate a friendly chat title from the first user message, via a cheap
+   * one-shot model call. `binary` is the resolved CLI path from the
+   * `<adapterId>.titleBinary` setting. Adapters without a cheap, side-effect-free
+   * title model omit this — callers then keep the deterministic truncated title
+   * (`deriveTitleFromMessage`) rather than cross-spawning another vendor's CLI.
+   */
+  generateTitle?(content: string, binary: string): Promise<string | null>;
+
   getContextFiles?(projectPath: string): {
     global: import('./context.js').ContextFile[];
     project: import('./context.js').ContextFile[];


### PR DESCRIPTION
## Summary

- Fixes todo #203 — Codex: No friendly session titles
- Fixes todo #204 — Codex: Import external sessions i think it's tied to Claude only

Chat title generation is now adapter-aware, and Codex external-session import scans the rollout JSONL Codex writes to disk instead of going through the app-server `thread/list` RPC.

## Root cause

- **Titles (#203):** the LLM title path hard-coded the Claude CLI (`claude -p --no-session-persistence …`). A Codex chat's title was produced by spawning the `claude` binary — cross-vendor, and silently title-less when Claude isn't installed. The path now sits behind an optional `Adapter.generateTitle`: Claude implements it (spawn moved into the claude plugin), Codex omits it so the deterministic first-message title (`deriveTitleFromMessage`) stands. A Codex-native LLM title would mean `codex exec`, which writes a rollout session to `~/.codex/sessions` — a ghost the external-session import would then surface — so deterministic is the deliberate fallback.
- **Import (#204):** Codex import ran through the app-server `thread/list` RPC, which needs a spawned app-server and only surfaces threads Codex's own state DB tracks — so sessions started outside Mainframe were missed. It now scans the rollout files directly (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`), the same authoritative-source approach the Claude scanner uses. A session belongs to a project when the `cwd` in its `session_meta` is the project root or nested under it; the first user prompt used for the title skips Codex's bundled context blocks (recommended_plugins, AGENTS.md, environment_context). Reads are two-tier — a small head for cwd/branch filtering, a larger one for the first prompt only on the enriched page window — both cached by mtime+size. The now-dead `thread/list` types were removed.

## Verification

- `pnpm --filter @qlan-ro/mainframe-types build` — clean
- `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit` — clean (exit 0)
- `pnpm --filter @qlan-ro/mainframe-core exec vitest run` on the four touched test files (`title-dispatch`, `title-generation`, `title-generator-args`, `codex/external-sessions`) — 4 files, 19 tests passed

## Needs live verification

Verified via typecheck + unit tests only. Not exercised against a live app or a real `~/.codex/sessions`: end-to-end Codex import listing/selection in the UI, and a live Codex-vs-Claude title-generation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)