### PR TITLE
fix: keep adapter model catalogs aligned with installed CLIs

### DIFF
--- a/.changeset/adapter-model-catalog-fixes.md
+++ b/.changeset/adapter-model-catalog-fixes.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-core': patch
+---
+
+Keep adapter model catalogs aligned with installed CLIs: Codex discovery now uses the configured executable, unset Codex models inherit the account default, and Claude removes the explicit alias that duplicates its semantic default.

--- a/.changeset/adapter-model-catalog-fixes.md
+++ b/.changeset/adapter-model-catalog-fixes.md
@@ -3,4 +3,4 @@
 '@qlan-ro/mainframe-core': patch
 ---
 
-Keep adapter model catalogs aligned with installed CLIs: Codex discovery now uses the configured executable, unset Codex models inherit the account default, and Claude removes the explicit alias that duplicates its semantic default.
+Keep adapter model catalogs aligned with installed CLIs: Codex discovery now uses the configured executable, unset Codex models inherit the account default, Claude removes the explicit alias that duplicates its semantic default, and stale saved provider defaults no longer leak raw model ids into new chats.

--- a/docs/plans/2026-07-10-adapter-model-catalog-design.md
+++ b/docs/plans/2026-07-10-adapter-model-catalog-design.md
@@ -7,6 +7,7 @@ PR #395 materialized adapter catalogs so daemon startup never waits for a CLI pr
 1. Codex model discovery launches the bare `codex` command instead of the executable path resolved by the registry. A packaged desktop process can verify the configured binary but fail the subsequent catalog probe, leaving the UI on its empty fallback.
 2. A chat without an explicit Codex model becomes an empty string inside collaboration settings. Codex CLI 0.144.1 rejects that value for ChatGPT accounts instead of treating it as the account default.
 3. Claude CLI 2.1.206 returns both `default` and `opus[1m]`, and both resolve to `claude-opus-4-8[1m]`. Rendering both produces duplicate Opus 4.8 rows.
+4. Saved provider defaults can outlive catalog identifiers. A stored `claude.defaultModel = opus` no longer matches the live catalog, so a new chat persists the stale id and the composer can render a synthetic lowercase `opus` row until an authoritative catalog arrives.
 
 The current Claude catalog exposes 1M Default/Opus, Fable, and Sonnet selectors, plus a 200k Haiku selector. Sonnet 5's usable window was live-verified at 967k tokens after the CLI reserve. The catalog does not expose separate 200k Opus or Sonnet selectors.
 
@@ -36,13 +37,20 @@ When a chat has no explicit model, Mainframe will omit the model field from Code
 
 Codex can then choose the default supported by the authenticated account. Explicit model selections continue to pass through unchanged.
 
+### Normalize stale provider defaults
+
+When a saved provider default is absent from a non-empty adapter catalog, Mainframe will treat it as unset. Provider-settings responses will omit the stale value so the UI selects the catalog's `isDefault` entry, and new-chat creation will avoid persisting or spawning with the stale id.
+
+An empty catalog is not authoritative. Mainframe will preserve the saved value until at least one model is available, preventing transient discovery failures from discarding a potentially valid preference.
+
 ## Data Flow
 
 1. The registry resolves and verifies an adapter executable after executable-path backfill.
 2. Claude or Codex probes that exact executable.
 3. Claude maps the live response, retains the default alias, and removes only its concrete duplicate.
 4. The registry publishes the normalized live catalog with a newer revision.
-5. New Codex chats with no selected model omit model configuration; chats with a selection send the selected identifier.
+5. Settings reads and chat creation validate saved defaults against the available catalog.
+6. New Codex chats with no selected model omit model configuration; chats with a selection send the selected identifier.
 
 ## Error Handling
 
@@ -60,6 +68,7 @@ Focused tests will cover:
 - Codex live discovery launches the provided executable path.
 - Codex thread start, thread resume, turn start, and collaboration settings omit an absent model.
 - Explicit Codex model selection remains unchanged.
+- Stale saved defaults are omitted when the catalog is non-empty, while valid defaults and values observed during an empty catalog are preserved.
 
 Core typechecking and the affected adapter test files will run after implementation.
 

--- a/docs/plans/2026-07-10-adapter-model-catalog-design.md
+++ b/docs/plans/2026-07-10-adapter-model-catalog-design.md
@@ -8,7 +8,7 @@ PR #395 materialized adapter catalogs so daemon startup never waits for a CLI pr
 2. A chat without an explicit Codex model becomes an empty string inside collaboration settings. Codex CLI 0.144.1 rejects that value for ChatGPT accounts instead of treating it as the account default.
 3. Claude CLI 2.1.206 returns both `default` and `opus[1m]`, and both resolve to `claude-opus-4-8[1m]`. Rendering both produces duplicate Opus 4.8 rows.
 
-The current Claude catalog exposes 1M Default/Opus and Fable selectors, plus 200k Sonnet and Haiku selectors. It does not expose a separate 200k Opus selector.
+The current Claude catalog exposes 1M Default/Opus, Fable, and Sonnet selectors, plus a 200k Haiku selector. Sonnet 5's usable window was live-verified at 967k tokens after the CLI reserve. The catalog does not expose separate 200k Opus or Sonnet selectors.
 
 ## Decisions
 

