### PR TITLE
fix(core): correct and dedupe session context panel paths, skills, and CLAUDE.md

### DIFF
--- a/.changeset/session-context-panel.md
+++ b/.changeset/session-context-panel.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix the session Context panel: report global CLAUDE.md/AGENTS.md with their real openable ~/.claude path, and stop listing duplicate skills and CLAUDE.md entries.

--- a/packages/core/src/chat/__tests__/context-tracker.test.ts
+++ b/packages/core/src/chat/__tests__/context-tracker.test.ts
@@ -3,16 +3,60 @@ import type { ContextFile, SkillFileEntry } from '@qlan-ro/mainframe-types';
 import { dedupeSkillFiles, dedupeContextFiles, getSessionContext } from '../context-tracker.js';
 
 describe('dedupeSkillFiles', () => {
-  it('collapses the same skill resolved to different paths into one entry', () => {
+  const plugin = '/home/me/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md';
+  const fallback = '/home/me/.claude/skills/tdd/SKILL.md';
+
+  it('drops the conventional fallback stub when the real skill path exists', () => {
     const skills: SkillFileEntry[] = [
-      { path: '/home/me/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md', displayName: 'tdd' },
-      { path: '/home/me/.claude/skills/tdd/SKILL.md', displayName: 'tdd' },
+      { path: plugin, displayName: 'tdd' },
+      { path: fallback, displayName: 'tdd' },
       { path: '/home/me/.claude/skills/verify/SKILL.md', displayName: 'verify' },
     ];
-    expect(dedupeSkillFiles(skills)).toEqual([
-      { path: '/home/me/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md', displayName: 'tdd' },
+    // Only the real plugin path (and verify) exist on disk; the fallback stub doesn't.
+    const exists = (p: string) => p === plugin || p.endsWith('verify/SKILL.md');
+    expect(dedupeSkillFiles(skills, exists)).toEqual([
+      { path: plugin, displayName: 'tdd' },
       { path: '/home/me/.claude/skills/verify/SKILL.md', displayName: 'verify' },
     ]);
+  });
+
+  it('keeps the real path even when the non-existent fallback is listed first', () => {
+    const skills: SkillFileEntry[] = [
+      { path: fallback, displayName: 'tdd' },
+      { path: plugin, displayName: 'tdd' },
+    ];
+    const exists = (p: string) => p === plugin;
+    expect(dedupeSkillFiles(skills, exists)).toEqual([{ path: plugin, displayName: 'tdd' }]);
+  });
+
+  it('keeps two distinct real skills that happen to share a leaf name', () => {
+    const personal = '/home/me/.claude/skills/tdd/SKILL.md';
+    const skills: SkillFileEntry[] = [
+      { path: personal, displayName: 'tdd' },
+      { path: plugin, displayName: 'tdd' },
+    ];
+    const exists = () => true; // both are real skill files on disk
+    expect(dedupeSkillFiles(skills, exists)).toEqual([
+      { path: personal, displayName: 'tdd' },
+      { path: plugin, displayName: 'tdd' },
+    ]);
+  });
+
+  it('surfaces the name once when no candidate exists on disk (all fallbacks)', () => {
+    const skills: SkillFileEntry[] = [
+      { path: plugin, displayName: 'tdd' },
+      { path: fallback, displayName: 'tdd' },
+    ];
+    const exists = () => false;
+    expect(dedupeSkillFiles(skills, exists)).toEqual([{ path: plugin, displayName: 'tdd' }]);
+  });
+
+  it('removes exact-path repeats regardless of on-disk state', () => {
+    const skills: SkillFileEntry[] = [
+      { path: plugin, displayName: 'tdd' },
+      { path: plugin, displayName: 'tdd' },
+    ];
+    expect(dedupeSkillFiles(skills, () => true)).toEqual([{ path: plugin, displayName: 'tdd' }]);
   });
 });
 
@@ -64,10 +108,13 @@ describe('getSessionContext', () => {
 
   it('returns deduped skill files and drops project files that duplicate a global one', async () => {
     const home = process.env.HOME ?? '/home/me';
+    // Skill paths under a root that cannot exist on any machine, so the on-disk
+    // dedup is deterministic (neither resolves → the first is kept).
+    const skillRoot = '/mf-nonexistent-test-root/.claude';
     const { db, adapters } = makeDeps(
       [
-        { path: `${home}/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
-        { path: `${home}/.claude/skills/tdd/SKILL.md`, displayName: 'tdd' },
+        { path: `${skillRoot}/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
+        { path: `${skillRoot}/skills/tdd/SKILL.md`, displayName: 'tdd' },
       ],
       {
         global: [{ path: '~/.claude/CLAUDE.md', content: 'g', source: 'global' }],
@@ -86,7 +133,7 @@ describe('getSessionContext', () => {
     );
 
     expect(ctx.skillFiles).toEqual([
-      { path: `${home}/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
+      { path: `${skillRoot}/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
     ]);
     expect(ctx.globalFiles).toHaveLength(1);
     expect(ctx.projectFiles).toEqual([]);

--- a/packages/core/src/chat/__tests__/context-tracker.test.ts
+++ b/packages/core/src/chat/__tests__/context-tracker.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { ContextFile, SkillFileEntry } from '@qlan-ro/mainframe-types';
+import { dedupeSkillFiles, dedupeContextFiles, getSessionContext } from '../context-tracker.js';
+
+describe('dedupeSkillFiles', () => {
+  it('collapses the same skill resolved to different paths into one entry', () => {
+    const skills: SkillFileEntry[] = [
+      { path: '/home/me/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md', displayName: 'tdd' },
+      { path: '/home/me/.claude/skills/tdd/SKILL.md', displayName: 'tdd' },
+      { path: '/home/me/.claude/skills/verify/SKILL.md', displayName: 'verify' },
+    ];
+    expect(dedupeSkillFiles(skills)).toEqual([
+      { path: '/home/me/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md', displayName: 'tdd' },
+      { path: '/home/me/.claude/skills/verify/SKILL.md', displayName: 'verify' },
+    ]);
+  });
+});
+
+describe('dedupeContextFiles', () => {
+  const home = '/home/me';
+
+  it('drops a project file that points at the same physical file as a global one', () => {
+    const global: ContextFile[] = [{ path: '~/.claude/CLAUDE.md', content: 'g', source: 'global' }];
+    // Project opened at the home dir: its .claude/CLAUDE.md IS the global file.
+    const project: ContextFile[] = [{ path: '.claude/CLAUDE.md', content: 'g', source: 'project' }];
+
+    const result = dedupeContextFiles(global, project, home, home);
+
+    expect(result.global).toEqual(global);
+    expect(result.project).toEqual([]);
+  });
+
+  it('keeps distinct project files and removes only exact within-list path repeats', () => {
+    const global: ContextFile[] = [];
+    const project: ContextFile[] = [
+      { path: 'CLAUDE.md', content: 'a', source: 'project' },
+      { path: 'CLAUDE.md', content: 'a', source: 'project' },
+      { path: '.claude/AGENTS.md', content: 'b', source: 'project' },
+    ];
+
+    const result = dedupeContextFiles(global, project, '/proj', home);
+
+    expect(result.project).toEqual([
+      { path: 'CLAUDE.md', content: 'a', source: 'project' },
+      { path: '.claude/AGENTS.md', content: 'b', source: 'project' },
+    ]);
+  });
+});
+
+describe('getSessionContext', () => {
+  function makeDeps(skillFiles: SkillFileEntry[], contextFiles: { global: ContextFile[]; project: ContextFile[] }) {
+    const db = {
+      chats: {
+        getMentions: () => [],
+        getPlanFiles: () => [],
+        getSkillFiles: () => skillFiles,
+      },
+    } as any;
+    const adapters = {
+      get: () => ({ getContextFiles: () => contextFiles }),
+    } as any;
+    return { db, adapters };
+  }
+
+  it('returns deduped skill files and drops project files that duplicate a global one', async () => {
+    const home = process.env.HOME ?? '/home/me';
+    const { db, adapters } = makeDeps(
+      [
+        { path: `${home}/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
+        { path: `${home}/.claude/skills/tdd/SKILL.md`, displayName: 'tdd' },
+      ],
+      {
+        global: [{ path: '~/.claude/CLAUDE.md', content: 'g', source: 'global' }],
+        project: [{ path: '.claude/CLAUDE.md', content: 'g', source: 'project' }],
+      },
+    );
+
+    const ctx = await getSessionContext(
+      'chat-1',
+      home, // project opened at home → its .claude/CLAUDE.md is the global file
+      db,
+      adapters,
+      undefined,
+      undefined,
+      'claude',
+    );
+
+    expect(ctx.skillFiles).toEqual([
+      { path: `${home}/.claude/plugins/cache/mkt/sp/1.0/skills/tdd/SKILL.md`, displayName: 'tdd' },
+    ]);
+    expect(ctx.globalFiles).toHaveLength(1);
+    expect(ctx.projectFiles).toEqual([]);
+  });
+});

--- a/packages/core/src/chat/context-tracker.ts
+++ b/packages/core/src/chat/context-tracker.ts
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid';
+import { existsSync } from 'node:fs';
 import { relative, isAbsolute, join } from 'node:path';
 import { homedir } from 'node:os';
 import type {
@@ -85,19 +86,49 @@ export async function getSessionContext(
 /**
  * Drop repeated skill entries. The same skill can be persisted under two paths
  * (a live probe hitting a real SKILL.md vs. a batch re-extraction falling back
- * to a conventional path), so path-only dedup lets duplicates through (#222).
- * Keyed on the display name, which the DB normalizes to the skill's leaf.
+ * to a conventional `~/.claude/skills/<leaf>/SKILL.md` stub), which path-only
+ * dedup lets through (#222). Display-name-only dedup over-corrects: two genuinely
+ * different skills that share a leaf name (e.g. a personal `tdd` and a plugin
+ * `superpowers:tdd`) would collapse, hiding one that was actually used.
+ *
+ * So within a same-display-name group we let on-disk existence break the tie:
+ * keep every entry whose file exists (distinct real skills survive), and drop
+ * the non-existent fallback stubs. When nothing in the group exists, keep the
+ * first so the skill name still surfaces. `pathExists` is injectable for tests.
  */
-export function dedupeSkillFiles(skills: SkillFileEntry[]): SkillFileEntry[] {
-  const seen = new Set<string>();
+export function dedupeSkillFiles(
+  skills: SkillFileEntry[],
+  pathExists: (p: string) => boolean = existsSync,
+): SkillFileEntry[] {
+  const byPath = dedupeSkillsByPath(skills);
+  const keyOf = (s: SkillFileEntry) => s.displayName || s.path;
+
+  const exists = new Map<string, boolean>();
+  for (const s of byPath) exists.set(s.path, pathExists(s.path));
+  const groupHasReal = new Set<string>();
+  for (const s of byPath) if (exists.get(s.path)) groupHasReal.add(keyOf(s));
+
+  const keptFallbackKey = new Set<string>();
   const out: SkillFileEntry[] = [];
-  for (const skill of skills) {
-    const key = skill.displayName || skill.path;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(skill);
+  for (const s of byPath) {
+    const key = keyOf(s);
+    if (groupHasReal.has(key)) {
+      if (exists.get(s.path)) out.push(s);
+    } else if (!keptFallbackKey.has(key)) {
+      keptFallbackKey.add(key);
+      out.push(s);
+    }
   }
   return out;
+}
+
+function dedupeSkillsByPath(skills: SkillFileEntry[]): SkillFileEntry[] {
+  const seen = new Set<string>();
+  return skills.filter((s) => {
+    if (seen.has(s.path)) return false;
+    seen.add(s.path);
+    return true;
+  });
 }
 
 /**

--- a/packages/core/src/chat/context-tracker.ts
+++ b/packages/core/src/chat/context-tracker.ts
@@ -1,6 +1,14 @@
 import { nanoid } from 'nanoid';
-import { relative, isAbsolute } from 'node:path';
-import type { SessionMention, SessionContext, ChatMessage, AdapterSession } from '@qlan-ro/mainframe-types';
+import { relative, isAbsolute, join } from 'node:path';
+import { homedir } from 'node:os';
+import type {
+  SessionMention,
+  SessionContext,
+  ChatMessage,
+  AdapterSession,
+  ContextFile,
+  SkillFileEntry,
+} from '@qlan-ro/mainframe-types';
 import type { DatabaseManager } from '../db/index.js';
 import type { AdapterRegistry } from '../adapters/index.js';
 import type { AttachmentStore } from '../attachment/index.js';
@@ -53,6 +61,8 @@ export async function getSessionContext(
 
   const toRelative = (p: string) => (isAbsolute(p) ? relative(projectPath, p) : p);
 
+  const dedupedFiles = dedupeContextFiles(globalFiles, projectFiles, projectPath);
+
   const rawMentions = db.chats.getMentions(chatId);
   const mentions = rawMentions.map((m) => ({
     ...m,
@@ -60,9 +70,70 @@ export async function getSessionContext(
   }));
   const attachments = (await attachmentStore?.list(chatId)) ?? [];
   const modifiedFiles = db.chats.getPlanFiles(chatId).map(toRelative);
-  const skillFiles = db.chats.getSkillFiles(chatId);
+  const skillFiles = dedupeSkillFiles(db.chats.getSkillFiles(chatId));
 
-  return { globalFiles, projectFiles, mentions, attachments, modifiedFiles, skillFiles };
+  return {
+    globalFiles: dedupedFiles.global,
+    projectFiles: dedupedFiles.project,
+    mentions,
+    attachments,
+    modifiedFiles,
+    skillFiles,
+  };
+}
+
+/**
+ * Drop repeated skill entries. The same skill can be persisted under two paths
+ * (a live probe hitting a real SKILL.md vs. a batch re-extraction falling back
+ * to a conventional path), so path-only dedup lets duplicates through (#222).
+ * Keyed on the display name, which the DB normalizes to the skill's leaf.
+ */
+export function dedupeSkillFiles(skills: SkillFileEntry[]): SkillFileEntry[] {
+  const seen = new Set<string>();
+  const out: SkillFileEntry[] = [];
+  for (const skill of skills) {
+    const key = skill.displayName || skill.path;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(skill);
+  }
+  return out;
+}
+
+/**
+ * Remove exact path repeats within each list and any project file that resolves
+ * to the same physical file as a global one (e.g. a session opened at the home
+ * dir, where .claude/CLAUDE.md IS the global CLAUDE.md) so it isn't listed twice
+ * (#222). Global entries are kept as canonical.
+ */
+export function dedupeContextFiles(
+  global: ContextFile[],
+  project: ContextFile[],
+  projectPath: string,
+  homeDir: string = homedir(),
+): { global: ContextFile[]; project: ContextFile[] } {
+  const dedupedGlobal = dedupeByPath(global);
+  const globalAbs = new Set(dedupedGlobal.map((f) => toAbsoluteContextPath(f.path, projectPath, homeDir)));
+  const dedupedProject = dedupeByPath(project).filter(
+    (f) => !globalAbs.has(toAbsoluteContextPath(f.path, projectPath, homeDir)),
+  );
+  return { global: dedupedGlobal, project: dedupedProject };
+}
+
+function dedupeByPath(files: ContextFile[]): ContextFile[] {
+  const seen = new Set<string>();
+  return files.filter((f) => {
+    if (seen.has(f.path)) return false;
+    seen.add(f.path);
+    return true;
+  });
+}
+
+function toAbsoluteContextPath(p: string, projectPath: string, homeDir: string): string {
+  if (p === '~') return homeDir;
+  if (p.startsWith('~/')) return join(homeDir, p.slice(2));
+  if (isAbsolute(p)) return p;
+  return join(projectPath, p);
 }
 
 export function extractLatestPlanFileFromMessages(messages: ChatMessage[]): string | null {

--- a/packages/core/src/plugins/builtin/claude/__tests__/context-files.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/context-files.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectClaudeContextFiles } from '../context-files.js';
+
+function tmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+describe('collectClaudeContextFiles', () => {
+  it('reports the global CLAUDE.md under ~/.claude, not as a bare basename', () => {
+    const home = tmp('home-');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'CLAUDE.md'), 'global rules');
+
+    const { global } = collectClaudeContextFiles(tmp('proj-'), home);
+
+    expect(global).toEqual([{ path: '~/.claude/CLAUDE.md', content: 'global rules', source: 'global' }]);
+  });
+
+  it('reports project files with project-relative paths (root and .claude/)', () => {
+    const project = tmp('proj-');
+    writeFileSync(join(project, 'CLAUDE.md'), 'root');
+    mkdirSync(join(project, '.claude'), { recursive: true });
+    writeFileSync(join(project, '.claude', 'AGENTS.md'), 'nested');
+
+    const { project: files } = collectClaudeContextFiles(project, tmp('home-'));
+
+    expect(files).toEqual([
+      { path: 'CLAUDE.md', content: 'root', source: 'project' },
+      { path: '.claude/AGENTS.md', content: 'nested', source: 'project' },
+    ]);
+  });
+
+  it('omits files that do not exist', () => {
+    const { global, project } = collectClaudeContextFiles(tmp('proj-'), tmp('home-'));
+    expect(global).toEqual([]);
+    expect(project).toEqual([]);
+  });
+});

--- a/packages/core/src/plugins/builtin/claude/__tests__/context-files.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/context-files.test.ts
@@ -9,14 +9,14 @@ function tmp(prefix: string): string {
 }
 
 describe('collectClaudeContextFiles', () => {
-  it('reports the global CLAUDE.md under ~/.claude, not as a bare basename', () => {
+  it('reports the global CLAUDE.md as an absolute ~/.claude path the daemon can open', () => {
     const home = tmp('home-');
     mkdirSync(join(home, '.claude'), { recursive: true });
     writeFileSync(join(home, '.claude', 'CLAUDE.md'), 'global rules');
 
     const { global } = collectClaudeContextFiles(tmp('proj-'), home);
 
-    expect(global).toEqual([{ path: '~/.claude/CLAUDE.md', content: 'global rules', source: 'global' }]);
+    expect(global).toEqual([{ path: join(home, '.claude', 'CLAUDE.md'), content: 'global rules', source: 'global' }]);
   });
 
   it('reports project files with project-relative paths (root and .claude/)', () => {

--- a/packages/core/src/plugins/builtin/claude/context-files.ts
+++ b/packages/core/src/plugins/builtin/claude/context-files.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import type { ContextFile } from '@qlan-ro/mainframe-types';
+
+const CONTEXT_FILE_NAMES = ['CLAUDE.md', 'AGENTS.md'] as const;
+
+/**
+ * Collect the Claude context files that apply to a session: the user-global
+ * ones under ~/.claude plus the project-scoped ones (repo root and .claude/).
+ * `homeDir` is injectable so the global path is testable without reading the
+ * real home directory.
+ */
+export function collectClaudeContextFiles(
+  projectPath: string,
+  homeDir: string = homedir(),
+): { global: ContextFile[]; project: ContextFile[] } {
+  const global: ContextFile[] = [];
+  const globalDir = path.join(homeDir, '.claude');
+  for (const name of CONTEXT_FILE_NAMES) {
+    const content = readIfPresent(path.join(globalDir, name));
+    if (content !== null) {
+      // Display the real global location so it can't be mistaken for a
+      // same-named project file (#222).
+      global.push({ path: `~/.claude/${name}`, content, source: 'global' });
+    }
+  }
+
+  const project: ContextFile[] = [];
+  for (const name of CONTEXT_FILE_NAMES) {
+    for (const dir of [projectPath, path.join(projectPath, '.claude')]) {
+      const abs = path.join(dir, name);
+      const content = readIfPresent(abs);
+      if (content !== null) {
+        project.push({ path: path.relative(projectPath, abs), content, source: 'project' });
+      }
+    }
+  }
+
+  return { global, project };
+}
+
+function readIfPresent(abs: string): string | null {
+  if (!existsSync(abs)) return null;
+  try {
+    return readFileSync(abs, 'utf-8');
+  } catch {
+    /* expected: unreadable file (perms/race) — skip it */
+    return null;
+  }
+}

--- a/packages/core/src/plugins/builtin/claude/context-files.ts
+++ b/packages/core/src/plugins/builtin/claude/context-files.ts
@@ -18,11 +18,13 @@ export function collectClaudeContextFiles(
   const global: ContextFile[] = [];
   const globalDir = path.join(homeDir, '.claude');
   for (const name of CONTEXT_FILE_NAMES) {
-    const content = readIfPresent(path.join(globalDir, name));
+    const abs = path.join(globalDir, name);
+    const content = readIfPresent(abs);
     if (content !== null) {
-      // Display the real global location so it can't be mistaken for a
-      // same-named project file (#222).
-      global.push({ path: `~/.claude/${name}`, content, source: 'global' });
+      // Absolute path (not a `~`-prefixed string): the daemon's GET /files route
+      // whitelists absolute paths under ~/.claude, and it distinguishes a global
+      // CLAUDE.md from a same-named project one — the UI never expands `~` (#222).
+      global.push({ path: abs, content, source: 'global' });
     }
   }
 

--- a/packages/core/src/plugins/builtin/claude/session.ts
+++ b/packages/core/src/plugins/builtin/claude/session.ts
@@ -1,7 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
 import { realpath as fsRealpath } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import path from 'node:path';
 import { nanoid } from 'nanoid';
 import type { ChildProcess } from 'node:child_process';
@@ -20,6 +18,7 @@ import type {
   ResolvedTuning,
 } from '@qlan-ro/mainframe-types';
 import { handleStdout, handleStderr } from './events.js';
+import { collectClaudeContextFiles } from './context-files.js';
 import { ControlRequestChannel } from './session-control.js';
 import { tuningToFlagSettings } from './tuning.js';
 import type { DetectedPrCore } from './pr-detection.js';
@@ -520,34 +519,7 @@ export class ClaudeSession implements AdapterSession {
   }
 
   getContextFiles(): { global: ContextFile[]; project: ContextFile[] } {
-    const globalDir = path.join(homedir(), '.claude');
-    const global: ContextFile[] = [];
-    for (const name of ['CLAUDE.md', 'AGENTS.md']) {
-      const p = path.join(globalDir, name);
-      if (existsSync(p)) {
-        try {
-          global.push({ path: name, content: readFileSync(p, 'utf-8'), source: 'global' });
-        } catch {
-          /* expected */
-        }
-      }
-    }
-    const project: ContextFile[] = [];
-    for (const name of ['CLAUDE.md', 'AGENTS.md']) {
-      // Check both project root and .claude/ subdirectory
-      for (const dir of [this.projectPath, path.join(this.projectPath, '.claude')]) {
-        const p = path.join(dir, name);
-        if (existsSync(p)) {
-          try {
-            const relPath = path.relative(this.projectPath, p);
-            project.push({ path: relPath, content: readFileSync(p, 'utf-8'), source: 'project' });
-          } catch {
-            /* expected */
-          }
-        }
-      }
-    }
-    return { global, project };
+    return collectClaudeContextFiles(this.projectPath);
   }
 
   async loadHistory(): Promise<ChatMessage[]> {


### PR DESCRIPTION
## Summary

Fixes todo #222 — Session context panel: wrong/duplicated paths, skills, and CLAUDE.md

The session Context panel showed the global `CLAUDE.md` with no usable path, duplicated skill and `CLAUDE.md` rows, and collapsed two distinct skills that shared a leaf directory. This branch corrects the reported paths and dedupes the assembled context.

## Root cause

- **Global context path unopenable.** The Claude adapter reported user-global context files (`~/.claude/CLAUDE.md`, `AGENTS.md`) with a bare basename, so the Global section showed `CLAUDE.md` with no path — indistinguishable from a project `CLAUDE.md` and a click targeted the wrong file. Reporting a `~/.claude/<name>` string didn't help either: the UI's `toFileRef` treats a non-`/`-prefixed path as project-relative and the daemon never expands a literal `~`, so a click resolved to `<base>/~/.claude/CLAUDE.md` and 403'd. Fix: report the **absolute** path, which `GET /files` whitelists under `~/.claude` via `resolveClaudeConfigPath`, so the click opens the real file and the row stays distinguishable from a same-named project file. Collection was extracted into a testable `context-files` module (home dir injectable).
- **Duplicated entries.** A skill persisted under two resolved paths (a live probe hitting a real `SKILL.md` vs. a batch re-extraction falling back to a conventional stub) survived the DB's path-only dedup, and a session opened at the home directory listed `~/.claude/CLAUDE.md` as both a global and a project file. Fix: dedupe in the core assembly (`getSessionContext`) — context files by resolved absolute path with the global kept canonical.
- **Distinct skills collapsing.** `dedupeSkillFiles` keyed on the display name (derived from the path's leaf directory), so a personal `tdd` and a plugin `superpowers:tdd` collapsed into one, hiding a skill that was actually used; first-wins could also keep a nonexistent fallback stub over the real path. Fix: within a same-name group, break the tie by on-disk existence — keep every entry whose `SKILL.md` exists, drop the fallback stubs, and fall back to the first entry only when nothing in the group resolves so the name still surfaces. The existence probe is injectable for tests.

## Verification

- `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit` → exit 0, no errors.
- `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/chat/__tests__/context-tracker.test.ts src/plugins/builtin/claude/__tests__/context-files.test.ts` → 2 files, 11 tests passed.

## Needs live verification

Changes are core-only and covered by unit tests, but the user-visible outcomes — the Global `CLAUDE.md`/`AGENTS.md` row opening the real `~/.claude` file on click, and no duplicate skill/`CLAUDE.md` rows — have not been exercised against the running app in this workflow. Worth a manual pass in the Context panel before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
