### PR TITLE
fix(ui): style scrollbars globally, drop the opt-in mf-thin-scrollbar class

### DIFF
--- a/.changeset/global-thin-scrollbars.md
+++ b/.changeset/global-thin-scrollbars.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Style scrollbars globally instead of per-element. The warm thin scrollbar was an opt-in class covering 9 of 66 scroll containers; every other surface (markdown preview, diff viewers, workflows, tab panels, …) painted the native track — near-white under light themes and permanently visible with a mouse attached. Two @layer base rules now give every scroller the thin, hover-revealed, transparent-track treatment across all themes and schemes; [scrollbar-width:none] opt-outs still win, and the mf-thin-scrollbar class is removed.

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -81,7 +81,7 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
           <ThreadPrimitive.Viewport
             data-testid="chat-thread-viewport"
             data-mf-chat-thread
-            className="mf-thin-scrollbar relative flex flex-1 flex-col overflow-y-auto"
+            className="relative flex flex-1 flex-col overflow-y-auto"
           >
             <div className="mx-auto w-full max-w-3xl flex-1 px-5 py-4">
               <LoadErrorBanner />

--- a/packages/ui/src/features/context-panel/BottomPanel.tsx
+++ b/packages/ui/src/features/context-panel/BottomPanel.tsx
@@ -58,7 +58,7 @@ export function BottomPanel() {
           })}
         </div>
       </div>
-      <div className="mf-thin-scrollbar min-h-0 flex-1 overflow-y-auto py-1">
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
         {tab === 'context' && <ContextInspector />}
         {tab === 'skills' && <SkillsList />}
         {tab === 'agents' && <AgentsList />}

