### PR TITLE
fix(ui): automations panel popovers hidden behind their own backdrop

### DIFF
--- a/.changeset/fix-automations-host-zindex.md
+++ b/.changeset/fix-automations-host-zindex.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-app-tauri": patch
+---
+
+Fix Automations panel popovers (add trigger, add step, token picker) rendering invisibly behind the panel's own backdrop. `AutomationsHost`'s overlay used `z-[4600]`, well above the `z-50` tier every Radix popover/dropdown in the app defaults to — so clicking "+ Add a trigger" or "+ Add step" opened the menu, just painted underneath the modal. Overlay now uses `z-50`, matching every other full-screen dialog in the app.

--- a/packages/ui/src/features/automations/AutomationsHost.tsx
+++ b/packages/ui/src/features/automations/AutomationsHost.tsx
@@ -50,7 +50,7 @@ export function AutomationsHost(): React.ReactElement | null {
   return (
     <div
       data-testid="automations-host"
-      className="fixed inset-0 z-[4600] flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={close}
     >
       <div


### PR DESCRIPTION
## Summary
- `AutomationsHost`'s overlay used `z-[4600]`, well above the `z-50` tier every Radix popover/dropdown (`PopoverContent`, `SettingsDialog`, `components/ui/dialog.tsx`) defaults to.
- Result: clicking "+ Add a trigger" or "+ Add step" in the automations editor opened the menu — it just painted underneath the panel's own backdrop, so it looked like the buttons did nothing.
- Fix: overlay now uses `z-50`, matching the convention every other full-screen dialog in the app follows.

Reported against #448 (Automations v2 Node + UI).

## Test plan
- [x] `tsc --noEmit` on `@qlan-ro/mainframe-ui` — clean
- [x] `AutomationEditor.test.tsx` / `WhenCard.test.tsx` / `AddStepMenu.test.tsx` — 21 tests pass
- [ ] Manual: open Workflows → New automation → click "+ Add a trigger" and "+ Add step", confirm the menus are now visible (jsdom can't catch this class of bug — it doesn't compute real CSS stacking, which is also why it shipped unnoticed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)