--- a/docs/plans/2026-07-10-adapter-model-catalog-design.md
+++ b/docs/plans/2026-07-10-adapter-model-catalog-design.md
@@ -1,0 +1,71 @@
+# Adapter Model Catalog Corrections
+
+## Context
+
+PR #395 materialized adapter catalogs so daemon startup never waits for a CLI probe. It also made live catalogs revisioned and replayable. Three provider-specific gaps remain:
+
+1. Codex model discovery launches the bare `codex` command instead of the executable path resolved by the registry. A packaged desktop process can verify the configured binary but fail the subsequent catalog probe, leaving the UI on its empty fallback.
+2. A chat without an explicit Codex model becomes an empty string inside collaboration settings. Codex CLI 0.144.1 rejects that value for ChatGPT accounts instead of treating it as the account default.
+3. Claude CLI 2.1.206 returns both `default` and `opus[1m]`, and both resolve to `claude-opus-4-8[1m]`. Rendering both produces duplicate Opus 4.8 rows.
+
+The current Claude catalog exposes 1M Default/Opus and Fable selectors, plus 200k Sonnet and Haiku selectors. It does not expose a separate 200k Opus selector.
+
+## Decisions
+
+### Preserve provider catalogs
+
+Mainframe will show the choices returned by each installed CLI. It will not restore removed Claude choices from static data or maintain a static Codex model snapshot.
+
+### Keep Claude's semantic default
+
+Claude normalization will retain the `default` alias and remove later entries whose concrete `resolvedModel` matches the default entry. The retained row remains marked `isDefault` and uses the `Default - <model>` label.
+
+This preserves account-tier default behavior when Claude changes the concrete default. It also avoids pinning new chats to today's explicit Opus identifier.
+
+Deduplication applies only when both entries expose the same non-empty `resolvedModel`. Entries without that metadata remain untouched.
+
+### Make Codex discovery path-aware
+
+The Codex adapter will expose live model probing that accepts the registry's resolved executable path. Both temporary catalog app-server processes and real sessions will use the configured path rather than relying on the desktop process's `PATH`.
+
+An empty or failed probe remains retryable under the registry behavior introduced by PR #395.
+
+### Omit absent Codex models
+
+When a chat has no explicit model, Mainframe will omit the model field from Codex thread and turn requests. It will also avoid constructing collaboration-mode settings with an empty model string.
+
+Codex can then choose the default supported by the authenticated account. Explicit model selections continue to pass through unchanged.
+
+## Data Flow
+
+1. The registry resolves and verifies an adapter executable after executable-path backfill.
+2. Claude or Codex probes that exact executable.
+3. Claude maps the live response, retains the default alias, and removes only its concrete duplicate.
+4. The registry publishes the normalized live catalog with a newer revision.
+5. New Codex chats with no selected model omit model configuration; chats with a selection send the selected identifier.
+
+## Error Handling
+
+- Failed live discovery logs the provider error and leaves the fallback snapshot in place.
+- Empty live results are not cached as successful, so a later registry refresh can retry.
+- Alias deduplication does nothing when Claude omits `resolvedModel`; uncertain entries remain visible.
+- No authentication type is inferred in Mainframe. Default-model compatibility comes from omitting an absent model for every Codex account type.
+
+## Tests
+
+Focused tests will cover:
+
+- Claude mapping retains `default`, labels it as default, and removes an explicit alias with the same `resolvedModel`.
+- Claude keeps distinct models and entries without resolution metadata.
+- Codex live discovery launches the provided executable path.
+- Codex thread start, thread resume, turn start, and collaboration settings omit an absent model.
+- Explicit Codex model selection remains unchanged.
+
+Core typechecking and the affected adapter test files will run after implementation.
+
+## Non-Goals
+
+- Inventing or restoring Claude model variants absent from the live CLI catalog.
+- Adding a static Codex fallback catalog.
+- Changing the revision/replay architecture from PR #395.
+- Inferring provider account tiers or authentication methods.

