### PR TITLE
fix(ui): sessions-list scrollbar + pinned group header see-through

### DIFF
--- a/.changeset/sessions-sticky-scrollbar.md
+++ b/.changeset/sessions-sticky-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fix the sessions-list scrollbar and pinned group headers. The mf-thin-scrollbar class mixed the standards scrollbar properties with ::-webkit-scrollbar rules; engines that honor the standard properties ignore the webkit rules, letting the native white classic scrollbar paint on warm panels — the class now uses the standards path only (thin, transparent, thumb on hover). Pinned group headers no longer show row content through them: the scroller's top padding opened a see-through band above the sticky header, and WKWebView's backdrop-filter does not reliably blur sibling rows scrolled beneath it — the pinned host now composites the glass tint over an opaque base. Also restores the sessions-list-scroll test hook that Virtuoso's own data-testid was overriding.

--- a/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
@@ -41,23 +41,45 @@ const SessionsScroller = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'di
     return (
       <div
         ref={ref}
-        data-testid="sessions-list-scroll"
         className={cn('mf-thin-scrollbar overscroll-contain bg-transparent', className)}
         {...rest}
+        // After {...rest}: Virtuoso injects its own data-testid ("virtuoso-scroller")
+        // which must not override the list's test hook.
+        data-testid="sessions-list-scroll"
       />
     );
   },
 );
 
-const VIRTUOSO_COMPONENTS = { Scroller: SessionsScroller };
+// The pinned group-header host. Its SessionGroupHeader child paints translucent
+// glass, but WKWebView's backdrop-filter does not reliably sample sibling rows
+// scrolled beneath a sticky element — row text ghosted through the pinned
+// header. Composite the glass tint over the opaque window color so the pinned
+// copy (and only it — in-flow headers have nothing beneath them) is opaque.
+const SessionsTopItemList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(function SessionsTopItemList(
+  { style, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      {...rest}
+      style={{ ...style, background: 'linear-gradient(var(--mf-glass), var(--mf-glass)), var(--mf-window)' }}
+    />
+  );
+});
+
+const VIRTUOSO_COMPONENTS = { Scroller: SessionsScroller, TopItemList: SessionsTopItemList };
 
 export function SessionListVirtuoso({ groups, showProject, renderItem }: SessionListVirtuosoProps) {
   const groupCounts = useMemo(() => groups.map((g) => g.items.length), [groups]);
   const flatItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
 
   return (
+    // pb only: top padding on the scroller opens a see-through band above the
+    // pinned group header (sticky pins to the content edge, below the padding).
     <GroupedVirtuoso
-      className="min-h-0 flex-1 py-0.5"
+      className="min-h-0 flex-1 pb-0.5"
       groupCounts={groupCounts}
       components={VIRTUOSO_COMPONENTS}
       // Skip the visible window as fast as it can; overscan a little so a quick

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1079,37 +1079,15 @@ code {
    Replaces the default browser scrollbar without taking over the native
    autoscroll Viewport (radix ScrollArea via asChild doesn't bind to it). */
 .mf-thin-scrollbar {
-  /* Deliberately NO scrollbar-width: thin — modern WebKit/Chromium honor it and
-     thereby DISABLE the ::-webkit-scrollbar rules below, falling back to native
-     (light) chrome. scrollbar-color stays as the Firefox/standards path. */
+  /* Standards path ONLY (scrollbar-width/scrollbar-color) — both shells' engines
+     (WKWebView ≥ 18.2, Chromium ≥ 121) support it, and setting EITHER standard
+     property makes the engine ignore ::-webkit-scrollbar rules entirely. Mixing
+     the two paths let the native (white) classic scrollbar leak through. */
+  scrollbar-width: thin;
   scrollbar-color: transparent transparent;
 }
 .mf-thin-scrollbar:hover {
   scrollbar-color: var(--mf-text-4) transparent;
-}
-.mf-thin-scrollbar::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-.mf-thin-scrollbar::-webkit-scrollbar-track {
-  background-color: transparent;
-}
-.mf-thin-scrollbar::-webkit-scrollbar-corner {
-  background-color: transparent;
-}
-.mf-thin-scrollbar::-webkit-scrollbar-thumb {
-  background-color: transparent;
-  border-radius: 9999px;
-  border: 3px solid transparent;
-  background-clip: padding-box;
-}
-.mf-thin-scrollbar:hover::-webkit-scrollbar-thumb {
-  background-color: var(--mf-text-4);
-  background-clip: padding-box;
-}
-.mf-thin-scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: var(--mf-text-3);
-  background-clip: padding-box;
 }
 
 /* In-chat Find (FindBar) — CSS Custom Highlight API paint. Only background-color


### PR DESCRIPTION
## Bugs (reported on rc.4)

1. **Scrollbar background still white** despite #438: `mf-thin-scrollbar` mixed the standards properties with `::-webkit-scrollbar` rules. Engines that honor `scrollbar-color` (current WKWebView — verified `CSS.supports` live) **ignore the webkit rules entirely** (the 10px width rule was provably dead: 15px native gutter), so the native white classic scrollbar painted on warm panels.
2. **Sessions list "flicker/gap" while scrolling**: two stacked causes at the pinned group header —
   - the scroller's `py-0.5` top padding opened a see-through band above the sticky header (sticky pins to the content edge, below the padding);
   - the header's translucent glass let row text ghost through, because WKWebView's `backdrop-filter` does not reliably blur sibling rows scrolled beneath a sticky element.
3. Bonus: the `sessions-list-scroll` test hook was silently lost — Virtuoso injects its own `data-testid="virtuoso-scroller"` via spread after ours.

## Fixes

- `mf-thin-scrollbar`: standards path only (`scrollbar-width: thin` + `scrollbar-color`, hover reveal); deleted the dead webkit block.
- Sessions scroller: `pb-0.5` only (no top padding).
- New `TopItemList` override composites the glass tint over the opaque window color — pinned copy opaque, in-flow headers untouched (nothing beneath them).
- `data-testid` moved after the spread.

## Verification (live in the dev app via the tauri-mcp bridge)

- Sticky gap = 0 at 60 scroll positions incl. every group boundary; frame-by-frame upward-scroll probe: zero Virtuoso position corrections.
- Scrollbar: thin (11px) gutter, panel-colored track, thumb on hover.
- Screenshot before/after: ghost row text above/behind the pinned "Earlier" header is gone.
- `vitest` sessions sidebar suites 214/214, UI typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)