--- a/packages/ui/src/features/files/InspectorPane.tsx
+++ b/packages/ui/src/features/files/InspectorPane.tsx
@@ -81,7 +81,7 @@ export function InspectorPane({ port }: { port: number }) {
       </div>
 
       {/* Body */}
-      <div className="min-h-0 flex-1 overflow-y-auto mf-thin-scrollbar">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {!projectId ? (
           <div className="px-3 py-4 text-caption text-muted-foreground">Open a session to browse its files.</div>
         ) : tab === 'files' ? (

--- a/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
@@ -31,17 +31,17 @@ export interface SessionListVirtuosoProps {
   renderItem: (item: SessionItem, flags: { inPinnedGroup: boolean; showProject: boolean }) => ReactNode;
 }
 
-// The scroll viewport. Carries the list test hook + the warm auto-hide
-// scrollbar; forwardRef is required — Virtuoso attaches its scroll listener to
-// this node. Defined at module scope so its identity is stable across renders
-// (an inline component would remount the scroller every render).
+// The scroll viewport. Carries the list test hook; forwardRef is required —
+// Virtuoso attaches its scroll listener to this node. Defined at module scope
+// so its identity is stable across renders (an inline component would remount
+// the scroller every render).
 const SessionsScroller = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
   function SessionsScroller(props, ref) {
     const { className, ...rest } = props;
     return (
       <div
         ref={ref}
-        className={cn('mf-thin-scrollbar overscroll-contain bg-transparent', className)}
+        className={cn('overscroll-contain bg-transparent', className)}
         {...rest}
         // After {...rest}: Virtuoso injects its own data-testid ("virtuoso-scroller")
         // which must not override the list's test hook.

--- a/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
@@ -218,7 +218,7 @@ function SessionSidebarImpl() {
 
       {filteredItems.length === 0 ? (
         <div
-          className="mf-thin-scrollbar overscroll-contain min-h-0 flex-1 overflow-y-auto bg-transparent py-0.5"
+          className="overscroll-contain min-h-0 flex-1 overflow-y-auto bg-transparent py-0.5"
           data-testid="sessions-list-scroll"
         >
           <EmptyState hasFilters={hasFilters} />

--- a/packages/ui/src/features/sessions/tags/TagPopover.tsx
+++ b/packages/ui/src/features/sessions/tags/TagPopover.tsx
@@ -211,7 +211,7 @@ export function TagPopover({
               {error}
             </div>
           )}
-          <div className="mf-thin-scrollbar max-h-56 overflow-y-auto mt-1">
+          <div className="max-h-56 overflow-y-auto mt-1">
             {filtered.map((t) =>
               renaming === t.name ? (
                 <Input

--- a/packages/ui/src/features/tasks/TaskColumn.tsx
+++ b/packages/ui/src/features/tasks/TaskColumn.tsx
@@ -72,7 +72,7 @@ export function TaskColumn({
       </div>
 
       {/* Cards — 9px gap per design (12-todos.jsx:621, finding 9.14) */}
-      <div className="mf-thin-scrollbar flex min-h-0 flex-1 flex-col gap-[9px] overflow-y-auto px-5 pb-5">
+      <div className="flex min-h-0 flex-1 flex-col gap-[9px] overflow-y-auto px-5 pb-5">
         {todos.map((todo) => (
           <TaskCard key={todo.id} todo={todo} onEdit={onEdit} onDelete={onDelete} onStartSession={onStartSession} />
         ))}

--- a/packages/ui/src/features/tasks/TaskListView.tsx
+++ b/packages/ui/src/features/tasks/TaskListView.tsx
@@ -140,7 +140,7 @@ export function TaskListView({ port, projectId, todos, filters, onEdit, onStartS
   return (
     <div
       ref={containerRef}
-      className="flex flex-col min-h-0 flex-1 overflow-y-auto mf-thin-scrollbar focus:outline-none"
+      className="flex flex-col min-h-0 flex-1 overflow-y-auto focus:outline-none"
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >

--- a/packages/ui/src/features/tasks/TasksDrawerList.tsx
+++ b/packages/ui/src/features/tasks/TasksDrawerList.tsx
@@ -38,7 +38,7 @@ export function TasksDrawerList({ port, projectId, onStartSession }: Props): Rea
 
   return (
     <>
-      <div className="flex flex-col overflow-y-auto min-h-0 mf-thin-scrollbar">
+      <div className="flex flex-col overflow-y-auto min-h-0">
         {active.length === 0 ? (
           <div data-testid="tasks-drawer-empty" className="px-3 py-4 text-caption text-muted-foreground">
             No active tasks.

--- a/packages/ui/src/layout/SurfacePicker.tsx
+++ b/packages/ui/src/layout/SurfacePicker.tsx
@@ -123,7 +123,7 @@ export function SurfacePicker({ surface }: Props) {
       className="flex flex-1 items-center justify-center bg-background p-[16px]"
     >
       <div className="w-[300px] overflow-hidden rounded-[13px] border-[0.5px] border-border bg-background shadow-[var(--mf-shadow-picker)]">
-        <div className="mf-thin-scrollbar max-h-[300px] overflow-y-auto p-[4px]">
+        <div className="max-h-[300px] overflow-y-auto p-[4px]">
           {surface === 'files' ? <FilesPickerContent /> : <RunPickerContent />}
         </div>
         <div className="[border-top:0.5px_solid_var(--border)] px-3.5 py-[7px] font-mono text-micro text-mf-text-4">

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1075,19 +1075,25 @@ code {
   100% { transform: translateX(420%); }
 }
 
-/* Warm-chrome thin scrollbar for the thread viewport (revealed on hover).
-   Replaces the default browser scrollbar without taking over the native
-   autoscroll Viewport (radix ScrollArea via asChild doesn't bind to it). */
-.mf-thin-scrollbar {
-  /* Standards path ONLY (scrollbar-width/scrollbar-color) — both shells' engines
-     (WKWebView ≥ 18.2, Chromium ≥ 121) support it, and setting EITHER standard
-     property makes the engine ignore ::-webkit-scrollbar rules entirely. Mixing
-     the two paths let the native (white) classic scrollbar leak through. */
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-}
-.mf-thin-scrollbar:hover {
-  scrollbar-color: var(--mf-text-4) transparent;
+/* Warm-chrome thin scrollbar, GLOBAL (hover-revealed thumb, transparent track).
+   Universal on purpose: the old opt-in .mf-thin-scrollbar class covered 9 of 66
+   scroll containers — every unstyled one painted the native track, near-white
+   under color-scheme:light and always visible with a mouse attached (classic
+   scrollbars). Standards path ONLY (scrollbar-width/scrollbar-color): setting
+   either standard property makes engines ignore ::-webkit-scrollbar rules, so
+   the two must never be mixed. Opt-outs like [scrollbar-width:none] still win
+   (class specificity beats the universal selector). */
+/* In @layer base so utilities keep winning — unlayered rules would outrank ALL
+   layered ones (cascade layers ignore specificity across layers), silently
+   re-enabling scrollbars on [scrollbar-width:none] opt-outs like the tab strips. */
+@layer base {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+  }
+  *:hover {
+    scrollbar-color: var(--mf-text-4) transparent;
+  }
 }
 
 /* In-chat Find (FindBar) — CSS Custom Highlight API paint. Only background-color


### PR DESCRIPTION
## The bug (rc.5 "scrollbars still broken")

#443 fixed the `mf-thin-scrollbar` class — and it works (verified: rc.5's built CSS ships the standards-only rules). But the class was **opt-in and only 9 of 66 scroll containers carried it**. Every other surface — markdown preview (the worst offender), diff viewers, WriteFile cards, PlanGate, tab panels, the entire workflows surface — painted the **native** track: near-white under `color-scheme: light` (clashes on warm panels) and permanently visible when a mouse is attached (`AppleShowScrollBars: Automatic` → classic scrollbars). It looked theme-dependent only because dark mode's native track is dark and blends in.

## The fix

Two universal rules in `@layer base` replace the class:

```css
@layer base {
  * { scrollbar-width: thin; scrollbar-color: transparent transparent; }
  *:hover { scrollbar-color: var(--mf-text-4) transparent; }
}
```

- Covers all 66 scrollers in every theme and scheme with the same auto-hide behavior the sessions list already had.
- `@layer base` placement is load-bearing: an unlayered rule outranks **all** layered utilities regardless of specificity, which silently re-enabled scrollbars on the tab strips' `[scrollbar-width:none]` opt-out (caught live during verification — computed `thin` unlayered vs `none` in base).
- `mf-thin-scrollbar` deleted along with all 10 call sites — no dead class left behind.

## Verification (live in the dev app via the tauri-mcp bridge)

- Every mounted scroller computes `scrollbar-width: thin` + transparent track (sessions list, chat thread — which no longer carries any class — and probe elements).
- `[scrollbar-width:none]` probe computes `none` (opt-out wins).
- Sessions sidebar + tasks suites 373/373, UI typecheck clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)