--- a/docs/plans/2026-07-10-adapter-model-catalog.md
+++ b/docs/plans/2026-07-10-adapter-model-catalog.md
@@ -1,0 +1,360 @@
+# Adapter Model Catalog Corrections Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep live Claude and Codex model catalogs accurate, remove Claude's duplicate default target, and let Codex choose its account default when Mainframe has no explicit model.
+
+**Architecture:** Normalize Claude's live probe at the provider boundary using the CLI's per-entry `resolvedModel`. Add a path-aware Codex probe so the revisioned registry from PR #395 launches the configured executable. Build Codex JSON-RPC payloads without a model property when the chat inherits the provider default.
+
+**Tech Stack:** TypeScript 6, Node.js child processes, Codex JSON-RPC app-server, Claude stream-json control protocol, Vitest, pnpm workspaces.
+
+---
+
+### Task 1: Deduplicate Claude's Concrete Default Target
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/claude/probe-models.ts:53-77`
+- Test: `packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts`
+
+**Step 1: Write the failing duplicate-alias test**
+
+Add a live-shaped payload containing:
+
+```ts
+models: [
+  {
+    value: 'default',
+    displayName: 'Default (recommended)',
+    description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+    resolvedModel: 'claude-opus-4-8[1m]',
+  },
+  {
+    value: 'opus[1m]',
+    displayName: 'Opus',
+    description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+    resolvedModel: 'claude-opus-4-8[1m]',
+  },
+  {
+    value: 'sonnet',
+    displayName: 'Sonnet',
+    resolvedModel: 'claude-sonnet-5',
+  },
+]
+```
+
+Assert that `extractProbePayload` returns `['default', 'sonnet']`, retains `default.isDefault`, and labels it `Default - Opus 4.8`.
+
+Add a second test proving that entries remain when there is no default `resolvedModel` or when their concrete targets differ.
+
+**Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run src/plugins/builtin/claude/__tests__/probe-models.test.ts
+```
+
+from `packages/core`.
+
+Expected: FAIL because `opus[1m]` is still present.
+
+**Step 3: Implement minimal provider-boundary normalization**
+
+Add a pure helper in `probe-models.ts`:
+
+```ts
+function removeConcreteDefaultDuplicate(models: AdapterModel[]): AdapterModel[] {
+  const defaultModel = models.find((model) => model.isDefault);
+  if (!defaultModel?.resolvedModel) return models;
+  return models.filter(
+    (model) => model === defaultModel || model.resolvedModel !== defaultModel.resolvedModel,
+  );
+}
+```
+
+Apply it after mapping the raw CLI entries and before returning `ProbeResult`. Keep the default entry's `resolvedModel` for context-window enrichment.
+
+**Step 4: Run Claude probe and context tests**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run \
+  src/plugins/builtin/claude/__tests__/probe-models.test.ts \
+  src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts \
+  src/plugins/builtin/claude/__tests__/probe-context-window.test.ts
+```
+
+Expected: all tests pass; Default/Opus deduplication does not change Sonnet, Fable, or Haiku window inference.
+
+**Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/claude/probe-models.ts \
+  packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
+git commit -m "fix(claude): collapse duplicate default model alias"
+```
+
+### Task 2: Use the Resolved Executable for Codex Discovery
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/codex/adapter.ts:69-88`
+- Modify: `packages/core/src/plugins/builtin/codex/adapter.ts:131-150`
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/list-models.test.ts`
+
+**Step 1: Write the failing path-aware probe test**
+
+Mock `node:child_process.spawn`, call:
+
+```ts
+const probe = adapter.probeModels('/configured/bin/codex');
+```
+
+Drive the mocked initialize and `model/list` responses through stdout. Assert:
+
+```ts
+expect(spawn).toHaveBeenCalledWith(
+  '/configured/bin/codex',
+  ['app-server'],
+  expect.objectContaining({ detached: false }),
+);
+```
+
+Also assert that hidden models are excluded and a non-empty result is returned.
+
+**Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run src/plugins/builtin/codex/__tests__/list-models.test.ts
+```
+
+Expected: FAIL because `CodexAdapter` has no `probeModels` method and its temporary app-server hardcodes `codex`.
+
+**Step 3: Implement a shared path-aware loader**
+
+Keep `listModels()` for direct callers and add the registry probe hook:
+
+```ts
+async listModels(): Promise<AdapterModel[]> {
+  return this.loadModels('codex');
+}
+
+async probeModels(executablePath?: string): Promise<AdapterModel[] | null> {
+  return this.loadModels(executablePath ?? 'codex');
+}
+```
+
+Move the existing request/cache/error handling into `loadModels(executable: string)`, and change `spawnTempAppServer` to accept that executable:
+
+```ts
+private async spawnTempAppServer(executable: string): Promise<JsonRpcClient> {
+  const child = spawn(executable, ['app-server'], { /* existing options */ });
+  // existing initialize handshake
+}
+```
+
+Keep empty results uncached so PR #395's registry can retry.
+
+**Step 4: Run Codex model and registry tests**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run \
+  src/plugins/builtin/codex/__tests__/list-models.test.ts \
+  src/adapters/__tests__/registry.test.ts \
+  src/__tests__/adapter-registry.test.ts
+```
+
+Expected: all tests pass and the registry continues to publish only successful live catalogs.
+
+**Step 5: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/adapter.ts \
+  packages/core/src/plugins/builtin/codex/__tests__/list-models.test.ts
+git commit -m "fix(codex): probe models with configured executable"
+```
+
+### Task 3: Omit an Unset Codex Model
+
+**Files:**
+- Modify: `packages/core/src/plugins/builtin/codex/types.ts:212-217`
+- Modify: `packages/core/src/plugins/builtin/codex/turn-config.ts:10-49`
+- Modify: `packages/core/src/plugins/builtin/codex/session.ts:199-251`
+- Test: `packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts`
+- Test: `packages/core/src/__tests__/codex-session.test.ts`
+
+**Step 1: Write the failing collaboration-settings test**
+
+Update `buildTurnConfig` tests to call it with `undefined` and assert:
+
+```ts
+expect(cfg.collaborationMode.settings).not.toHaveProperty('model');
+```
+
+Keep the existing explicit-model assertion for `gpt-5.5`.
+
+**Step 2: Run the turn-config test and verify it fails**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run src/plugins/builtin/codex/__tests__/turn-config.test.ts
+```
+
+Expected: FAIL because `modelId` is required and the builder always creates `model`.
+
+**Step 3: Make collaboration-mode model optional**
+
+Change `CollaborationModeSettings.model` to optional in `types.ts`, accept `modelId?: string` in `buildTurnConfig`, and construct settings with:
+
+```ts
+settings: {
+  ...(modelId ? { model: modelId } : {}),
+  reasoning_effort: tuning.effort as string | null,
+  developer_instructions: null,
+},
+```
+
+Pass `this.pendingModel` directly from `CodexSession`.
+
+**Step 4: Run the turn-config test and verify it passes**
+
+Run the command from Step 2.
+
+Expected: PASS.
+
+**Step 5: Write failing JSON-RPC payload tests**
+
+Extend the existing `CodexSession` mocked-process harness. For a new session spawned without a model, capture `thread/start` and `turn/start`, then assert:
+
+```ts
+expect(threadStart.params).not.toHaveProperty('model');
+expect(turnStart.params).not.toHaveProperty('model');
+expect(turnStart.params.collaborationMode.settings).not.toHaveProperty('model');
+```
+
+Add a resume case asserting `thread/resume.params` also omits `model`. Retain or add an explicit-model case proving `gpt-5.6-sol` appears in all applicable payloads.
+
+**Step 6: Run the session test and verify it fails**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run src/__tests__/codex-session.test.ts
+```
+
+Expected: FAIL because the request objects include `model: undefined` before JSON serialization or collaboration settings include an empty model.
+
+**Step 7: Omit model fields at request construction**
+
+Create one local object per send:
+
+```ts
+const modelParams = this.pendingModel ? { model: this.pendingModel } : {};
+```
+
+Spread `modelParams` into `thread/start`, `thread/resume`, and `turn/start` instead of assigning `model` directly. Keep all other JSON-RPC parameters unchanged.
+
+**Step 8: Run Codex session and configuration tests**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run \
+  src/__tests__/codex-session.test.ts \
+  src/plugins/builtin/codex/__tests__/turn-config.test.ts \
+  src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts
+```
+
+Expected: all tests pass for inherited and explicit model selections.
+
+**Step 9: Commit**
+
+```bash
+git add packages/core/src/plugins/builtin/codex/types.ts \
+  packages/core/src/plugins/builtin/codex/turn-config.ts \
+  packages/core/src/plugins/builtin/codex/session.ts \
+  packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts \
+  packages/core/src/__tests__/codex-session.test.ts
+git commit -m "fix(codex): omit unset model from app-server requests"
+```
+
+### Task 4: Changeset and Verification
+
+**Files:**
+- Create: `.changeset/<generated-name>.md`
+
+**Step 1: Add a patch changeset**
+
+Run `pnpm changeset`, select `@qlan-ro/mainframe-core`, choose `patch`, and summarize the catalog and default-model compatibility fixes.
+
+**Step 2: Run formatting checks on changed files**
+
+Run Prettier on the touched TypeScript and Markdown files, then run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+**Step 3: Run all focused tests**
+
+Run:
+
+```bash
+node node_modules/vitest/vitest.mjs run \
+  src/plugins/builtin/claude/__tests__/probe-models.test.ts \
+  src/plugins/builtin/claude/__tests__/adapter-enrich.test.ts \
+  src/plugins/builtin/claude/__tests__/probe-context-window.test.ts \
+  src/plugins/builtin/codex/__tests__/list-models.test.ts \
+  src/plugins/builtin/codex/__tests__/turn-config.test.ts \
+  src/plugins/builtin/codex/__tests__/collaboration-mode.test.ts \
+  src/__tests__/codex-session.test.ts \
+  src/adapters/__tests__/registry.test.ts \
+  src/__tests__/adapter-registry.test.ts
+```
+
+from `packages/core`.
+
+Expected: all files pass.
+
+**Step 4: Typecheck core**
+
+Run:
+
+```bash
+node node_modules/typescript/bin/tsc --noEmit -p tsconfig.json
+```
+
+from `packages/core`.
+
+Expected: exit 0 with no output.
+
+**Step 5: Run live provider smoke probes**
+
+Probe Claude 2.1.206 and confirm the normalized catalog contains one Opus 4.8 default row. Probe Codex 0.144.1 by absolute path and confirm its current non-hidden models are returned.
+
+Do not modify the user's running daemon or its database during the smoke test.
+
+**Step 6: Commit**
+
+```bash
+git add .changeset/<generated-name>.md
+git commit -m "chore: add adapter model catalog changeset"
+```
+
+**Step 7: Review final branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktree on `fix/adapter-model-catalog` with design, implementation, tests, and changeset commits.

