### PR TITLE
fix(ui,app-tauri): open chat-transcript links in the external browser

### DIFF
--- a/.changeset/chat-external-links.md
+++ b/.changeset/chat-external-links.md
@@ -1,0 +1,6 @@
+---
+"@qlan-ro/mainframe-app-tauri": patch
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix chat-transcript links doing nothing in the Tauri shell. The `opener:allow-open-url` capability was a bare permission string, which enables the command but grants no URL scope, so tauri-plugin-opener rejected every click. Scope it to http/https/mailto/tel plus the app schemes the markdown renderer linkifies (slack, vscode, cursor, zed, figma, linear, notion, …), and add a release-safety test that fails if the scope regresses to the bare string.

--- a/packages/app-tauri/src-tauri/capabilities/main.json
+++ b/packages/app-tauri/src-tauri/capabilities/main.json
@@ -7,7 +7,26 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "opener:allow-open-url",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "http://*" },
+        { "url": "https://*" },
+        { "url": "mailto:*" },
+        { "url": "tel:*" },
+        { "url": "slack://*" },
+        { "url": "vscode://*" },
+        { "url": "vscode-insiders://*" },
+        { "url": "cursor://*" },
+        { "url": "jetbrains://*" },
+        { "url": "idea://*" },
+        { "url": "zed://*" },
+        { "url": "figma://*" },
+        { "url": "linear://*" },
+        { "url": "notion://*" },
+        { "url": "discord://*" }
+      ]
+    },
     "notification:allow-notify",
     "notification:allow-is-permission-granted",
     "updater:default",

--- a/packages/ui/src/__tests__/tauri-config.test.ts
+++ b/packages/ui/src/__tests__/tauri-config.test.ts
@@ -18,6 +18,9 @@ import viteConfig from '../../vite.config';
 
 const BASE_CONFIG_PATH = path.resolve(__dirname, '../../../app-tauri/src-tauri/tauri.conf.json');
 const DEV_OVERLAY_PATH = path.resolve(__dirname, '../../../app-tauri/src-tauri/tauri.dev.conf.json');
+const MAIN_CAPABILITY_PATH = path.resolve(__dirname, '../../../app-tauri/src-tauri/capabilities/main.json');
+
+type PermissionEntry = string | { identifier: string; allow?: Array<{ url?: string }> };
 
 describe('tauri config release safety', () => {
   it('base config does not inject window.__TAURI__ (withGlobalTauri is false)', () => {
@@ -50,5 +53,36 @@ describe('tauri config release safety', () => {
   it('uses a Vite target supported by the current desktop build toolchain', () => {
     const config = typeof viteConfig === 'function' ? viteConfig({ mode: 'production', command: 'build' }) : viteConfig;
     expect(config.build?.target).toBe('es2020');
+  });
+});
+
+describe('opener capability scope (transcript external links)', () => {
+  // `opener:allow-open-url` as a bare string enables the command with NO scope,
+  // so tauri-plugin-opener rejects every URL ("Not allowed to open url …") and
+  // clicking a transcript link silently does nothing. The permission MUST carry
+  // an `allow` URL scope. Keep the scheme list in sync with EXTRA_SAFE_PROTOCOLS
+  // in features/chat/parts/markdown-url-transform.ts.
+  function openUrlScope(): string[] {
+    const raw = readFileSync(MAIN_CAPABILITY_PATH, 'utf8');
+    const cap = JSON.parse(raw) as { permissions: PermissionEntry[] };
+    const entry = cap.permissions.find(
+      (p): p is { identifier: string; allow?: Array<{ url?: string }> } =>
+        typeof p === 'object' && p.identifier === 'opener:allow-open-url',
+    );
+    expect(entry, 'opener:allow-open-url must be a scoped object, not a bare string').toBeDefined();
+    return (entry!.allow ?? []).map((s) => s.url).filter((u): u is string => typeof u === 'string');
+  }
+
+  it('grants an http/https URL scope so external links open in the system browser', () => {
+    const urls = openUrlScope();
+    expect(urls).toContain('http://*');
+    expect(urls).toContain('https://*');
+  });
+
+  it('grants the app-protocol schemes that the markdown renderer linkifies', () => {
+    const urls = openUrlScope();
+    for (const scheme of ['slack', 'vscode', 'cursor', 'zed', 'figma', 'linear', 'notion']) {
+      expect(urls).toContain(`${scheme}://*`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes todo #230. Clicking a URL in the chat transcript did nothing in the Tauri shell — links now open in the system default browser. The report also asked to audit the right-click context menu on transcript links, since the user was unsure any of its actions worked in the Tauri shell.

Context-menu / link-action audit (verified live in the Tauri dev shell):

| Action | Path | Verdict |
|--------|------|---------|
| Left-click a link | `openExternal` → `open_url` | **Was broken, now fixed** |
| Context menu → Open link (`chat-link-open`) | same `open_url` path | **Was broken, now fixed** (shared the same rejected command) |
| Context menu → Copy link (`chat-link-copy`) | `navigator.clipboard.writeText` | Already worked — web clipboard API, no Tauri capability needed |
| Tooltip → Copy (`chat-link-copy-url`) | `navigator.clipboard.writeText` | Already worked — same web API |

Net change: the two `open_url` actions were the only broken ones; the clipboard actions never needed a webview permission.

## Root cause

`opener:allow-open-url` was listed as a bare permission **string** in `capabilities/main.json`. A bare string enables the `open_url` command but grants **no URL scope**, so `tauri-plugin-opener` rejected every link with "Not allowed to open url …". The rejection was swallowed by a `console.warn` in `markdown-text.tsx`, so the click was silently inert.

The fix scopes the permission to `http`/`https`/`mailto`/`tel` plus the app schemes the markdown renderer linkifies (`slack`, `vscode`, `vscode-insiders`, `cursor`, `jetbrains`, `idea`, `zed`, `figma`, `linear`, `notion`, `discord`), kept in sync with `EXTRA_SAFE_PROTOCOLS` in `features/chat/parts/markdown-url-transform.ts`. A release-safety test asserts the scope is present so a revert to the bare string is caught.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — pass
- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/__tests__/tauri-config.test.ts` — 7 passed (asserts http/https + app-scheme scope present)
- `cargo check` (from `packages/app-tauri/src-tauri`) — clean; the scoped capability compiles through Tauri's ACL codegen
- **Live Tauri dev shell:** after the fix a transcript link opens the default browser (`open_url` resolves), `ftp://` stays denied (scope enforced), and the Copy link / tooltip Copy actions confirmed working via `navigator.clipboard`. Before/after screenshots captured (`01-initial-state`, `02-link-fix-verified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)