### PR TITLE
feat(ui): resolve new-session draft worktree and branch context before first send

### DIFF
--- a/.changeset/draft-session-context.md
+++ b/.changeset/draft-session-context.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Reflect a new session's worktree and branch choice before the first message is sent.
+
+A new-session draft has no daemon chat yet, so the titlebar branch chip, worktree popover, and file tree used to fall back to the project root while you composed — hiding the branch you picked. The active identity now resolves from the seeded draft config, so those surfaces show the chosen branch and worktree pre-send, and the choice carries into chat creation on first send: an existing worktree attaches with the new chat, and a new worktree is created before the CLI spawns.

--- a/packages/ui/src/app/AppShell.tsx
+++ b/packages/ui/src/app/AppShell.tsx
@@ -78,7 +78,7 @@ function RuntimeBody({ port }: { port: number }) {
   const sidebarVisible = useUiPrefs((s) => s.sidebarVisible);
   const toggleSidebar = useUiPrefs((s) => s.toggleSidebar);
   const inspectorVisible = useUiPrefs((s) => s.inspectorVisible);
-  const { projectName, branchName, worktreePath, projectPath, projectId, chatId } = useActiveIdentity();
+  const { projectName, branchName, worktreePath, projectPath, projectId, chatId, isWorktree } = useActiveIdentity();
 
   // Sync the active bases into the store so the intent subscriber (outside React)
   // can normalize open-file path flavors to a canonical relative key (F1 fix).
@@ -164,7 +164,7 @@ function RuntimeBody({ port }: { port: number }) {
           onExpandSidebar={expandSidebar}
           projectName={projectName}
           branchName={branchName}
-          isWorktree={Boolean(worktreePath)}
+          isWorktree={isWorktree}
           windowStyle={windowStyle}
           port={port}
           projectId={projectId}

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreeDraftPanel.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreeDraftPanel.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+/**
+ * WorktreeDraftPanel — WorktreePopover body for a `__LOCALID_*` draft whose
+ * worktree choice is stashed in the draft config (todo #223). No daemon chat
+ * exists yet, so the choice applies on first send: an EXISTING worktree attach
+ * goes through the createChat payload; a NEW worktree (pendingWorktree) is
+ * created by the coordinator right after the chat. Cancel un-stashes so the
+ * session starts in the main repo instead.
+ */
+import { MenuDivider } from '@/components/ui/menu';
+import { TruncatedWithTooltip } from '@/components/ui/truncated-with-tooltip';
+import type { DraftCfg } from '@/features/sessions/runtime/draft-config';
+
+export interface WorktreeDraftPanelProps {
+  draft: DraftCfg;
+  onCancel: () => void;
+}
+
+export function WorktreeDraftPanel({ draft, onCancel }: WorktreeDraftPanelProps) {
+  const pending = draft.pendingWorktree;
+  const branch = pending?.branchName ?? draft.branchName ?? '—';
+
+  return (
+    <div data-testid="composer-worktree-draft-panel" className="space-y-[6px] px-[8px] py-[6px]">
+      <div className="flex items-center gap-[6px]">
+        <span className="inline-block size-[7px] shrink-0 rounded-full bg-mf-success" aria-hidden />
+        <span className="text-caption font-medium text-mf-success">
+          {pending ? 'New worktree on first message' : 'Isolates in worktree on first message'}
+        </span>
+      </div>
+      <MenuDivider />
+      <div className="grid grid-cols-[auto_1fr] items-start gap-x-[8px] gap-y-[2px]">
+        <span className="text-caption text-mf-text-3">Branch</span>
+        <span className="truncate font-mono text-caption text-foreground">{branch}</span>
+        {pending ? (
+          <>
+            <span className="text-caption text-mf-text-3">From</span>
+            <span className="truncate font-mono text-caption text-foreground">{pending.baseBranch}</span>
+          </>
+        ) : (
+          <>
+            <span className="text-caption text-mf-text-3">Path</span>
+            <TruncatedWithTooltip
+              text={draft.worktreePath ?? ''}
+              className="font-mono text-caption text-foreground"
+              contentClassName="font-mono break-all"
+            />
+          </>
+        )}
+      </div>
+      <div className="flex justify-end pt-[2px]">
+        <button
+          type="button"
+          data-testid="composer-worktree-draft-cancel"
+          onClick={onCancel}
+          className="rounded-[6px] px-[10px] py-[4px] text-caption text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground"
+        >
+          Don&apos;t isolate
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreePopover.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreePopover.tsx
@@ -25,6 +25,8 @@ import { MenuDivider, MenuLabel } from '@/components/ui/menu';
 import { enableWorktree, attachWorktree, getGitBranches, getProjectWorktrees } from '@/lib/api/git';
 import type { WorktreeEntry } from '@/lib/api/git';
 import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
+import { useDraftConfig, patchDraftConfig } from '@/features/sessions/runtime/draft-config';
+import { WorktreeDraftPanel } from './WorktreeDraftPanel';
 import { WorktreeNewForm } from './WorktreeNewForm';
 import { WorktreeTabBar, WorktreeExistingTab } from './WorktreeExistingTab';
 import type { WorktreeTab } from './WorktreeExistingTab';
@@ -67,6 +69,14 @@ export interface WorktreePopoverProps {
 export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
   const port = useDaemonPort();
 
+  // Draft mode (todo #223): a __LOCALID_* thread has no daemon chat, so the
+  // choice is stashed in the draft config — an existing-worktree attach rides
+  // the createChat payload; a new worktree is created by the coordinator right
+  // after createChat on first send. Never call the chat-scoped endpoints here.
+  const isLocalDraft = chat.id.startsWith('__LOCALID_');
+  const draft = useDraftConfig(isLocalDraft ? chat.id : null);
+  const pendingWorktree = draft?.pendingWorktree;
+
   const [branches, setBranches] = useState<string[]>([]);
   const [currentBranch, setCurrentBranch] = useState('');
   const [worktrees, setWorktrees] = useState<WorktreeEntry[]>([]);
@@ -107,6 +117,11 @@ export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
 
   const handleEnable = useCallback(
     async (baseBranch: string, branchName: string) => {
+      if (isLocalDraft) {
+        patchDraftConfig(chat.id, { pendingWorktree: { baseBranch, branchName } });
+        setOpen(false);
+        return;
+      }
       setSubmitting(true);
       setApiError(null);
       try {
@@ -118,15 +133,20 @@ export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
         setSubmitting(false);
       }
     },
-    [port, chat.id],
+    [port, chat.id, isLocalDraft],
   );
 
   const handleAttach = useCallback(
     async (wt: WorktreeEntry) => {
+      const branch = wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached';
+      if (isLocalDraft) {
+        patchDraftConfig(chat.id, { worktreePath: wt.path, branchName: branch });
+        setOpen(false);
+        return;
+      }
       setSubmitting(true);
       setApiError(null);
       try {
-        const branch = wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached';
         await attachWorktree(port, chat.id, wt.path, branch);
         setOpen(false);
       } catch (err: unknown) {
@@ -135,11 +155,18 @@ export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
         setSubmitting(false);
       }
     },
-    [port, chat.id],
+    [port, chat.id, isLocalDraft],
   );
 
+  // Cancel a stashed draft choice — the session starts in the main repo instead.
+  const handleDraftCancel = useCallback(() => {
+    patchDraftConfig(chat.id, { worktreePath: undefined, branchName: undefined, pendingWorktree: undefined });
+  }, [chat.id]);
+
   const isIsolated = Boolean(chat.worktreePath);
-  const branchLabel = isIsolated ? (chat.branchName ?? 'Worktree') : null;
+  const isPendingDraft = isLocalDraft && pendingWorktree != null;
+  const showIsolated = isIsolated || isPendingDraft;
+  const branchLabel = isIsolated ? (chat.branchName ?? 'Worktree') : isPendingDraft ? pendingWorktree.branchName : null;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -149,25 +176,25 @@ export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
             <button
               type="button"
               data-testid="composer-worktree-trigger"
-              aria-label={isIsolated ? `Worktree: ${branchLabel}` : 'Isolate in worktree'}
+              aria-label={showIsolated ? `Worktree: ${branchLabel}` : 'Isolate in worktree'}
               className={[
                 'relative flex h-[20px] w-[26px] shrink-0 items-center justify-center gap-[3px]',
                 'rounded-sm border-[0.5px] text-muted-foreground',
-                isIsolated ? 'border-mf-success text-mf-success' : 'border-border',
+                showIsolated ? 'border-mf-success text-mf-success' : 'border-border',
                 'hover:bg-accent hover:text-accent-foreground',
                 'data-[state=open]:border-primary data-[state=open]:bg-mf-selection',
                 'transition-colors focus-visible:outline-none',
               ].join(' ')}
             >
               <GitFork size={13} />
-              {isIsolated && (
+              {showIsolated && (
                 <span className="absolute right-0.5 top-0.5 size-[5px] rounded-full bg-primary" aria-hidden />
               )}
             </button>
           </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side="top">
-          {isIsolated ? `Worktree: ${branchLabel}` : 'Isolate session in a worktree'}
+          {showIsolated ? `Worktree: ${branchLabel}` : 'Isolate session in a worktree'}
         </TooltipContent>
       </Tooltip>
 
@@ -178,7 +205,9 @@ export function WorktreePopover({ chat, hasMessages }: WorktreePopoverProps) {
         sideOffset={6}
         className="w-[280px] p-[5px]"
       >
-        {isIsolated ? (
+        {isLocalDraft && draft != null && showIsolated ? (
+          <WorktreeDraftPanel draft={draft} onCancel={handleDraftCancel} />
+        ) : isIsolated ? (
           <ActiveInfo chat={chat} />
         ) : loading ? (
           <div className="flex items-center justify-center py-[20px]">

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/WorktreePopover.test.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/WorktreePopover.test.tsx
@@ -54,6 +54,7 @@ vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
 // Import component AFTER mocks are in place
 import { WorktreePopover } from '../WorktreePopover';
 import type { Chat } from '@qlan-ro/mainframe-types';
+import { useDraftConfigStore, setDraftConfig, getDraftConfig } from '@/features/sessions/runtime/draft-config';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -100,6 +101,7 @@ beforeEach(() => {
   attachWorktreeMock.mockClear();
   getGitBranchesMock.mockClear();
   getProjectWorktreesMock.mockClear();
+  useDraftConfigStore.setState({ drafts: new Map() });
 });
 
 // ---------------------------------------------------------------------------
@@ -357,5 +359,84 @@ describe('WorktreePopover — isolated-state indicator', () => {
     const trigger = screen.getByTestId('composer-worktree-trigger');
     const dot = trigger.querySelector('span[aria-hidden]');
     expect(dot).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Draft mode (todo #223) — a __LOCALID_* chat has no daemon chat yet, so the
+// choice is stashed in the draft config and carried into first-send creation.
+// ---------------------------------------------------------------------------
+
+const DRAFT_ID = '__LOCALID_d1';
+
+function makeDraftChat(overrides?: Partial<Chat>): Chat {
+  return makeChat({ id: DRAFT_ID, ...overrides });
+}
+
+describe('WorktreePopover — draft mode stashes instead of calling the daemon', () => {
+  it('Existing-tab attach patches the draft config and never calls attachWorktree', async () => {
+    setDraftConfig(DRAFT_ID, { projectId: 'p1', adapterId: 'claude' });
+    renderPopover(makeDraftChat());
+
+    openPopover();
+    fireEvent.click(await screen.findByTestId('composer-worktree-tab-existing'));
+    fireEvent.click(await screen.findByTestId('composer-worktree-attach-/wt/feat-a'));
+
+    await waitFor(() => expect(getDraftConfig(DRAFT_ID)?.worktreePath).toBe('/wt/feat-a'));
+    expect(getDraftConfig(DRAFT_ID)?.branchName).toBe('feat-a');
+    expect(attachWorktreeMock).not.toHaveBeenCalled();
+  });
+
+  it('New-tab enable stashes a pendingWorktree and never calls enableWorktree', async () => {
+    setDraftConfig(DRAFT_ID, { projectId: 'p1', adapterId: 'claude' });
+    renderPopover(makeDraftChat());
+
+    openPopover();
+    const input = await screen.findByTestId('composer-worktree-branch-name');
+    fireEvent.change(input, { target: { value: 'feat/new' } });
+    fireEvent.click(screen.getByTestId('composer-worktree-enable'));
+
+    await waitFor(() =>
+      expect(getDraftConfig(DRAFT_ID)?.pendingWorktree).toEqual({ baseBranch: 'main', branchName: 'feat/new' }),
+    );
+    expect(enableWorktreeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('WorktreePopover — draft panel reflects the stashed choice', () => {
+  it('shows the draft panel for an attached draft worktree and cancel clears it', async () => {
+    setDraftConfig(DRAFT_ID, {
+      projectId: 'p1',
+      adapterId: 'claude',
+      worktreePath: '/wt/feat-a',
+      branchName: 'feat-a',
+    });
+    // ComposerToolbar synthesizes the draft chat from the same draft config.
+    renderPopover(makeDraftChat({ worktreePath: '/wt/feat-a', branchName: 'feat-a' }));
+
+    openPopover();
+
+    expect(await screen.findByTestId('composer-worktree-draft-panel')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('composer-worktree-draft-cancel'));
+
+    expect(getDraftConfig(DRAFT_ID)?.worktreePath).toBeUndefined();
+    expect(getDraftConfig(DRAFT_ID)?.branchName).toBeUndefined();
+  });
+
+  it('shows the draft panel for a pending new worktree and cancel clears the intent', async () => {
+    setDraftConfig(DRAFT_ID, {
+      projectId: 'p1',
+      adapterId: 'claude',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feat/new' },
+    });
+    renderPopover(makeDraftChat());
+
+    openPopover();
+
+    const panel = await screen.findByTestId('composer-worktree-draft-panel');
+    expect(panel.textContent).toContain('feat/new');
+    fireEvent.click(screen.getByTestId('composer-worktree-draft-cancel'));
+
+    expect(getDraftConfig(DRAFT_ID)?.pendingWorktree).toBeUndefined();
   });
 });

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
@@ -158,3 +158,32 @@ describe('synthesizeDraftChat — placeholder fields', () => {
     expect(chat.worktreeMissing).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 7. Pre-send worktree attach (todo #223)
+// ---------------------------------------------------------------------------
+
+describe('synthesizeDraftChat — pre-send worktree attach', () => {
+  it('carries worktreePath and branchName from the draft', () => {
+    const draft: DraftCfg = {
+      projectId: 'p1',
+      adapterId: 'claude',
+      worktreePath: '/wt/feat-a',
+      branchName: 'feat-a',
+    };
+
+    const chat = synthesizeDraftChat('__LOCALID_x', draft);
+
+    expect(chat.worktreePath).toBe('/wt/feat-a');
+    expect(chat.branchName).toBe('feat-a');
+  });
+
+  it('leaves worktreePath and branchName undefined when the draft has none', () => {
+    const draft: DraftCfg = { projectId: 'p1', adapterId: 'claude' };
+
+    const chat = synthesizeDraftChat('__LOCALID_x', draft);
+
+    expect(chat.worktreePath).toBeUndefined();
+    expect(chat.branchName).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
@@ -38,6 +38,10 @@ export function synthesizeDraftChat(id: string, d: DraftCfg): Chat {
     fast: d.fast ?? null,
     ultracode: d.ultracode ?? null,
     adaptiveThinking: d.adaptiveThinking ?? null,
+    // A pre-send worktree attach — carried so the worktree trigger/panel and the
+    // titlebar chip reflect the choice before the chat exists (todo #223).
+    worktreePath: d.worktreePath,
+    branchName: d.branchName,
     worktreeMissing: false,
   };
 }

--- a/packages/ui/src/features/git/BranchPopover.tsx
+++ b/packages/ui/src/features/git/BranchPopover.tsx
@@ -21,21 +21,16 @@
  * Hint-inside-asChild-trigger trap in `NewSessionPickerPopover`).
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useAuiState } from '@assistant-ui/react';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Hint } from '@/components/ui/hint';
-import { activeSessionCustom } from '../sessions/view-model/chat-to-thread-custom';
-import { useActiveDraftConfig } from '../sessions/use-active-draft-config';
 import { useBranchActions } from './use-branch-actions';
-import { useWorktreeSession } from './use-worktree-session';
+import { useNewSessionAction } from './use-new-session-action';
 import { BranchPopoverListPane } from './BranchPopoverListPane';
 import { BranchPopoverOverlay } from './BranchPopoverOverlay';
 import type { BranchInfo } from '@qlan-ro/mainframe-types';
 
 type View = 'list' | 'new-branch' | 'conflict' | 'rename';
-
-const DEFAULT_ADAPTER_ID = 'claude';
 
 // Each panel (list, submenu, overlay) is its own card; the popover container is
 // bare so the list + submenu read as two separate cards with a gap (13-popover
@@ -71,12 +66,6 @@ export function BranchPopover({
   children,
   triggerLabel,
 }: BranchPopoverProps) {
-  // Resolve adapterId from the active thread's custom, else the pre-send draft
-  // config (a __LOCALID_* thread has no custom yet) — falls back to 'claude'.
-  const customAdapterId = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems)?.adapterId);
-  const draft = useActiveDraftConfig();
-  const adapterId = customAdapterId ?? draft?.adapterId ?? DEFAULT_ADAPTER_ID;
-
   const {
     branches,
     conflictFiles,
@@ -172,15 +161,8 @@ export function BranchPopover({
     [handleCreateBranch, goToList, onBranchChanged],
   );
 
-  const newSession = useWorktreeSession(port, projectId, adapterId);
-
-  const handleNewSession = useCallback(
-    (dirName: string, branchName?: string) => {
-      void newSession(dirName, branchName);
-      onOpenChange(false);
-    },
-    [newSession, onOpenChange],
-  );
+  const closePopover = useCallback(() => onOpenChange(false), [onOpenChange]);
+  const handleNewSession = useNewSessionAction(port, projectId, closePopover);
 
   const handleDeleteWorktreeAction = useCallback(
     async (dirName: string, branchName?: string): Promise<boolean> => {

--- a/packages/ui/src/features/git/BranchPopover.tsx
+++ b/packages/ui/src/features/git/BranchPopover.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Hint } from '@/components/ui/hint';
 import { activeSessionCustom } from '../sessions/view-model/chat-to-thread-custom';
+import { useActiveDraftConfig } from '../sessions/use-active-draft-config';
 import { useBranchActions } from './use-branch-actions';
 import { useWorktreeSession } from './use-worktree-session';
 import { BranchPopoverListPane } from './BranchPopoverListPane';
@@ -70,11 +71,11 @@ export function BranchPopover({
   children,
   triggerLabel,
 }: BranchPopoverProps) {
-  // Resolve adapterId from the active thread's custom — falls back to 'claude'.
-  const adapterId = useAuiState((s) => {
-    const custom = activeSessionCustom(s.threadListItem, s.threads.threadItems);
-    return custom?.adapterId ?? DEFAULT_ADAPTER_ID;
-  });
+  // Resolve adapterId from the active thread's custom, else the pre-send draft
+  // config (a __LOCALID_* thread has no custom yet) — falls back to 'claude'.
+  const customAdapterId = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems)?.adapterId);
+  const draft = useActiveDraftConfig();
+  const adapterId = customAdapterId ?? draft?.adapterId ?? DEFAULT_ADAPTER_ID;
 
   const {
     branches,

--- a/packages/ui/src/features/git/__tests__/use-new-session-action.test.ts
+++ b/packages/ui/src/features/git/__tests__/use-new-session-action.test.ts
@@ -1,0 +1,89 @@
+/**
+ * useNewSessionAction — BranchPopover's "new session in worktree" action.
+ *
+ * Pins the adapter resolution order (live session custom → pre-send draft →
+ * 'claude' default) and the action wiring (create the worktree session, then
+ * close the popover).
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDraftConfigStore, setDraftConfig } from '@/features/sessions/runtime/draft-config';
+
+interface FakeItem {
+  id: string;
+  remoteId?: string;
+  status: string;
+  custom?: Record<string, unknown>;
+}
+interface FakeAuiState {
+  threadListItem: FakeItem | undefined;
+  threads: { threadItems: FakeItem[] };
+}
+
+let fakeAuiState: FakeAuiState = { threadListItem: undefined, threads: { threadItems: [] } };
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (s: FakeAuiState) => unknown) => selector(fakeAuiState),
+}));
+
+const mockCreateSession = vi.fn();
+let capturedAdapterId: string | undefined;
+vi.mock('../use-worktree-session', () => ({
+  useWorktreeSession: (_port: number, _projectId: string | undefined, adapterId: string) => {
+    capturedAdapterId = adapterId;
+    return mockCreateSession;
+  },
+}));
+
+import { useNewSessionAction } from '../use-new-session-action';
+
+const LIVE_CUSTOM = { projectId: 'proj-a', adapterId: 'codex' };
+
+beforeEach(() => {
+  useDraftConfigStore.setState({ drafts: new Map() });
+  fakeAuiState = { threadListItem: undefined, threads: { threadItems: [] } };
+  mockCreateSession.mockReset().mockResolvedValue(undefined);
+  capturedAdapterId = undefined;
+});
+
+describe('useNewSessionAction — adapter resolution', () => {
+  it('resolves the adapter from the live session custom', () => {
+    const item: FakeItem = { id: '__LOCALID_1', remoteId: 'chat-9', status: 'regular' };
+    fakeAuiState = {
+      threadListItem: item,
+      threads: { threadItems: [item, { id: 'chat-9', remoteId: 'chat-9', status: 'regular', custom: LIVE_CUSTOM }] },
+    };
+
+    renderHook(() => useNewSessionAction(31415, 'proj-a', vi.fn()));
+
+    expect(capturedAdapterId).toBe('codex');
+  });
+
+  it('falls back to the pre-send draft adapter for a custom-less __LOCALID_* thread', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', { projectId: 'proj-a', adapterId: 'gemini' });
+
+    renderHook(() => useNewSessionAction(31415, 'proj-a', vi.fn()));
+
+    expect(capturedAdapterId).toBe('gemini');
+  });
+
+  it("defaults to 'claude' when neither custom nor draft exists", () => {
+    renderHook(() => useNewSessionAction(31415, 'proj-a', vi.fn()));
+
+    expect(capturedAdapterId).toBe('claude');
+  });
+});
+
+describe('useNewSessionAction — action wiring', () => {
+  it('creates the worktree session and closes the popover', () => {
+    const onDone = vi.fn();
+    const { result } = renderHook(() => useNewSessionAction(31415, 'proj-a', onDone));
+
+    result.current('wt-dir', 'feat/x');
+
+    expect(mockCreateSession).toHaveBeenCalledWith('wt-dir', 'feat/x');
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/git/use-new-session-action.ts
+++ b/packages/ui/src/features/git/use-new-session-action.ts
@@ -1,0 +1,34 @@
+/**
+ * useNewSessionAction — BranchPopover's "new session in worktree" action.
+ *
+ * Resolves the adapter for the created chat from the active thread's custom,
+ * else the pre-send draft config (a `__LOCALID_*` thread has no custom yet),
+ * falling back to 'claude' — then creates the worktree-scoped session and
+ * closes the popover via `onDone`.
+ */
+import { useCallback } from 'react';
+import { useAuiState } from '@assistant-ui/react';
+import { activeSessionCustom } from '../sessions/view-model/chat-to-thread-custom';
+import { useActiveDraftConfig } from '../sessions/use-active-draft-config';
+import { useWorktreeSession } from './use-worktree-session';
+
+const DEFAULT_ADAPTER_ID = 'claude';
+
+export function useNewSessionAction(
+  port: number,
+  projectId: string | undefined,
+  onDone: () => void,
+): (worktreeDirName: string, branchName?: string) => void {
+  const customAdapterId = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems)?.adapterId);
+  const draft = useActiveDraftConfig();
+  const adapterId = customAdapterId ?? draft?.adapterId ?? DEFAULT_ADAPTER_ID;
+
+  const newSession = useWorktreeSession(port, projectId, adapterId);
+  return useCallback(
+    (worktreeDirName: string, branchName?: string) => {
+      void newSession(worktreeDirName, branchName);
+      onDone();
+    },
+    [newSession, onDone],
+  );
+}

--- a/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
+++ b/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * useActiveIdentity — draft-aware identity resolution (todo #223).
+ *
+ * Behaviors covered:
+ *  1. Live session: fields resolve from the remoteId-keyed custom (unchanged).
+ *  2. Draft (`__LOCALID_*`, no custom): projectId/adapterId/projectPath resolve
+ *     from the seeded draft config, so project-scoped surfaces light up while
+ *     composing; chatId stays undefined (no daemon chat yet).
+ *  3. Draft worktree attach: worktreePath/branchName surface from the draft.
+ *  4. First-send gap: the draft is consumed before threads.reload lands — the
+ *     SAME item keeps its resolved identity (no dark flicker mid-handoff).
+ *  5. No leak: a different custom-less item never inherits the cached identity.
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Project } from '@qlan-ro/mainframe-types';
+import { useDraftConfigStore, setDraftConfig } from '../runtime/draft-config';
+
+interface FakeItem {
+  id: string;
+  remoteId?: string;
+  status: string;
+  custom?: Record<string, unknown>;
+}
+interface FakeAuiState {
+  threadListItem: FakeItem | undefined;
+  threads: { threadItems: FakeItem[] };
+}
+
+let fakeAuiState: FakeAuiState = { threadListItem: undefined, threads: { threadItems: [] } };
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (s: FakeAuiState) => unknown) => selector(fakeAuiState),
+}));
+
+const PROJECTS: Project[] = [
+  { id: 'proj-a', name: 'Alpha', path: '/repos/alpha' } as Project,
+  { id: 'proj-b', name: 'Beta', path: '/repos/beta' } as Project,
+];
+
+vi.mock('../use-projects', () => ({
+  useProjects: () => ({ projects: PROJECTS, loading: false }),
+}));
+
+import { useActiveIdentity } from '../use-active-identity';
+
+const LIVE_CUSTOM = {
+  projectId: 'proj-a',
+  adapterId: 'claude',
+  tags: [],
+  pinned: false,
+  status: 'active',
+  displayStatus: 'idle',
+  hasPending: false,
+  detectedPrs: [],
+  worktreeMissing: false,
+  transcriptMissing: false,
+  branchName: 'main',
+  updatedAt: 0,
+};
+
+beforeEach(() => {
+  useDraftConfigStore.setState({ drafts: new Map() });
+  fakeAuiState = { threadListItem: undefined, threads: { threadItems: [] } };
+});
+
+describe('useActiveIdentity — live session (unchanged behavior)', () => {
+  it('resolves project/branch/chatId from the remoteId-keyed custom', () => {
+    const item: FakeItem = { id: '__LOCALID_1', remoteId: 'chat-9', status: 'regular' };
+    fakeAuiState = {
+      threadListItem: item,
+      threads: { threadItems: [item, { id: 'chat-9', remoteId: 'chat-9', status: 'regular', custom: LIVE_CUSTOM }] },
+    };
+
+    const { result } = renderHook(() => useActiveIdentity());
+
+    expect(result.current.projectId).toBe('proj-a');
+    expect(result.current.projectName).toBe('Alpha');
+    expect(result.current.branchName).toBe('main');
+    expect(result.current.chatId).toBe('chat-9');
+    expect(result.current.projectPath).toBe('/repos/alpha');
+  });
+});
+
+describe('useActiveIdentity — seeded draft resolves the project scope pre-send', () => {
+  it('resolves projectId/adapterId/projectName/projectPath from the draft config', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', { projectId: 'proj-b', adapterId: 'codex' });
+
+    const { result } = renderHook(() => useActiveIdentity());
+
+    expect(result.current.projectId).toBe('proj-b');
+    expect(result.current.adapterId).toBe('codex');
+    expect(result.current.projectName).toBe('Beta');
+    expect(result.current.projectPath).toBe('/repos/beta');
+    expect(result.current.chatId).toBeUndefined();
+  });
+
+  it('surfaces a pre-send worktree attach from the draft', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', {
+      projectId: 'proj-a',
+      adapterId: 'claude',
+      worktreePath: '/wt/feat',
+      branchName: 'feat/x',
+    });
+
+    const { result } = renderHook(() => useActiveIdentity());
+
+    expect(result.current.worktreePath).toBe('/wt/feat');
+    expect(result.current.branchName).toBe('feat/x');
+  });
+
+  it('stays empty for a custom-less draft with NO seeded config (picker not resolved yet)', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+
+    const { result } = renderHook(() => useActiveIdentity());
+
+    expect(result.current.projectId).toBeUndefined();
+    expect(result.current.projectName).toBe('Mainframe');
+  });
+});
+
+describe('useActiveIdentity — first-send gap continuity', () => {
+  it('keeps the resolved identity on the SAME item after the draft is consumed', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', { projectId: 'proj-b', adapterId: 'codex' });
+
+    const { result, rerender } = renderHook(() => useActiveIdentity());
+    expect(result.current.projectId).toBe('proj-b');
+
+    // First send: the coordinator clears the draft; threads.reload has not
+    // landed yet, so the item still has no custom.
+    useDraftConfigStore.setState({ drafts: new Map() });
+    rerender();
+
+    expect(result.current.projectId).toBe('proj-b');
+    expect(result.current.projectName).toBe('Beta');
+  });
+
+  it('does NOT leak the cached identity to a different custom-less item', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', { projectId: 'proj-b', adapterId: 'codex' });
+
+    const { result, rerender } = renderHook(() => useActiveIdentity());
+    expect(result.current.projectId).toBe('proj-b');
+
+    useDraftConfigStore.setState({ drafts: new Map() });
+    const other: FakeItem = { id: '__LOCALID_other', status: 'new' };
+    fakeAuiState = { threadListItem: other, threads: { threadItems: [other] } };
+    rerender();
+
+    expect(result.current.projectId).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
+++ b/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
@@ -111,6 +111,23 @@ describe('useActiveIdentity — seeded draft resolves the project scope pre-send
 
     expect(result.current.worktreePath).toBe('/wt/feat');
     expect(result.current.branchName).toBe('feat/x');
+    expect(result.current.isWorktree).toBe(true);
+  });
+
+  it('surfaces a pending NEW worktree as branch + isWorktree, with no worktreePath', () => {
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', {
+      projectId: 'proj-a',
+      adapterId: 'claude',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feat/pending' },
+    });
+
+    const { result } = renderHook(() => useActiveIdentity());
+
+    expect(result.current.branchName).toBe('feat/pending');
+    expect(result.current.isWorktree).toBe(true);
+    expect(result.current.worktreePath).toBeUndefined();
   });
 
   it('stays empty for a custom-less draft with NO seeded config (picker not resolved yet)', () => {

--- a/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
+++ b/packages/ui/src/features/sessions/__tests__/use-active-identity.test.tsx
@@ -15,6 +15,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Project } from '@qlan-ro/mainframe-types';
 import { useDraftConfigStore, setDraftConfig } from '../runtime/draft-config';
+import { useDiscardedDraftStore, markDraftDiscarded } from '../new-thread/discarded-drafts';
 
 interface FakeItem {
   id: string;
@@ -61,6 +62,7 @@ const LIVE_CUSTOM = {
 
 beforeEach(() => {
   useDraftConfigStore.setState({ drafts: new Map() });
+  useDiscardedDraftStore.setState({ ids: new Set() });
   fakeAuiState = { threadListItem: undefined, threads: { threadItems: [] } };
 });
 
@@ -173,5 +175,25 @@ describe('useActiveIdentity — first-send gap continuity', () => {
     rerender();
 
     expect(result.current.projectId).toBeUndefined();
+  });
+
+  it('drops the bridged identity when the parked slot was explicitly discarded', () => {
+    // ✕ discard clears the draft and marks the slot discarded, but the user can
+    // stay parked on it (returnThreadId pointed at the slot itself, or there
+    // are zero sessions to switch to). The first-send bridge must not keep the
+    // discarded project's scope alive on that slot.
+    const item: FakeItem = { id: '__LOCALID_d', status: 'new' };
+    fakeAuiState = { threadListItem: item, threads: { threadItems: [item] } };
+    setDraftConfig('__LOCALID_d', { projectId: 'proj-b', adapterId: 'codex' });
+
+    const { result, rerender } = renderHook(() => useActiveIdentity());
+    expect(result.current.projectId).toBe('proj-b');
+
+    useDraftConfigStore.setState({ drafts: new Map() });
+    markDraftDiscarded('__LOCALID_d');
+    rerender();
+
+    expect(result.current.projectId).toBeUndefined();
+    expect(result.current.projectName).toBe('Mainframe');
   });
 });

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
@@ -20,13 +20,24 @@ vi.mock('../new-thread-ready-store', () => ({
   },
 }));
 
+// Mock enableWorktree (pendingWorktree carry) and the toast raised on its failure.
+vi.mock('../../../../lib/api/git', () => ({
+  enableWorktree: vi.fn().mockResolvedValue(undefined),
+}));
+const toastErrorSpy = vi.fn();
+vi.mock('../../../../lib/toast', () => ({
+  mfToast: { error: (...args: unknown[]) => toastErrorSpy(...args) },
+}));
+
 // Import AFTER the mock is registered so the module under test picks up the mock.
 import { createForLocal } from '../new-thread-coordinator';
 import { createChat, setChatTuning, setChatConfig } from '../../../../lib/api/chats';
+import { enableWorktree } from '../../../../lib/api/git';
 
 const mockCreateChat = createChat as MockedFunction<typeof createChat>;
 const mockSetChatTuning = setChatTuning as MockedFunction<typeof setChatTuning>;
 const mockSetChatConfig = setChatConfig as MockedFunction<typeof setChatConfig>;
+const mockEnableWorktree = enableWorktree as MockedFunction<typeof enableWorktree>;
 
 // ---------------------------------------------------------------------------
 // Reset draft-config singleton state + mock call counts between cases
@@ -268,5 +279,52 @@ describe('new-thread-coordinator — permissionMode omission fix', () => {
     const result = await createForLocal('__LOCALID_b', 31415);
 
     expect(result).toEqual({ remoteId: 'chat-1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pendingWorktree — a "New" worktree chosen pre-send is created right after
+// the chat (enable-worktree is chat-scoped, so it can't run on a draft)
+// ---------------------------------------------------------------------------
+
+describe('new-thread-coordinator — pendingWorktree is created right after the chat', () => {
+  it('calls enableWorktree(port, chatId, baseBranch, branchName) and omits pendingWorktree from the createChat body', async () => {
+    setDraftConfig('__LOCALID_a', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feat/new' },
+    });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-55' } as Chat);
+
+    const result = await createForLocal('__LOCALID_a', 31415);
+
+    expect(result).toEqual({ remoteId: 'chat-55' });
+    expect(mockEnableWorktree).toHaveBeenCalledExactlyOnceWith(31415, 'chat-55', 'main', 'feat/new');
+    const body = mockCreateChat.mock.calls[0]![1];
+    expect('pendingWorktree' in body).toBe(false);
+  });
+
+  it('does NOT call enableWorktree when the draft has no pendingWorktree', async () => {
+    setDraftConfig('__LOCALID_a', { projectId: 'p1', adapterId: 'claude' });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-56' } as Chat);
+
+    await createForLocal('__LOCALID_a', 31415);
+
+    expect(mockEnableWorktree).not.toHaveBeenCalled();
+  });
+
+  it('still resolves and raises an error toast when enableWorktree fails (session falls back to the main repo)', async () => {
+    setDraftConfig('__LOCALID_a', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feat/new' },
+    });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-57' } as Chat);
+    mockEnableWorktree.mockRejectedValueOnce(new Error('branch exists'));
+
+    const result = await createForLocal('__LOCALID_a', 31415);
+
+    expect(result).toEqual({ remoteId: 'chat-57' });
+    expect(toastErrorSpy).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/features/sessions/runtime/draft-config.ts
+++ b/packages/ui/src/features/sessions/runtime/draft-config.ts
@@ -31,6 +31,12 @@ export interface DraftCfg {
   adaptiveThinking?: boolean | null;
   worktreePath?: string;
   branchName?: string;
+  /**
+   * A "New" worktree chosen pre-send. It cannot be created yet (enable-worktree
+   * is chat-scoped and no daemon chat exists), so the coordinator runs
+   * enable-worktree right after createChat on first send.
+   */
+  pendingWorktree?: { baseBranch: string; branchName: string };
 }
 
 interface DraftConfigState {

--- a/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
@@ -28,6 +28,8 @@
  */
 import type { Chat, SessionTuning } from '@qlan-ro/mainframe-types';
 import { createChat, setChatConfig, setChatTuning } from '../../../lib/api/chats';
+import { enableWorktree } from '../../../lib/api/git';
+import { mfToast } from '../../../lib/toast';
 import { getDraftConfig, clearDraftConfig, type DraftCfg } from './draft-config';
 import { useNewThreadReady } from './new-thread-ready-store';
 
@@ -51,6 +53,27 @@ async function applyDraftTuning(port: number, chatId: string, cfg: DraftCfg): Pr
     if (cfg.planMode != null) await setChatConfig(port, chatId, { planMode: cfg.planMode });
   } catch (err) {
     console.warn('[new-thread-coordinator] applyDraftTuning failed', { chatId, err });
+  }
+}
+
+/**
+ * Create the "New" worktree chosen pre-send (WorktreePopover on a draft) —
+ * enable-worktree is chat-scoped, so it can only run once the chat exists,
+ * BEFORE the first send spawns the CLI (so it spawns in the worktree cwd).
+ * Best-effort: on failure the session continues in the main repo, surfaced
+ * with an error toast (the popover that reported errors inline is long gone).
+ */
+async function applyPendingWorktree(port: number, chatId: string, cfg: DraftCfg): Promise<void> {
+  if (!cfg.pendingWorktree) return;
+  const { baseBranch, branchName } = cfg.pendingWorktree;
+  try {
+    await enableWorktree(port, chatId, baseBranch, branchName);
+  } catch (err) {
+    console.warn('[new-thread-coordinator] applyPendingWorktree failed', { chatId, err });
+    mfToast.error(`Couldn't create worktree "${branchName}"`, {
+      description: 'The session continues in the main repository.',
+      chatId,
+    });
   }
 }
 
@@ -80,8 +103,10 @@ export function createForLocal(localId: string, port: number): Promise<{ remoteI
     ...(cfg.branchName !== undefined ? { branchName: cfg.branchName } : {}),
   })
     .then(async (chat: Chat) => {
-      // Carry the draft fields createChat can't take (planMode/effort/features)
-      // onto the new chat BEFORE the first send spawns the CLI.
+      // Carry the draft fields createChat can't take (a pending new worktree,
+      // planMode/effort/features) onto the new chat BEFORE the first send
+      // spawns the CLI.
+      await applyPendingWorktree(port, chat.id, cfg);
       await applyDraftTuning(port, chat.id, cfg);
       // Created — the draft is consumed and the cache entry can be evicted so a
       // future recycled localId starts fresh. The reactive ready flag is cleared

--- a/packages/ui/src/features/sessions/use-active-draft-config.ts
+++ b/packages/ui/src/features/sessions/use-active-draft-config.ts
@@ -1,0 +1,19 @@
+/**
+ * useActiveDraftConfig — the active thread's draft config, but ONLY while it is
+ * a `__LOCALID_*` draft with no session custom yet (pre-first-send).
+ *
+ * The single gate for "should this surface read the draft instead of aui
+ * custom" — shared by useActiveIdentity and the toolbar BranchPopover so the
+ * draft/live decision can't drift between consumers. Once any custom resolves
+ * (the thread is a real session), the draft is never consulted.
+ */
+import { useAuiState } from '@assistant-ui/react';
+import { activeSessionCustom } from './view-model/chat-to-thread-custom';
+import { useDraftConfig, type DraftCfg } from './runtime/draft-config';
+
+export function useActiveDraftConfig(): DraftCfg | undefined {
+  const localId = useAuiState((s) => s.threadListItem?.id ?? null);
+  const hasCustom = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems) != null);
+  const isDraft = !hasCustom && localId != null && localId.startsWith('__LOCALID_');
+  return useDraftConfig(isDraft ? localId : null);
+}

--- a/packages/ui/src/features/sessions/use-active-identity.ts
+++ b/packages/ui/src/features/sessions/use-active-identity.ts
@@ -18,6 +18,7 @@ import { useAuiState } from '@assistant-ui/react';
 import { useProjects } from './use-projects';
 import { activeSessionCustom } from './view-model/chat-to-thread-custom';
 import { useActiveDraftConfig } from './use-active-draft-config';
+import { useDiscardedDraftStore } from './new-thread/discarded-drafts';
 import { resolveActiveScope, bridgeScopeGap, type ScopeCache } from './view-model/draft-identity';
 
 export interface ActiveIdentity {
@@ -46,8 +47,12 @@ export function useActiveIdentity(): ActiveIdentity {
   const localId = useAuiState((s) => s.threadListItem?.id ?? null);
   const draft = useActiveDraftConfig();
 
+  // An explicitly discarded (✕) slot must not be bridged — the user may stay
+  // parked on it, and the gap-bridge alone can't tell that from a first send.
+  const discarded = useDiscardedDraftStore((s) => localId != null && s.ids.has(localId));
+
   const cacheRef = useRef<ScopeCache | null>(null);
-  const bridged = bridgeScopeGap(cacheRef.current, localId, resolveActiveScope(custom, draft));
+  const bridged = bridgeScopeGap(cacheRef.current, localId, resolveActiveScope(custom, draft), discarded);
   useEffect(() => {
     cacheRef.current = bridged.cache;
   });

--- a/packages/ui/src/features/sessions/use-active-identity.ts
+++ b/packages/ui/src/features/sessions/use-active-identity.ts
@@ -4,12 +4,21 @@
  * (via activeSessionCustom) for projectId + branchName, and resolves the project
  * name from the loaded project list. Runs inside the assistant-ui runtime provider.
  *
+ * Draft-aware (todo #223): a `__LOCALID_*` thread has no custom until the first
+ * send creates the daemon chat, so the scope falls back to the seeded draft
+ * config — project-scoped surfaces (file tree, branch chip, skills, launch
+ * scope) resolve while composing. The first-send gap (draft consumed, reload
+ * pending) is bridged so those surfaces don't flicker dark mid-handoff.
+ *
  * Also exposes `worktreePath` and `projectPath` so callers (AppShell) can push
  * the canonical bases into `useActiveBasesStore` for the intent subscriber (F1 fix).
  */
+import { useEffect, useRef } from 'react';
 import { useAuiState } from '@assistant-ui/react';
 import { useProjects } from './use-projects';
 import { activeSessionCustom } from './view-model/chat-to-thread-custom';
+import { useActiveDraftConfig } from './use-active-draft-config';
+import { resolveActiveScope, bridgeScopeGap, type ScopeCache } from './view-model/draft-identity';
 
 export interface ActiveIdentity {
   projectName: string;
@@ -32,15 +41,25 @@ export function useActiveIdentity(): ActiveIdentity {
   // stale on __LOCALID_* threads (returned refs are store-stable, Object.is-safe).
   const custom = useAuiState((s) => activeSessionCustom(s.threadListItem, s.threads.threadItems));
   const chatId = useAuiState((s) => s.threadListItem?.remoteId ?? undefined);
+  const localId = useAuiState((s) => s.threadListItem?.id ?? null);
+  const draft = useActiveDraftConfig();
+
+  const cacheRef = useRef<ScopeCache | null>(null);
+  const bridged = bridgeScopeGap(cacheRef.current, localId, resolveActiveScope(custom, draft));
+  useEffect(() => {
+    cacheRef.current = bridged.cache;
+  });
+  const scope = bridged.scope;
+
   const { projects } = useProjects();
-  const project = custom?.projectId ? projects.find((p) => p.id === custom.projectId) : undefined;
+  const project = scope.projectId ? projects.find((p) => p.id === scope.projectId) : undefined;
   return {
     projectName: project?.name ?? 'Mainframe',
-    branchName: custom?.branchName,
-    projectId: custom?.projectId,
-    adapterId: custom?.adapterId,
+    branchName: scope.branchName,
+    projectId: scope.projectId,
+    adapterId: scope.adapterId,
     chatId,
-    worktreePath: custom?.worktreePath,
+    worktreePath: scope.worktreePath,
     projectPath: project?.path,
   };
 }

--- a/packages/ui/src/features/sessions/use-active-identity.ts
+++ b/packages/ui/src/features/sessions/use-active-identity.ts
@@ -33,6 +33,8 @@ export interface ActiveIdentity {
   worktreePath?: string;
   /** Absolute path to the active project root (for path normalization). */
   projectPath?: string;
+  /** Worktree isolation for the branch chip — true for a pending pre-send choice too. */
+  isWorktree: boolean;
 }
 
 export function useActiveIdentity(): ActiveIdentity {
@@ -61,5 +63,6 @@ export function useActiveIdentity(): ActiveIdentity {
     chatId,
     worktreePath: scope.worktreePath,
     projectPath: project?.path,
+    isWorktree: scope.isWorktree ?? false,
   };
 }

--- a/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
@@ -131,4 +131,21 @@ describe('bridgeScopeGap — first-send gap continuity', () => {
     expect(scope).toEqual({});
     expect(cache).toBeNull();
   });
+
+  it('does NOT serve the cached scope for a slot the user explicitly discarded', () => {
+    // Explicit ✕ discard, user stays parked on the cleared slot (returnThreadId
+    // pointed at the slot itself, or zero sessions to switch to) — the bridge
+    // must not keep the discarded project alive.
+    const cache: ScopeCache = { itemId: '__LOCALID_1', scope: resolved };
+    const { scope, cache: next } = bridgeScopeGap(cache, '__LOCALID_1', {}, true);
+    expect(scope).toEqual({});
+    expect(next).toBeNull();
+  });
+
+  it('still resolves a fresh scope on a previously-discarded slot (marker outlives a re-arm race)', () => {
+    const fresh = { projectId: 'p2', adapterId: 'codex' };
+    const { scope, cache } = bridgeScopeGap(null, '__LOCALID_1', fresh, true);
+    expect(scope).toBe(fresh);
+    expect(cache).toEqual({ itemId: '__LOCALID_1', scope: fresh });
+  });
 });

--- a/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
@@ -36,14 +36,19 @@ function makeDraft(overrides?: Partial<DraftCfg>): DraftCfg {
 }
 
 describe('resolveActiveScope — custom wins wholesale', () => {
-  it('returns all four scope fields from custom when present', () => {
+  it('returns all scope fields from custom when present', () => {
     const custom = makeCustom({ branchName: 'main', worktreePath: '/wt/live' });
     expect(resolveActiveScope(custom, makeDraft())).toEqual({
       projectId: 'proj-live',
       adapterId: 'claude',
       branchName: 'main',
       worktreePath: '/wt/live',
+      isWorktree: true,
     });
+  });
+
+  it('derives isWorktree=false from a custom without a worktree', () => {
+    expect(resolveActiveScope(makeCustom(), undefined).isWorktree).toBe(false);
   });
 
   it('never mixes draft fields into a live custom (undefined custom fields stay undefined)', () => {
@@ -61,17 +66,32 @@ describe('resolveActiveScope — draft fallback for a not-yet-created thread', (
       adapterId: 'codex',
       branchName: undefined,
       worktreePath: undefined,
+      isWorktree: false,
     });
   });
 
-  it('surfaces a pre-send worktree attach (worktreePath + branchName) from the draft', () => {
+  it('surfaces a pre-send worktree attach (worktreePath + branchName + isWorktree) from the draft', () => {
     const scope = resolveActiveScope(undefined, makeDraft({ worktreePath: '/wt/feat', branchName: 'feat/y' }));
     expect(scope.worktreePath).toBe('/wt/feat');
     expect(scope.branchName).toBe('feat/y');
+    expect(scope.isWorktree).toBe(true);
+  });
+
+  it('surfaces a pending NEW worktree as the draft branch, without fabricating a path', () => {
+    // The worktree does not exist until first send — the chip shows the chosen
+    // branch (intent, matching the attach case) but no path-scoped surface
+    // (file tree, launch scope) may point at a directory that isn't there yet.
+    const scope = resolveActiveScope(
+      undefined,
+      makeDraft({ pendingWorktree: { baseBranch: 'main', branchName: 'feat/pending' } }),
+    );
+    expect(scope.branchName).toBe('feat/pending');
+    expect(scope.isWorktree).toBe(true);
+    expect(scope.worktreePath).toBeUndefined();
   });
 
   it('returns an empty scope when neither custom nor draft exists', () => {
-    expect(resolveActiveScope(undefined, undefined)).toEqual({});
+    expect(resolveActiveScope(undefined, undefined)).toEqual({ isWorktree: false });
   });
 });
 

--- a/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/draft-identity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * draft-identity — pure derivation for the draft-aware active identity.
+ *
+ * A new (`__LOCALID_*`) thread has no aui `custom` until the first send creates
+ * the daemon chat, so every custom-derived surface (file tree, branch chip,
+ * skills, launch scope) went dark while composing (todo #223). These tests pin
+ * the resolution order: the freshest session custom wins wholesale; a draft
+ * config fills in ONLY when no custom exists; and the first-send gap (draft
+ * consumed, reload not yet landed) is bridged by the last resolved scope for
+ * the SAME thread item.
+ */
+import { describe, it, expect } from 'vitest';
+import type { SessionCustom } from '../chat-to-thread-custom';
+import type { DraftCfg } from '../../runtime/draft-config';
+import { resolveActiveScope, bridgeScopeGap, type ScopeCache } from '../draft-identity';
+
+function makeCustom(overrides?: Partial<SessionCustom>): SessionCustom {
+  return {
+    projectId: 'proj-live',
+    adapterId: 'claude',
+    tags: [],
+    pinned: false,
+    status: 'active',
+    displayStatus: 'idle',
+    hasPending: false,
+    detectedPrs: [],
+    worktreeMissing: false,
+    transcriptMissing: false,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeDraft(overrides?: Partial<DraftCfg>): DraftCfg {
+  return { projectId: 'proj-draft', adapterId: 'codex', ...overrides };
+}
+
+describe('resolveActiveScope — custom wins wholesale', () => {
+  it('returns all four scope fields from custom when present', () => {
+    const custom = makeCustom({ branchName: 'main', worktreePath: '/wt/live' });
+    expect(resolveActiveScope(custom, makeDraft())).toEqual({
+      projectId: 'proj-live',
+      adapterId: 'claude',
+      branchName: 'main',
+      worktreePath: '/wt/live',
+    });
+  });
+
+  it('never mixes draft fields into a live custom (undefined custom fields stay undefined)', () => {
+    const custom = makeCustom(); // no branchName / worktreePath
+    const scope = resolveActiveScope(custom, makeDraft({ branchName: 'feat/x', worktreePath: '/wt/draft' }));
+    expect(scope.branchName).toBeUndefined();
+    expect(scope.worktreePath).toBeUndefined();
+  });
+});
+
+describe('resolveActiveScope — draft fallback for a not-yet-created thread', () => {
+  it('resolves projectId + adapterId from the draft when no custom exists', () => {
+    expect(resolveActiveScope(undefined, makeDraft())).toEqual({
+      projectId: 'proj-draft',
+      adapterId: 'codex',
+      branchName: undefined,
+      worktreePath: undefined,
+    });
+  });
+
+  it('surfaces a pre-send worktree attach (worktreePath + branchName) from the draft', () => {
+    const scope = resolveActiveScope(undefined, makeDraft({ worktreePath: '/wt/feat', branchName: 'feat/y' }));
+    expect(scope.worktreePath).toBe('/wt/feat');
+    expect(scope.branchName).toBe('feat/y');
+  });
+
+  it('returns an empty scope when neither custom nor draft exists', () => {
+    expect(resolveActiveScope(undefined, undefined)).toEqual({});
+  });
+});
+
+describe('bridgeScopeGap — first-send gap continuity', () => {
+  const resolved = { projectId: 'p1', adapterId: 'claude' };
+
+  it('passes a resolved scope through and caches it for the item', () => {
+    const { scope, cache } = bridgeScopeGap(null, '__LOCALID_1', resolved);
+    expect(scope).toBe(resolved);
+    expect(cache).toEqual({ itemId: '__LOCALID_1', scope: resolved });
+  });
+
+  it('returns the cached scope while the SAME item momentarily has none (draft consumed, reload pending)', () => {
+    const cache: ScopeCache = { itemId: '__LOCALID_1', scope: resolved };
+    const { scope, cache: next } = bridgeScopeGap(cache, '__LOCALID_1', {});
+    expect(scope).toBe(resolved);
+    expect(next).toBe(cache);
+  });
+
+  it('does NOT leak the cached scope to a DIFFERENT item id', () => {
+    const cache: ScopeCache = { itemId: '__LOCALID_1', scope: resolved };
+    const { scope, cache: next } = bridgeScopeGap(cache, '__LOCALID_2', {});
+    expect(scope).toEqual({});
+    expect(next).toBeNull();
+  });
+
+  it('replaces the cache when the same item resolves a NEW scope', () => {
+    const cache: ScopeCache = { itemId: '__LOCALID_1', scope: resolved };
+    const fresh = { projectId: 'p2', adapterId: 'codex' };
+    const { scope, cache: next } = bridgeScopeGap(cache, '__LOCALID_1', fresh);
+    expect(scope).toBe(fresh);
+    expect(next).toEqual({ itemId: '__LOCALID_1', scope: fresh });
+  });
+
+  it('returns the raw empty scope with no cache when there is no active item', () => {
+    const { scope, cache } = bridgeScopeGap({ itemId: '__LOCALID_1', scope: resolved }, null, {});
+    expect(scope).toEqual({});
+    expect(cache).toBeNull();
+  });
+});

--- a/packages/ui/src/features/sessions/view-model/draft-identity.ts
+++ b/packages/ui/src/features/sessions/view-model/draft-identity.ts
@@ -69,16 +69,23 @@ export interface ScopeCache {
  * for the SAME item keeps the file tree / chip / run scope lit through the
  * handoff. A different item never inherits the cache (a fresh draft slot or a
  * real thread must resolve on its own).
+ *
+ * `discarded` (isDraftDiscarded for the slot) disambiguates the bridge from an
+ * explicit ✕ discard: the user can stay parked on the cleared slot (the discard
+ * return target was the slot itself, or there were zero sessions to switch to),
+ * which is indistinguishable from the first-send gap by state alone. A
+ * discarded slot gets the raw empty scope, never the cache.
  */
 export function bridgeScopeGap(
   cache: ScopeCache | null,
   itemId: string | null,
   raw: ActiveScope,
+  discarded = false,
 ): { scope: ActiveScope; cache: ScopeCache | null } {
   if (itemId != null && raw.projectId != null) {
     return { scope: raw, cache: { itemId, scope: raw } };
   }
-  if (itemId != null && cache != null && cache.itemId === itemId) {
+  if (itemId != null && cache != null && cache.itemId === itemId && !discarded) {
     return { scope: cache.scope, cache };
   }
   return { scope: raw, cache: null };

--- a/packages/ui/src/features/sessions/view-model/draft-identity.ts
+++ b/packages/ui/src/features/sessions/view-model/draft-identity.ts
@@ -1,0 +1,76 @@
+/**
+ * Draft-aware active-scope derivation (todo #223).
+ *
+ * A new (`__LOCALID_*`) thread has no aui `custom` until the first send creates
+ * the daemon chat, so every custom-derived surface (file tree, branch chip,
+ * skills, launch scope) went dark while composing — even though the new-session
+ * entry points had already seeded the draft config with the project. These pure
+ * helpers resolve the active scope from the freshest custom OR that draft, and
+ * bridge the first-send gap (draft consumed by the coordinator, threads.reload
+ * not yet landed) so surfaces don't flicker dark mid-handoff.
+ *
+ * Pure and aui-free (type-only imports), matching the rest of the view-model.
+ */
+import type { SessionCustom } from './chat-to-thread-custom';
+import type { DraftCfg } from '../runtime/draft-config';
+
+/** The custom-derived fields project-scoped surfaces key off. */
+export interface ActiveScope {
+  projectId?: string;
+  adapterId?: string;
+  branchName?: string;
+  worktreePath?: string;
+}
+
+/**
+ * Resolve the active scope: a live session's custom wins wholesale (never mix a
+ * draft into it — the draft belongs to a different, not-yet-created thread
+ * state); the draft fills in only when no custom exists.
+ */
+export function resolveActiveScope(custom: SessionCustom | undefined, draft: DraftCfg | undefined): ActiveScope {
+  if (custom) {
+    return {
+      projectId: custom.projectId,
+      adapterId: custom.adapterId,
+      branchName: custom.branchName,
+      worktreePath: custom.worktreePath,
+    };
+  }
+  if (draft) {
+    return {
+      projectId: draft.projectId,
+      adapterId: draft.adapterId,
+      branchName: draft.branchName,
+      worktreePath: draft.worktreePath,
+    };
+  }
+  return {};
+}
+
+/** Last resolved scope, keyed by the thread item it was resolved for. */
+export interface ScopeCache {
+  itemId: string;
+  scope: ActiveScope;
+}
+
+/**
+ * First-send gap continuity: on send, the coordinator clears the draft config
+ * BEFORE the `chat.created` reload lands the remoteId-keyed custom, so the same
+ * `__LOCALID_*` item briefly resolves an empty scope. Returning the cached scope
+ * for the SAME item keeps the file tree / chip / run scope lit through the
+ * handoff. A different item never inherits the cache (a fresh draft slot or a
+ * real thread must resolve on its own).
+ */
+export function bridgeScopeGap(
+  cache: ScopeCache | null,
+  itemId: string | null,
+  raw: ActiveScope,
+): { scope: ActiveScope; cache: ScopeCache | null } {
+  if (itemId != null && raw.projectId != null) {
+    return { scope: raw, cache: { itemId, scope: raw } };
+  }
+  if (itemId != null && cache != null && cache.itemId === itemId) {
+    return { scope: cache.scope, cache };
+  }
+  return { scope: raw, cache: null };
+}

--- a/packages/ui/src/features/sessions/view-model/draft-identity.ts
+++ b/packages/ui/src/features/sessions/view-model/draft-identity.ts
@@ -20,12 +20,19 @@ export interface ActiveScope {
   adapterId?: string;
   branchName?: string;
   worktreePath?: string;
+  /** Worktree isolation for the branch chip — includes a pending pre-send choice. */
+  isWorktree?: boolean;
 }
 
 /**
  * Resolve the active scope: a live session's custom wins wholesale (never mix a
  * draft into it — the draft belongs to a different, not-yet-created thread
  * state); the draft fills in only when no custom exists.
+ *
+ * A draft's pending NEW worktree resolves its branch + isWorktree (the chip
+ * shows the chosen isolation, matching the attach case) but never a
+ * worktreePath — the directory doesn't exist until first send, so path-scoped
+ * surfaces (file tree, launch scope) must keep reading the project root.
  */
 export function resolveActiveScope(custom: SessionCustom | undefined, draft: DraftCfg | undefined): ActiveScope {
   if (custom) {
@@ -34,17 +41,19 @@ export function resolveActiveScope(custom: SessionCustom | undefined, draft: Dra
       adapterId: custom.adapterId,
       branchName: custom.branchName,
       worktreePath: custom.worktreePath,
+      isWorktree: custom.worktreePath != null,
     };
   }
   if (draft) {
     return {
       projectId: draft.projectId,
       adapterId: draft.adapterId,
-      branchName: draft.branchName,
+      branchName: draft.branchName ?? draft.pendingWorktree?.branchName,
       worktreePath: draft.worktreePath,
+      isWorktree: draft.worktreePath != null || draft.pendingWorktree != null,
     };
   }
-  return {};
+  return { isWorktree: false };
 }
 
 /** Last resolved scope, keyed by the thread item it was resolved for. */

--- a/packages/ui/src/layout/MainToolbar.tsx
+++ b/packages/ui/src/layout/MainToolbar.tsx
@@ -48,6 +48,29 @@ function chipClass(open: boolean, isWorktree: boolean): string {
   return cn('border-transparent text-muted-foreground', open ? 'bg-accent' : 'hover:bg-accent');
 }
 
+/** Shared chip innards — the interactive trigger and the disabled stub render identically. */
+function BranchChipContent({ branch, isWorktree }: { branch: string; isWorktree: boolean }) {
+  return (
+    <>
+      {isWorktree ? (
+        <GitFork size={11} className="flex-shrink-0 text-primary" />
+      ) : (
+        <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
+      )}
+      <span className="truncate">{branch}</span>
+      {isWorktree && (
+        <span
+          data-testid="main-toolbar-branch-wt"
+          className="ml-[1px] inline-flex h-[14px] flex-shrink-0 items-center rounded-[4px] bg-primary/12 px-[5px] text-micro font-semibold uppercase tracking-wide text-primary"
+        >
+          wt
+        </span>
+      )}
+      <ChevronDown size={8} className="flex-shrink-0 text-mf-text-4" />
+    </>
+  );
+}
+
 /**
  * Shell-level surface-area toolbar (above SurfaceHost): project · branch identity
  * on the left, workspace controls on the right. Wired: the in-flow show-sidebar
@@ -107,7 +130,10 @@ export function MainToolbar({
   // A worktree DRAFT (no chatId yet — the chat is created on first send) can't
   // resolve its branch live: without a chatId the fetch reads the project ROOT.
   // Trust the draft's own branch name there; every other state prefers live.
-  const displayBranch = isWorktree && !chatId ? (branchName ?? liveBranch) : (liveBranch ?? branchName);
+  // The popover stays off too — useBranchActions without a chatId would mutate
+  // the ROOT repo while the chip advertises worktree isolation.
+  const isDraftWorktree = isWorktree && !chatId;
+  const displayBranch = isDraftWorktree ? (branchName ?? liveBranch) : (liveBranch ?? branchName);
 
   return (
     <div
@@ -132,7 +158,7 @@ export function MainToolbar({
           {displayBranch && (
             <>
               <span className="font-normal text-mf-text-4">|</span>
-              {displayBranch && projectId ? (
+              {displayBranch && projectId && !isDraftWorktree ? (
                 <BranchPopover
                   port={port}
                   projectId={projectId}
@@ -154,35 +180,29 @@ export function MainToolbar({
                     onClick={() => setBranchOpen((o) => !o)}
                     className={cn(CHIP_BASE, 'cursor-pointer', chipClass(branchOpen, isWorktree))}
                   >
-                    {isWorktree ? (
-                      <GitFork size={11} className="flex-shrink-0 text-primary" />
-                    ) : (
-                      <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
-                    )}
-                    <span className="truncate">{displayBranch}</span>
-                    {isWorktree && (
-                      <span
-                        data-testid="main-toolbar-branch-wt"
-                        className="ml-[1px] inline-flex h-[14px] flex-shrink-0 items-center rounded-[4px] bg-primary/12 px-[5px] text-micro font-semibold uppercase tracking-wide text-primary"
-                      >
-                        wt
-                      </span>
-                    )}
-                    <ChevronDown size={8} className="flex-shrink-0 text-mf-text-4" />
+                    <BranchChipContent branch={displayBranch} isWorktree={isWorktree} />
                   </button>
                 </BranchPopover>
               ) : (
-                <Hint label="Switch branch — coming with its surface">
+                <Hint
+                  label={
+                    isDraftWorktree
+                      ? 'Branch actions unlock on first message'
+                      : 'Switch branch — coming with its surface'
+                  }
+                >
                   <button
                     data-testid="main-toolbar-branch"
                     data-worktree={isWorktree ? 'true' : 'false'}
                     type="button"
                     disabled
-                    className={cn(CHIP_BASE, 'cursor-not-allowed text-muted-foreground opacity-80')}
+                    className={cn(
+                      CHIP_BASE,
+                      'cursor-not-allowed opacity-80',
+                      isWorktree ? 'border-primary/25 bg-primary/8 text-foreground' : 'text-muted-foreground',
+                    )}
                   >
-                    <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
-                    <span className="truncate">{displayBranch}</span>
-                    <ChevronDown size={8} className="flex-shrink-0 text-mf-text-4" />
+                    <BranchChipContent branch={displayBranch} isWorktree={isWorktree} />
                   </button>
                 </Hint>
               )}

--- a/packages/ui/src/layout/MainToolbar.tsx
+++ b/packages/ui/src/layout/MainToolbar.tsx
@@ -104,7 +104,10 @@ export function MainToolbar({
         console.warn('[MainToolbar] failed to refresh branch after popover write', err);
       });
   }, [port, projectId, chatId]);
-  const displayBranch = liveBranch ?? branchName;
+  // A worktree DRAFT (no chatId yet — the chat is created on first send) can't
+  // resolve its branch live: without a chatId the fetch reads the project ROOT.
+  // Trust the draft's own branch name there; every other state prefers live.
+  const displayBranch = isWorktree && !chatId ? (branchName ?? liveBranch) : (liveBranch ?? branchName);
 
   return (
     <div

--- a/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
+++ b/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
@@ -145,6 +145,33 @@ describe('MainToolbar — branch chip', () => {
     expect(chip.getAttribute('data-worktree')).toBe('true');
   });
 
+  it('disables the chip (no popover) for a pre-send worktree draft', async () => {
+    // Without a chatId, branch actions would run against the project ROOT while
+    // the chip advertises worktree isolation — the popover must stay off until
+    // the first send stamps the chatId.
+    mockGetGitBranch.mockResolvedValue({ branch: 'main' });
+
+    render(
+      <MainToolbar
+        leadingInset={0}
+        sidebarRendered={true}
+        onExpandSidebar={vi.fn()}
+        projectName="mainframe"
+        branchName="feat/wt-draft"
+        isWorktree
+        projectId="p1"
+        windowStyle="glass"
+        port={31415}
+      />,
+    );
+
+    const chip = await screen.findByTestId('main-toolbar-branch');
+    expect(chip).toBeDisabled();
+    expect(screen.queryByTestId('mock-branch-changed')).toBeNull();
+    // The pending worktree choice stays visible on the disabled chip.
+    expect(screen.getByTestId('main-toolbar-branch-wt').textContent?.trim()).toBe('wt');
+  });
+
   it('renders a disabled stub chip when a branch is persisted but no projectId is available', () => {
     render(
       <MainToolbar

--- a/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
+++ b/packages/ui/src/layout/__tests__/MainToolbar.test.tsx
@@ -120,6 +120,31 @@ describe('MainToolbar — branch chip', () => {
     expect(screen.getByTestId('main-toolbar-branch-wt').textContent?.trim()).toBe('wt');
   });
 
+  it('prefers the draft worktree branch over the live project-root branch when there is no chatId yet', async () => {
+    // A draft attached to a worktree has no daemon chat yet, so the live fetch
+    // can only see the project ROOT branch — the chip must show the worktree's.
+    mockGetGitBranch.mockResolvedValue({ branch: 'main' });
+
+    render(
+      <MainToolbar
+        leadingInset={0}
+        sidebarRendered={true}
+        onExpandSidebar={vi.fn()}
+        projectName="mainframe"
+        branchName="feat/wt-draft"
+        isWorktree
+        projectId="p1"
+        windowStyle="glass"
+        port={31415}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetGitBranch).toHaveBeenCalled());
+    const chip = await screen.findByTestId('main-toolbar-branch');
+    expect(chip.textContent).toContain('feat/wt-draft');
+    expect(chip.getAttribute('data-worktree')).toBe('true');
+  });
+
   it('renders a disabled stub chip when a branch is persisted but no projectId is available', () => {
     render(
       <MainToolbar


### PR DESCRIPTION
## Summary

Fixes todo #223 — New session: no branch selection, no current-branch indicator, no file tree

A new-session draft has no daemon chat yet, so every surface that derives from the active chat — the titlebar branch chip, the composer worktree popover, the file tree, skills, and launch scope — fell back to the project root while you were composing, hiding the branch and worktree you had already picked. This branch resolves the active identity from the seeded draft config so those surfaces reflect the choice pre-send, and carries the pending worktree choice through to chat creation on first send:

- Active identity falls back to the draft config the new-session entry points already seed; the first-send gap (draft consumed before `threads.reload` lands) is bridged by the last resolved scope for the same thread item, so surfaces don't flicker dark mid-handoff. An explicit ✕ discard drops the bridged identity, so a cleared slot returns to the empty scope instead of keeping the discarded project's scope.
- The composer `WorktreePopover` on a `__LOCALID_*` draft stashes the choice in the draft config instead of calling chat-scoped endpoints with the placeholder id. An existing-worktree attach rides the `createChat` payload; a new worktree is recorded as `pendingWorktree` and created by the coordinator right after `createChat`, before the first send spawns the CLI. A draft panel shows the stashed choice with a cancel action.
- `MainToolbar`'s live branch fetch prefers the draft's own branch name (a worktree draft has no chatId, so the fetch can only see the project root), and `BranchPopover`'s adapter falls back to the draft's adapter instead of hardcoded `claude`.
- The titlebar chip derives `isWorktree` in one place and resolves the pending choice's branch name without fabricating a `worktreePath` — the directory doesn't exist until first send, so path-scoped surfaces (file tree, launch scope) correctly keep the project root until then. The interactive chip is rendered disabled for a pre-send worktree draft (no chatId yet) so its checkout/merge/rebase actions can't mutate the project root while the chip advertises worktree isolation.
- `BranchPopover` had grown past the 300-line cap; its new-session action (adapter resolution + create-worktree-session) was extracted into `useNewSessionAction`, with tests pinning the resolution order.

## Root cause

A `__LOCALID_*` draft has no `chatId` and no assistant-ui custom until the first send creates the daemon chat. Two consequences:

1. Every custom-derived UI surface read the daemon chat that didn't exist yet and fell back to the project root, so a draft with a chosen worktree showed the wrong (root) branch and no file tree while composing.
2. The composer worktree popover called the chat-scoped enable/attach endpoints with the `__LOCALID_*` placeholder id, which the daemon rejects with a 404. A stashed NEW worktree also lit the composer trigger but not the titlebar chip, so two surfaces disagreed about the same draft.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — pass (tsc --noEmit, no errors)
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>` for each changed test file — all pass (98 tests):
  - `features/chat/composer/config-toolbar/__tests__/WorktreePopover.test.tsx` — 22 passed
  - `features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts` — 12 passed
  - `features/git/__tests__/use-new-session-action.test.ts` — 4 passed
  - `features/sessions/__tests__/use-active-identity.test.tsx` — 8 passed
  - `features/sessions/runtime/__tests__/new-thread-coordinator.test.ts` — 18 passed
  - `features/sessions/view-model/__tests__/draft-identity.test.ts` — 14 passed
  - `layout/__tests__/MainToolbar.test.tsx` — 20 passed
- Secret scan over `git diff origin/main...HEAD` — no matches

## Needs live verification

The titlebar-chip path was live-verified in the browser target during development (stash a New worktree on a draft → chip shows branch + WT badge pre-send; first send stays consistent). Before this leaves draft, exercise against a running daemon: (1) the first-send round-trip — coordinator creating the `pendingWorktree` after `createChat` and before the CLI spawns, and an existing worktree attaching via the `createChat` payload; (2) a ✕ discard on a parked draft returning the titlebar/file tree/launch scope to the empty scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