--- a/docs/plans/2026-07-10-adapter-model-catalog.md
+++ b/docs/plans/2026-07-10-adapter-model-catalog.md
@@ -358,3 +358,54 @@ git log --oneline origin/main..HEAD
 ```
 
 Expected: clean worktree on `fix/adapter-model-catalog` with design, implementation, tests, and changeset commits.
+
+### Task 5: Normalize Stale Saved Provider Defaults
+
+**Files:**
+- Create: `packages/core/src/settings/model-default.ts`
+- Create: `packages/core/src/settings/__tests__/model-default.test.ts`
+- Modify: `packages/core/src/chat/lifecycle-manager.ts`
+- Modify: `packages/core/src/__tests__/chat/create-on-worktree.test.ts`
+- Modify: `packages/core/src/server/routes/settings.ts`
+- Modify: `packages/core/src/__tests__/routes/settings.test.ts`
+
+**Step 1: Write failing resolver tests**
+
+Cover three cases: preserve a matching model id, preserve any value while the catalog is empty, and return `undefined` for an id absent from a non-empty catalog.
+
+**Step 2: Run the resolver test and verify it fails**
+
+Expected: FAIL because the resolver does not exist.
+
+**Step 3: Implement the pure resolver**
+
+```ts
+export function normalizeSavedDefaultModel(
+  configuredModel: string | undefined,
+  models: AdapterModel[],
+): string | undefined {
+  if (!configuredModel || models.length === 0) return configuredModel;
+  return models.some((model) => model.id === configuredModel) ? configuredModel : undefined;
+}
+```
+
+**Step 4: Write failing integration tests**
+
+Assert that provider-settings responses omit stale defaults once a non-empty catalog is available, and that `createChatWithDefaults` does not pass a stale saved id to `createChat`. Retain valid defaults and values observed during an empty catalog.
+
+**Step 5: Apply the resolver at both boundaries**
+
+Read the adapter snapshot synchronously from `AdapterRegistry.getSnapshots()`, normalize the saved value, and leave explicit per-chat model selections unchanged.
+
+**Step 6: Run focused settings and lifecycle tests**
+
+```bash
+node node_modules/vitest/vitest.mjs run \
+  src/settings/__tests__/model-default.test.ts \
+  src/__tests__/routes/settings.test.ts \
+  src/__tests__/chat/create-on-worktree.test.ts
+```
+
+**Step 7: Update the existing changeset and rerun final verification**
+
+Mention stale provider-default normalization, then rerun formatting, focused adapter/settings tests, core typecheck, core build, and live catalog probes.

--- a/packages/core/src/__tests__/chat/create-on-worktree.test.ts
+++ b/packages/core/src/__tests__/chat/create-on-worktree.test.ts
@@ -39,7 +39,7 @@ function makeDeps(overrides: Partial<LifecycleManagerDeps> = {}): LifecycleManag
       projects: { get: vi.fn() },
       settings: { get: vi.fn() },
     } as any,
-    adapters: { get: vi.fn(), all: vi.fn().mockReturnValue([]) } as any,
+    adapters: { get: vi.fn(), all: vi.fn().mockReturnValue([]), getSnapshots: vi.fn().mockReturnValue([]) } as any,
     activeChats: new Map(),
     messages: { get: vi.fn(), set: vi.fn(), delete: vi.fn() } as any,
     permissions: {
@@ -187,5 +187,41 @@ describe('ChatLifecycleManager.createChatWithDefaults — worktree attachment', 
 
     expect(chat.planMode).toBe(true);
     expect(deps.db.chats.update).toHaveBeenCalledWith(chat.id, { planMode: true });
+  });
+
+  it('omits a saved default model absent from a non-empty catalog', async () => {
+    const deps = makeDeps({
+      db: {
+        chats: {
+          get: vi.fn(() => makeChat()),
+          create: vi.fn(() => makeChat()),
+          update: vi.fn(),
+        },
+        projects: { get: vi.fn() },
+        settings: {
+          get: vi.fn((category: string, key: string) =>
+            category === 'provider' && key === 'claude.defaultModel' ? 'opus' : undefined,
+          ),
+        },
+      } as any,
+      adapters: {
+        get: vi.fn(),
+        getSnapshots: vi.fn().mockReturnValue([
+          {
+            id: 'claude',
+            models: [
+              { id: 'default', label: 'Default - Opus 4.8', isDefault: true },
+              { id: 'sonnet', label: 'Sonnet 5' },
+            ],
+          },
+        ]),
+      } as any,
+    });
+    const lifecycle = new ChatLifecycleManager(deps);
+    const createChat = vi.spyOn(lifecycle, 'createChat');
+
+    await lifecycle.createChatWithDefaults('proj-1', 'claude');
+
+    expect(createChat).toHaveBeenCalledWith('proj-1', 'claude', undefined, undefined, undefined, undefined);
   });
 });

--- a/packages/core/src/__tests__/codex-session.test.ts
+++ b/packages/core/src/__tests__/codex-session.test.ts
@@ -127,6 +127,7 @@ describe('CodexSession', () => {
     if (threadStartMsg.method === 'thread/start') {
       expect(threadStartMsg.params.approvalPolicy).toBe('never');
       expect(threadStartMsg.params.sandbox).toBe('danger-full-access');
+      expect(threadStartMsg.params).not.toHaveProperty('model');
       // Respond to thread/start
       proc.stdout.push(JSON.stringify({ id: threadStartMsg.id, result: { thread: { id: 'thr_1' } } }) + '\n');
       // Respond to thread/started notification
@@ -137,10 +138,75 @@ describe('CodexSession', () => {
     await vi.waitFor(() => expect(written.length).toBeGreaterThan(1));
     const lastMsg = JSON.parse(written[written.length - 1]!.trim());
     if (lastMsg.method === 'turn/start') {
+      expect(lastMsg.params).not.toHaveProperty('model');
+      expect(lastMsg.params.collaborationMode.settings).not.toHaveProperty('model');
       proc.stdout.push(
         JSON.stringify({ id: lastMsg.id, result: { turn: { id: 'turn_1', status: 'running' } } }) + '\n',
       );
     }
+
+    await sendPromise;
+  });
+
+  it('omits an unset model when resuming a thread', async () => {
+    const session = new CodexSession({
+      projectPath: '/tmp/project',
+      mainframeChatId: 'test-chat',
+      chatId: 'thread-existing',
+    });
+    const spawnPromise = session.spawn({}, createSink());
+    const proc = (spawn as unknown as ReturnType<typeof vi.fn>).mock.results[0]!.value;
+    proc.stdout.push(JSON.stringify({ id: 1, result: { userAgent: 'codex/1.0', codexHome: '/tmp' } }) + '\n');
+    await spawnPromise;
+
+    const written: string[] = [];
+    proc.stdin.write = vi.fn((data: string, _enc?: unknown, callback?: () => void) => {
+      written.push(data);
+      callback?.();
+      return true;
+    });
+
+    const sendPromise = session.sendMessage('hello');
+    await vi.waitFor(() => expect(written.length).toBeGreaterThan(0));
+    const resume = JSON.parse(written[0]!.trim());
+    expect(resume.method).toBe('thread/resume');
+    expect(resume.params).not.toHaveProperty('model');
+    proc.stdout.push(JSON.stringify({ id: resume.id, result: { thread: { id: 'thread-existing' } } }) + '\n');
+
+    await vi.waitFor(() => expect(written.length).toBeGreaterThan(1));
+    const turn = JSON.parse(written[1]!.trim());
+    expect(turn.params).not.toHaveProperty('model');
+    expect(turn.params.collaborationMode.settings).not.toHaveProperty('model');
+    proc.stdout.push(JSON.stringify({ id: turn.id, result: { turn: { id: 'turn-1', status: 'inProgress' } } }) + '\n');
+
+    await sendPromise;
+  });
+
+  it('sends an explicitly selected model in thread and turn requests', async () => {
+    const session = new CodexSession({ projectPath: '/tmp/project', mainframeChatId: 'test-chat' });
+    const spawnPromise = session.spawn({ model: 'gpt-5.6-sol' }, createSink());
+    const proc = (spawn as unknown as ReturnType<typeof vi.fn>).mock.results[0]!.value;
+    proc.stdout.push(JSON.stringify({ id: 1, result: { userAgent: 'codex/1.0', codexHome: '/tmp' } }) + '\n');
+    await spawnPromise;
+
+    const written: string[] = [];
+    proc.stdin.write = vi.fn((data: string, _enc?: unknown, callback?: () => void) => {
+      written.push(data);
+      callback?.();
+      return true;
+    });
+
+    const sendPromise = session.sendMessage('hello');
+    await vi.waitFor(() => expect(written.length).toBeGreaterThan(0));
+    const start = JSON.parse(written[0]!.trim());
+    expect(start.params.model).toBe('gpt-5.6-sol');
+    proc.stdout.push(JSON.stringify({ id: start.id, result: { thread: { id: 'thread-new' } } }) + '\n');
+
+    await vi.waitFor(() => expect(written.length).toBeGreaterThan(1));
+    const turn = JSON.parse(written[1]!.trim());
+    expect(turn.params.model).toBe('gpt-5.6-sol');
+    expect(turn.params.collaborationMode.settings.model).toBe('gpt-5.6-sol');
+    proc.stdout.push(JSON.stringify({ id: turn.id, result: { turn: { id: 'turn-1', status: 'inProgress' } } }) + '\n');
 
     await sendPromise;
   });

--- a/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
+++ b/packages/core/src/__tests__/routes/settings-resolved-executable.test.ts
@@ -16,7 +16,7 @@ function createMockContext(): RouteContext {
       },
     } as any,
     chats: { getChat: vi.fn(), on: vi.fn() } as any,
-    adapters: { get: vi.fn(), list: vi.fn(), getAll: vi.fn() } as any,
+    adapters: { get: vi.fn(), list: vi.fn(), getAll: vi.fn(), getSnapshots: vi.fn().mockReturnValue([]) } as any,
   };
 }
 

--- a/packages/core/src/__tests__/routes/settings.test.ts
+++ b/packages/core/src/__tests__/routes/settings.test.ts
@@ -26,7 +26,12 @@ function createMockContext(): RouteContext {
       },
     } as any,
     chats: { getChat: vi.fn(), on: vi.fn() } as any,
-    adapters: { get: vi.fn(), list: vi.fn(), getAll: vi.fn().mockReturnValue([]) } as any,
+    adapters: {
+      get: vi.fn(),
+      list: vi.fn(),
+      getAll: vi.fn().mockReturnValue([]),
+      getSnapshots: vi.fn().mockReturnValue([]),
+    } as any,
   };
 }
 
@@ -71,6 +76,29 @@ describe('settingRoutes', () => {
       // resolvedExecutable is now added per adapter; use toMatchObject to tolerate the new key
       expect(call.data.claude).toMatchObject({ defaultModel: 'opus', defaultMode: 'normal' });
       expect(call.data.gemini).toMatchObject({ defaultModel: 'pro' });
+    });
+
+    it('omits a saved default model absent from a non-empty catalog', async () => {
+      (ctx.db.settings.getByCategory as any).mockReturnValue({
+        'claude.defaultModel': 'opus',
+      });
+      (ctx.adapters.getSnapshots as any).mockReturnValue([
+        {
+          id: 'claude',
+          models: [
+            { id: 'default', label: 'Default - Opus 4.8', isDefault: true },
+            { id: 'sonnet', label: 'Sonnet 5' },
+          ],
+        },
+      ]);
+
+      const router = settingRoutes(ctx);
+      const handler = extractHandler(router, 'get', '/api/settings/providers');
+      const res = mockRes();
+
+      await handler({ params: {}, query: {} }, res, vi.fn());
+
+      expect(res.json.mock.calls[0][0].data.claude.defaultModel).toBeUndefined();
     });
 
     it('maps legacy skipPermissions to defaultMode yolo', async () => {

--- a/packages/core/src/chat/lifecycle-manager.ts
+++ b/packages/core/src/chat/lifecycle-manager.ts
@@ -18,6 +18,7 @@ import type { PermissionManager } from './permission-manager.js';
 import type { ActiveChat } from './types.js';
 import { resolveTuningForChat } from './resolve-tuning-for-chat.js';
 import { getProviderConfig } from '../settings/provider-config.js';
+import { normalizeSavedDefaultModel } from '../settings/model-default.js';
 
 const log = createChildLogger('chat:lifecycle');
 
@@ -113,7 +114,10 @@ export class ChatLifecycleManager {
       const defaultMode = this.deps.db.settings.get('provider', `${adapterId}.defaultMode`);
       const defaultPlanMode = this.deps.db.settings.get('provider', `${adapterId}.defaultPlanMode`);
 
-      if (!effectiveModel && defaultModel) effectiveModel = defaultModel;
+      if (!effectiveModel && defaultModel) {
+        const models = this.deps.adapters.getSnapshots().find((snapshot) => snapshot.id === adapterId)?.models ?? [];
+        effectiveModel = normalizeSavedDefaultModel(defaultModel, models);
+      }
       if (!effectiveMode && defaultMode) effectiveMode = defaultMode;
       if (defaultPlanMode === 'true') effectivePlanMode = true;
     }

--- a/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
+++ b/packages/core/src/plugins/builtin/claude/__tests__/probe-models.test.ts
@@ -48,4 +48,51 @@ describe('extractProbePayload', () => {
     expect(out?.models[0]?.resolvedModel).toBe('claude-sonnet-5');
     expect(out?.models[1]?.resolvedModel).toBeUndefined();
   });
+
+  it('keeps the default alias and removes another entry resolving to the same model', () => {
+    const event = {
+      type: 'control_response',
+      response: {
+        response: {
+          models: [
+            {
+              value: 'default',
+              displayName: 'Default (recommended)',
+              description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+              resolvedModel: 'claude-opus-4-8[1m]',
+            },
+            {
+              value: 'opus[1m]',
+              displayName: 'Opus',
+              description: 'Opus 4.8 with 1M context · Best for everyday, complex tasks',
+              resolvedModel: 'claude-opus-4-8[1m]',
+            },
+            { value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' },
+          ],
+        },
+      },
+    };
+
+    const out = extractProbePayload(event);
+
+    expect(out?.models.map((model) => model.id)).toEqual(['default', 'sonnet']);
+    expect(out?.models[0]).toMatchObject({ label: 'Default - Opus 4.8', isDefault: true });
+  });
+
+  it('keeps entries with distinct or unresolved concrete models', () => {
+    const event = {
+      type: 'control_response',
+      response: {
+        response: {
+          models: [
+            { value: 'default', displayName: 'Default' },
+            { value: 'opus[1m]', displayName: 'Opus', resolvedModel: 'claude-opus-4-8[1m]' },
+            { value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' },
+          ],
+        },
+      },
+    };
+
+    expect(extractProbePayload(event)?.models.map((model) => model.id)).toEqual(['default', 'opus[1m]', 'sonnet']);
+  });
 });

--- a/packages/core/src/plugins/builtin/claude/probe-models.ts
+++ b/packages/core/src/plugins/builtin/claude/probe-models.ts
@@ -55,6 +55,12 @@ export interface ProbeResult {
   resolvedModel?: string;
 }
 
+function removeConcreteDefaultDuplicate(models: AdapterModel[]): AdapterModel[] {
+  const defaultModel = models.find((model) => model.isDefault);
+  if (!defaultModel?.resolvedModel) return models;
+  return models.filter((model) => model === defaultModel || model.resolvedModel !== defaultModel.resolvedModel);
+}
+
 /**
  * Parse the (possibly double-wrapped) `initialize` control_response.
  *
@@ -70,7 +76,7 @@ export function extractProbePayload(event: Record<string, unknown>): ProbeResult
   const payload = ((response?.response as Record<string, unknown>) ?? response) as Record<string, unknown> | undefined;
   const rawModels = payload?.models;
   if (!Array.isArray(rawModels)) return null;
-  const models = (rawModels as CliModelInfo[]).map(mapModelInfo);
+  const models = removeConcreteDefaultDuplicate((rawModels as CliModelInfo[]).map(mapModelInfo));
   const defaultEntry = (rawModels as CliModelInfo[]).find((m) => m.value === 'default');
   const resolvedModel = typeof defaultEntry?.resolvedModel === 'string' ? defaultEntry.resolvedModel : undefined;
   return { models, resolvedModel };

--- a/packages/core/src/plugins/builtin/codex/__tests__/list-models.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/list-models.test.ts
@@ -1,20 +1,93 @@
-import { describe, it, expect } from 'vitest';
-import { mapCodexModel } from '../adapter.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(() => {
+    const process = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    const written: string[] = [];
+    process.written = written;
+    process.stdin = new Writable({
+      write: (chunk, _encoding, callback) => {
+        written.push(chunk.toString());
+        callback();
+      },
+    });
+    process.stdout = new Readable({ read() {} });
+    process.stderr = new Readable({ read() {} });
+    process.kill = vi.fn(() => {
+      process.emit('close', 0);
+      return true;
+    });
+    return process;
+  }),
+}));
+
+import { spawn } from 'node:child_process';
+import { CodexAdapter, mapCodexModel } from '../adapter.js';
 
 describe('mapCodexModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('maps efforts, default, fast tier, personality, isDefault', () => {
     const m = mapCodexModel({
-      id: 'gpt-5.5', displayName: 'GPT-5.5', description: 'Frontier',
-      hidden: false, isDefault: false, supportsPersonality: true,
-      additionalSpeedTiers: ['fast'], defaultReasoningEffort: 'medium',
+      id: 'gpt-5.5',
+      displayName: 'GPT-5.5',
+      description: 'Frontier',
+      hidden: false,
+      isDefault: false,
+      supportsPersonality: true,
+      additionalSpeedTiers: ['fast'],
+      defaultReasoningEffort: 'medium',
       supportedReasoningEfforts: [
-        { reasoningEffort: 'low', description: '' }, { reasoningEffort: 'medium', description: '' },
-        { reasoningEffort: 'high', description: '' }, { reasoningEffort: 'xhigh', description: '' },
+        { reasoningEffort: 'low', description: '' },
+        { reasoningEffort: 'medium', description: '' },
+        { reasoningEffort: 'high', description: '' },
+        { reasoningEffort: 'xhigh', description: '' },
       ],
     });
     expect(m.supportedEfforts).toEqual(['low', 'medium', 'high', 'xhigh']);
     expect(m.defaultEffort).toBe('medium');
     expect(m.supportsFast).toBe(true);
     expect(m.supportsPersonality).toBe(true);
+  });
+
+  it('probes models with the configured executable path', async () => {
+    const adapter = new CodexAdapter();
+    const probe = (adapter as unknown as { probeModels(executablePath?: string): Promise<unknown[]> }).probeModels(
+      '/configured/bin/codex',
+    );
+    const process = (spawn as unknown as ReturnType<typeof vi.fn>).mock.results[0]!.value;
+
+    process.stdout.push(
+      JSON.stringify({ id: 1, result: { userAgent: 'codex/0.144.1', codexHome: '/tmp/.codex' } }) + '\n',
+    );
+    await vi.waitFor(() =>
+      expect((process.written as string[]).some((line) => JSON.parse(line).method === 'model/list')).toBe(true),
+    );
+    process.stdout.push(
+      JSON.stringify({
+        id: 2,
+        result: {
+          data: [
+            { id: 'gpt-5.6-sol', displayName: 'GPT-5.6-Sol', hidden: false, isDefault: true },
+            { id: 'hidden-model', displayName: 'Hidden', hidden: true, isDefault: false },
+          ],
+          nextCursor: null,
+        },
+      }) + '\n',
+    );
+
+    await expect(probe).resolves.toEqual([
+      expect.objectContaining({ id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol', isDefault: true }),
+    ]);
+    expect(spawn).toHaveBeenCalledWith(
+      '/configured/bin/codex',
+      ['app-server'],
+      expect.objectContaining({ detached: false }),
+    );
   });
 });

--- a/packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts
+++ b/packages/core/src/plugins/builtin/codex/__tests__/turn-config.test.ts
@@ -40,4 +40,15 @@ describe('buildTurnConfig', () => {
     expect(cfg.personality).toBeUndefined();
     expect(cfg.summary).toBeUndefined();
   });
+
+  it.each([undefined, ''])('omits the model setting when no model is selected (%s)', (model) => {
+    const cfg = buildTurnConfig(
+      { effort: 'high', fast: false, ultracode: false, adaptiveThinking: false },
+      {},
+      model,
+      'default',
+    );
+
+    expect(cfg.collaborationMode.settings).not.toHaveProperty('model');
+  });
 });

--- a/packages/core/src/plugins/builtin/codex/adapter.ts
+++ b/packages/core/src/plugins/builtin/codex/adapter.ts
@@ -71,10 +71,18 @@ export class CodexAdapter implements Adapter {
   }
 
   async listModels(): Promise<AdapterModel[]> {
+    return this.loadModels('codex');
+  }
+
+  async probeModels(executablePath?: string): Promise<AdapterModel[] | null> {
+    return this.loadModels(executablePath ?? 'codex');
+  }
+
+  private async loadModels(executable: string): Promise<AdapterModel[]> {
     if (this.cachedModels) return this.cachedModels;
     let client: JsonRpcClient | null = null;
     try {
-      client = await this.spawnTempAppServer();
+      client = await this.spawnTempAppServer(executable);
       const result = await client.request<ModelListResult>('model/list');
       const models = result.data.filter((m) => !m.hidden).map(mapCodexModel);
       if (models.length > 0) this.cachedModels = models; // don't cache transient failures (empty)
@@ -128,8 +136,8 @@ export class CodexAdapter implements Adapter {
     return isCodexTranscriptPresent(sessionId);
   }
 
-  private async spawnTempAppServer(): Promise<JsonRpcClient> {
-    const child = spawn('codex', ['app-server'], {
+  private async spawnTempAppServer(executable: string): Promise<JsonRpcClient> {
+    const child = spawn(executable, ['app-server'], {
       detached: false,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },

--- a/packages/core/src/plugins/builtin/codex/session.ts
+++ b/packages/core/src/plugins/builtin/codex/session.ts
@@ -234,7 +234,7 @@ export class CodexSession implements AdapterSession {
     const turnCfg = buildTurnConfig(
       this.pendingTuning ?? DEFAULT_RESOLVED,
       this.codexProviderTuning,
-      this.pendingModel ?? '',
+      this.pendingModel,
       this.pendingPlanMode ? 'plan' : 'default',
     );
 

--- a/packages/core/src/plugins/builtin/codex/turn-config.ts
+++ b/packages/core/src/plugins/builtin/codex/turn-config.ts
@@ -30,14 +30,14 @@ export interface CodexTurnConfig {
 export function buildTurnConfig(
   tuning: ResolvedTuning,
   codex: CodexProviderTuning,
-  modelId: string,
+  modelId: string | undefined,
   mode: 'plan' | 'default',
 ): CodexTurnConfig {
   const cfg: CodexTurnConfig = {
     collaborationMode: {
       mode,
       settings: {
-        model: modelId,
+        ...(modelId ? { model: modelId } : {}),
         reasoning_effort: tuning.effort as string | null,
         developer_instructions: null,
       },

--- a/packages/core/src/plugins/builtin/codex/types.ts
+++ b/packages/core/src/plugins/builtin/codex/types.ts
@@ -210,7 +210,7 @@ export interface CollaborationMode {
 }
 
 export interface CollaborationModeSettings {
-  model: string;
+  model?: string;
   reasoning_effort?: string | null;
   developer_instructions?: string | null;
 }

--- a/packages/core/src/server/routes/settings.ts
+++ b/packages/core/src/server/routes/settings.ts
@@ -8,6 +8,7 @@ import type { RouteContext } from './types.js';
 import { validate, UpdateProviderSettingsBody, UpdateGeneralSettingsBody } from './schemas.js';
 import { asyncHandler } from './async-handler.js';
 import { resolveAdapterExecutableCached, defaultRun } from '../../adapters/resolve-executable.js';
+import { normalizeSavedDefaultModel } from '../../settings/model-default.js';
 
 // Per-group validation so a single bad leaf doesn't discard the user's other
 // valid overrides on read.
@@ -66,6 +67,16 @@ function persistNotifications(ctx: RouteContext, patch: NotificationPatch): void
   ctx.db.settings.set('general', 'notifications', JSON.stringify(merged));
 }
 
+function normalizeProviderDefaultModels(providers: Record<string, Record<string, unknown>>, ctx: RouteContext): void {
+  const catalogs = new Map(ctx.adapters.getSnapshots().map((snapshot) => [snapshot.id, snapshot.models]));
+  for (const [adapterId, provider] of Object.entries(providers)) {
+    const configured = typeof provider.defaultModel === 'string' ? provider.defaultModel : undefined;
+    if (configured && normalizeSavedDefaultModel(configured, catalogs.get(adapterId) ?? []) === undefined) {
+      delete provider.defaultModel;
+    }
+  }
+}
+
 export function settingRoutes(ctx: RouteContext): Router {
   const router = Router();
 
@@ -121,6 +132,7 @@ export function settingRoutes(ctx: RouteContext): Router {
         }
         delete provider.skipPermissions;
       }
+      normalizeProviderDefaultModels(providers, ctx);
       const ids = new Set<string>(Object.keys(providers));
       for (const a of ctx.adapters.getAll()) ids.add(a.id);
       const idList = Array.from(ids);

--- a/packages/core/src/settings/__tests__/model-default.test.ts
+++ b/packages/core/src/settings/__tests__/model-default.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSavedDefaultModel } from '../model-default.js';
+
+describe('normalizeSavedDefaultModel', () => {
+  it('preserves a configured model present in the catalog', () => {
+    expect(normalizeSavedDefaultModel('sonnet', [{ id: 'sonnet', label: 'Sonnet 5' }])).toBe('sonnet');
+  });
+
+  it('preserves a configured model while the catalog is empty', () => {
+    expect(normalizeSavedDefaultModel('opus', [])).toBe('opus');
+  });
+
+  it('omits a configured model absent from a non-empty catalog', () => {
+    expect(
+      normalizeSavedDefaultModel('opus', [
+        { id: 'default', label: 'Default - Opus 4.8', isDefault: true },
+        { id: 'sonnet', label: 'Sonnet 5' },
+      ]),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/settings/model-default.ts
+++ b/packages/core/src/settings/model-default.ts
@@ -1,0 +1,9 @@
+import type { AdapterModel } from '@qlan-ro/mainframe-types';
+
+export function normalizeSavedDefaultModel(
+  configuredModel: string | undefined,
+  models: AdapterModel[],
+): string | undefined {
+  if (!configuredModel || models.length === 0) return configuredModel;
+  return models.some((model) => model.id === configuredModel) ? configuredModel : undefined;
+}


### PR DESCRIPTION
## Summary

- use the configured Codex executable for live model discovery, completing the resolved-path flow introduced by #395
- omit unset Codex model fields so ChatGPT-account sessions inherit the CLI default instead of sending an empty model
- retain Claude's semantic default alias while removing the explicit entry that resolves to the same Opus model
- ignore stale saved provider defaults once a non-empty catalog proves them invalid, preventing raw ids such as lowercase `opus` from leaking into new chats

## Current catalog behavior

- Claude: Default/Opus 4.8 (1M), Fable 5 (1M), Sonnet 5 (1M), Haiku 4.5 (200k)
- Codex: catalog comes from the installed CLI; live verification against 0.144.1 returned GPT-5.6-Sol/Terra/Luna, GPT-5.5, GPT-5.4, and GPT-5.4-Mini

## Test plan

- [x] 12 focused Vitest files, 71 tests
- [x] core TypeScript typecheck
- [x] core build
- [x] targeted ESLint (0 errors)
- [x] compiled live Claude 2.1.206 and Codex 0.144.1 catalog probes
- [x] rebased on current `main` before verification

## Changeset

Patch changesets for `@qlan-ro/mainframe-types` and `@qlan-ro/mainframe-core`.