### PR TITLE
fix(ui): dark-theme scrollbars — declare color-scheme and repair mf-thin-scrollbar

### DIFF
--- a/.changeset/scrollbar-dark-theme.md
+++ b/.changeset/scrollbar-dark-theme.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix dark-theme scrollbars: declare color-scheme and repair the mf-thin-scrollbar styling so surfaces no longer paint a white native track.

--- a/packages/ui/src/features/sessions/tags/TagPopover.tsx
+++ b/packages/ui/src/features/sessions/tags/TagPopover.tsx
@@ -211,7 +211,7 @@ export function TagPopover({
               {error}
             </div>
           )}
-          <div className="max-h-56 overflow-y-auto mt-1">
+          <div className="mf-thin-scrollbar max-h-56 overflow-y-auto mt-1">
             {filtered.map((t) =>
               renaming === t.name ? (
                 <Input

--- a/packages/ui/src/layout/SurfacePicker.tsx
+++ b/packages/ui/src/layout/SurfacePicker.tsx
@@ -123,7 +123,7 @@ export function SurfacePicker({ surface }: Props) {
       className="flex flex-1 items-center justify-center bg-background p-[16px]"
     >
       <div className="w-[300px] overflow-hidden rounded-[13px] border-[0.5px] border-border bg-background shadow-[var(--mf-shadow-picker)]">
-        <div className="max-h-[300px] overflow-y-auto p-[4px]">
+        <div className="mf-thin-scrollbar max-h-[300px] overflow-y-auto p-[4px]">
           {surface === 'files' ? <FilesPickerContent /> : <RunPickerContent />}
         </div>
         <div className="[border-top:0.5px_solid_var(--border)] px-3.5 py-[7px] font-mono text-micro text-mf-text-4">

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -21,6 +21,9 @@
    CLASSIC · LIGHT (default) — warm paper, iOS-blue accent
    ──────────────────────────────────────────────────────────────────────── */
 :root {
+  /* Tells the engine to paint native scrollbars/form controls light. */
+  color-scheme: light;
+
   /* ── Radius (shadcn derives sm/md/lg/xl from --radius) ──
      Prototype scale: xs 4 · sm 6 · md 8 · lg 11 · xl 13. Base = md. */
   --radius: 0.5rem; /* 8px */
@@ -210,6 +213,10 @@
    (Redesigned 2026-06-12: was warm charcoal + shared blue.)
    ──────────────────────────────────────────────────────────────────────── */
 .dark {
+  /* Without this WebKit paints native scrollbar chrome (the white track) light
+     on dark surfaces; must flip with the .dark theme toggle. */
+  color-scheme: dark;
+
   --background: #262835;
   --foreground: #f2f2f8;
   --card: #212330;
@@ -1072,7 +1079,9 @@ code {
    Replaces the default browser scrollbar without taking over the native
    autoscroll Viewport (radix ScrollArea via asChild doesn't bind to it). */
 .mf-thin-scrollbar {
-  scrollbar-width: thin;
+  /* Deliberately NO scrollbar-width: thin — modern WebKit/Chromium honor it and
+     thereby DISABLE the ::-webkit-scrollbar rules below, falling back to native
+     (light) chrome. scrollbar-color stays as the Firefox/standards path. */
   scrollbar-color: transparent transparent;
 }
 .mf-thin-scrollbar:hover {


### PR DESCRIPTION
## Summary

Fixes todo #229 — a white native scrollbar track painted on the dark theme, worst on the chat surface. Dark surfaces now render the designed thin, transparent-track scrollbars.

## Root cause

- **Missing `color-scheme`.** The dark theme toggled `.dark` but never declared `color-scheme`, so WebKit painted native scrollbar (and form-control) chrome light on dark surfaces — the full-height white track. Declaring `color-scheme: light` on `:root` and `color-scheme: dark` on `.dark` flips it with the theme.
- **`scrollbar-width: thin` self-sabotage.** `.mf-thin-scrollbar` set `scrollbar-width: thin`; modern WebKit/Chromium honor that property and thereby DISABLE the class's own `::-webkit-scrollbar` rules, falling back to the native (light) chrome. Dropping it re-activates the designed transparent-track / hover-reveal-thumb styling (`scrollbar-color` stays for the Firefox/standards path).
- Two scrollers (SurfacePicker, TagPopover) had no scrollbar styling at all and inherited the native light bar — both now use the shared `mf-thin-scrollbar`.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/tags/__tests__/TagPopover.test.tsx src/layout/__tests__/SurfacePicker.test.tsx` — 28 passed
- Before/after dark-theme screenshots were captured during implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)