### PR TITLE
fix(tasks): refetch todos when the Tasks modal opens

### DIFF
--- a/.changeset/todos-modal-refresh.md
+++ b/.changeset/todos-modal-refresh.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Refetch todos when the Tasks modal or quick-add opens so it shows current data instead of boot-time statuses.

--- a/packages/ui/src/features/tasks/TasksBoard.tsx
+++ b/packages/ui/src/features/tasks/TasksBoard.tsx
@@ -142,8 +142,9 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
         todos={todos}
       />
 
-      {/* Body */}
-      {loading ? (
+      {/* Body — only blank to the loading state on the first load; a refetch
+          (e.g. reopening the modal) keeps the previous list rendered. */}
+      {loading && todos.length === 0 ? (
         <div
           data-testid="tasks-board-loading"
           className="flex-1 flex items-center justify-center text-caption text-muted-foreground"

--- a/packages/ui/src/features/tasks/TasksModalHost.tsx
+++ b/packages/ui/src/features/tasks/TasksModalHost.tsx
@@ -4,11 +4,12 @@
  *
  * Resolves projectId from useActiveIdentity(). Registers ⌘⇧T → openQuick().
  * Listens for `mf:open-tasks` custom event (dispatched by SidebarHeader TasksBtn).
- * Triggers a load() on mount so the modal shows correct data even when the
- * inspector drawer is hidden.
+ * Loads on mount (so the inspector drawer has data) and refetches on the
+ * open/quick-add rising edge (so externally-made changes are reflected — the
+ * todos store has no WS event).
  * Mounted once in AppShell's outlet block.
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { useActiveIdentity } from '@/features/sessions/use-active-identity';
@@ -27,6 +28,8 @@ export function TasksModalHost({ port }: Props): React.ReactElement | null {
   const { projectId } = useActiveIdentity();
   const startSession = useStartTodoSession(port, projectId);
   const { load, view } = useTodosStore();
+  const prevOpen = useRef(false);
+  const prevQuick = useRef(false);
 
   // Eagerly load todos so modal and quick-add show correct data even when
   // the inspector drawer is hidden.
@@ -34,6 +37,19 @@ export function TasksModalHost({ port }: Props): React.ReactElement | null {
     if (!projectId || !port) return;
     void load(port, projectId);
   }, [port, projectId, load]);
+
+  // Refetch on the open/quickOpen rising edge. The store has no WS event
+  // (single-window refetch-on-mutation), so a change made outside this window
+  // — agent sessions, another window, direct DB writes — would otherwise leave
+  // the modal showing boot-time statuses. The store's _loadSeq guard keeps
+  // concurrent loads safe; todos are not cleared, so the list stays rendered.
+  useEffect(() => {
+    if (!projectId || !port) return;
+    const justOpened = (open && !prevOpen.current) || (quickOpen && !prevQuick.current);
+    prevOpen.current = open;
+    prevQuick.current = quickOpen;
+    if (justOpened) void load(port, projectId);
+  }, [open, quickOpen, projectId, port, load]);
 
   // ⌘⇧T → open quick-add dialog
   useEffect(() => {

--- a/packages/ui/src/features/tasks/__tests__/TasksBoard.test.tsx
+++ b/packages/ui/src/features/tasks/__tests__/TasksBoard.test.tsx
@@ -20,11 +20,13 @@ import userEvent from '@testing-library/user-event';
 const mockSetView = vi.fn();
 const mockSetSort = vi.fn();
 const mockSetFilters = vi.fn();
+let mockTodos: import('@/lib/api/todos').Todo[] = [];
+let mockLoading = false;
 
 vi.mock('../use-todos-store', () => ({
   useTodosStore: vi.fn(() => ({
-    todos: [],
-    loading: false,
+    todos: mockTodos,
+    loading: mockLoading,
     filters: { types: [], priorities: [], labels: [], search: '' },
     sort: { key: 'priority', dir: 'asc' },
     view: 'list',
@@ -49,6 +51,30 @@ vi.mock('../TaskBoardView', () => ({
 // ---------------------------------------------------------------------------
 
 import { TasksBoard } from '../TasksBoard';
+import type { Todo } from '@/lib/api/todos';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTodo(overrides: Partial<Todo> & { id: string; number: number }): Todo {
+  return {
+    project_id: 'proj-1',
+    title: 'Default title',
+    body: '',
+    status: 'open',
+    type: 'feature',
+    priority: 'medium',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    dependencies: [],
+    order_index: 0,
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Render helper
@@ -61,6 +87,8 @@ function renderBoard(onClose = vi.fn()) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockTodos = [];
+  mockLoading = false;
 });
 
 describe('TasksBoard — root testid', () => {
@@ -98,6 +126,24 @@ describe('TasksBoard — segmented view switch + new button still render', () =>
     expect(screen.getByTestId('tasks-view-list')).toBeTruthy();
     expect(screen.getByTestId('tasks-view-board')).toBeTruthy();
     expect(screen.getByTestId('tasks-board-new')).toBeTruthy();
+  });
+});
+
+describe('TasksBoard — loading does not blank the board on refetch (todo #225)', () => {
+  it('shows the loading placeholder only on the first load (no todos yet)', () => {
+    mockLoading = true;
+    mockTodos = [];
+    renderBoard();
+    expect(screen.getByTestId('tasks-board-loading')).toBeTruthy();
+    expect(screen.queryByTestId('task-list-view-stub')).toBeNull();
+  });
+
+  it('keeps the previous list rendered while a refetch is in flight (todos present)', () => {
+    mockLoading = true;
+    mockTodos = [makeTodo({ id: 'todo-1', number: 1, status: 'open' })];
+    renderBoard();
+    expect(screen.queryByTestId('tasks-board-loading')).toBeNull();
+    expect(screen.getByTestId('task-list-view-stub')).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/features/tasks/__tests__/TasksModalHost.test.tsx
+++ b/packages/ui/src/features/tasks/__tests__/TasksModalHost.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * TasksModalHost.test.tsx
+ *
+ * Regression coverage for todo #225: the Tasks modal showed boot-time todos
+ * forever because opening it never refetched. These tests exercise the real
+ * useTodosStore + useTasksModal against a mocked lib/api/todos, so a fresh
+ * listTodos call on open (and quick-add open) is observable end-to-end.
+ *
+ * Behaviors covered:
+ *  1.  Opening the full modal after an external change refetches (listTodos
+ *      called again) and renders the fresh statuses.
+ *  2.  Opening the quick-add dialog refetches.
+ *  3.  Closing then re-opening the modal refetches each time (rising edge).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mock lib/api/todos BEFORE importing the store-backed component
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/api/todos', () => ({
+  listTodos: vi.fn(),
+  createTodo: vi.fn(),
+  updateTodo: vi.fn(),
+  moveTodo: vi.fn(),
+  deleteTodo: vi.fn(),
+  uploadAttachment: vi.fn(),
+}));
+
+// Identity + session spawn are out of scope here.
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({ projectId: 'proj-1', chatId: null }),
+}));
+vi.mock('../use-start-todo-session', () => ({
+  useStartTodoSession: () => vi.fn(),
+}));
+
+// Heavy list/board views are irrelevant — assert on the board header chip.
+vi.mock('../TaskListView', () => ({
+  TaskListView: () => <div data-testid="task-list-view-stub" />,
+}));
+vi.mock('../TaskBoardView', () => ({
+  TaskBoardView: () => <div data-testid="task-board-view-stub" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks
+// ---------------------------------------------------------------------------
+
+import { TasksModalHost } from '../TasksModalHost';
+import { useTasksModal } from '../use-tasks-modal';
+import { useTodosStore } from '../use-todos-store';
+import * as todosApi from '@/lib/api/todos';
+import type { Todo } from '@/lib/api/todos';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PORT = 31415;
+
+function makeTodo(overrides: Partial<Todo> & { id: string; number: number }): Todo {
+  return {
+    project_id: 'proj-1',
+    title: 'Default title',
+    body: '',
+    status: 'open',
+    type: 'feature',
+    priority: 'medium',
+    labels: [],
+    assignees: [],
+    milestone: null,
+    dependencies: [],
+    order_index: 0,
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const OPEN_TODO = makeTodo({ id: 'todo-1', number: 1, status: 'open' });
+const DONE_TODO = makeTodo({ id: 'todo-1', number: 1, status: 'done' });
+
+// ---------------------------------------------------------------------------
+// Reset stores + mocks between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useTasksModal.setState({ open: false, quickOpen: false });
+    useTodosStore.setState({ todos: [], loading: false, error: null, loadedProjectId: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Opening the modal refetches + renders fresh statuses
+// ---------------------------------------------------------------------------
+
+describe('TasksModalHost — refetch on modal open (todo #225)', () => {
+  it('refetches and renders fresh statuses when the modal opens after an external change', async () => {
+    vi.mocked(todosApi.listTodos)
+      .mockResolvedValueOnce([OPEN_TODO]) // boot load
+      .mockResolvedValueOnce([DONE_TODO]); // external change picked up on open
+
+    render(<TasksModalHost port={PORT} />);
+
+    // Boot load fires once so the inspector drawer has data.
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useTasksModal.getState().openModal();
+    });
+
+    // Opening the modal issues a fresh listTodos call…
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(2));
+    // …and the board reflects the refetched (done) status.
+    expect(await screen.findByText('0 active · 1 done')).toBeTruthy();
+  });
+
+  it('refetches again on every re-open (rising edge, not once)', async () => {
+    vi.mocked(todosApi.listTodos).mockResolvedValue([OPEN_TODO]);
+
+    render(<TasksModalHost port={PORT} />);
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(1));
+
+    act(() => useTasksModal.getState().openModal());
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(2));
+
+    act(() => useTasksModal.getState().closeModal());
+    act(() => useTasksModal.getState().openModal());
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(3));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Opening the quick-add dialog refetches
+// ---------------------------------------------------------------------------
+
+describe('TasksModalHost — refetch on quick-add open', () => {
+  it('refetches when the quick-add dialog opens', async () => {
+    vi.mocked(todosApi.listTodos).mockResolvedValue([OPEN_TODO]);
+
+    render(<TasksModalHost port={PORT} />);
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(1));
+
+    act(() => useTasksModal.getState().openQuick());
+    await waitFor(() => expect(todosApi.listTodos).toHaveBeenCalledTimes(2));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes todo #225 — Tasks modal shows stale todos (no refetch on open).

The Tasks modal and quick-add now refetch the project's todos on the open/quick-add rising edge, so they reflect changes made outside the current window (agent sessions, another window, direct DB writes) instead of boot-time statuses. The board keeps the previous list rendered during a refetch (it only blanks to the loading state on the very first load), so reopening no longer flashes an empty board.

## Root cause

`TasksModalHost` only loaded todos once, in a mount-time effect. The todos store is single-window and refetch-on-mutation — it emits no WebSocket event on external change — so after boot the modal never re-read the store and displayed stale statuses. `TasksBoard` also blanked to its loading state on every refetch, not just the first load.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` → passed (tsc --noEmit, no errors).
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/tasks/__tests__/TasksModalHost.test.tsx src/features/tasks/__tests__/TasksBoard.test.tsx` → 2 files passed, 12 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)