### PR TITLE
fix(ui,core): ws-client boot race + reliable live file-watch delivery

### DIFF
--- a/.changeset/ws-boot-race.md
+++ b/.changeset/ws-boot-race.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-core': patch
+'@qlan-ro/mainframe-ui': patch
+---
+
+Keep live file-watching reliable and stop a spurious boot-time CSP error. The editor now re-subscribes its file watches on every WebSocket reconnect and the daemon re-arms watchers after inode-replacing (atomic) saves, so external edits keep reaching the open editor and the disk-conflict banner now also shows for markdown files. The client no longer opens a doomed `ws://127.0.0.1:0` connection before the daemon target is seeded.

--- a/packages/core/src/__tests__/file-watcher-rearm.test.ts
+++ b/packages/core/src/__tests__/file-watcher-rearm.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Atomic saves (sed -i, most editors, agent Edit tools) replace the file's
+ * inode; fs.watch follows the OLD inode, fires one 'rename' and then goes
+ * permanently silent (verified empirically on macOS). The service must
+ * re-arm the watch on 'rename' so it tracks the path, not the inode.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { DaemonEvent } from '@qlan-ro/mainframe-types';
+
+const { fakeWatchers, watchBehavior } = vi.hoisted(() => {
+  interface FakeWatcher {
+    path: string;
+    callback: (eventType: string) => void;
+    close: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  }
+  const fakeWatchers: FakeWatcher[] = [];
+  const watchBehavior = { failNextCalls: 0 };
+  return { fakeWatchers, watchBehavior };
+});
+
+vi.mock('node:fs', () => ({
+  watch: vi.fn((path: string, _opts: unknown, cb: (eventType: string) => void) => {
+    if (watchBehavior.failNextCalls > 0) {
+      watchBehavior.failNextCalls--;
+      throw Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+    }
+    const watcher = { path, callback: cb, close: vi.fn(), on: vi.fn() };
+    fakeWatchers.push(watcher);
+    return watcher;
+  }),
+}));
+
+import { FileWatcherService } from '../files/file-watcher.js';
+import { watch } from 'node:fs';
+
+const PATH = '/tmp/project/file.ts';
+
+describe('FileWatcherService — re-arm after rename (inode replacement)', () => {
+  let broadcast: ReturnType<typeof vi.fn>;
+  let service: FileWatcherService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    broadcast = vi.fn();
+    service = new FileWatcherService(broadcast as unknown as (event: DaemonEvent) => void);
+    fakeWatchers.length = 0;
+    watchBehavior.failNextCalls = 0;
+    vi.mocked(watch).mockClear();
+  });
+
+  afterEach(() => {
+    service.stopAll();
+    vi.useRealTimers();
+  });
+
+  it('re-arms the watch on rename so later changes still broadcast', () => {
+    service.subscribe(PATH);
+    expect(fakeWatchers).toHaveLength(1);
+
+    // Atomic replace: the kernel watch follows the old inode and dies.
+    fakeWatchers[0]!.callback('rename');
+
+    expect(fakeWatchers[0]!.close).toHaveBeenCalled();
+    expect(fakeWatchers).toHaveLength(2);
+    expect(fakeWatchers[1]!.path).toBe(PATH);
+
+    // The rename itself still broadcasts after the debounce.
+    vi.advanceTimersByTime(200);
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith({ type: 'file:changed', path: PATH } satisfies DaemonEvent);
+
+    // A later in-place change arrives via the NEW watcher and still broadcasts.
+    fakeWatchers[1]!.callback('change');
+    vi.advanceTimersByTime(200);
+    expect(broadcast).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries once when the path is briefly absent mid-replace', () => {
+    service.subscribe(PATH);
+
+    watchBehavior.failNextCalls = 1; // the immediate re-watch hits the gap
+    fakeWatchers[0]!.callback('rename');
+    expect(fakeWatchers).toHaveLength(1); // immediate re-arm failed
+
+    vi.advanceTimersByTime(100); // retry timer
+    expect(fakeWatchers).toHaveLength(2);
+
+    fakeWatchers[1]!.callback('change');
+    vi.advanceTimersByTime(200);
+    expect(broadcast).toHaveBeenCalled();
+  });
+
+  it('cleans up the entry when the path stays gone after the retry', () => {
+    service.subscribe(PATH);
+
+    watchBehavior.failNextCalls = 2; // both the immediate re-watch and the retry fail
+    fakeWatchers[0]!.callback('rename');
+    vi.advanceTimersByTime(100);
+
+    expect(fakeWatchers).toHaveLength(1);
+    // Entry is gone: the pending debounce was cancelled and nothing broadcasts.
+    vi.advanceTimersByTime(500);
+    expect(broadcast).not.toHaveBeenCalled();
+    // A fresh subscribe starts over cleanly.
+    service.subscribe(PATH);
+    expect(fakeWatchers).toHaveLength(2);
+  });
+
+  it('a re-armed watch keeps the existing refcount (unsubscribe still tears down)', () => {
+    service.subscribe(PATH);
+    service.subscribe(PATH); // refCount 2
+
+    fakeWatchers[0]!.callback('rename');
+    expect(fakeWatchers).toHaveLength(2);
+
+    service.unsubscribe(PATH);
+    expect(fakeWatchers[1]!.close).not.toHaveBeenCalled();
+    service.unsubscribe(PATH);
+    expect(fakeWatchers[1]!.close).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/files/file-watcher.ts
+++ b/packages/core/src/files/file-watcher.ts
@@ -6,6 +6,8 @@ import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 const log = createChildLogger('file-watcher');
 
 const DEBOUNCE_MS = 200;
+/** Grace delay before the second re-watch attempt when the path is briefly absent mid-replace. */
+const REARM_RETRY_MS = 100;
 
 type BroadcastFn = (event: DaemonEvent) => void;
 
@@ -36,24 +38,60 @@ export class FileWatcherService {
       return;
     }
 
+    const watcher = this.openWatcher(absolutePath);
+    if (!watcher) return;
+
+    const entry: WatchEntry = { watcher, refCount: 1, debounceTimer: null };
+    this.watchers.set(absolutePath, entry);
+    log.debug({ path: absolutePath }, 'file watch started');
+  }
+
+  private openWatcher(absolutePath: string): FSWatcher | null {
     let watcher: FSWatcher;
     try {
-      watcher = watch(absolutePath, { persistent: false }, (_eventType) => {
+      watcher = watch(absolutePath, { persistent: false }, (eventType) => {
+        // Atomic saves (rename-over: sed -i, most editors, agent Edit tools)
+        // replace the inode; the kernel watch follows the OLD inode and goes
+        // permanently silent. Re-arm so the watch tracks the path.
+        if (eventType === 'rename') this.rearm(absolutePath);
         this.scheduleEmit(absolutePath);
       });
     } catch (err) {
       log.warn({ err, path: absolutePath }, 'failed to start file watcher');
-      return;
+      return null;
     }
 
     watcher.on('error', (err) => {
       log.warn({ err, path: absolutePath }, 'file watcher error');
       this.cleanup(absolutePath);
     });
+    return watcher;
+  }
 
-    const entry: WatchEntry = { watcher, refCount: 1, debounceTimer: null };
-    this.watchers.set(absolutePath, entry);
-    log.debug({ path: absolutePath }, 'file watch started');
+  private rearm(absolutePath: string): void {
+    const entry = this.watchers.get(absolutePath);
+    if (!entry) return;
+    try {
+      entry.watcher.close();
+    } catch (err) {
+      log.warn({ err, path: absolutePath }, 'error closing file watcher during re-arm');
+    }
+    const next = this.openWatcher(absolutePath);
+    if (next) {
+      entry.watcher = next;
+      return;
+    }
+    // The path can be briefly absent mid-replace — retry once before giving up.
+    setTimeout(() => {
+      if (this.watchers.get(absolutePath) !== entry) return;
+      const retry = this.openWatcher(absolutePath);
+      if (retry) {
+        entry.watcher = retry;
+        return;
+      }
+      log.warn({ path: absolutePath }, 'file watch lost after rename (path gone) — cleaning up');
+      this.cleanup(absolutePath);
+    }, REARM_RETRY_MS);
   }
 
   unsubscribe(absolutePath: string): void {

--- a/packages/ui/src/features/editor/EditorTab.tsx
+++ b/packages/ui/src/features/editor/EditorTab.tsx
@@ -23,6 +23,7 @@ import { useTabsStore } from '@/store/tabs';
 import { ViewerRouter } from '@/features/viewers/viewer-router';
 import { lspClientManager, getLspLanguage } from '@/lib/lsp';
 import { EditorContextMenu } from './context-menu/EditorContextMenu';
+import { DiskConflictBanner, SaveErrorBanner } from './editor-banners';
 import { CmEditorWithComments } from './inline-comments/CmEditorWithComments';
 import { MarkdownEditorTab } from './MarkdownEditorTab';
 import { useFileWatchReload } from './use-file-watch-reload';
@@ -229,6 +230,9 @@ export function EditorTab({ tabId, path, readOnly = false }: EditorTabProps) {
 
   return (
     <div data-testid="editor-tab" className="flex h-full flex-col overflow-hidden">
+      {/* Above ViewerRouter so BOTH code branches (plain + markdown) show them. */}
+      {saveError !== null && <SaveErrorBanner message={saveError} />}
+      {diskConflict !== null && <DiskConflictBanner onReload={reloadFromDisk} onKeepMine={keepMine} />}
       <ViewerRouter
         path={path}
         renderCode={() =>
@@ -248,36 +252,6 @@ export function EditorTab({ tabId, path, readOnly = false }: EditorTabProps) {
                   className="flex-shrink-0 bg-mf-tab-bar px-3 py-0.5 text-caption text-mf-text-3"
                 >
                   Read-only
-                </div>
-              )}
-              {saveError !== null && (
-                <div
-                  data-testid="editor-tab-save-error"
-                  className="flex-shrink-0 bg-mf-destructive-tint px-3 py-1 text-caption text-destructive"
-                >
-                  Save failed: {saveError}
-                </div>
-              )}
-              {diskConflict !== null && (
-                <div
-                  data-testid="editor-tab-disk-conflict"
-                  className="flex flex-shrink-0 items-center gap-2 bg-mf-warning-tint px-3 py-1 text-caption text-mf-warning"
-                >
-                  <span className="flex-1">File changed on disk</span>
-                  <button
-                    data-testid="editor-tab-reload"
-                    onClick={reloadFromDisk}
-                    className="rounded px-2 py-0.5 hover:opacity-80"
-                  >
-                    Reload
-                  </button>
-                  <button
-                    data-testid="editor-tab-keep-mine"
-                    onClick={keepMine}
-                    className="rounded px-2 py-0.5 hover:opacity-80"
-                  >
-                    Keep mine
-                  </button>
                 </div>
               )}
               <EditorContextMenu

--- a/packages/ui/src/features/editor/__tests__/EditorTab.test.tsx
+++ b/packages/ui/src/features/editor/__tests__/EditorTab.test.tsx
@@ -551,6 +551,29 @@ describe('EditorTab — live disk-change reload (D4)', () => {
     expect(screen.queryByTestId('editor-tab-keep-mine')).toBeNull();
   });
 
+  it('DIRTY buffer + file-change on a MARKDOWN file → conflict banner appears (not just code files)', async () => {
+    activeIdentityState.projectId = 'proj-d4-md';
+    activeIdentityState.chatId = 'chat-d4-md';
+    activeIdentityState.projectPath = '/project';
+    mockBufferDirty = true;
+    vi.mocked(getProjectFile).mockResolvedValue('disk content v2');
+
+    render(<EditorTab tabId="tab-d4-md" path="/project/notes.md" />);
+    await screen.findByTestId('markdown-editor-mock');
+
+    await act(async () => {
+      fireFileChange('/project/notes.md');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The banner must render for markdown files too — the markdown branch
+    // previously skipped it, silently swallowing external-change conflicts.
+    expect(screen.getByTestId('editor-tab-disk-conflict')).toBeTruthy();
+    expect(screen.getByTestId('editor-tab-reload')).toBeTruthy();
+    expect(screen.getByTestId('editor-tab-keep-mine')).toBeTruthy();
+  });
+
   it('Keep-mine button dismisses the banner without applying disk content', async () => {
     activeIdentityState.projectId = 'proj-d4-keep';
     activeIdentityState.chatId = 'chat-d4-keep';

--- a/packages/ui/src/features/editor/editor-banners.tsx
+++ b/packages/ui/src/features/editor/editor-banners.tsx
@@ -1,0 +1,33 @@
+/**
+ * Status banners shared by every EditorTab code path (plain code AND the
+ * markdown Preview/Source tab). Hoisted out of the code-only branch so a
+ * dirty-buffer disk conflict on a markdown file is never silently swallowed.
+ */
+
+export function SaveErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="editor-tab-save-error"
+      className="flex-shrink-0 bg-mf-destructive-tint px-3 py-1 text-caption text-destructive"
+    >
+      Save failed: {message}
+    </div>
+  );
+}
+
+export function DiskConflictBanner({ onReload, onKeepMine }: { onReload: () => void; onKeepMine: () => void }) {
+  return (
+    <div
+      data-testid="editor-tab-disk-conflict"
+      className="flex flex-shrink-0 items-center gap-2 bg-mf-warning-tint px-3 py-1 text-caption text-mf-warning"
+    >
+      <span className="flex-1">File changed on disk</span>
+      <button data-testid="editor-tab-reload" onClick={onReload} className="rounded px-2 py-0.5 hover:opacity-80">
+        Reload
+      </button>
+      <button data-testid="editor-tab-keep-mine" onClick={onKeepMine} className="rounded px-2 py-0.5 hover:opacity-80">
+        Keep mine
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/lib/daemon/__tests__/ws-client-boot.test.ts
+++ b/packages/ui/src/lib/daemon/__tests__/ws-client-boot.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Boot-race guard: the active-daemon singleton starts at the unseeded default
+ * `http://127.0.0.1:0` until the first successful /health poll seeds it, but
+ * App.tsx calls daemonWs.connect() as soon as the bridge port resolves. The
+ * client must NEVER open a socket to `ws://…:0` (a guaranteed CSP violation on
+ * every fresh load) — it defers the connect until the target is seeded.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { DaemonTarget } from '@qlan-ro/mainframe-types';
+import { setActiveDaemon } from '../active-daemon';
+import { DaemonWsClient } from '../ws-client';
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  sendSpy = vi.fn<(data: string) => void>();
+  send: (data: string) => void = this.sendSpy as unknown as (data: string) => void;
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+  });
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  static instances: FakeWebSocket[] = [];
+  static reset() {
+    FakeWebSocket.instances = [];
+  }
+}
+
+const UNSEEDED: DaemonTarget = {
+  id: 'local',
+  kind: 'local',
+  label: 'Local',
+  baseUrl: 'http://127.0.0.1:0',
+  token: null,
+};
+
+const SEEDED_LOCAL: DaemonTarget = {
+  id: 'local',
+  kind: 'local',
+  label: 'Local',
+  baseUrl: 'http://127.0.0.1:31415',
+  token: null,
+};
+
+let client: DaemonWsClient;
+
+beforeEach(() => {
+  FakeWebSocket.reset();
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  setActiveDaemon(UNSEEDED);
+  client = new DaemonWsClient();
+});
+
+afterEach(() => {
+  client.disconnect();
+  vi.unstubAllGlobals();
+});
+
+describe('DaemonWsClient — boot race (unseeded active daemon)', () => {
+  it('connect() before the target is seeded opens no socket', () => {
+    client.setPort(31415);
+    client.connect();
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('connects automatically (with the real URL) once the target is seeded', () => {
+    client.setPort(31415);
+    client.connect();
+
+    setActiveDaemon(SEEDED_LOCAL);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]?.url).toBe('ws://127.0.0.1:31415');
+  });
+
+  it('never attempts a ws URL with port 0, even via the send() reconnect kick', () => {
+    client.setPort(31415);
+    client.connect();
+    // send() while down buffers and kicks a reconnect — that kick must also defer.
+    client.send({ type: 'subscribe', chatId: 'chat-1' });
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    setActiveDaemon(SEEDED_LOCAL);
+
+    expect(FakeWebSocket.instances.every((s) => !s.url.includes(':0'))).toBe(true);
+  });
+
+  it('flushes messages buffered during the deferral once the deferred socket opens', () => {
+    client.setPort(31415);
+    client.connect();
+    client.send({ type: 'subscribe', chatId: 'chat-1' });
+
+    setActiveDaemon(SEEDED_LOCAL);
+    const socket = FakeWebSocket.instances[0];
+    expect(socket).toBeDefined();
+    socket!.readyState = FakeWebSocket.OPEN;
+    socket!.onopen?.();
+
+    expect(socket!.sendSpy).toHaveBeenCalledWith(JSON.stringify({ type: 'subscribe', chatId: 'chat-1' }));
+  });
+
+  it('disconnect() during the deferral cancels the pending connect', () => {
+    client.setPort(31415);
+    client.connect();
+    client.disconnect();
+
+    setActiveDaemon(SEEDED_LOCAL);
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it('only one socket is opened when connect() was called repeatedly during the deferral', () => {
+    client.setPort(31415);
+    client.connect();
+    client.connect();
+    client.connect();
+
+    setActiveDaemon(SEEDED_LOCAL);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/lib/daemon/__tests__/ws-client-boot.test.ts
+++ b/packages/ui/src/lib/daemon/__tests__/ws-client-boot.test.ts
@@ -132,4 +132,21 @@ describe('DaemonWsClient — boot race (unseeded active daemon)', () => {
 
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
+
+  it('keeps waiting through a still-unseeded notification (no socket, no re-subscribe loop)', () => {
+    client.setPort(31415);
+    client.connect();
+
+    // Set iteration visits listeners added during the notify loop — an
+    // unguarded listener that cancels + reconnects on an unseeded target
+    // re-subscribes inside that loop and never terminates.
+    setActiveDaemon({ ...UNSEEDED });
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    setActiveDaemon(SEEDED_LOCAL);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0]?.url).toBe('ws://127.0.0.1:31415');
+  });
 });

--- a/packages/ui/src/lib/daemon/__tests__/ws-client.test.ts
+++ b/packages/ui/src/lib/daemon/__tests__/ws-client.test.ts
@@ -361,6 +361,88 @@ describe('DaemonWsClient — H5: file-watch API', () => {
     expect(listener).toHaveBeenCalledOnce(); // still just once
   });
 
+  // Daemon file subscriptions are per-connection state (WsFileWatch is wiped in
+  // ws.on('close')). The client must re-send subscribe:file for every live watch
+  // whenever a new socket opens, or file:changed silently stops after a reconnect.
+  describe('resubscription across reconnects', () => {
+    function reconnect(client: DaemonWsClient, oldSocket: FakeWebSocket): FakeWebSocket {
+      oldSocket.readyState = FakeWebSocket.CLOSED;
+      client.connect();
+      const next = lastSocket();
+      openSocket(next);
+      return next;
+    }
+
+    it('re-sends subscribe:file for each live watch when a new socket opens', () => {
+      const { client, socket } = setupConnectedClient();
+      client.subscribeFile('src/a.ts', { projectId: 'p1', chatId: 'c1' });
+      client.subscribeFile('/abs/b.ts');
+
+      const next = reconnect(client, socket);
+
+      expect(next.sendSpy.mock.calls.map((c) => c[0])).toEqual(
+        expect.arrayContaining([
+          JSON.stringify({ type: 'subscribe:file', path: 'src/a.ts', projectId: 'p1', chatId: 'c1' }),
+          JSON.stringify({ type: 'subscribe:file', path: '/abs/b.ts' }),
+        ]),
+      );
+    });
+
+    it('does NOT resubscribe a watch that was unsubscribed before the reconnect', () => {
+      const { client, socket } = setupConnectedClient();
+      client.subscribeFile('src/a.ts', { projectId: 'p1' });
+      client.unsubscribeFile('src/a.ts', { projectId: 'p1' });
+
+      const next = reconnect(client, socket);
+
+      expect(next.sendSpy.mock.calls.map((c) => c[0])).not.toContain(
+        JSON.stringify({ type: 'subscribe:file', path: 'src/a.ts', projectId: 'p1' }),
+      );
+    });
+
+    it('refcounts duplicate watches: one wire frame, survives one unsubscribe, dies on the last', () => {
+      const { client, socket } = setupConnectedClient();
+      client.subscribeFile('src/a.ts', { projectId: 'p1' });
+      client.subscribeFile('src/a.ts', { projectId: 'p1' });
+      // Only one subscribe frame goes over the wire.
+      expect(socket.sendSpy).toHaveBeenCalledOnce();
+
+      client.unsubscribeFile('src/a.ts', { projectId: 'p1' });
+      // Still one holder — no unsubscribe frame yet, and the watch survives a reconnect.
+      expect(socket.sendSpy).toHaveBeenCalledOnce();
+      const second = reconnect(client, socket);
+      expect(second.sendSpy.mock.calls.map((c) => c[0])).toContain(
+        JSON.stringify({ type: 'subscribe:file', path: 'src/a.ts', projectId: 'p1' }),
+      );
+
+      second.sendSpy.mockClear();
+      client.unsubscribeFile('src/a.ts', { projectId: 'p1' });
+      // Last holder gone — unsubscribe frame sent, no resubscribe on the next socket.
+      expect(second.sendSpy).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'unsubscribe:file', path: 'src/a.ts', projectId: 'p1' }),
+      );
+      const third = reconnect(client, second);
+      expect(third.sendSpy.mock.calls.map((c) => c[0])).not.toContain(
+        JSON.stringify({ type: 'subscribe:file', path: 'src/a.ts', projectId: 'p1' }),
+      );
+    });
+
+    it('keeps routing file:changed to listeners after a reconnect re-ack', () => {
+      const { client, socket } = setupConnectedClient();
+      const listener = vi.fn();
+      client.subscribeFile('src/a.ts', { projectId: 'p1' });
+      client.onFileChange('src/a.ts', listener);
+
+      const next = reconnect(client, socket);
+      next.onmessage?.({
+        data: JSON.stringify({ type: 'subscribe:file:ack', requestedPath: 'src/a.ts', resolvedPath: '/real/a.ts' }),
+      });
+      next.onmessage?.({ data: JSON.stringify({ type: 'file:changed', path: '/real/a.ts' }) });
+
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
   // Fix 4: unsubscribeFile must clean up filePathMap to prevent stale routing
   it('unsubscribeFile removes the requestedPath entry from the internal path map', () => {
     const { client, socket } = setupConnectedClient();

--- a/packages/ui/src/lib/daemon/__tests__/ws-client.test.ts
+++ b/packages/ui/src/lib/daemon/__tests__/ws-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { DaemonEvent } from '@qlan-ro/mainframe-types';
+import { setActiveDaemon } from '../active-daemon';
 import { DaemonWsClient } from '../ws-client';
 
 // ---------------------------------------------------------------------------
@@ -69,6 +70,8 @@ beforeEach(() => {
   // The source guards on `WebSocket.OPEN`, `WebSocket.CONNECTING` etc. as
   // static properties. vi.stubGlobal replaces the global constructor so those
   // statics are available via `WebSocket.OPEN` in the module under test.
+  // connect() refuses the unseeded boot placeholder (:0) — seed a real target.
+  setActiveDaemon({ id: 'local', kind: 'local', label: 'Local', baseUrl: 'http://127.0.0.1:31415', token: null });
 });
 
 afterEach(() => {

--- a/packages/ui/src/lib/daemon/ws-client.ts
+++ b/packages/ui/src/lib/daemon/ws-client.ts
@@ -7,11 +7,25 @@
  * - Exposes only what Phase 1 needs: connect, subscribe, send, onEvent, disconnect
  */
 import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
-import { getActiveDaemon } from './active-daemon';
+import { getActiveDaemon, subscribeActiveDaemon } from './active-daemon';
 
 type EventHandler = (event: DaemonEvent) => void;
 type ConnectionListener = () => void;
 type FileChangeListener = () => void;
+
+/**
+ * The active-daemon singleton boots with the placeholder `http://127.0.0.1:0`
+ * until the first successful /health poll seeds the real target. A target with
+ * an explicit port 0 is that placeholder — connecting to it is always wrong
+ * (ws://…:0 is a guaranteed CSP violation on every fresh load).
+ */
+function isSeededTarget(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).port !== '0';
+  } catch {
+    return false;
+  }
+}
 
 export class DaemonWsClient {
   private ws: WebSocket | null = null;
@@ -22,6 +36,8 @@ export class DaemonWsClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempts = 0;
   private intentionalClose = false;
+  /** Non-null while a connect() is deferred waiting for the target to be seeded. */
+  private seedWaitUnsub: (() => void) | null = null;
   /** Maps requestedPath → resolvedPath, populated from subscribe:file:ack */
   private filePathMap = new Map<string, string>();
   /** Maps requestedPath → set of listeners */
@@ -45,6 +61,11 @@ export class DaemonWsClient {
     this.intentionalClose = false;
 
     const t = getActiveDaemon();
+    if (!isSeededTarget(t.baseUrl)) {
+      this.connectWhenSeeded();
+      return;
+    }
+    this.cancelSeedWait();
     const wsBase = t.baseUrl.replace(/^http/, 'ws');
     const url = t.token ? `${wsBase}?token=${encodeURIComponent(t.token)}` : wsBase;
     const socket = new WebSocket(url);
@@ -93,6 +114,7 @@ export class DaemonWsClient {
 
   disconnect(): void {
     this.intentionalClose = true;
+    this.cancelSeedWait();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -199,6 +221,20 @@ export class DaemonWsClient {
 
   private notifyConnectionListeners(): void {
     this.connectionListeners.forEach((fn) => fn());
+  }
+
+  /** Defer the connect until setActiveDaemon() delivers a seeded target. */
+  private connectWhenSeeded(): void {
+    if (this.seedWaitUnsub) return;
+    this.seedWaitUnsub = subscribeActiveDaemon(() => {
+      this.cancelSeedWait();
+      this.connect();
+    });
+  }
+
+  private cancelSeedWait(): void {
+    this.seedWaitUnsub?.();
+    this.seedWaitUnsub = null;
   }
 
   private scheduleReconnect(): void {

--- a/packages/ui/src/lib/daemon/ws-client.ts
+++ b/packages/ui/src/lib/daemon/ws-client.ts
@@ -8,6 +8,7 @@
  */
 import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
 import { getActiveDaemon, subscribeActiveDaemon } from './active-daemon';
+import { FileWatchRegistry, type FileWatchContext } from './ws-file-watch-registry';
 
 type EventHandler = (event: DaemonEvent) => void;
 type ConnectionListener = () => void;
@@ -38,10 +39,7 @@ export class DaemonWsClient {
   private intentionalClose = false;
   /** Non-null while a connect() is deferred waiting for the target to be seeded. */
   private seedWaitUnsub: (() => void) | null = null;
-  /** Maps requestedPath → resolvedPath, populated from subscribe:file:ack */
-  private filePathMap = new Map<string, string>();
-  /** Maps requestedPath → set of listeners */
-  private fileListeners = new Map<string, Set<FileChangeListener>>();
+  private fileWatch = new FileWatchRegistry();
 
   /** Call once before connect() — the port comes from getDaemonPort() in the Tauri bridge. */
   setPort(port: number): void {
@@ -74,6 +72,7 @@ export class DaemonWsClient {
     socket.onopen = () => {
       this.reconnectAttempts = 0;
       this.flushPending();
+      this.resubscribeFiles();
       this.notifyConnectionListeners();
     };
 
@@ -97,7 +96,7 @@ export class DaemonWsClient {
       }
       const data = parsed as DaemonEvent;
       this.handlers.forEach((h) => h(data));
-      this.handleFileWatchEvent(data);
+      this.fileWatch.handleEvent(data);
     };
 
     socket.onclose = () => {
@@ -141,9 +140,13 @@ export class DaemonWsClient {
     }
     // Never silently drop: a lost message.send / permission.respond looks like
     // success while the daemon never received it. Buffer and let the
-    // (re)connection flush it (`flushPending` runs on `onopen`). A CONNECTING
-    // socket flushes on its own; an absent/CLOSED one needs a reconnect kick.
+    // (re)connection flush it (`flushPending` runs on `onopen`).
     this.pendingMessages.push(event);
+    this.kickReconnect();
+  }
+
+  /** A CONNECTING socket opens on its own; an absent/CLOSED one needs a kick. */
+  private kickReconnect(): void {
     if (
       !this.intentionalClose &&
       this.port != null &&
@@ -162,56 +165,33 @@ export class DaemonWsClient {
     this.send({ type: 'unsubscribe', chatId });
   }
 
-  subscribeFile(path: string, context?: { projectId?: string; chatId?: string }): void {
-    this.send({ type: 'subscribe:file', path, ...context });
-  }
-
-  unsubscribeFile(path: string, context?: { projectId?: string; chatId?: string }): void {
-    this.filePathMap.delete(path);
-    this.send({ type: 'unsubscribe:file', path, ...context });
-  }
-
   /**
-   * Register a listener for changes to `path`. Returns an unsubscribe fn.
-   *
-   * The daemon REALPATHs the subscribed path; `file:changed` carries the
-   * resolved path. An ack (`subscribe:file:ack`) maps requestedPath →
-   * resolvedPath so we can route the resolved path back to listeners keyed
-   * by the original requested path.
+   * File watches are per-connection state on the daemon (wiped when the socket
+   * closes), so subscribe/unsubscribe frames are NOT buffered like send():
+   * the registry is replayed wholesale by resubscribeFiles() on every open.
    */
-  onFileChange(path: string, listener: FileChangeListener): () => void {
-    let listeners = this.fileListeners.get(path);
-    if (!listeners) {
-      listeners = new Set();
-      this.fileListeners.set(path, listeners);
+  subscribeFile(path: string, context?: FileWatchContext): void {
+    const frame = this.fileWatch.subscribe(path, context);
+    if (!frame) return;
+    if (this.connected) {
+      this.send(frame);
+    } else {
+      this.kickReconnect();
     }
-    listeners.add(listener);
-    return () => {
-      const set = this.fileListeners.get(path);
-      if (set) {
-        set.delete(listener);
-        if (set.size === 0) this.fileListeners.delete(path);
-      }
-    };
   }
 
-  private handleFileWatchEvent(data: DaemonEvent): void {
-    if (data.type === 'subscribe:file:ack') {
-      this.filePathMap.set(data.requestedPath, data.resolvedPath);
-      return;
-    }
-    if (data.type === 'file:changed') {
-      const resolvedPath = data.path;
-      // Find all requested paths that resolved to this path and invoke listeners.
-      for (const [requestedPath, mapped] of this.filePathMap) {
-        if (mapped === resolvedPath) {
-          const listeners = this.fileListeners.get(requestedPath);
-          if (listeners) {
-            listeners.forEach((fn) => fn());
-          }
-        }
-      }
-    }
+  unsubscribeFile(path: string, context?: FileWatchContext): void {
+    const frame = this.fileWatch.unsubscribe(path, context);
+    if (frame && this.connected) this.send(frame);
+  }
+
+  private resubscribeFiles(): void {
+    for (const frame of this.fileWatch.replayFrames()) this.send(frame);
+  }
+
+  /** Register a listener for changes to `path`. Returns an unsubscribe fn. */
+  onFileChange(path: string, listener: FileChangeListener): () => void {
+    return this.fileWatch.addListener(path, listener);
   }
 
   private flushPending(): void {

--- a/packages/ui/src/lib/daemon/ws-client.ts
+++ b/packages/ui/src/lib/daemon/ws-client.ts
@@ -68,7 +68,10 @@ export class DaemonWsClient {
     const url = t.token ? `${wsBase}?token=${encodeURIComponent(t.token)}` : wsBase;
     const socket = new WebSocket(url);
     this.ws = socket;
+    this.attachSocketHandlers(socket);
+  }
 
+  private attachSocketHandlers(socket: WebSocket): void {
     socket.onopen = () => {
       this.reconnectAttempts = 0;
       this.flushPending();

--- a/packages/ui/src/lib/daemon/ws-client.ts
+++ b/packages/ui/src/lib/daemon/ws-client.ts
@@ -206,7 +206,10 @@ export class DaemonWsClient {
   /** Defer the connect until setActiveDaemon() delivers a seeded target. */
   private connectWhenSeeded(): void {
     if (this.seedWaitUnsub) return;
-    this.seedWaitUnsub = subscribeActiveDaemon(() => {
+    // Ignore unseeded notifications: reacting to one would re-subscribe inside
+    // setActiveDaemon's listener iteration (Sets visit entries added mid-loop).
+    this.seedWaitUnsub = subscribeActiveDaemon((t) => {
+      if (!isSeededTarget(t.baseUrl)) return;
       this.cancelSeedWait();
       this.connect();
     });

--- a/packages/ui/src/lib/daemon/ws-file-watch-registry.ts
+++ b/packages/ui/src/lib/daemon/ws-file-watch-registry.ts
@@ -1,0 +1,106 @@
+/**
+ * Client-side file-watch bookkeeping for DaemonWsClient.
+ *
+ * File watches are per-connection state on the daemon (WsFileWatch is wiped
+ * when the socket closes), so the client keeps its own registry of live
+ * watches and replays `subscribe:file` for each of them on every socket open.
+ *
+ * The daemon REALPATHs the subscribed path; `file:changed` carries the
+ * resolved path. An ack (`subscribe:file:ack`) maps requestedPath →
+ * resolvedPath so the resolved path routes back to listeners keyed by the
+ * original requested path.
+ */
+import type { ClientEvent, DaemonEvent } from '@qlan-ro/mainframe-types';
+
+export interface FileWatchContext {
+  projectId?: string;
+  chatId?: string;
+}
+
+type FileChangeListener = () => void;
+
+interface FileSubscription {
+  path: string;
+  context?: FileWatchContext;
+  /** Live holders (components) of this watch — the wire sub dies at 0. */
+  count: number;
+}
+
+/** Mirrors the daemon's WsFileWatch composite key (projectId|chatId|path). */
+function fileSubKey(path: string, context?: FileWatchContext): string {
+  return `${context?.projectId ?? ''}|${context?.chatId ?? ''}|${path}`;
+}
+
+export class FileWatchRegistry {
+  /** Maps requestedPath → resolvedPath, populated from subscribe:file:ack */
+  private filePathMap = new Map<string, string>();
+  /** Maps requestedPath → set of listeners */
+  private fileListeners = new Map<string, Set<FileChangeListener>>();
+  /** Live watches, keyed by fileSubKey — replayed on every socket open. */
+  private subscriptions = new Map<string, FileSubscription>();
+
+  /** Returns the frame to send, or null when another holder already owns the watch. */
+  subscribe(path: string, context?: FileWatchContext): ClientEvent | null {
+    const key = fileSubKey(path, context);
+    const existing = this.subscriptions.get(key);
+    if (existing) {
+      existing.count++;
+      return null;
+    }
+    this.subscriptions.set(key, { path, context, count: 1 });
+    return { type: 'subscribe:file', path, ...context };
+  }
+
+  /** Returns the frame to send, or null while other holders remain. */
+  unsubscribe(path: string, context?: FileWatchContext): ClientEvent | null {
+    const key = fileSubKey(path, context);
+    const sub = this.subscriptions.get(key);
+    if (sub && --sub.count > 0) return null;
+    this.subscriptions.delete(key);
+    const pathStillWatched = [...this.subscriptions.values()].some((s) => s.path === path);
+    if (!pathStillWatched) this.filePathMap.delete(path);
+    return { type: 'unsubscribe:file', path, ...context };
+  }
+
+  /** Register a listener for changes to `path`. Returns an unsubscribe fn. */
+  addListener(path: string, listener: FileChangeListener): () => void {
+    let listeners = this.fileListeners.get(path);
+    if (!listeners) {
+      listeners = new Set();
+      this.fileListeners.set(path, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      const set = this.fileListeners.get(path);
+      if (set) {
+        set.delete(listener);
+        if (set.size === 0) this.fileListeners.delete(path);
+      }
+    };
+  }
+
+  /** One subscribe:file frame per live watch — sent on every socket open. */
+  replayFrames(): ClientEvent[] {
+    return [...this.subscriptions.values()].map(({ path, context }) => ({
+      type: 'subscribe:file',
+      path,
+      ...context,
+    }));
+  }
+
+  handleEvent(data: DaemonEvent): void {
+    if (data.type === 'subscribe:file:ack') {
+      this.filePathMap.set(data.requestedPath, data.resolvedPath);
+      return;
+    }
+    if (data.type === 'file:changed') {
+      const resolvedPath = data.path;
+      // Find all requested paths that resolved to this path and invoke listeners.
+      for (const [requestedPath, mapped] of this.filePathMap) {
+        if (mapped === resolvedPath) {
+          this.fileListeners.get(requestedPath)?.forEach((fn) => fn());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes todo #216 — V1: ws-client boot race (CSP ws://127.0.0.1:0) + intermittent file-watch delivery

Two coupled defects surfaced in the 2026-07-09 test-worktree fleet run: every fresh load logged a CSP violation from a doomed `ws://127.0.0.1:0` connect, and live file-watch delivery to the open editor worked once then repeatedly stopped firing (blocking the disk-conflict-banner scenario even after full reloads). This branch fixes the boot race and every link in the file-watch delivery chain.

## Root cause

- **Boot race (CSP `ws://127.0.0.1:0`)** — `App.tsx` opens the daemon WS as soon as the bridge port resolves, but the WS URL comes from the active-daemon singleton, which stays at the `http://127.0.0.1:0` placeholder until the first successful `/health` poll seeds it. Each fresh load fired one doomed `ws://127.0.0.1:0` connect (a CSP violation) before the 500ms reconnect healed it. `connect()` now defers while the target is unseeded and completes automatically when `setActiveDaemon` delivers a real target; `disconnect()` cancels the pending wait.
- **File watches dropped on reconnect** — Daemon file watches are per-connection state (wiped in `ws.on('close')`), but the client only sent `subscribe:file` from the editor mount effect. Any socket drop silently killed live delivery for every open editor until a full remount. The client now keeps a refcounted `FileWatchRegistry` and replays `subscribe:file` for each live watch on every socket open.
- **Watcher goes silent after atomic saves** — `fs.watch` follows the inode, not the path: an atomic save (`sed -i`, most editors, agent Edit tools) renames a temp file over the target, so the watch fires one `rename` then goes permanently silent (verified on macOS). The service now closes the dead watcher and re-watches the same path on `rename`, with one delayed retry for the mid-replace window, preserving refcounts and debounce.
- **Seed-wait listener could hang** — The seed-wait listener cancelled itself and re-called `connect()` on every active-daemon notification; notified with a still-unseeded target it re-subscribed a new listener inside `setActiveDaemon`'s Set iteration, so the notify loop could never terminate. It now ignores unseeded targets and stays subscribed until a seeded one arrives.
- **Markdown lost the banners** — The save-error and disk-conflict banners lived inside the non-markdown branch of `EditorTab.renderCode`, so a dirty markdown buffer plus an external change silently swallowed the conflict. Both banners are hoisted (extracted to `editor-banners.tsx`) above `ViewerRouter` so every code path renders them.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — pass
- `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit` — pass
- `pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/file-watcher-rearm.test.ts` — 4 passed
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/daemon/__tests__/ws-client-boot.test.ts src/lib/daemon/__tests__/ws-client.test.ts src/features/editor/__tests__/EditorTab.test.tsx` — 57 passed

## Needs live verification

Unit coverage exercises the boot gate, reconnect replay, watcher re-arm, and banner rendering, but the original symptoms were caught in a live fleet run. Recommend confirming end-to-end in the running app: fresh load produces no `ws://127.0.0.1:0` CSP error, and editing a file externally (atomic save) while it is open repeatedly surfaces the disk-conflict banner for both code and markdown files, including after a socket drop/reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)