### PR TITLE
fix(ui): typography & text-color legibility overhaul

### DIFF
--- a/.changeset/typography-legibility-remediation.md
+++ b/.changeset/typography-legibility-remediation.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': minor
+---
+
+Overhaul UI typography and text-color legibility. Re-tint the tertiary/semantic ink tokens (mf-text-3, mf-success, mf-warning) across all six themes so they clear WCAG 4.5:1, reclassify mf-text-4 as ornament-only, and add a globals.css contrast guardrail test. Re-anchor the UI scale factors (compact 0.92 / normal 1.0 / large 1.15) so normal mode renders crisp un-zoomed 13px text and compact is legible. Repair shared primitives (button icon default, menu/dropdown/command eyebrows, tooltip size) and add CountBadge + SectionHeader. Sweep every surface to promote must-read text off 10–11px, move semantic hues off text onto icons/tints, replace the invisible white-on-accent count badges with capsule-less counts, and give session-row selection a macOS-style neutral fill. Fixes hundreds of contrast and small-text findings from the 2026-07-11 legibility audit.

--- a/docs/architecture/2026-07-11-typography-legibility-audit.md
+++ b/docs/architecture/2026-07-11-typography-legibility-audit.md
@@ -1,0 +1,228 @@
+# Typography & legibility audit — diagnosis and proposal (2026-07-11)
+
+Status: **PROPOSAL — awaiting user triage.** Companion finding inventory:
+[2026-07-11-typography-legibility-findings.md](2026-07-11-typography-legibility-findings.md).
+
+Trigger: project-picker pills are barely readable in compact mode, their count
+badge is near-invisible at any scale, and the sessions list reads as
+black/washed-black instead of the macOS-sidebar gray + accent-selection
+hierarchy. A full static audit of `packages/ui` (4 parallel surface audits +
+measured WCAG math over all six theme blocks) found these are instances of
+seven systemic root causes, not isolated styling mistakes: ~20 P0
+(unreadable/invisible), ~300 P1 (fails legibility norms), ~115 P2
+(inconsistency).
+
+## How this was measured
+
+- Type/zoom math: semantic tokens are micro 10 / caption 11 / label 12 /
+  body 13 / heading 15 / title 17 px; "UI scale" is native page zoom
+  (`store/theme.ts`: compact ×1.0, normal ×1.15, large ×1.3), so **compact
+  renders raw token pixels**.
+- Contrast: WCAG ratios computed from `globals.css` token values for all six
+  appearance blocks, compositing alpha colors over their real backdrops
+  (glass-over-window, accent-over-glass, white/25-over-primary). Script kept at
+  the session scratchpad (`contrast-audit.mjs`, `token-solver.mjs`); the
+  proposal below includes a CI guard so the numbers stay checked.
+
+## Root causes
+
+**R1 — The app is authored one type-rung below its own scale.**
+`text-caption` (11px) is the de-facto body (417 uses); `text-micro` (10px) is
+the de-facto secondary (162 uses); `text-body` (13px) has only 157. The zoom
+factors were then tuned to compensate (`UI_SCALE_FACTORS` comment: "tuned so
+Normal dominant text ≈ 13px" — i.e. 11px caption ×1.15 ≈ 12.7px). Compact
+(×1.0) exposes the raw 10–11px text.
+
+**R2 — The bottom half of the ink ramp fails everywhere.**
+`foreground` (≥13:1) and `muted-foreground` (4.8–7:1) pass. But `mf-text-3`
+measures **2.5–4.4:1** (fails the 4.5:1 text floor in every theme; worst on
+light glass) and is used pervasively as the everyday secondary text color.
+`mf-text-4` measures **1.5–2.3:1** and carries real content (timestamps, file
+paths, log tails, status rings, kbd hints, placeholders); one site stacks
+`opacity-50` on it (≈1.3:1). Opacity-stacking on muted inks appears in ~10
+more places.
+
+**R3 — Semantic hues used as text color.**
+`text-mf-success` / `text-mf-warning` ≈ 2.7–2.9:1 on light themes (PR links,
+diff +N/−N stats, "Viewed", saved/unsaved chips, branch ahead/behind). The
+fixed task-type/priority/workflow hues have **no dark-theme overrides** and
+fail hardest on dark cards. Colored text on a same-hue tint (green-on-green
+"Approved") compounds it.
+
+**R4 — The badge/count treatment is mathematically invisible.**
+`FilterPill`: 10px bold `text-white` on `bg-white/25`-over-primary =
+**1.8–2.9:1** (the reported badge). Inactive: white-on-primary 2.1–4.1:1 —
+and hardcoded `text-white` breaks the two dark schemes whose accents are
+light (should be `primary-foreground`). Same pattern in BottomPanel tab
+counts, tool-group "N calls", workflow "Answer now"/"Needs you".
+
+**R5 — The eyebrow antipattern, copied everywhere.**
+`text-micro font-bold uppercase tracking-wide text-mf-text-3` — 10px + bold +
+uppercase + wide tracking + failing color, stacked. Verbatim in ≥13 feature
+files **and** in five shared primitives (`menu.tsx` MenuLabel,
+`dropdown-menu.tsx`, `command.tsx` ×2, `context-menu.tsx`), so every popover
+section header in the app inherits it.
+
+**R6 — Compressed-spacing icon traps and icon anarchy.**
+The theme redefines integer spacing (`--spacing-3`=6px, `--spacing-4`=8px), so
+`size-3` icons render 6px and `size-4` 8px. `button.tsx` applies
+`[&_svg]:size-4` → **8px icons in every Button**, and its specificity silently
+defeats child `size-*` overrides (the composer's Paperclip/AtSign, authored
+6px, render 8px — both wrong). Two icons are larger than their boxes and clip
+(`WfEditorChrome.tsx:89`, `TaskListRow.tsx:83`). Meaningful lucide glyphs span
+6–16px with no scale (9px warning triangles, 9px close buttons, 6px chevrons).
+
+**R7 — Sessions sidebar ignores the macOS label hierarchy it's aiming for.**
+Row titles are near-black `foreground`, then metadata falls off a cliff to the
+failing `mf-text-3/4` grays — there is no macOS-like secondary-label middle
+step in use ("black / washed black"). Selection is a 2px left border + 4%
+black wash, not the Finder-style rounded fill + accent treatment. The idle
+status glyph is `mf-text-4` + `opacity-50` (≈1.3:1, invisible).
+
+## Proposal
+
+### 1. Fix the ink ramp values (token-only; biggest visual lift, zero call-site churn)
+
+Adopt macOS label semantics and re-tint the failing tiers, hue-preserved,
+solved per theme to clear 4.5:1 on glass, background, and card:
+
+| Token | Role | classic L | classic D | ocean L | ocean D | velvet L | velvet D |
+|---|---|---|---|---|---|---|---|
+| `--mf-text-3` | Tertiary text (short metadata only) | `#92918d`→**`#6c6b68`** | `#7d8099`→**`#8b8ea4`** | `#89989d`→**`#5f6d72`** | `#76869b`→**`#7e8da1`** | `#94899c`→**`#72677b`** | `#877b97`→**`#9287a1`** |
+| `--mf-success` (text use, light only) | | `#28a745`→**`#1d7b33`** | keep | `#1e9e58`→**`#177a44`** | keep | `#1f9e54`→**`#187b41`** | keep |
+| `--mf-warning` (text use, light only) | | `#d97706`→**`#a15804`** | keep | `#c07a12`→**`#955f0e`** | keep | `#c0741f`→**`#9a5d19`** | keep |
+
+`--mf-text-4` keeps its value but is **reclassified as ornament**
+(hairlines, drag grips, scrollbars — it already paints `mf-thin-scrollbar`).
+Policy: never on text or meaning-bearing icons; the ~20 P0 sites move up to
+`mf-text-3`/`muted-foreground`. (Alternative if visible "disabled" text is
+wanted: solved 3:1 values exist — classic L `#8b877f`, classic D `#6c708e`,
+ocean L `#738c94`, ocean D `#607085`, velvet L `#93829d`, velvet D `#75688c` —
+but this thickens every hairline; policy-only is recommended.)
+
+Additional color rules:
+- Never stack `opacity-*` on an ink token; pick the right tier instead.
+- Semantic hues (success/warning/task-type/priority/wf-kind) live on the
+  icon/dot/tint-background; the text next to them is `foreground`/
+  `muted-foreground`. Fixed-hue chip tokens get dark-theme overrides.
+- `text-white` only on true scrims; on accent fills use `text-primary-foreground`.
+- White-on-accent text (active pills, primary buttons) is kept per Apple
+  convention but only ≥12px medium/semibold — never 10px, never on
+  translucent `white/NN` fills.
+
+### 2. Re-anchor the type roles (the compact-mode fix)
+
+Keep the 8-rung scale (it is macOS HIG). Fix the **role mapping** and promote
+must-read text one rung, per the findings inventory:
+
+| Role | Token | Goes here |
+|---|---|---|
+| Primary content, labels users act on | `body` 13 | session titles (already), menu items, picker values, question text, message/inputs, button labels |
+| Secondary supporting text | `label` 12 | descriptions, tooltips, code/diff text, table cells, meta rows users rely on |
+| Compact annotations | `caption` 11 | chips, badges, eyebrows, keycaps, timestamps |
+| Ornament only | `micro` 10 | nothing that must be read (target: deprecate) |
+
+Then retune `UI_SCALE_FACTORS` **in the same PR** (coupled — see phasing):
+`compact 0.92 / normal 1.0 / large 1.15` → dominant text 12 / 13 / 15 px.
+Normal becomes true HIG 13px at crisp ×1.0 zoom (today it's a zoomed 12.65px);
+compact becomes a legible small mode (12px dominant, ~11px secondary) instead
+of 11px/10px.
+
+**Interim option (single line, ships day 1):** bump compact 1.0 → **1.08**
+(dominant 11.9px, micro 10.8px). Honest tradeoff: compact temporarily sits
+close to normal (×1.08 vs ×1.15) until the re-anchor lands.
+
+### 3. One `CountBadge` primitive (the pill badge fix)
+
+macOS-style, replacing every ad-hoc count:
+- **Informational count** (project pills, tab counts, "N calls"): no capsule —
+  `text-caption font-semibold tabular-nums text-muted-foreground`, switching to
+  `text-primary` when it means unread. (Finder/Mail sidebar style.)
+- **On accent fills** (active pill): same size, `text-primary-foreground` at
+  full opacity; the `bg-white/25` capsule is deleted.
+- **Alerting badge** (needs-input): filled `bg-primary`/`bg-destructive`
+  capsule, ≥16px tall, `text-caption` semibold `primary-foreground`.
+
+Pill labels move `caption→label` (12px) with `max-w` widened accordingly.
+
+### 4. Primitive repairs (each clears dozens of call sites)
+
+- `menu.tsx` MenuLabel + `dropdown-menu.tsx:179` + `command.tsx:32,89` +
+  `context-menu.tsx:183` → one **`SectionHeader`** recipe:
+  `text-caption font-medium text-muted-foreground`, sentence case, no
+  bold/uppercase/tracking-wide below 12px. (If uppercase eyebrows are wanted
+  as a design signature: 11px semibold + `tracking-wide` is acceptable **only**
+  in `muted-foreground`.)
+- `menu.tsx:64` MenuRow hint: `text-mf-text-4` → `text-mf-text-3` (new value).
+- `tooltip.tsx:33`: `text-caption` → `text-label` (tooltips are the only label
+  for every icon-only control).
+- `button.tsx:13`: `[&_svg]:size-4` (8px) →
+  `[&_svg:not([class*='size-'])]:size-3.5` (14px + child overrides respected —
+  the guard `menu-variants.ts` already uses).
+- `Composer.tsx:125` placeholder → `placeholder:text-mf-text-3`.
+- Add paired line-height tokens so text utilities emit sane leading:
+  `--text-micro/caption/label--line-height: 1.3`, `--text-body: 1.45`,
+  `--text-heading/title: 1.25`.
+
+### 5. Icon grid
+
+Meaningful glyphs land on a 12/14/16 px grid (12 inside chips/meta rows,
+14 default UI, 16 headers/nav); 9–11px glyphs promoted; decorative dots
+exempt. Icons never use integer `size-N` utilities (compressed scale) — always
+fractional (`size-3.5`) or explicit (`size-[12px]`, lucide `size={12}`).
+Fix the two clip bugs (`WfEditorChrome.tsx:89`, `TaskListRow.tsx:83`) and the
+6px glyph family (quote/directive/attachment/ImportSessionsDialog chevron).
+
+### 6. Sessions sidebar — macOS treatment (the color complaint)
+
+- **Selection:** inset rounded fill (`rounded-md`, neutral 6–8% ink wash, the
+  existing `mf-chip`/`accent` family) with the accent carried by the status
+  dot + unread/title accents — replacing the 2px left border + 4% wash.
+  (Finder model: gray fill, accent glyph.)
+- **Row inks:** title `foreground`; metadata/timestamps `muted-foreground`
+  (not `mf-text-3`); group headers = SectionHeader (caption,
+  `muted-foreground` — the Finder "Favorites" gray); hover actions
+  `muted-foreground`→`foreground`; idle status glyph loses `opacity-50` and
+  uses `mf-text-3` minimum.
+- Meta row `micro`→`caption`; PR link uses the new success value at `caption`.
+
+### 7. Guardrails (keep it fixed)
+
+- **Contrast unit test** in `packages/ui`: parse `globals.css`, composite the
+  real backdrops, assert `muted-foreground`/`mf-text-3` ≥ 4.5:1 and every
+  `*-tint`+hue text pair ≥ 4.5:1 across all six blocks.
+- **Static lint sweep** (script or CI grep): forbid `text-mf-text-4`/
+  `border-mf-text-4` outside an allowlist; forbid integer `size-N` on svg;
+  forbid `text-white` outside scrim contexts; forbid `opacity-*` adjacent to
+  ink tokens; forbid the `text-micro font-bold uppercase` stack.
+
+## Phasing (PR-sized, each independently shippable)
+
+1. **PR-1 "ink & primitives"** — token re-tints (§1), primitive repairs (§4),
+   CountBadge (§3), sidebar treatment (§6), icon-clip/6px bug fixes, guardrail
+   test. Zero-to-low call-site churn, immediate app-wide lift; fixes the
+   reported badge + washed-gray complaints at every scale. Optionally includes
+   the interim compact ×1.08 bump.
+2. **PR-2 "P0/P1 sweep"** — mechanical promotion of the ~320 flagged sites per
+   the findings doc (micro→caption, caption→label/body, hue-text→foreground,
+   9–11px→12/14px icons). Bulk-mechanical: suited to codex delegation with the
+   findings doc as the worklist, then a design-conformance pass.
+3. **PR-3 "re-anchor"** — the coupled change: dominant text to `body` where
+   still below it + `UI_SCALE_FACTORS` → 0.92/1.0/1.15 (+ revert the interim
+   bump). Must land atomically or normal mode grows ~15%.
+4. **PR-4 "icon grid + P2s"** — sibling-size normalization, status-dot grid,
+   token-drift cleanups (destructive vs diff-del-text, wf-violet pairing).
+
+Verification per PR: `pnpm --filter @qlan-ro/mainframe-ui typecheck`, the new
+contrast test, and a live render pass (test-worktree / design-conformance)
+across classic/ocean/velvet × light/dark × compact/normal.
+
+## Decision points
+
+1. Eyebrows: sentence-case (recommended) vs keep-uppercase-at-11px signature.
+2. Informational counts: capsule-less gray text (recommended, Finder-style) vs
+   keep filled capsules with fixed contrast.
+3. Interim compact ×1.08 in PR-1: yes (quick relief) / no (wait for PR-3).
+4. `mf-text-4`: policy-only reclassification (recommended) vs darken to 3:1.
+5. Selection: neutral fill + accent glyphs (recommended, Finder) vs
+   accent-tinted fill (`mf-selection`).

--- a/docs/architecture/2026-07-11-typography-legibility-findings.md
+++ b/docs/architecture/2026-07-11-typography-legibility-findings.md
@@ -1,0 +1,284 @@
+# Typography & legibility audit — consolidated findings (2026-07-11)
+
+Worklist companion to
+[2026-07-11-typography-legibility-audit.md](2026-07-11-typography-legibility-audit.md)
+(read that first for the root causes R1–R7, the measured contrast table, and
+the remediation recipes referenced below). Paths relative to
+`packages/ui/src`. Line numbers verified on audit day against `main`.
+
+Grading: **P0** invisible/unreadable must-read content · **P1** fails
+legibility norms (size and/or contrast) · **P2** inconsistency/polish.
+
+## P0 — invisible content (exhaustive)
+
+All are `mf-text-4`-grade contrast (≈1.5–2.3:1) carrying meaning. Fix: move to
+`mf-text-3` (re-tinted) or `muted-foreground`, and promote `micro`→`caption`
+where noted.
+
+| Site | What's invisible |
+|---|---|
+| `features/sessions/sidebar/DraftSessionRow.tsx:80` | "draft — clears if you leave without sending" (micro + text-4) |
+| `features/sessions/new-thread/FirstRunState.tsx:41` | "Your files stay on disk…" reassurance (micro + text-4) |
+| `layout/SurfacePicker.tsx:129` | footer guidance ("opens route here automatically") (micro + text-4) |
+| `features/chat/tools/cards/SearchCard.tsx:107` | "in {path}" — where the search ran (micro + text-4) |
+| `components/ui/menu.tsx:64` | MenuRow keyboard hints (⌘1, ↵) (caption + text-4) |
+| `features/chat/composer/ComposerEditMode.tsx:63` | "esc to cancel" (micro + text-4) |
+| `features/chat/messages/QueuedUserTurn.tsx:80-81` | queued-status line, `dimmed` branch (micro + text-4) |
+| `features/context-panel/BottomPanel.tsx:53-54` | inactive tab counts (micro + text-4) |
+| `features/editor/DiffHeader.tsx:52` | diffed file path breadcrumb (micro + text-4) |
+| `features/run/ConsolePane.tsx:121` | log-count chip (micro + text-4) |
+| `features/run/ConsolePane.tsx:183` | collapsed-drawer last-log-line preview (micro + text-4) |
+| `features/preview/PreviewBodyState.tsx:45,46,78` | tunnel error detail, recovery instruction, target URL (micro + text-4) |
+| `features/preview/PreviewUrlBar.tsx:81` | URL bar in stopped state (text-4 branch) |
+| `features/review/ReviewFileToolbar.tsx:31` | file-path directory segment (caption + text-4) |
+| `features/tasks/TaskListRow.tsx:86` | "open" status ring — `border-mf-text-4` is the only open-state signal |
+| `features/workflows/WfStatus.tsx:119` + `workflows/glyphs.ts:153` | "skipped" status tag color |
+| `features/workflows/editor/WfYamlPane.tsx:30,44` | "canonical" tag, "Validating…" state |
+| `features/git/BranchRow.tsx:22` | "up to date" divergence status |
+| Borderline (meaning-bearing icons at text-4): `features/workflows/WfRunsList.tsx:25-28,127-130` | trigger icons, "child" tag |
+
+## P1 by pattern
+
+### A. `text-mf-text-3` on must-read text → `muted-foreground` (+ size rung where flagged ↑)
+
+Sidebar/sessions: `SessionRow.tsx:93`↑ (timestamp, micro), `SessionRow.tsx:48`
+(idle status glyph — also drop `opacity-50`), `SessionRowMeta.tsx:72`↑ (meta
+row, micro), `SessionRowMeta.tsx:48`↑ (degraded AlertTriangle 9px),
+`SessionGroupHeader.tsx:17`↑ (group headers — SectionHeader),
+`DraftSessionRow.tsx:66`↑, `ProjectFilterPillBar.tsx:115` (Add project),
+`filter/TagFilterBar.tsx:131`↑ (Tags eyebrow), `ExternalSessionRow.tsx:51,92`,
+`ArchivedSessionsDialog.tsx:45,67`, `ImportSessionsDialog.tsx:41`↑ (eyebrow),
+`NewSessionPickerPopover.tsx:89`↑, `SessionSidebar.tsx:53` (empty state →
+body), `SessionSidebar.tsx:71`↑, `layout/SidebarFooter.tsx:11,18`↑ (status
+counts).
+
+Chrome/tabs: `layout/FilesTabStrip.tsx:92` + `layout/RunTabStrip.tsx:72`
+(inactive tab titles), `layout/SurfaceRail.tsx:49` (inactive nav icons at
+text-4 → text-3-new), `features/tour/WsTourLabel.tsx:44` (Step X of Y),
+`features/sessions/new-thread/WelcomeState.tsx:50`,
+`SuggestionRow.tsx:46,50`↑ (micro).
+
+Chat: `tools/cards/marker-pill.tsx:64` (pill label — also ↑label),
+`marker-pill.tsx:73` (icon wrapper at text-4), `marker-pill.tsx:113`↑
+(ARGUMENTS/RESULT caps), `marker-pill.tsx:124`, consumers
+`MCPToolCard.tsx:68`, `SchedulePillCard.tsx:92,129,136,141,198` (several at
+text-4), `WorktreeStatusPillCard.tsx:78`, `SkillLoadedCard.tsx:28`;
+`SearchCard.tsx:95`↑, `ReadFileCard.tsx:79`↑ (text-4),
+`TaskCard.tsx:58` (model label, text-4), `TaskProgressCard.tsx:111` (pending
+subject, body-size but text-3), `SlashCommandCard.tsx:31`,
+`tool-group.tsx:128`↑ (redundant "N calls", text-4 — or drop),
+`reasoning.tsx:134-135`, `messages/MessageTimestamp.tsx:17`↑ (text-4),
+`MessageTiming.tsx:56`↑ (text-4), `SystemMessage.tsx:26,44-48`,
+`QueuedUserTurn.tsx:54-55` (Edit/Cancel + head status),
+`ReviewCommentCard.tsx:32,67`↑ (text-4), `code-snippet.tsx:16`↑ (line numbers,
+text-4), `UserAttachments.tsx:53,102`↑, diff gutters
+`tools/shared/diff.tsx:117,122,124` (text-4 → text-3-new).
+
+Composer/panels: `composer/BackgroundActivityBar.tsx:88,92`↑,
+`WorktreePopover.tsx:45,47`, `WorktreeNewForm.tsx:132,143`↑ (form labels,
+micro), `WorktreeNewForm.tsx:176` (Cancel), `WorktreeExistingTab.tsx:30,43`
+(inactive tab), `WorktreeExistingTab.tsx:89`↑, `EffortPicker.tsx:67` (Lock at
+text-4 → warning/muted), `attachment.tsx:185-187,215-217` (toolbar button
+ink), `ChatSessionInline.tsx:87`↑ (context %),
+`ChatCardHeader.tsx:106,116,130` (header icons),
+`context-panel/ScopedListRow.tsx:27,30`↑ (description + scope chip, micro),
+`ContextSection.tsx:33,39`↑ (section header smaller than children +count),
+`ContextFileItem.tsx:46`, `ContextInspector.tsx:11,47`↑,
+`TasksSection.tsx:27`↑, `AgentsList.tsx:7-8`, `SkillsList.tsx:7-8`,
+`components/ui/menu-variants.ts:20` (menu icon default ink).
+
+Files/run/review/tasks/wf/settings/git: `files/ChangesPanel.tsx:177,216`↑,
+`files/FileTree.tsx:263`↑ (root header stack), `files/InspectorPane.tsx:78`↑,
+`editor/DiffHeader.tsx:62`, `editor/EditorTab.tsx:248` (read-only banner),
+`review/ReviewCommitRail.tsx:51,113` (disabled commit),
+`review/ReviewFileTree.tsx:55`↑,`:91`↑, `review/ReviewPanelHeader.tsx:57,63`,
+`tasks/TaskColumn.tsx:71`, `tasks/TasksBoard.tsx:85`, `tasks/TasksDrawer.tsx:126`,
+`tasks/TaskListView.tsx:205`, `wf/WfLibrary.tsx:122`↑,
+`wf/WfRunsList.tsx:125,135,145`↑, `wf/WfRunDetail.tsx:135,159,225↑,232`,
+`wf/WfStepNode.tsx:55,91,164,175,186,194` (skipped-step title loses contrast
+when it matters most), `wf/editor/WfStepLibrary.tsx:187,229`,
+`settings/general/GeneralPane.tsx:39,44` (h3s),
+`settings/shared/SettingGroup.tsx:11`↑ (eyebrow),
+`settings/about/AboutPane.tsx:52`, `git/BranchGroupSection.tsx:76`↑ (eyebrow),
+`git/WorktreeSection.tsx:42`↑ (eyebrow), `git/BranchRow.tsx:25,83`
+(counts wrapper; chevron at text-4), `git/BranchSubmenu.tsx:204`.
+
+### B. Must-read text at `micro`/`caption` with passing color → promote rung
+
+Chat content: `ReadFileCard.tsx:50` (code preview→label),
+`diff.tsx:162,214` (diff body→label), `BashCard.tsx:66` (terminal
+output→label; default line color off `mf-term-cmt`, see D),
+`SearchCard.tsx:87` (pattern→label), `WebFetchCard.tsx:56,96` (URL/query),
+`PlanCard.tsx:79` (plan body), `AskUserQuestionCard.tsx:83,106` (question →
+body), `AskUserQuestionCard.tsx:63-67` (answer pills — also drop
+`opacity-60`), `tool-fallback.tsx:111` + `tool-fallback-parts.tsx:24,47-48,80`
+(unknown-tool name/args/result), `reasoning.tsx:177` (content→label),
+`quote.tsx:41` (→label, drop italic), `directive-text.tsx:56` (chips→label),
+`markdown-text.tsx:60-67` (inline code — use `text-[0.9em]` so it tracks
+prose), `code-snippet.tsx:15` (→label), `UserMessage.tsx:143` (SlashPill),
+`UserMessage.tsx:280,289` (send-failure + Retry→label),
+`UserAttachments.tsx:47`↑ (ext badge, see D), `:98`,
+`gates/AskQuestionWizard.tsx:73` (option descriptions→label),
+`gates/AskUserQuestionGate.tsx:163` ("N of M"), `gates/GateShell.tsx:62`
+(eyebrow — SectionHeader recipe; warning-hue variant see D),
+`gates/PlanGate.tsx:27-30` (h3 11px < body 13px hierarchy inversion; code→label),
+`gates/PlanGate.tsx:223-228` (running status — also color A).
+
+Composer/pickers: `ProviderModelSelect.tsx:162,169` (model name→label),
+`PermissionSelect.tsx:54,63` (mode→label), `ComposerEditMode.tsx:61,108`,
+`WorktreeNewForm.tsx:164,167` (errors→label), `ChatCardHeader.tsx:39,69`
+(session title→label/body — header is size-flat, see P2),
+`ws-toast.tsx:163,176` (CTA→label; `text-primary` ≈3:1 on light, see D),
+`components/ui/read-more.tsx:73` (Read more→label + color),
+`components/ui/tooltip.tsx:33` (all tooltips→label).
+
+Files/run/preview: `files/ChangesPanel.tsx:39,182,213,220`,
+`files/InspectorPane.tsx:23`, `files/use-file-search.tsx:46`,
+`run/ConsolePane.tsx:99` (console output→body), `:181,206`,
+`preview/CaptureAnnotationPopover.tsx:40,43` (annotation input→body),
+`preview/PreviewBodyState.tsx:57,89`, `preview/PreviewCaptureCluster.tsx:29`,
+`review/ReviewCommitRail.tsx:81,94,101`, `review/ReviewFileToolbar.tsx:32-34`,
+`review/ReviewPanelHeader.tsx:48`.
+
+Tasks (systemic — data/inputs/CTAs at caption): `TaskCard.tsx:66,79,98,110`,
+`TaskListRow.tsx:101,158,174,242,244,263,272,288,300`,
+`TasksDrawerList.tsx:59,60` (title 11px vs 13px siblings),
+`TaskColumn.tsx:68`, `TaskListView.tsx:163,168` (drop `/70`),
+`TasksDrawer.tsx:119`, `FilterMenu.tsx:61`, `LabelAutocomplete.tsx:106`
+(ghost `opacity-40`), `DependencyPicker.tsx`, `QuickTaskDialog.tsx`,
+`TaskEditModal.tsx:182,218,263,273,281`, `TaskMetaFields.tsx`,
+`TaskSelectFields.tsx:37,52,67`, `TasksFilterBar.tsx:108,143`,
+`TaskAttachments.tsx:205,232` — all field inputs/CTAs → `label`/`body`.
+
+Workflows: `WfStatus.tsx:119` (all status tags — size + hue policy),
+`WfLibrary.tsx:100`, `WorkflowsView.tsx:52,80`,
+`WfInteractionCard.tsx:104,117,168` (drop `/70`),
+`WfNeedsYou.tsx:41`, `WfTree.tsx:68,128,168`, `WfbStepRow.tsx:85`,
+`WfBuilderPane.tsx:35,78,236,267`, `WfbDropdowns.tsx:46`,
+`editor/WfEditorChrome.tsx:80,105`, `editor/WfStepLibrary.tsx:169`.
+
+Settings/git/dialogs: `providers/ProvidersPane.tsx:28`,
+`providers/ConfigConflictsWarning.tsx:18`,
+`remote-access/DevicesSection.tsx:57,73,74`,
+`remote-access/NamedTunnelSection.tsx:60,105-107,115,178,186`,
+`remote-access/PairingSection.tsx:64,118`,
+`remote-access/QuickTunnelSection.tsx:21,50`,
+`remote-access/TunnelStatusRow.tsx:23,34,44,45,55,56,60`,
+`remote-access/RemoteAccessPane.tsx:16`, `git/BranchGroupSection.tsx:39`,
+`git/ConflictView.tsx:37,64`, `git/NewBranchDialog.tsx:89,94,104` (branch
+input→body), `git/RenameBranchView.tsx:36`,
+`sessions/sidebar/ProjectPillContextMenu.tsx:49,60` (menu items),
+`chat/thread/ChatSessionInline.tsx:58`, `chat/DegradedChatCard.tsx:15,24`,
+`composer/ComposerTriggers.tsx:52`, `context-panel/BottomPanel.tsx:45`,
+`context-panel/ScopedListRow.tsx:25`, `ContextFileItem.tsx:44`.
+
+### C. Badges/counts (CountBadge recipe)
+
+`sessions/sidebar/FilterPill.tsx:25-26,34-35` and
+`ProjectPillContextMenu.tsx:32-33,72-73` — the reported pill: label
+caption→label; badge `bg-white/25`+`text-white` deleted per recipe.
+`context-panel/BottomPanel.tsx:53-54` (counts), `tool-group.tsx:128`,
+`context-panel/ContextFileItem.tsx:50` (same-hue 20% tint badge),
+`ScopedListRow.tsx:30` (scope chip), `messages/PlanBubble.tsx:39-41`
+(green-on-green "Approved"), `messages/UserAttachments.tsx:47` (ext badge on
+same-hue tint), `review/ReviewFileTree.tsx:80-83` (A/M/D/R),
+`tasks type/priority chips` (`TaskCard.tsx:79,98`, `TaskListRow.tsx:101,174` —
+hue on tint/dot only + dark overrides), `wf/WfStatus.tsx:160` + `WfTree.tsx:94`
++ `glyphs.ts:47` (kind chips), `settings/SettingsSidebar.tsx:64` (avatar
+initial), `preview/PreviewBodyState.tsx:100` (CLICK AN ELEMENT).
+
+### D. Semantic hue / accent-fill text
+
+`mf-success` as text (light): `SessionRowMeta.tsx:112` (PR link),
+`ChatCardHeader.tsx:91`, `editor/DiffHeader.tsx:56`, `editor/EditorTab.tsx:46,55`
+(chips), `review/ReviewFileToolbar.tsx:58,65`, `ReviewPanelHeader.tsx:57,63`,
+`git/BranchRow.tsx:25-32` (ahead/behind), `wf/WfYamlPane.tsx:33`,
+`composer/WorktreePopover.tsx:41`. `mf-warning` as text:
+`files/ChangesPanel.tsx:220`, `editor/EditorTab.tsx:264`,
+`review/ReviewCommitRail.tsx:94`, `remote-access/TunnelStatusRow.tsx:60`,
+`SidebarFooter.tsx:10`, `gates/GateShell.tsx:62` (warning eyebrow variant),
+`wf` status tags. White-on-accent CTAs at <12px:
+`FirstRunState.tsx:36`, `tour/WsTourLabel.tsx:92`, `WorktreeNewForm.tsx:189`,
+`ComposerEditMode.tsx:108`, `wf/WfRunDetail.tsx:200` ("Answer now"),
+`WorkflowsView.tsx:80`, `preview/PreviewRunControl.tsx:26` (Run).
+`BashCard.tsx:34,66` — default output lines use `mf-term-cmt` (dimmest
+terminal color) instead of `mf-term-fg`. `render-highlights.tsx:17-20` +
+`read-more.tsx:73` + `ws-toast.tsx:163` — `text-primary` at ≈3:1 on light
+backgrounds: acceptable for 13px+ semibold links only; smaller → darken or
+underline affordance.
+
+### E. Form-control visibility
+
+`gates/AskQuestionWizard.tsx:67` — unselected radio ring `border-mf-text-4`
+(invisible control) → `border-input`/`mf-text-3`.
+`Composer.tsx:125` placeholder text-4 → text-3.
+`WorktreeNewForm.tsx:159` input placeholder text-3 (keep with new value).
+`review/ReviewCommitRail.tsx:113` disabled state → dedicated disabled ink.
+
+### F. Meaningful icons < 12px (promote to 12/14 grid)
+
+6–8px class (compressed-scale bugs): `attachment.tsx:118,187,217`,
+`quote.tsx:31-32`, `directive-text.tsx:59`, `ImportSessionsDialog.tsx:167`
+(`size-3`=6px), `button.tsx:13` (`[&_svg]:size-4`=8px app-wide),
+`select.tsx:30,45,59,133` + `command.tsx:45,117` + dropdown/context
+`:34,136,163` (8px/4px), `Composer.tsx:43` (Cancel Square 6px vs Send 14px),
+`ChatThread.tsx:105` (scroll-down 8px). Clip bugs:
+`wf/editor/WfEditorChrome.tsx:89` (Check 10px in 8px box),
+`tasks/TaskListRow.tsx:83` (Check 9px in 8px box), `run/ConsolePane.tsx:133`
+(Trash 10px in 12px button). 9–11px meaningful:
+`SessionRowMeta.tsx:48,100` (9px), `SessionGroupHeader.tsx:21` (9px),
+`FilesTabStrip.tsx:107` + `RunTabStrip.tsx:85` (9px close),
+`ProviderModelSelect.tsx:162` + `PermissionSelect.tsx` + `EffortPicker.tsx:66-69`
+(9-11px chevrons/locks), `FilterMenu.tsx:89` (9px check),
+`git/BranchRow.tsx:27,32` (9px arrows), `wf/WfStatus.tsx:65` (8px X),
+`review/ReviewFileTree.tsx:46` (7px meter squares), hover actions
+`SessionRow.tsx:135,140,144` (11px), `SessionsNewButton.tsx:65,99` /
+`SessionSortMenu.tsx:34` / `SessionsMoreMenu.tsx:51` (11-12px header
+controls), `context-panel` `size={9-11}` chevrons/icons, `ws-toast.tsx:198`
+(11px dismiss + `opacity-40`).
+
+## P2 themes (fix opportunistically per surface)
+
+- **Sibling icon-size drift**: FileTree 9/11/12; DiffHeader 11/12/13;
+  ReviewPanelHeader 11/12/15/16; PreviewRunControl 10/11/13;
+  PreviewUrlBar 12/13; TasksDrawer 11/13; TaskListRow vs TaskCard same actions
+  at 12/13/14; toolbar chips Gauge 11 / Shield 11 / Sliders 12 / Clipboard 12 /
+  GitFork 13 next to 8px attach/mention. Normalize per cluster to 12/14/16.
+- **Status-dot drift**: 4px (TunnelStatusRow, NamedTunnelSection idle+opacity),
+  5px (BackgroundActivityBar), 6px (ProvidersPane), 8/14/15px (tasks). Pick a
+  6/8/10 grid.
+- **Header hierarchy flatness**: `ChatCardHeader` title = model chip = buttons
+  (all caption); `tool-group.tsx:120` uppercase-bold summary at caption;
+  `CodeHeader.tsx:37` uppercase caption; `markdown-table.tsx:27,35` 12px cells;
+  `syntax-highlight.tsx:17` 12px vs inline-code 11px mismatch.
+- **Token drift, same semantic**: deletions `text-destructive`
+  (ReviewFileToolbar:34) vs `text-mf-diff-del-text` (ReviewPanelHeader:60,
+  ReviewFileTree); violet pair `bg-mf-accent-violet`+`text-mf-wf-violet`
+  (WfStepLibrary:169); `badge.tsx:6` muted variant stacks `opacity-80`.
+- **Small-but-passing** (size-only, promote when touched): keycaps
+  (`MainToolbar.tsx:203`), branch chip (`MainToolbar.tsx:36`), UpdatePill CTA,
+  eyebrows already on `muted-foreground` (`SessionSidebar.tsx:70`,
+  `WelcomeState.tsx:64`, `NewSessionPickerPopover.tsx:74`,
+  `TagRecolorPanel.tsx:29`), `GateButton.tsx:22` 12px gate actions,
+  `PermissionGate.tsx:20-21` tool name → body/foreground,
+  `TagPopover.tsx:205,210` 11px errors, `DegradedChatCard` 11px recovery
+  actions, `mf-text-shimmer` running label (gradient can dip mid-animation).
+
+## Healthy patterns — do not regress
+
+- Titles/primary rows: `text-body`+`text-foreground` (SessionRow, task cards,
+  branch rows, file trees, dialogs) — the top of the hierarchy is right.
+- `muted-foreground` secondary prose (passes everywhere), dialog
+  heading/body pairs, `PairingSection` 22px pairing code.
+- `menu-variants.ts`: 12px rows, 13px icon default with
+  `:not([class*='size-'])` override guard — the model for `button.tsx`.
+- No phantom tokens and no `/opacity`-on-CSS-var anywhere (the two documented
+  traps are fully respected; `chrome.tsx`/`diff.tsx` "phantom" strings are
+  doc-comments).
+- `FamilyTile` 13px-in-22px tool icons; `SidebarHeader` 14-15px chrome icons;
+  arbitrary-px spacing used deliberately to dodge the compressed scale.
+- `PreviewRunControl` Stop (bordered, foreground) and `ws-toast`
+  title/description pair — correct templates.
+- macOS HIG anchoring of the token scale itself (13px body) — per the
+  2026-07-02 typography policy, size tokens stay HIG-based; this audit changes
+  role assignment and ink values, not the HIG anchor.

--- a/packages/ui/src/components/ui/__tests__/count-badge.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/count-badge.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CountBadge } from '../count-badge';
+
+describe('CountBadge', () => {
+  it('renders nothing when the count is zero or negative', () => {
+    const { container, rerender } = render(<CountBadge count={0} data-testid="cb" />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<CountBadge count={-3} data-testid="cb" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the count and passes through data-testid', () => {
+    render(<CountBadge count={7} data-testid="cb" />);
+    const el = screen.getByTestId('cb');
+    expect(el).toHaveTextContent('7');
+  });
+
+  it('info variant is capsule-less muted gray, not a filled capsule', () => {
+    render(<CountBadge count={4} variant="info" data-testid="cb" />);
+    const cls = screen.getByTestId('cb').className;
+    expect(cls).toContain('text-muted-foreground');
+    expect(cls).toContain('text-caption');
+    expect(cls).toContain('tabular-nums');
+    expect(cls).not.toContain('rounded-full');
+    expect(cls).not.toContain('bg-primary');
+  });
+
+  it('unread variant uses the accent ink', () => {
+    render(<CountBadge count={2} variant="unread" data-testid="cb" />);
+    const cls = screen.getByTestId('cb').className;
+    expect(cls).toContain('text-primary');
+    expect(cls).not.toContain('text-muted-foreground');
+  });
+
+  it('onAccent forces primary-foreground and drops the muted/accent ink', () => {
+    render(<CountBadge count={5} variant="unread" onAccent data-testid="cb" />);
+    const cls = screen.getByTestId('cb').className;
+    expect(cls).toContain('text-primary-foreground');
+  });
+
+  it('alert variant is a filled primary capsule', () => {
+    render(<CountBadge count={1} variant="alert" data-testid="cb" />);
+    const cls = screen.getByTestId('cb').className;
+    expect(cls).toContain('rounded-full');
+    expect(cls).toContain('bg-primary');
+    expect(cls).toContain('text-primary-foreground');
+    expect(cls).not.toContain('bg-destructive');
+  });
+
+  it('alert variant honors the destructive tone', () => {
+    render(<CountBadge count={1} variant="alert" tone="destructive" data-testid="cb" />);
+    const cls = screen.getByTestId('cb').className;
+    expect(cls).toContain('bg-destructive');
+    expect(cls).not.toContain('bg-primary');
+  });
+});

--- a/packages/ui/src/components/ui/__tests__/menu.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/menu.test.tsx
@@ -38,11 +38,12 @@ describe('menu vocabulary', () => {
     expect(screen.getByTestId('x-del').className).toContain('text-destructive');
   });
 
-  it('MenuLabel renders an uppercase eyebrow', () => {
+  it('MenuLabel renders a sentence-case muted eyebrow', () => {
     render(<MenuLabel>Tags</MenuLabel>);
     const el = screen.getByText('Tags');
-    expect(el.closest('div')?.className).toContain('uppercase');
-    expect(el.closest('div')?.className).toContain('text-micro');
+    expect(el.closest('div')?.className).not.toContain('uppercase');
+    expect(el.closest('div')?.className).toContain('text-caption');
+    expect(el.closest('div')?.className).toContain('text-muted-foreground');
   });
 
   it('MenuCheckRow reflects checked state', () => {

--- a/packages/ui/src/components/ui/__tests__/section-header.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/section-header.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SectionHeader } from '../section-header';
+
+describe('SectionHeader', () => {
+  it('renders its children as the label', () => {
+    render(<SectionHeader data-testid="sh">Favorites</SectionHeader>);
+    expect(screen.getByTestId('sh')).toHaveTextContent('Favorites');
+  });
+
+  it('uses the muted caption recipe, not the old bold/uppercase eyebrow', () => {
+    render(<SectionHeader data-testid="sh">Favorites</SectionHeader>);
+    const cls = screen.getByTestId('sh').className;
+    expect(cls).toContain('text-caption');
+    expect(cls).toContain('font-medium');
+    expect(cls).toContain('text-muted-foreground');
+    expect(cls).not.toContain('uppercase');
+    expect(cls).not.toContain('font-bold');
+    expect(cls).not.toContain('text-micro');
+  });
+
+  it('renders the trailing slot alongside the label', () => {
+    render(
+      <SectionHeader data-testid="sh" trailing={<button data-testid="sh-more">More</button>}>
+        Favorites
+      </SectionHeader>,
+    );
+    expect(screen.getByTestId('sh-more')).toBeInTheDocument();
+  });
+
+  it('merges caller className while keeping default padding', () => {
+    render(
+      <SectionHeader data-testid="sh" className="mt-4">
+        Favorites
+      </SectionHeader>,
+    );
+    const cls = screen.getByTestId('sh').className;
+    expect(cls).toContain('mt-4');
+    expect(cls).toContain('px-2');
+  });
+});

--- a/packages/ui/src/components/ui/assistant-ui/__tests__/attachment.test.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/__tests__/attachment.test.tsx
@@ -37,12 +37,12 @@ function renderWithTooltip(children: React.ReactNode) {
 }
 
 describe('ComposerAddAttachment — paperclip glyph size', () => {
-  it('renders the Paperclip icon at size-3 (matches the design 12px glyph inside the 22px button)', () => {
+  it('renders the Paperclip icon at size-3.5 (14px glyph inside the 22px button)', () => {
     renderWithTooltip(<ComposerAddAttachment />);
     const btn = screen.getByTestId('composer-add-attachment');
     const svg = btn.querySelector('svg');
     expect(svg).not.toBeNull();
-    expect(svg!.getAttribute('class')).toContain('size-3');
+    expect(svg!.getAttribute('class')).toContain('size-3.5');
   });
 });
 

--- a/packages/ui/src/components/ui/assistant-ui/__tests__/tool-fallback.test.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/__tests__/tool-fallback.test.tsx
@@ -6,7 +6,7 @@ import { ToolFallback } from '../tool-fallback';
 const status = (type: string): ToolCallMessagePartStatus => ({ type }) as ToolCallMessagePartStatus;
 
 describe('ToolFallbackTrigger running shimmer', () => {
-  it('overlay geometry matches the base label so it does not ghost (text-caption + font-medium)', () => {
+  it('overlay geometry matches the base label so it does not ghost (text-label + font-medium)', () => {
     render(
       <ToolFallback.Root defaultOpen>
         <ToolFallback.Trigger toolName="DesignSync" status={status('running')} />
@@ -16,9 +16,9 @@ describe('ToolFallbackTrigger running shimmer', () => {
     expect(shimmer).not.toBeNull();
     // The running overlay is a duplicate text copy stacked on the base with a
     // sheen sweep; it must render at the SAME size/weight as the base
-    // (text-caption 11px + font-medium 500), else it renders wider (13px/700)
+    // (text-label 12px + font-medium 500), else it renders wider (13px/700)
     // and misaligns into doubled "Used tool: X" ghosting.
-    expect(shimmer!.className).toContain('text-caption');
+    expect(shimmer!.className).toContain('text-label');
     expect(shimmer!.querySelector('b')?.className).toContain('font-medium');
   });
 

--- a/packages/ui/src/components/ui/assistant-ui/__tests__/tool-group.test.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/__tests__/tool-group.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Behavior tests for ToolGroupTrigger typography/state (design parity area 5).
  *
- * Design contract (09-toolcards.jsx:172-182):
- *  - Leading chevron (11px), then an uppercase 11px/700 title with
- *    letter-spacing, then a separate mono 10px muted "N calls" segment.
+ * Design contract (09-toolcards.jsx:172-182, retuned by the 2026-07-11
+ * typography-legibility pass):
+ *  - Leading chevron, then a sentence-case medium-weight title, then a
+ *    separate mono muted "N calls" segment.
  *  - No running/active loader or shimmer on the ToolGroup header — that
  *    affordance is reserved for ThinkingBlock.
  */
@@ -21,11 +22,12 @@ function renderGroup(props: Partial<React.ComponentProps<typeof ToolGroupTrigger
 }
 
 describe('ToolGroupTrigger — typography', () => {
-  it('renders the label in an uppercase, bold, letter-spaced title segment', () => {
+  it('renders the label in a sentence-case, medium-weight title segment', () => {
     renderGroup({ label: 'Read 3 files' });
     const label = screen.getByTestId('tool-group-trigger-label');
-    expect(label).toHaveClass('uppercase');
-    expect(label).toHaveClass('font-bold');
+    expect(label).toHaveClass('font-medium');
+    expect(label).not.toHaveClass('uppercase');
+    expect(label).not.toHaveClass('font-bold');
   });
 
   it('renders a separate mono call-count segment alongside the title', () => {

--- a/packages/ui/src/components/ui/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/attachment.tsx
@@ -115,7 +115,7 @@ const AttachmentRemove: FC = () => {
           '[&_svg]:text-foreground hover:[&_svg]:text-destructive',
         )}
       >
-        <XIcon className="size-3" />
+        <XIcon className="size-[12px]" />
       </TooltipIconButton>
     </AttachmentPrimitive.Remove>
   );
@@ -182,9 +182,9 @@ export const ComposerAddAttachment: FC = () => {
         size="icon"
         aria-label="Add Attachment"
         onMouseDown={(e) => e.preventDefault()}
-        className="size-[22px] rounded-sm p-1 text-mf-text-3 hover:text-foreground"
+        className="size-[22px] rounded-sm p-1 text-muted-foreground hover:text-foreground"
       >
-        <Paperclip className="size-3 stroke-[1.5px]" />
+        <Paperclip className="size-3.5 stroke-[1.5px]" />
       </TooltipIconButton>
     </ComposerPrimitive.AddAttachment>
   );
@@ -212,9 +212,9 @@ export const ComposerAddMention: FC = () => {
       aria-label="Mention a file or agent"
       onClick={handleClick}
       onMouseDown={(e) => e.preventDefault()}
-      className="size-[22px] rounded-sm p-1 text-mf-text-3 hover:text-foreground"
+      className="size-[22px] rounded-sm p-1 text-muted-foreground hover:text-foreground"
     >
-      <AtSignIcon className="size-3 stroke-[1.5px]" />
+      <AtSignIcon className="size-3.5 stroke-[1.5px]" />
     </TooltipIconButton>
   );
 };

--- a/packages/ui/src/components/ui/assistant-ui/directive-text.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/directive-text.tsx
@@ -52,11 +52,11 @@ function DirectiveChip({ type, label, id, Icon }: DirectiveChipProps) {
         'inline-flex items-center gap-1',
         'rounded-md px-1.5 py-0.5',
         'bg-mf-chip text-primary',
-        'font-mono text-caption font-medium',
+        'font-mono text-label font-medium',
         'border border-border',
       )}
     >
-      {Icon && <Icon className="size-3 shrink-0" />}
+      {Icon && <Icon className="size-3.5 shrink-0" />}
       {label}
     </span>
   );

--- a/packages/ui/src/components/ui/assistant-ui/quote.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/quote.tsx
@@ -29,7 +29,7 @@ function QuoteBlockIcon({ className, ...props }: ComponentProps<typeof QuoteIcon
   return (
     <QuoteIcon
       data-slot="quote-block-icon"
-      className={cn('mt-0.5 size-3 shrink-0 text-muted-foreground', className)}
+      className={cn('mt-0.5 size-3.5 shrink-0 text-muted-foreground', className)}
       {...props}
     />
   );
@@ -38,7 +38,7 @@ function QuoteBlockText({ className, ...props }: ComponentProps<'p'>) {
   return (
     <p
       data-slot="quote-block-text"
-      className={cn('line-clamp-2 min-w-0 text-caption italic text-muted-foreground', className)}
+      className={cn('line-clamp-2 min-w-0 text-label text-muted-foreground', className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/reasoning.tsx
@@ -131,7 +131,7 @@ function ReasoningTrigger({
       data-slot="reasoning-trigger"
       data-testid="chat-reasoning-toggle"
       className={cn(
-        'aui-reasoning-trigger group/trigger text-mf-text-3 hover:text-muted-foreground',
+        'aui-reasoning-trigger group/trigger text-muted-foreground hover:text-foreground',
         'flex max-w-[75%] items-center gap-1.5 py-1 text-caption transition-colors',
         className,
       )}
@@ -174,7 +174,7 @@ function ReasoningContent({ className, children, ...props }: React.ComponentProp
     <CollapsibleContent
       data-slot="reasoning-content"
       className={cn(
-        'aui-reasoning-content text-muted-foreground relative overflow-hidden text-caption outline-none',
+        'aui-reasoning-content text-muted-foreground relative overflow-hidden text-label outline-none',
         'group/collapsible-content ease-out',
         'data-[state=closed]:animate-collapsible-up',
         'data-[state=open]:animate-collapsible-down',

--- a/packages/ui/src/components/ui/assistant-ui/tool-fallback-parts.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/tool-fallback-parts.tsx
@@ -21,7 +21,7 @@ export function ToolFallbackArgs({
       className={cn('aui-tool-fallback-args', className)}
       {...props}
     >
-      <pre className="aui-tool-fallback-args-value text-caption text-muted-foreground whitespace-pre-wrap font-mono break-all">
+      <pre className="aui-tool-fallback-args-value text-label text-muted-foreground whitespace-pre-wrap font-mono break-all">
         {argsText}
       </pre>
     </div>
@@ -44,8 +44,8 @@ export function ToolFallbackResult({
       className={cn('aui-tool-fallback-result border-t border-dashed border-border pt-2', className)}
       {...props}
     >
-      <p className="aui-tool-fallback-result-header text-caption font-semibold text-muted-foreground mb-1">Result</p>
-      <pre className="aui-tool-fallback-result-content text-caption text-muted-foreground whitespace-pre-wrap font-mono break-all">
+      <p className="aui-tool-fallback-result-header text-label font-semibold text-muted-foreground mb-1">Result</p>
+      <pre className="aui-tool-fallback-result-content text-label text-muted-foreground whitespace-pre-wrap font-mono break-all">
         {typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
       </pre>
     </div>
@@ -76,8 +76,8 @@ export function ToolFallbackError({
       className={cn('aui-tool-fallback-error', className)}
       {...props}
     >
-      <p className="aui-tool-fallback-error-header text-caption font-semibold text-destructive mb-1">{headerText}</p>
-      <p className="aui-tool-fallback-error-reason text-caption text-muted-foreground">{errorText}</p>
+      <p className="aui-tool-fallback-error-header text-label font-semibold text-destructive mb-1">{headerText}</p>
+      <p className="aui-tool-fallback-error-reason text-label text-muted-foreground">{errorText}</p>
     </div>
   );
 }

--- a/packages/ui/src/components/ui/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/tool-fallback.tsx
@@ -108,14 +108,14 @@ function ToolFallbackTrigger({
           isCancelled && 'opacity-50 line-through',
         )}
       >
-        <span className="text-caption">
+        <span className="text-label">
           {label}: <b className="text-foreground font-medium">{toolName}</b>
         </span>
         {isRunning && (
           <span
             aria-hidden
             data-slot="tool-fallback-trigger-shimmer"
-            className="aui-tool-fallback-trigger-shimmer shimmer text-caption pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            className="aui-tool-fallback-trigger-shimmer shimmer text-label pointer-events-none absolute inset-0 motion-reduce:animate-none"
           >
             {label}: <b className="font-medium">{toolName}</b>
           </span>

--- a/packages/ui/src/components/ui/assistant-ui/tool-group.tsx
+++ b/packages/ui/src/components/ui/assistant-ui/tool-group.tsx
@@ -116,16 +116,14 @@ function ToolGroupTrigger({
       <span
         data-testid="tool-group-trigger-label"
         data-slot="tool-group-trigger-label"
-        className={cn(
-          'aui-tool-group-trigger-label-wrapper text-start leading-none font-bold uppercase tracking-[0.5px] text-foreground',
-        )}
+        className={cn('aui-tool-group-trigger-label-wrapper text-start leading-none font-medium text-foreground')}
       >
         {label}
       </span>
       <span
         data-testid="tool-group-trigger-count"
         data-slot="tool-group-trigger-count"
-        className="font-mono text-micro text-mf-text-4"
+        className="font-mono text-caption text-muted-foreground"
       >
         {countLabel}
       </span>

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         secondary: 'bg-secondary text-secondary-foreground border-transparent',
         destructive: 'bg-destructive text-destructive-foreground border-transparent',
         outline: 'text-foreground border-border bg-transparent',
-        muted: 'bg-muted-foreground text-background border-transparent opacity-80',
+        muted: 'bg-muted text-muted-foreground border-transparent',
         success: 'bg-mf-success text-primary-foreground border-transparent',
         warning: 'bg-mf-warning text-primary-foreground border-transparent',
       },

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     'transition-colors',
     'focus-visible:outline-none',
     'disabled:pointer-events-none disabled:opacity-[0.45]',
-    '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    "[&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:shrink-0",
   ],
   {
     variants: {

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -29,7 +29,7 @@ function CommandDialog({ children, className, 'data-testid': testId, ...props }:
   return (
     <Dialog {...props}>
       <DialogContent data-testid={testId} className={cn('overflow-hidden p-0', className)}>
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-bold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:text-micro [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-mf-text-3 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-[54px] [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-[54px] [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2">
           {children}
         </Command>
       </DialogContent>
@@ -86,8 +86,8 @@ const CommandGroup = React.forwardRef<
     className={cn(
       'overflow-hidden p-1 text-foreground',
       '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5',
-      '[&_[cmdk-group-heading]]:text-micro [&_[cmdk-group-heading]]:font-bold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide',
-      '[&_[cmdk-group-heading]]:text-mf-text-3',
+      '[&_[cmdk-group-heading]]:text-caption [&_[cmdk-group-heading]]:font-medium',
+      '[&_[cmdk-group-heading]]:text-muted-foreground',
       className,
     )}
     {...props}

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -180,7 +180,7 @@ function ContextMenuLabel({
       data-slot="context-menu-label"
       data-inset={inset}
       className={cn(
-        'px-[8px] pb-[4px] pt-[5px] text-micro font-bold uppercase tracking-wide text-mf-text-3',
+        'px-[8px] pb-[4px] pt-[5px] text-caption font-medium text-muted-foreground',
         'data-[inset]:pl-8',
         className,
       )}

--- a/packages/ui/src/components/ui/count-badge.tsx
+++ b/packages/ui/src/components/ui/count-badge.tsx
@@ -1,0 +1,60 @@
+import { cn } from '@/lib/utils';
+
+export interface CountBadgeProps {
+  count: number;
+  variant?: 'info' | 'unread' | 'alert';
+  onAccent?: boolean;
+  tone?: 'primary' | 'destructive';
+  /** Render a `0` instead of nothing — for section-size counts, not unread/alert badges. */
+  showZero?: boolean;
+  className?: string;
+  'data-testid'?: string;
+}
+
+/**
+ * macOS-style count indicator. `info`/`unread` are capsule-less gray/accent
+ * numerals (Finder/Mail sidebar style); `alert` is a filled attention capsule.
+ * Renders nothing when there is nothing to count.
+ */
+export function CountBadge({
+  count,
+  variant = 'info',
+  onAccent,
+  tone = 'primary',
+  showZero,
+  className,
+  ...rest
+}: CountBadgeProps) {
+  if (count <= 0 && !showZero) return null;
+
+  if (variant === 'alert') {
+    return (
+      <span
+        className={cn(
+          'inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1',
+          'text-caption font-semibold tabular-nums',
+          tone === 'destructive' ? 'bg-destructive' : 'bg-primary',
+          'text-primary-foreground',
+          className,
+        )}
+        {...rest}
+      >
+        {count}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'text-caption font-semibold tabular-nums',
+        variant === 'unread' ? 'text-primary' : 'text-muted-foreground',
+        onAccent && 'text-primary-foreground',
+        className,
+      )}
+      {...rest}
+    >
+      {count}
+    </span>
+  );
+}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -176,7 +176,7 @@ function DropdownMenuLabel({
   return (
     <DropdownMenuPrimitive.Label
       className={cn(
-        'px-[8px] pb-[4px] pt-[5px] text-micro font-bold uppercase tracking-wide text-mf-text-3',
+        'px-[8px] pb-[4px] pt-[5px] text-caption font-medium text-muted-foreground',
         inset && 'pl-8',
         className,
       )}

--- a/packages/ui/src/components/ui/menu-variants.ts
+++ b/packages/ui/src/components/ui/menu-variants.ts
@@ -15,9 +15,7 @@ export const menuItemVariants = cva(
     'flex items-center gap-[9px] rounded-sm px-[8px] py-[7px]',
     'text-label outline-none transition-colors',
     "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-[13px]",
-    // Default icon color is the muted tertiary text token (design T.text3), not the
-    // darker T.text2-mapped --muted-foreground — see design-parity finding 10.2.
-    "[&_svg:not([class*='text-'])]:text-mf-text-3",
+    "[&_svg:not([class*='text-'])]:text-muted-foreground",
   ],
   {
     variants: {

--- a/packages/ui/src/components/ui/menu.tsx
+++ b/packages/ui/src/components/ui/menu.tsx
@@ -17,7 +17,7 @@ export function MenuLabel({
   return (
     <div
       className={cn(
-        'flex items-center justify-between px-[8px] pb-[4px] pt-[5px] text-micro font-bold uppercase tracking-wide text-mf-text-3',
+        'flex items-center justify-between px-[8px] pb-[4px] pt-[5px] text-caption font-medium text-muted-foreground',
         className,
       )}
     >
@@ -57,11 +57,11 @@ export const MenuRow = React.forwardRef<HTMLButtonElement, MenuRowProps>(
     >
       {icon}
       <span className="min-w-0 flex-1 truncate">{label}</span>
-      {note != null && <span className="shrink-0 text-caption text-mf-text-3">{note}</span>}
+      {note != null && <span className="shrink-0 text-caption text-muted-foreground">{note}</span>}
       {/* font-mono for keyboard-shortcut style hints (e.g. ⌘1, ⤓, ↵) — SKIPPED-macos-typography
           on the 11px→10px size delta itself (finding 10.12); font-mono is a genuine missing
           treatment, not a size/weight token swap. */}
-      {hint != null && <span className="shrink-0 font-mono text-caption text-mf-text-4">{hint}</span>}
+      {hint != null && <span className="shrink-0 font-mono text-caption text-mf-text-3">{hint}</span>}
       {trailing}
     </button>
   ),

--- a/packages/ui/src/components/ui/read-more.tsx
+++ b/packages/ui/src/components/ui/read-more.tsx
@@ -70,15 +70,15 @@ export function ReadMore({
           data-testid={testId}
           type="button"
           onClick={() => setExpanded((e) => !e)}
-          className="inline-flex items-center gap-2 text-caption font-semibold text-primary hover:underline"
+          className="inline-flex items-center gap-2 text-label font-semibold text-primary hover:underline"
           aria-label={expanded ? 'Show less' : 'Read more'}
           aria-expanded={expanded}
         >
           {expanded ? 'Show less' : 'Read more'}
           {expanded ? (
-            <ChevronsUpDown size={10} className="text-primary" />
+            <ChevronsUpDown size={12} className="text-primary" />
           ) : (
-            <ChevronDown size={10} className="text-primary" />
+            <ChevronDown size={12} className="text-primary" />
           )}
         </button>
       )}

--- a/packages/ui/src/components/ui/section-header.tsx
+++ b/packages/ui/src/components/ui/section-header.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SectionHeaderProps {
+  children: React.ReactNode;
+  trailing?: React.ReactNode;
+  className?: string;
+  'data-testid'?: string;
+}
+
+/**
+ * Shared section/eyebrow header: sentence-case caption in muted ink — the
+ * Finder "Favorites" gray. Replaces the app-wide
+ * `text-micro font-bold uppercase tracking-wide` eyebrow antipattern.
+ */
+export function SectionHeader({ children, trailing, className, ...rest }: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between px-2 pb-1 pt-1.5',
+        'text-caption font-medium text-muted-foreground',
+        className,
+      )}
+      {...rest}
+    >
+      <span>{children}</span>
+      {trailing}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -27,7 +27,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50 shrink-0" />
+        <ChevronDownIcon className="size-3.5 opacity-50 shrink-0" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -42,7 +42,7 @@ function SelectScrollUpButton({
       className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
-      <ChevronUpIcon className="size-4" />
+      <ChevronUpIcon className="size-3.5" />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -56,7 +56,7 @@ function SelectScrollDownButton({
       className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
-      <ChevronDownIcon className="size-4" />
+      <ChevronDownIcon className="size-3.5" />
     </SelectPrimitive.ScrollDownButton>
   );
 }
@@ -130,7 +130,7 @@ function SelectItem({ className, children, ...props }: React.ComponentPropsWitho
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="size-3.5" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -30,7 +30,7 @@ function TooltipContent({
           // Default width floor so long content wraps instead of stretching the
           // tooltip across the viewport. Callers override via a `max-w-*` class.
           'max-w-xs break-words',
-          'text-caption leading-snug text-popover-foreground',
+          'text-label leading-snug text-popover-foreground',
           'shadow-[var(--mf-shadow-pop)]',
           'animate-in fade-in-0 zoom-in-95',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',

--- a/packages/ui/src/components/ui/ws-toast.tsx
+++ b/packages/ui/src/components/ui/ws-toast.tsx
@@ -160,7 +160,7 @@ export function WsToastCard({ id, type, title, description, action, chatId, onOp
               action.onClick();
               onDismiss(id);
             }}
-            className="text-caption font-medium text-primary mt-[6px] block"
+            className="text-label font-medium text-primary mt-[6px] block"
           >
             {action.label} →
           </button>
@@ -173,7 +173,7 @@ export function WsToastCard({ id, type, title, description, action, chatId, onOp
               onOpenSession?.(chatId);
               onDismiss(id);
             }}
-            className="text-caption font-medium text-primary mt-[6px] block"
+            className="text-label font-medium text-primary mt-[6px] block"
           >
             Open session →
           </button>
@@ -192,10 +192,10 @@ export function WsToastCard({ id, type, title, description, action, chatId, onOp
         className={cn(
           'w-[20px] h-[20px] shrink-0 rounded-[6px] inline-flex items-center justify-center',
           'border-none bg-transparent cursor-pointer',
-          'opacity-40 hover:opacity-85 hover:bg-accent transition-opacity',
+          'text-mf-text-3 hover:text-foreground hover:bg-accent transition-colors',
         )}
       >
-        <X size={11} aria-hidden />
+        <X size={14} aria-hidden />
       </button>
 
       {/* countdown rail — hidden for errors and while hovered */}

--- a/packages/ui/src/features/automations/run/RunStepRow.tsx
+++ b/packages/ui/src/features/automations/run/RunStepRow.tsx
@@ -109,7 +109,7 @@ export function RunStepRow({
             <span
               data-testid={`${testId}-kept-going`}
               title="This step failed but the automation kept going"
-              className="inline-flex h-[18px] shrink-0 items-center rounded-full bg-mf-warning/15 px-[8px] text-caption font-bold text-mf-warning"
+              className="inline-flex h-[18px] shrink-0 items-center rounded-full bg-mf-warning/15 px-[8px] text-caption font-semibold text-muted-foreground"
             >
               Kept going
             </span>

--- a/packages/ui/src/features/automations/steps/CommandPreview.tsx
+++ b/packages/ui/src/features/automations/steps/CommandPreview.tsx
@@ -31,9 +31,9 @@ export function CommandPreview({ script, testId }: CommandPreviewProps) {
         <span
           key={warning.index}
           data-testid={`${testId}-warning-${warning.index}`}
-          className="flex items-start gap-1.5 text-caption font-medium text-mf-warning"
+          className="flex items-start gap-1.5 text-caption font-medium text-muted-foreground"
         >
-          <TriangleAlert size={11} className="mt-0.5 shrink-0" aria-hidden />
+          <TriangleAlert size={11} className="mt-0.5 shrink-0 text-mf-warning" aria-hidden />
           {warning.message}
         </span>
       ))}

--- a/packages/ui/src/features/chat/composer/BackgroundActivityBar.tsx
+++ b/packages/ui/src/features/chat/composer/BackgroundActivityBar.tsx
@@ -85,11 +85,11 @@ export function BackgroundActivityBar() {
                   data-testid={`composer-background-activity-item-${task.id}`}
                   className="flex items-center gap-2 rounded-md px-2 py-1.5"
                 >
-                  <Icon size={13} className="flex-shrink-0 text-mf-text-3" aria-hidden />
+                  <Icon size={14} className="flex-shrink-0 text-muted-foreground" aria-hidden />
                   <span className="min-w-0 flex-1 truncate text-caption text-foreground">
                     {task.description || 'Background task'}
                   </span>
-                  <span className="flex-shrink-0 font-mono text-micro tabular-nums text-mf-text-3">
+                  <span className="flex-shrink-0 font-mono text-caption tabular-nums text-muted-foreground">
                     {formatElapsed(task.startedAt, now)}
                   </span>
                 </li>

--- a/packages/ui/src/features/chat/composer/Composer.tsx
+++ b/packages/ui/src/features/chat/composer/Composer.tsx
@@ -40,7 +40,7 @@ function SendOrCancelButton({ sendDisabled }: { sendDisabled?: boolean }) {
         aria-label="Stop"
         className={cn(base, 'bg-foreground text-background hover:opacity-90')}
       >
-        <SquareIcon className="size-3 fill-current" />
+        <SquareIcon className="size-3.5 fill-current" />
       </ComposerPrimitive.Cancel>
     );
   }
@@ -122,7 +122,7 @@ export function Composer() {
               placeholder={hasQuote ? 'Add a message…' : 'Reply to Mainframe…'}
               rows={1}
               autoFocus
-              className="relative w-full resize-none overflow-hidden bg-transparent px-[14px] pt-[10px] pb-[4px] font-sans text-body leading-relaxed text-transparent caret-foreground outline-none placeholder:text-mf-text-4 disabled:cursor-not-allowed disabled:opacity-50"
+              className="relative w-full resize-none overflow-hidden bg-transparent px-[14px] pt-[10px] pb-[4px] font-sans text-body leading-relaxed text-transparent caret-foreground outline-none placeholder:text-mf-text-3 disabled:cursor-not-allowed disabled:opacity-50"
             />
           </div>
 

--- a/packages/ui/src/features/chat/composer/config-toolbar/EffortPicker.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/EffortPicker.tsx
@@ -63,10 +63,10 @@ export function EffortPicker({ chat, model, setEffort, disabled, providerDefault
                 'focus-visible:outline-none',
               ].join(' ')}
             >
-              <Gauge size={11} className="shrink-0" />
+              <Gauge size={12} className="shrink-0" />
               <span className="hidden @[560px]:inline whitespace-nowrap text-label font-medium">{triggerLabel}</span>
-              {locked && <Lock size={10} className="shrink-0 text-mf-text-4" />}
-              <ChevronDown size={9} className="hidden @[560px]:inline shrink-0 opacity-60" />
+              {locked && <Lock size={12} className="shrink-0 text-mf-warning" />}
+              <ChevronDown size={12} className="hidden @[560px]:inline shrink-0 text-mf-text-3" />
             </button>
           </DropdownMenuTrigger>
         </TooltipTrigger>

--- a/packages/ui/src/features/chat/composer/config-toolbar/PermissionSelect.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/PermissionSelect.tsx
@@ -51,7 +51,7 @@ export function PermissionSelect({ chat, setPermissionMode }: PermissionSelectPr
               className={[
                 'flex h-[20px] shrink-0 items-center justify-center gap-[5px] px-[6px]',
                 '@[560px]:justify-start @[560px]:pl-[8px] @[560px]:pr-[7px]',
-                'rounded-[11px] border-[0.5px] border-border text-caption',
+                'rounded-[11px] border-[0.5px] border-border text-label',
                 'hover:bg-accent hover:text-accent-foreground',
                 'data-[state=open]:border-primary data-[state=open]:bg-mf-selection',
                 'transition-colors',
@@ -59,9 +59,9 @@ export function PermissionSelect({ chat, setPermissionMode }: PermissionSelectPr
                 isYolo ? 'text-destructive' : 'text-muted-foreground',
               ].join(' ')}
             >
-              <Shield size={11} className="shrink-0" />
-              <span className="hidden @[560px]:inline truncate text-caption font-medium">{currentLabel}</span>
-              <ChevronDown size={9} className="hidden @[560px]:inline shrink-0 opacity-60" />
+              <Shield size={12} className="shrink-0" />
+              <span className="hidden @[560px]:inline truncate text-label font-medium">{currentLabel}</span>
+              <ChevronDown size={12} className="hidden @[560px]:inline shrink-0 text-mf-text-3" />
             </button>
           </DropdownMenuTrigger>
         </TooltipTrigger>

--- a/packages/ui/src/features/chat/composer/config-toolbar/ProviderModelSelect.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/ProviderModelSelect.tsx
@@ -159,7 +159,7 @@ export function ProviderModelSelect({
               data-tut="model"
               aria-label={`Provider and model: ${triggerLabel}`}
               className={cn(
-                'flex h-[20px] min-w-0 items-center gap-[5px] rounded-[11px] border-[0.5px] border-border pl-[8px] pr-[7px] text-caption text-muted-foreground',
+                'flex h-[20px] min-w-0 items-center gap-[5px] rounded-[11px] border-[0.5px] border-border pl-[8px] pr-[7px] text-label text-muted-foreground',
                 'hover:bg-accent hover:text-accent-foreground',
                 'data-[state=open]:border-primary data-[state=open]:bg-mf-selection',
                 'transition-colors focus-visible:outline-none',
@@ -169,7 +169,7 @@ export function ProviderModelSelect({
               <span className="max-w-[150px] truncate font-medium @max-[560px]:max-w-[90px] @max-[430px]:max-w-[56px]">
                 {triggerLabel}
               </span>
-              <ChevronDown size={9} className="flex-shrink-0 opacity-60" />
+              <ChevronDown size={12} className="flex-shrink-0 text-mf-text-3" />
             </button>
           </PopoverTrigger>
         </TooltipTrigger>
@@ -188,7 +188,7 @@ export function ProviderModelSelect({
             trailing={
               locked ? (
                 <span className="flex items-center gap-1 text-caption text-muted-foreground">
-                  <Lock size={11} /> Locked
+                  <Lock size={12} /> Locked
                 </span>
               ) : undefined
             }

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreeDraftPanel.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreeDraftPanel.tsx
@@ -25,22 +25,22 @@ export function WorktreeDraftPanel({ draft, onCancel }: WorktreeDraftPanelProps)
     <div data-testid="composer-worktree-draft-panel" className="space-y-[6px] px-[8px] py-[6px]">
       <div className="flex items-center gap-[6px]">
         <span className="inline-block size-[7px] shrink-0 rounded-full bg-mf-success" aria-hidden />
-        <span className="text-caption font-medium text-mf-success">
+        <span className="text-caption font-medium text-foreground">
           {pending ? 'New worktree on first message' : 'Isolates in worktree on first message'}
         </span>
       </div>
       <MenuDivider />
       <div className="grid grid-cols-[auto_1fr] items-start gap-x-[8px] gap-y-[2px]">
-        <span className="text-caption text-mf-text-3">Branch</span>
+        <span className="text-caption text-muted-foreground">Branch</span>
         <span className="truncate font-mono text-caption text-foreground">{branch}</span>
         {pending ? (
           <>
-            <span className="text-caption text-mf-text-3">From</span>
+            <span className="text-caption text-muted-foreground">From</span>
             <span className="truncate font-mono text-caption text-foreground">{pending.baseBranch}</span>
           </>
         ) : (
           <>
-            <span className="text-caption text-mf-text-3">Path</span>
+            <span className="text-caption text-muted-foreground">Path</span>
             <TruncatedWithTooltip
               text={draft.worktreePath ?? ''}
               className="font-mono text-caption text-foreground"
@@ -54,7 +54,7 @@ export function WorktreeDraftPanel({ draft, onCancel }: WorktreeDraftPanelProps)
           type="button"
           data-testid="composer-worktree-draft-cancel"
           onClick={onCancel}
-          className="rounded-[6px] px-[10px] py-[4px] text-caption text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground"
+          className="rounded-[6px] px-[10px] py-[4px] text-label text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
           Don&apos;t isolate
         </button>

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreeExistingTab.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreeExistingTab.tsx
@@ -30,7 +30,7 @@ export function WorktreeTabBar({ active, onChange }: TabBarProps) {
           'flex-1 rounded-[5px] px-[8px] py-[2px] text-caption transition-colors',
           active === 'new'
             ? 'bg-popover font-medium text-foreground shadow-sm'
-            : 'text-mf-text-3 hover:text-foreground',
+            : 'text-muted-foreground hover:text-foreground',
         ].join(' ')}
       >
         New
@@ -43,7 +43,7 @@ export function WorktreeTabBar({ active, onChange }: TabBarProps) {
           'flex-1 rounded-[5px] px-[8px] py-[2px] text-caption transition-colors',
           active === 'existing'
             ? 'bg-popover font-medium text-foreground shadow-sm'
-            : 'text-mf-text-3 hover:text-foreground',
+            : 'text-muted-foreground hover:text-foreground',
         ].join(' ')}
       >
         Existing
@@ -86,10 +86,10 @@ export function WorktreeExistingTab({ worktrees, submitting, onAttach, error }: 
           <span className="truncate font-mono text-caption text-foreground">
             {wt.branch ? wt.branch.replace('refs/heads/', '') : 'detached'}
           </span>
-          <span className="truncate text-micro text-mf-text-3">{wt.path}</span>
+          <span className="truncate text-label text-muted-foreground">{wt.path}</span>
         </button>
       ))}
-      {error && <p className="mt-[4px] px-[8px] text-caption text-destructive">{error}</p>}
+      {error && <p className="mt-[4px] px-[8px] text-label text-destructive">{error}</p>}
     </div>
   );
 }

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreeNewForm.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreeNewForm.tsx
@@ -60,7 +60,7 @@ function BranchSelect({ value, options, currentBranch, onChange }: BranchSelectP
           ].join(' ')}
         >
           <span className="truncate">{label}</span>
-          <ChevronDown size={11} className="shrink-0 text-mf-text-3" />
+          <ChevronDown size={12} className="shrink-0 text-mf-text-3" />
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -129,7 +129,7 @@ export function WorktreeNewForm({
     <div className="space-y-[6px]">
       {/* Base branch */}
       <div>
-        <label className="mb-[3px] block text-micro text-mf-text-3">Base branch</label>
+        <label className="mb-[3px] block text-label text-muted-foreground">Base branch</label>
         <BranchSelect
           value={effectiveBranch}
           options={branches}
@@ -140,7 +140,7 @@ export function WorktreeNewForm({
 
       {/* Branch name */}
       <div>
-        <label className="mb-[3px] block text-micro text-mf-text-3" htmlFor="wt-branch-name">
+        <label className="mb-[3px] block text-label text-muted-foreground" htmlFor="wt-branch-name">
           Branch name
         </label>
         <input
@@ -156,15 +156,15 @@ export function WorktreeNewForm({
           autoComplete="off"
           className={[
             'w-full rounded-[6px] border-[0.5px] bg-muted px-[8px] py-[4px]',
-            'font-mono text-caption text-foreground placeholder:text-mf-text-3',
+            'font-mono text-label text-foreground placeholder:text-mf-text-3',
             'outline-none transition-colors focus:border-primary',
             validationError ? 'border-destructive' : 'border-border',
           ].join(' ')}
         />
-        {validationError && <p className="mt-[2px] text-micro text-destructive">{validationError}</p>}
+        {validationError && <p className="mt-[2px] text-label text-destructive">{validationError}</p>}
       </div>
 
-      {apiError && !validationError && <p className="text-micro text-destructive">{apiError}</p>}
+      {apiError && !validationError && <p className="text-label text-destructive">{apiError}</p>}
 
       {/* Actions */}
       <div className="flex items-center justify-end gap-[6px] pt-[2px]">
@@ -173,7 +173,7 @@ export function WorktreeNewForm({
           data-testid="composer-worktree-cancel"
           onClick={onCancel}
           className={[
-            'rounded-[6px] px-[10px] py-[4px] text-caption text-mf-text-3',
+            'rounded-[6px] px-[10px] py-[4px] text-label text-muted-foreground',
             'hover:bg-accent hover:text-foreground transition-colors',
           ].join(' ')}
         >
@@ -186,12 +186,12 @@ export function WorktreeNewForm({
           onClick={handleEnable}
           className={[
             'flex items-center gap-[4px] rounded-[6px] px-[10px] py-[4px]',
-            'bg-primary text-caption text-primary-foreground',
+            'bg-primary text-label text-primary-foreground',
             'hover:opacity-90 transition-opacity',
             'disabled:pointer-events-none disabled:opacity-40',
           ].join(' ')}
         >
-          {submitting ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+          {submitting ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
           Enable
         </button>
       </div>

--- a/packages/ui/src/features/chat/composer/config-toolbar/WorktreePopover.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/WorktreePopover.tsx
@@ -40,13 +40,13 @@ function ActiveInfo({ chat }: { chat: Chat }) {
     <div data-testid="composer-worktree-active-info" className="space-y-[6px] px-[8px] py-[6px]">
       <div className="flex items-center gap-[6px]">
         <span className="inline-block size-[7px] shrink-0 rounded-full bg-mf-success" aria-hidden />
-        <span className="text-caption font-medium text-mf-success">Isolated in worktree</span>
+        <span className="text-caption font-medium text-foreground">Isolated in worktree</span>
       </div>
       <MenuDivider />
       <div className="grid grid-cols-[auto_1fr] items-start gap-x-[8px] gap-y-[2px]">
-        <span className="text-caption text-mf-text-3">Branch</span>
+        <span className="text-caption text-muted-foreground">Branch</span>
         <span className="truncate font-mono text-caption text-foreground">{chat.branchName ?? '—'}</span>
-        <span className="text-caption text-mf-text-3">Path</span>
+        <span className="text-caption text-muted-foreground">Path</span>
         <TruncatedWithTooltip
           text={chat.worktreePath ?? ''}
           className="font-mono text-caption text-foreground"

--- a/packages/ui/src/features/chat/composer/edit/ComposerEditMode.tsx
+++ b/packages/ui/src/features/chat/composer/edit/ComposerEditMode.tsx
@@ -56,11 +56,11 @@ export function ComposerEditMode({ edit, onDone }: { edit: QueuedEdit; onDone: (
         </span>
         <span className="text-label font-semibold text-foreground">Editing queued message</span>
         {saveError ? (
-          <span className="text-caption text-destructive">{saveError}</span>
+          <span className="text-label text-destructive">{saveError}</span>
         ) : (
-          <span className="text-caption text-mf-text-3">· stays queued until the run finishes</span>
+          <span className="text-label text-muted-foreground">· stays queued until the run finishes</span>
         )}
-        <span className="ml-auto font-mono text-micro text-mf-text-4">esc to cancel</span>
+        <span className="ml-auto font-mono text-caption text-muted-foreground">esc to cancel</span>
       </div>
 
       <textarea
@@ -95,7 +95,7 @@ export function ComposerEditMode({ edit, onDone }: { edit: QueuedEdit; onDone: (
             type="button"
             data-testid="chat-composer-edit-cancel"
             onClick={onDone}
-            className="rounded-md px-[12px] py-1.5 text-caption font-medium text-foreground transition-colors hover:bg-accent [border-width:0.5px] border-border"
+            className="rounded-md px-[12px] py-1.5 text-label font-medium text-foreground transition-colors hover:bg-accent [border-width:0.5px] border-border"
           >
             Cancel edit
           </button>
@@ -105,7 +105,7 @@ export function ComposerEditMode({ edit, onDone }: { edit: QueuedEdit; onDone: (
             onClick={handleSave}
             disabled={saving}
             className={cn(
-              'inline-flex items-center gap-1.5 rounded-md bg-primary pl-[11px] pr-[13px] py-1.5 text-caption font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50',
+              'inline-flex items-center gap-1.5 rounded-md bg-primary pl-[11px] pr-[13px] py-1.5 text-label font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50',
             )}
           >
             <CheckIcon size={14} />

--- a/packages/ui/src/features/chat/composer/triggers/ComposerTriggers.tsx
+++ b/packages/ui/src/features/chat/composer/triggers/ComposerTriggers.tsx
@@ -49,7 +49,7 @@ function ItemRow({ item, testidPrefix }: { item: Unstable_TriggerItem; testidPre
                  data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
     >
       <span className="font-medium text-foreground">{item.label}</span>
-      {item.description != null && <span className="text-caption text-muted-foreground">{item.description}</span>}
+      {item.description != null && <span className="text-label text-muted-foreground">{item.description}</span>}
     </ComposerPrimitive.Unstable_TriggerPopoverItem>
   );
 }

--- a/packages/ui/src/features/chat/gates/AskQuestionWizard.tsx
+++ b/packages/ui/src/features/chat/gates/AskQuestionWizard.tsx
@@ -52,25 +52,20 @@ function OptionRow({ label, description, isSelected, isMulti, testId, onToggle }
     >
       {isMulti ? (
         // Shared pixel-accurate Checkbox primitive (17x17, rounded-[5px], real checkmark icon).
-        <Checkbox
-          className="mt-0.5 pointer-events-none"
-          checked={isSelected}
-          tabIndex={-1}
-          aria-hidden="true"
-        />
+        <Checkbox className="mt-0.5 pointer-events-none" checked={isSelected} tabIndex={-1} aria-hidden="true" />
       ) : (
         // Radio indicator: thick border when selected (no fill), hairline when not.
         <span
           data-radio-indicator
           className={cn(
             'mt-0.5 size-[17px] shrink-0 rounded-full transition-all',
-            isSelected ? 'border-[5px] border-primary' : 'border-[1.5px] border-mf-text-4',
+            isSelected ? 'border-[5px] border-primary' : 'border-[1.5px] border-input',
           )}
         />
       )}
       <span className="min-w-0">
         <span className="block text-body font-semibold text-foreground">{label}</span>
-        {description && <span className="block text-caption text-mf-text-3">{description}</span>}
+        {description && <span className="block text-label text-muted-foreground">{description}</span>}
       </span>
     </div>
   );

--- a/packages/ui/src/features/chat/gates/AskUserQuestionGate.tsx
+++ b/packages/ui/src/features/chat/gates/AskUserQuestionGate.tsx
@@ -156,11 +156,10 @@ export function AskUserQuestionGate({ entry, reply }: AskUserQuestionGateProps) 
           icon={<MessageCircleQuestionIcon className="size-[15px]" />}
           tileClassName="bg-mf-selection text-primary"
           eyebrow={eyebrow}
-          eyebrowClassName="text-primary"
           title={title}
           right={
             questions.length > 1 ? (
-              <span className="shrink-0 rounded-full bg-background px-2 py-0.5 text-micro font-semibold text-mf-text-3 ring-1 ring-border">
+              <span className="shrink-0 rounded-full bg-background px-2 py-0.5 text-caption font-semibold text-muted-foreground ring-1 ring-border">
                 {current + 1} of {questions.length}
               </span>
             ) : undefined

--- a/packages/ui/src/features/chat/gates/PermissionGate.tsx
+++ b/packages/ui/src/features/chat/gates/PermissionGate.tsx
@@ -16,8 +16,8 @@ export type { ReplyFn } from './gate-types';
 function ToolNameRow({ toolName }: { toolName: string }) {
   return (
     <div className="flex items-center gap-2 px-3.5 pb-2 pl-[49px]">
-      <TerminalIcon className="size-3.5 text-mf-text-3" />
-      <span className="font-mono text-label font-semibold text-muted-foreground">{toolName}</span>
+      <TerminalIcon className="size-3.5 text-muted-foreground" />
+      <span className="font-mono text-body font-semibold text-foreground">{toolName}</span>
     </div>
   );
 }
@@ -98,7 +98,6 @@ export function PermissionGate({ entry, reply }: PermissionGateProps) {
           icon={<ShieldIcon className="size-[15px]" />}
           tileClassName="bg-mf-warning-tint text-mf-warning"
           eyebrow="Permission required"
-          eyebrowClassName="text-mf-warning"
           title="Permission Required"
         />
         <ToolNameRow toolName={request.toolName} />

--- a/packages/ui/src/features/chat/gates/PlanGate.tsx
+++ b/packages/ui/src/features/chat/gates/PlanGate.tsx
@@ -24,10 +24,10 @@ const PLAN_MD_COMPONENTS: Components = {
   li: ({ children }) => <li className="mb-1">{children}</li>,
   h1: ({ children }) => <h1 className="mb-1 mt-3 text-heading font-semibold text-foreground">{children}</h1>,
   h2: ({ children }) => <h2 className="mb-1 mt-3 text-body font-semibold text-foreground">{children}</h2>,
-  h3: ({ children }) => <h3 className="mb-1 mt-3 text-caption font-semibold text-foreground">{children}</h3>,
-  code: ({ children }) => <code className="rounded bg-mf-raised px-1 py-0.5 font-mono text-caption">{children}</code>,
+  h3: ({ children }) => <h3 className="mb-1 mt-3 text-body font-semibold text-foreground">{children}</h3>,
+  code: ({ children }) => <code className="rounded bg-mf-raised px-1 py-0.5 font-mono text-label">{children}</code>,
   pre: ({ children }) => (
-    <pre className="mb-2 overflow-auto rounded-md bg-mf-raised p-3 font-mono text-caption">{children}</pre>
+    <pre className="mb-2 overflow-auto rounded-md bg-mf-raised p-3 font-mono text-label">{children}</pre>
   ),
   strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
   a: ({ href, children }) => (
@@ -200,7 +200,6 @@ export function PlanGate({ entry, reply, onApprove }: PlanGateProps) {
           icon={<SquareCheckIcon className="size-[15px]" />}
           tileClassName="bg-mf-selection text-primary"
           eyebrow="Plan"
-          eyebrowClassName="text-primary"
           title="Ready to implement"
         />
         {plan && <PlanBody plan={plan} />}
@@ -220,7 +219,7 @@ export function PlanGate({ entry, reply, onApprove }: PlanGateProps) {
             <span
               className={`inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full ${execMode === 'yolo' ? 'bg-destructive' : 'bg-primary'}`}
             />
-            <span className="text-body text-mf-text-3">
+            <span className="text-body text-muted-foreground">
               Executing in{' '}
               <b className={execMode === 'yolo' ? 'font-semibold text-destructive' : 'font-semibold text-foreground'}>
                 {EXEC_MODE_LABELS[execMode]}

--- a/packages/ui/src/features/chat/gates/__tests__/AskUserQuestionGate.test.tsx
+++ b/packages/ui/src/features/chat/gates/__tests__/AskUserQuestionGate.test.tsx
@@ -198,7 +198,7 @@ describe('AskUserQuestionGate', () => {
     const option = screen.getByTestId('chat-question-option-0-MP4');
     const indicator = option.querySelector('[data-radio-indicator]');
     expect(indicator).not.toBeNull();
-    expect(indicator).toHaveClass('size-[17px]', 'border-[1.5px]', 'border-mf-text-4');
+    expect(indicator).toHaveClass('size-[17px]', 'border-[1.5px]', 'border-input');
 
     fireEvent.click(option);
     expect(indicator).toHaveClass('border-[5px]', 'border-primary');

--- a/packages/ui/src/features/chat/gates/shared/GateButton.tsx
+++ b/packages/ui/src/features/chat/gates/shared/GateButton.tsx
@@ -19,7 +19,7 @@ export function GateButton({
     <Button
       size="sm"
       variant="ghost"
-      className={cn('h-8 px-3.5 text-label font-semibold', KIND_CLASS[kind], className)}
+      className={cn('h-8 px-3.5 text-body font-semibold', KIND_CLASS[kind], className)}
       {...props}
     />
   );

--- a/packages/ui/src/features/chat/gates/shared/GateShell.tsx
+++ b/packages/ui/src/features/chat/gates/shared/GateShell.tsx
@@ -6,7 +6,9 @@ type GateAccent = 'primary' | 'warning';
 // Accent-tinted "live card" glow per gate type (blue for Question/Plan, amber for
 // Permission) — replaces the generic popover shadow while a gate is unresolved.
 const ACCENT_SHADOW: Record<GateAccent, CSSProperties> = {
-  primary: { boxShadow: '0 1px 0 rgba(0,0,0,0.02), 0 6px 22px -12px color-mix(in srgb, var(--primary) 55%, transparent)' },
+  primary: {
+    boxShadow: '0 1px 0 rgba(0,0,0,0.02), 0 6px 22px -12px color-mix(in srgb, var(--primary) 55%, transparent)',
+  },
   warning: {
     boxShadow: '0 1px 0 rgba(0,0,0,0.02), 0 6px 22px -12px color-mix(in srgb, var(--mf-warning) 55%, transparent)',
   },
@@ -38,7 +40,7 @@ export function GateCardShell({
 export function GateHead({
   icon,
   eyebrow,
-  eyebrowClassName = 'text-mf-text-3',
+  eyebrowClassName = 'text-muted-foreground',
   title,
   tileClassName,
   right,
@@ -59,7 +61,7 @@ export function GateHead({
         {icon}
       </span>
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className={cn('text-micro font-bold uppercase tracking-wide', eyebrowClassName)}>{eyebrow}</span>
+        <span className={cn('text-caption font-medium', eyebrowClassName)}>{eyebrow}</span>
         <span className="text-body font-semibold leading-tight text-foreground">{title}</span>
       </div>
       {right}

--- a/packages/ui/src/features/chat/messages/MessageActionBar.tsx
+++ b/packages/ui/src/features/chat/messages/MessageActionBar.tsx
@@ -92,7 +92,7 @@ const MoreMenu: FC = () => (
             'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
           )}
         >
-          <DownloadIcon className="size-4 shrink-0" />
+          <DownloadIcon className="size-3.5 shrink-0" />
           Export as Markdown
         </ActionBarMorePrimitive.Item>
       </ActionBarPrimitive.ExportMarkdown>

--- a/packages/ui/src/features/chat/messages/MessageTimestamp.tsx
+++ b/packages/ui/src/features/chat/messages/MessageTimestamp.tsx
@@ -13,7 +13,7 @@ export function MessageTimestamp() {
   if (!createdAt) return null;
   const label = createdAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   return (
-    <span data-testid="chat-message-timestamp" className="font-mono text-micro tabular-nums text-mf-text-4">
+    <span data-testid="chat-message-timestamp" className="font-mono text-caption tabular-nums text-mf-text-3">
       {label}
     </span>
   );

--- a/packages/ui/src/features/chat/messages/MessageTiming.tsx
+++ b/packages/ui/src/features/chat/messages/MessageTiming.tsx
@@ -53,7 +53,7 @@ export const MessageTiming: FC<MessageTimingProps> = ({ className, side = 'top' 
           data-testid="chat-message-timing"
           aria-label="Message timing"
           className={cn(
-            'cursor-default rounded-sm px-1 py-0.5 font-mono text-micro tabular-nums text-mf-text-4 transition-colors hover:bg-accent hover:text-mf-text-3',
+            'cursor-default rounded-sm px-1 py-0.5 font-mono text-caption tabular-nums text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground',
             className,
           )}
         >

--- a/packages/ui/src/features/chat/messages/PlanBubble.tsx
+++ b/packages/ui/src/features/chat/messages/PlanBubble.tsx
@@ -36,8 +36,8 @@ export function PlanBubble({ plan }: { plan: string }) {
           <SquareCheck className="size-[12px] text-mf-success" />
         </span>
         <span className="text-body font-bold tracking-tight">Implementing plan</span>
-        <span className="inline-flex items-center gap-[4px] rounded-[20px] bg-mf-success-tint px-[8px] py-[2px] text-micro font-semibold text-mf-success">
-          <Check className="size-[10px]" strokeWidth={2.4} />
+        <span className="inline-flex items-center gap-[4px] rounded-[20px] bg-mf-success-tint px-[8px] py-[2px] text-caption font-semibold text-muted-foreground">
+          <Check className="size-[12px] text-mf-success" strokeWidth={2.4} />
           Approved
         </span>
       </div>

--- a/packages/ui/src/features/chat/messages/QueuedUserTurn.tsx
+++ b/packages/ui/src/features/chat/messages/QueuedUserTurn.tsx
@@ -51,7 +51,7 @@ function QueuedAction({ icon: Icon, label, onClick, danger, testid }: QueuedActi
         // Design 7.10: icon/label gap 4 (gap-1 was 2px), radius 7 (rounded-md
         // is 8px) — both arbitrary, no exact compressed-scale token.
         'inline-flex items-center gap-[4px] rounded-[7px] border border-transparent h-[24px] px-[9px]',
-        'text-caption text-mf-text-3 transition-colors',
+        'text-caption text-muted-foreground transition-colors',
         'hover:bg-mf-content2 hover:border-border',
         danger && 'hover:text-destructive hover:border-destructive/35',
       )}
@@ -72,15 +72,9 @@ function QueuedMeta({ position = 1, total = 1 }: { position?: number; total?: nu
 
   // Non-head items use a steady amber dot (no spin); head/single uses the spinner.
   const showSpinner = isHead || !isMulti;
-  const dimmed = isMulti && !isHead;
 
   return (
-    <span
-      className={cn(
-        'mr-1 inline-flex items-center gap-1.5 font-mono text-micro tracking-tight',
-        dimmed ? 'text-mf-text-4' : 'text-mf-text-3',
-      )}
-    >
+    <span className="mr-1 inline-flex items-center gap-1.5 font-mono text-caption tracking-tight text-muted-foreground">
       {showSpinner ? (
         <span
           className="inline-block h-[7px] w-[7px] shrink-0 animate-spin rounded-full border-[1.5px] border-mf-warning"

--- a/packages/ui/src/features/chat/messages/ReviewCommentCard.tsx
+++ b/packages/ui/src/features/chat/messages/ReviewCommentCard.tsx
@@ -29,7 +29,7 @@ function CommentSection({ item, id }: { item: ReviewCommentItem; id: string }) {
   const lines = item.code ? item.code.split('\n') : [];
   return (
     <div data-testid={`chat-user-review-comment-L${item.start}`} className="flex flex-col gap-1.5 px-3 py-2.5">
-      <span className="font-mono text-micro text-mf-text-4">{rangeLabel({ start: item.start, end: item.end })}</span>
+      <span className="font-mono text-caption text-mf-text-3">{rangeLabel({ start: item.start, end: item.end })}</span>
       {lines.length > 0 && (
         <div className="select-text rounded-md border-[0.5px] border-border bg-mf-raised py-1">
           <SnippetBlock id={id} lines={lines} start={item.start} />
@@ -64,9 +64,9 @@ export function ReviewCommentCard({ review }: { review: ReviewComment }) {
         </Hint>
         <span className="flex-1" />
         {review.comments.length > 1 && (
-          <span className="flex-shrink-0 font-mono text-micro text-mf-text-4">{review.comments.length} comments</span>
+          <span className="flex-shrink-0 font-mono text-caption text-mf-text-3">{review.comments.length} comments</span>
         )}
-        <QuoteIcon size={11} className="flex-shrink-0 text-mf-text-4" />
+        <QuoteIcon size={12} className="flex-shrink-0 text-mf-text-3" />
       </div>
       {/* No /opacity modifier on token colors (CLAUDE.md token trap). */}
       <div className="divide-y divide-border">

--- a/packages/ui/src/features/chat/messages/SystemMessage.tsx
+++ b/packages/ui/src/features/chat/messages/SystemMessage.tsx
@@ -8,8 +8,8 @@
  *   2. skillLoaded  → the rich SkillLoadedCard ("Using skill: X", expandable)
  *   3. plain text   → quiet pill (AlertTriangle for CLI errors, else Zap)
  *
- * Metadata via the one `useMainframeMeta()` contract. Tokens: bg-mf-chip /
- * text-mf-text-3 (no /opacity on --mf-* vars). data-testid: chat-system-message.
+ * Metadata via the one `useMainframeMeta()` contract. Tokens: bg-mf-content2 /
+ * text-muted-foreground (no /opacity on --mf-* vars). data-testid: chat-system-message.
  */
 import { AlertTriangleIcon, LayersIcon, ZapIcon } from 'lucide-react';
 import { MessagePrimitive } from '@assistant-ui/react';
@@ -23,9 +23,9 @@ export function CompactionPill() {
     <div className="my-2 flex justify-center">
       <div
         data-testid="chat-compaction-pill"
-        className="inline-flex select-none items-center gap-1.5 rounded-full border border-border bg-mf-content2 px-3 py-1 font-mono text-caption text-mf-text-3"
+        className="inline-flex select-none items-center gap-1.5 rounded-full border border-border bg-mf-content2 px-3 py-1 font-mono text-caption text-muted-foreground"
       >
-        <LayersIcon size={11} className="shrink-0 text-mf-text-3" />
+        <LayersIcon size={12} className="shrink-0 text-muted-foreground" />
         <span>Context compacted</span>
       </div>
     </div>
@@ -44,10 +44,10 @@ function SystemTextPill({ text }: { text: string }) {
           'inline-flex select-none items-center gap-1.5 rounded-full border px-3 py-1 font-mono text-caption',
           isError
             ? 'border-destructive bg-mf-destructive-tint text-destructive'
-            : 'border-border bg-mf-content2 text-mf-text-3',
+            : 'border-border bg-mf-content2 text-muted-foreground',
         )}
       >
-        <Icon size={11} className="shrink-0" />
+        <Icon size={12} className="shrink-0" />
         <span>{text}</span>
       </div>
     </div>

--- a/packages/ui/src/features/chat/messages/UserAttachments.tsx
+++ b/packages/ui/src/features/chat/messages/UserAttachments.tsx
@@ -44,13 +44,13 @@ function FilePill({ name }: { name: string }) {
         className="inline-flex size-[36px] flex-shrink-0 items-center justify-center rounded-lg"
         style={{ background: extTint(m.color) }}
       >
-        <span className="font-mono text-micro font-bold" style={{ color: m.color }}>
+        <span className="font-mono text-caption font-bold" style={{ color: m.color }}>
           .{m.ext}
         </span>
       </span>
       <span className="flex min-w-0 flex-col gap-px">
         <span className="max-w-[150px] truncate text-label font-semibold text-mf-um-ink">{name}</span>
-        <span className="text-micro text-mf-text-3">{subline}</span>
+        <span className="text-caption text-muted-foreground">{subline}</span>
       </span>
     </div>
   );
@@ -95,11 +95,13 @@ function ImageAttachment({ name }: { name: string }) {
           <TruncatedWithTooltip
             data-testid="chat-capture-selector"
             text={capture.selector}
-            className="font-mono text-caption text-mf-code-fn"
+            className="font-mono text-label text-mf-code-fn"
             contentClassName="font-mono break-all"
           />
         )}
-        {capture?.annotation && <span className="truncate text-micro text-mf-text-3">{capture.annotation}</span>}
+        {capture?.annotation && (
+          <span className="truncate text-caption text-muted-foreground">{capture.annotation}</span>
+        )}
       </span>
     </span>
   );

--- a/packages/ui/src/features/chat/messages/UserMessage.tsx
+++ b/packages/ui/src/features/chat/messages/UserMessage.tsx
@@ -140,7 +140,7 @@ function SlashPill({ kind, name }: SlashPillProps) {
     // exact 8px tokens, gap-[5px] has no matching integer step (arbitrary).
     <span className={cn('mr-4 inline-flex items-center gap-[5px] rounded-md py-0.5 pl-1.5 pr-4', bgClass)}>
       <Icon size={12} className={colorClass} />
-      <span className={cn('font-mono text-caption font-semibold', colorClass)}>/{name}</span>
+      <span className={cn('font-mono text-label font-semibold', colorClass)}>/{name}</span>
     </span>
   );
 }
@@ -277,7 +277,7 @@ function UserMessageImpl() {
 
       {sendError != null && (
         <div className="flex items-center gap-2">
-          <span data-testid="chat-user-message-send-failed" className="text-caption text-destructive">
+          <span data-testid="chat-user-message-send-failed" className="text-label text-destructive">
             Failed to send
           </span>
           {retryClientId && chatExtras && (
@@ -285,7 +285,7 @@ function UserMessageImpl() {
               type="button"
               data-testid="chat-user-message-retry"
               onClick={() => void chatExtras.retryMessage(retryClientId)}
-              className="text-caption font-medium text-primary hover:underline"
+              className="text-label font-medium text-primary hover:underline"
             >
               Retry
             </button>

--- a/packages/ui/src/features/chat/messages/code-snippet.tsx
+++ b/packages/ui/src/features/chat/messages/code-snippet.tsx
@@ -12,8 +12,10 @@ export function SnippetLines({ lines, start }: { lines: readonly string[]; start
       {lines.map((line, i) => (
         // 18px line-height pins the line-number gutter alignment — a fixed
         // layout metric (matches the prototype), not a typography token.
-        <div key={i} className="flex min-h-[18px] font-mono text-caption" style={{ lineHeight: '18px' }}>
-          <span className="w-10 flex-shrink-0 select-none pr-3 text-right text-micro text-mf-text-4">{start + i}</span>
+        <div key={i} className="flex min-h-[18px] font-mono text-label" style={{ lineHeight: '18px' }}>
+          <span className="w-10 flex-shrink-0 select-none pr-3 text-right text-caption text-mf-text-3">
+            {start + i}
+          </span>
           <span className="flex-1 whitespace-pre pr-3 text-foreground">{line}</span>
         </div>
       ))}
@@ -59,7 +61,9 @@ export function SnippetBlock({ id, lines, start }: { id: string; lines: readonly
     <div className="relative">
       <div
         data-testid={`chat-user-snippet-scroll-${id}`}
-        style={collapsed ? { maxHeight: COLLAPSED_HEIGHT_PX } : expanded ? { maxHeight: EXPANDED_MAX_HEIGHT_PX } : undefined}
+        style={
+          collapsed ? { maxHeight: COLLAPSED_HEIGHT_PX } : expanded ? { maxHeight: EXPANDED_MAX_HEIGHT_PX } : undefined
+        }
         className={cn(collapsed && 'overflow-hidden', expanded && 'max-h-[240px] overflow-y-auto')}
       >
         <SnippetLines lines={lines} start={start} />

--- a/packages/ui/src/features/chat/parts/markdown-text.tsx
+++ b/packages/ui/src/features/chat/parts/markdown-text.tsx
@@ -63,7 +63,7 @@ function Code({ className, children, ...props }: React.ComponentProps<'code'>) {
         // distinct from the fenced-code-block `mf-code-fg` token.
         'bg-mf-raised text-mf-code-inline-fg',
         'rounded-xs border border-border px-1.5 py-0.5',
-        'font-mono text-caption',
+        'font-mono text-label',
         className,
       )}
       {...props}
@@ -155,7 +155,7 @@ function LinkWithPreview({
           className={cn(
             'shrink-0 px-1.5 py-0.5 rounded-sm',
             'bg-accent hover:bg-muted text-muted-foreground hover:text-foreground',
-            'transition-colors text-micro',
+            'transition-colors text-caption',
           )}
         >
           {copied ? 'Copied' : 'Copy'}

--- a/packages/ui/src/features/chat/thread/ChatCardHeader.tsx
+++ b/packages/ui/src/features/chat/thread/ChatCardHeader.tsx
@@ -36,7 +36,7 @@ function ChatCardHeaderDraft({ projectId, projectName }: { projectId: string | n
     <div data-testid="chat-header" data-drag-region className={HEADER_ROOT_CLASS}>
       <GripHorizontal size={13} className="flex-shrink-0 cursor-grab text-mf-text-4" />
       <MessageSquare size={13} className="flex-shrink-0 text-primary" />
-      <span className="min-w-0 flex-initial truncate text-caption font-semibold">New Session</span>
+      <span className="min-w-0 flex-initial truncate text-body font-semibold">New Session</span>
       {projectId != null && projectName != null && (
         <ProjectChip projectId={projectId} name={projectName} size={16} data-testid="chat-header-project" />
       )}
@@ -66,7 +66,7 @@ function ChatCardHeaderReal() {
     <div data-testid="chat-header" data-drag-region className={HEADER_ROOT_CLASS}>
       <GripHorizontal size={13} className="flex-shrink-0 cursor-grab text-mf-text-4" />
       <MessageSquare size={13} className="flex-shrink-0 text-primary" />
-      <span className="min-w-0 flex-initial truncate text-caption font-semibold">{title}</span>
+      <span className="min-w-0 flex-initial truncate text-body font-semibold">{title}</span>
       <ChatSessionInline part="model" />
       <span className="flex-1" />
       <ChatSessionInline part="status" />
@@ -88,9 +88,9 @@ function ChatCardHeaderReal() {
             data-testid={`chat-header-pr-${pr.number}`}
             type="button"
             onClick={() => void host.shell.openExternal(pr.url)}
-            className="inline-flex flex-shrink-0 items-center gap-1 font-mono text-caption font-semibold text-mf-success hover:underline"
+            className="inline-flex flex-shrink-0 items-center gap-1 font-mono text-caption font-semibold text-foreground hover:underline"
           >
-            <GitPullRequest size={12} className="flex-shrink-0" />#{pr.number}
+            <GitPullRequest size={12} className="flex-shrink-0 text-mf-success" />#{pr.number}
           </button>
         </Hint>
       ))}
@@ -103,7 +103,7 @@ function ChatCardHeaderReal() {
               onClick={() => splitSurface('v')}
               className={HDR_BTN}
             >
-              <LayoutPanelLeft size={13} className="text-mf-text-3" />
+              <LayoutPanelLeft size={13} className="text-muted-foreground" />
             </button>
           </Hint>
           <Hint label="Split down">
@@ -113,7 +113,7 @@ function ChatCardHeaderReal() {
               onClick={() => splitSurface('h')}
               className={HDR_BTN}
             >
-              <LayoutPanelTop size={13} className="text-mf-text-3" />
+              <LayoutPanelTop size={13} className="text-muted-foreground" />
             </button>
           </Hint>
         </>
@@ -127,7 +127,7 @@ function ChatCardHeaderReal() {
           onClick={() => toggleSurface('chat')}
           className={`${HDR_BTN} ${chatIsFloor ? 'cursor-not-allowed opacity-40' : ''}`}
         >
-          <EyeOff size={13} className="text-mf-text-3" />
+          <EyeOff size={13} className="text-muted-foreground" />
         </button>
       </Hint>
     </div>

--- a/packages/ui/src/features/chat/thread/ChatSessionInline.tsx
+++ b/packages/ui/src/features/chat/thread/ChatSessionInline.tsx
@@ -50,10 +50,7 @@ export function ChatSessionInline({ part }: { part: 'model' | 'status' }) {
     if (modelLabel == null) return null;
     return (
       <Hint label={`${adapter?.name ?? chat.adapterId} · ${modelLabel}`}>
-        <span
-          data-testid="chat-header-model"
-          className="inline-flex min-w-0 shrink items-center gap-[5px] text-caption"
-        >
+        <span data-testid="chat-header-model" className="inline-flex min-w-0 shrink items-center gap-[5px] text-label">
           <span className={cn('size-1.5 flex-shrink-0 rounded-full', providerDot(chat.adapterId))} />
           <span className="truncate font-medium text-muted-foreground">{modelLabel}</span>
         </span>
@@ -84,7 +81,7 @@ export function ChatSessionInline({ part }: { part: 'model' | 'status' }) {
           ))}
         </span>
       </Hint>
-      <span data-testid="chat-header-context-pct" className="font-mono text-micro tabular-nums text-mf-text-3">
+      <span data-testid="chat-header-context-pct" className="font-mono text-caption tabular-nums text-muted-foreground">
         {pct}%
       </span>
     </span>

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -39,7 +39,7 @@ function LoadErrorBanner() {
         data-testid="chat-thread-load-retry"
         type="button"
         onClick={() => void extras.retry()}
-        className="rounded-md border border-border px-3 py-1.5 text-caption text-foreground transition-colors hover:bg-accent"
+        className="rounded-md border border-border px-3 py-1.5 text-label text-foreground transition-colors hover:bg-accent"
       >
         Retry
       </button>
@@ -102,7 +102,7 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
                   aria-label="Scroll to bottom"
                   className="absolute -top-10 left-1/2 z-10 flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-[var(--mf-shadow-pop)] transition-opacity hover:text-foreground disabled:invisible"
                 >
-                  <ArrowDownIcon className="size-4" />
+                  <ArrowDownIcon className="size-3.5" />
                 </button>
               </ThreadPrimitive.ScrollToBottom>
 

--- a/packages/ui/src/features/chat/thread/DegradedChatCard.tsx
+++ b/packages/ui/src/features/chat/thread/DegradedChatCard.tsx
@@ -12,7 +12,7 @@ import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
 import { archiveChat, continueChatHere, continueChatInProjectRoot, recreateChatWorktree } from '@/lib/api/chats';
 
 const ACTION_BUTTON =
-  'rounded-md border border-border px-3 py-1.5 text-caption text-foreground transition-colors hover:bg-accent disabled:opacity-50';
+  'rounded-md border border-border px-3 py-1.5 text-label text-foreground transition-colors hover:bg-accent disabled:opacity-50';
 
 function CauseSection({ title, body }: { title: string; body: string }) {
   return (
@@ -21,7 +21,7 @@ function CauseSection({ title, body }: { title: string; body: string }) {
         <AlertTriangleIcon className="size-3.5 shrink-0 text-destructive" />
         {title}
       </p>
-      <p className="text-caption text-muted-foreground">{body}</p>
+      <p className="text-label text-muted-foreground">{body}</p>
     </div>
   );
 }
@@ -75,7 +75,7 @@ export function DegradedChatCard() {
       )}
 
       {recreateError != null && (
-        <p data-testid="chat-degraded-error" className="text-caption text-destructive">
+        <p data-testid="chat-degraded-error" className="text-label text-destructive">
           {recreateError}
         </p>
       )}

--- a/packages/ui/src/features/chat/tools/cards/AskUserQuestionCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/AskUserQuestionCard.tsx
@@ -63,10 +63,10 @@ function AnswerPills({ options, answer }: { options: { label: string }[]; answer
               'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-caption',
               known
                 ? 'bg-mf-content2 text-primary border border-border'
-                : 'bg-card text-muted-foreground border border-border opacity-60',
+                : 'bg-card text-muted-foreground border border-border',
             )}
           >
-            <Check size={11} className="shrink-0" />
+            <Check size={12} className="shrink-0" />
             {label}
           </span>
         );
@@ -80,7 +80,7 @@ function AnswerPills({ options, answer }: { options: { label: string }[]; answer
 function AnswerEntry({ entry, question }: { entry: AskUserQuestionAnswer; question: QuestionArg | undefined }) {
   return (
     <div className="space-y-1.5">
-      <p data-testid="chat-ask-question-text" className="text-caption text-foreground">
+      <p data-testid="chat-ask-question-text" className="text-body text-foreground">
         {entry.question}
       </p>
       <AnswerPills options={question?.options ?? []} answer={entry.answer} />
@@ -103,7 +103,7 @@ function AnswerEntry({ entry, question }: { entry: AskUserQuestionAnswer; questi
 function PendingQuestion({ question }: { question: QuestionArg }) {
   return (
     <div>
-      <p className="text-caption text-muted-foreground">{question.question}</p>
+      <p className="text-body text-muted-foreground">{question.question}</p>
     </div>
   );
 }
@@ -143,7 +143,7 @@ export const AskUserQuestionCard: ToolCallMessagePartComponent = (part) => {
           <span data-testid="chat-ask-header" className="text-body text-muted-foreground flex-1 truncate min-w-0">
             {firstHeader}
             {shortAnswerText && (
-              <span className="text-foreground opacity-70">
+              <span className="text-muted-foreground">
                 {' — '}
                 {shortAnswerText}
               </span>

--- a/packages/ui/src/features/chat/tools/cards/BashCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/BashCard.tsx
@@ -31,12 +31,12 @@ function outputLineClass(line: string): string {
   const t = line.trim();
   if (t.includes('✓') || /\bpass(ed|ing)?\b/i.test(t)) return 'text-mf-term-green';
   if (t.includes('✗') || /\b(error|fail(ed|ure)?)\b/i.test(t)) return 'text-destructive';
-  return 'text-mf-term-cmt';
+  return 'text-mf-term-fg';
 }
 
 function ExitLine({ text }: { text: string }) {
   const match = /exit\s+(\d+)/i.exec(text);
-  if (!match) return <span className="text-mf-term-cmt">{text}</span>;
+  if (!match) return <span className="text-mf-term-fg">{text}</span>;
   const code = parseInt(match[1] ?? '0', 10);
   return <span className={code === 0 ? 'text-mf-term-green' : 'text-destructive'}>{text}</span>;
 }
@@ -63,7 +63,7 @@ function TerminalBody({ command, resultText, isError, chatId, toolCallId, trunca
       {truncated && chatId && toolCallId ? (
         <ToolResultExpand chatId={chatId} toolUseId={toolCallId} truncatedContent={resultText} fullBytes={fullBytes} />
       ) : (
-        <pre data-testid="chat-bash-output" className="font-mono text-caption overflow-x-auto whitespace-pre-wrap">
+        <pre data-testid="chat-bash-output" className="font-mono text-label overflow-x-auto whitespace-pre-wrap">
           <span className="text-mf-term-green">$ </span>
           <span className="text-mf-term-fg">{command}</span>
           {'\n'}

--- a/packages/ui/src/features/chat/tools/cards/EditFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/EditFileCard.tsx
@@ -37,9 +37,9 @@ import type { DiffHunk } from '@qlan-ro/mainframe-types';
 function StatPills({ added, removed }: { added: number | null; removed: number | null }) {
   if (added === null && removed === null) return null;
   return (
-    <span className="flex items-center gap-1.5 font-mono tabular-nums text-micro shrink-0">
-      {added !== null && <span className="font-semibold text-mf-diff-add-text">+{added}</span>}
-      {removed !== null && <span className="font-semibold text-mf-diff-del-text">−{removed}</span>}
+    <span className="flex items-center gap-1.5 font-mono tabular-nums text-caption shrink-0 text-muted-foreground">
+      {added !== null && <span className="font-semibold">+{added}</span>}
+      {removed !== null && <span className="font-semibold">−{removed}</span>}
     </span>
   );
 }
@@ -120,7 +120,7 @@ function EditCardBody({
           ) : (
             <pre
               data-testid="chat-edit-error-text"
-              className="text-caption font-mono overflow-x-auto whitespace-pre-wrap text-muted-foreground"
+              className="text-label font-mono overflow-x-auto whitespace-pre-wrap text-muted-foreground"
             >
               {resultText}
             </pre>

--- a/packages/ui/src/features/chat/tools/cards/MCPToolCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/MCPToolCard.tsx
@@ -65,7 +65,7 @@ export const MCPToolCard: ToolCallMessagePartComponent = ({ toolName, args, resu
   const resultText = extractResultText(result);
 
   const pillContent = (
-    <span className="font-mono text-caption text-mf-text-3">
+    <span className="font-mono text-label text-muted-foreground">
       {server} {verb} {state !== 'error' && <span className="text-primary">{tool}</span>}
       {state === 'error' && <span className="text-destructive">{tool}</span>}
     </span>
@@ -88,7 +88,7 @@ export const MCPToolCard: ToolCallMessagePartComponent = ({ toolName, args, resu
             </MarkerPill>
           </span>
         </TooltipTrigger>
-        <TooltipContent side="top" className="font-mono text-caption max-w-xs break-all">
+        <TooltipContent side="top" className="font-mono text-label max-w-xs break-all">
           {toolName}
         </TooltipContent>
       </Tooltip>

--- a/packages/ui/src/features/chat/tools/cards/PlanCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/PlanCard.tsx
@@ -60,10 +60,10 @@ export const PlanCard: ToolCallMessagePartComponent = (part) => {
             hasResult ? 'hover:bg-accent transition-colors cursor-pointer' : 'cursor-default',
           )}
         >
-          <FileText size={15} className={cn('shrink-0', hasResult ? 'text-muted-foreground' : 'text-mf-text-4')} />
+          <FileText size={15} className={cn('shrink-0', hasResult ? 'text-muted-foreground' : 'text-mf-text-3')} />
           <span
             data-testid="chat-plan-label"
-            className={cn('text-body flex-1', hasResult ? 'text-muted-foreground' : 'text-mf-text-4')}
+            className={cn('text-body flex-1', hasResult ? 'text-muted-foreground' : 'text-mf-text-3')}
           >
             Updated plan
           </span>
@@ -76,7 +76,7 @@ export const PlanCard: ToolCallMessagePartComponent = (part) => {
             <div className="ml-5 border-l border-border py-1">
               <pre
                 data-testid="chat-plan-body"
-                className="text-caption font-mono text-muted-foreground whitespace-pre-wrap px-3"
+                className="text-label font-mono text-muted-foreground whitespace-pre-wrap px-3"
               >
                 {resultText}
               </pre>

--- a/packages/ui/src/features/chat/tools/cards/ReadFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/ReadFileCard.tsx
@@ -47,7 +47,7 @@ function CodePreview({ text }: CodePreviewProps) {
   return (
     <pre
       data-testid="read-card-code-preview"
-      className="bg-mf-code-bg font-mono text-caption leading-normal text-mf-code-fg overflow-x-auto whitespace-pre px-3 py-2"
+      className="bg-mf-code-bg font-mono text-label leading-normal text-mf-code-fg overflow-x-auto whitespace-pre px-3 py-2"
     >
       {text}
     </pre>
@@ -76,7 +76,7 @@ export const ReadFileCard: ToolCallMessagePartComponent = ({ toolCallId, args, r
 
   const trailing = (
     <>
-      {metaLabel && <span className="shrink-0 font-mono text-micro text-mf-text-4">{metaLabel}</span>}
+      {metaLabel && <span className="shrink-0 font-mono text-caption text-mf-text-3">{metaLabel}</span>}
       <StatusDot result={result} isError={isError} />
     </>
   );

--- a/packages/ui/src/features/chat/tools/cards/SchedulePillCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SchedulePillCard.tsx
@@ -89,8 +89,8 @@ function buildDoneLabel(kind: ScheduleKind, args: Record<string, unknown>, parse
       <>
         Scheduled: <span className="text-primary">{human}</span>
         {' · '}
-        <span className="text-mf-text-4">{recurring ? 'recurring' : 'one-shot'}</span>
-        {durable === false && <span className="text-mf-text-4"> · session-only</span>}
+        <span className="text-mf-text-3">{recurring ? 'recurring' : 'one-shot'}</span>
+        {durable === false && <span className="text-mf-text-3"> · session-only</span>}
       </>
     );
   }
@@ -126,19 +126,19 @@ function buildBody(kind: ScheduleKind, parsed: unknown, text: string): React.Rea
     const jobs = Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : [];
     if (jobs.length === 0) return null;
     return (
-      <div className="flex flex-col gap-1.5 font-mono text-caption text-mf-text-3">
+      <div className="flex flex-col gap-1.5 font-mono text-label text-muted-foreground">
         {jobs.map((j) => (
           <div key={String(j['id'] ?? '')}>
             <div>
               {'• '}
               <span className="text-primary">{String(j['id'] ?? '')}</span>{' '}
               {String(j['humanSchedule'] ?? j['cron'] ?? '')}{' '}
-              <span className="text-mf-text-4">
+              <span className="text-mf-text-3">
                 ({j['recurring'] ? 'recurring' : 'one-shot'}
                 {j['durable'] === false ? ', session-only' : ''})
               </span>
             </div>
-            {Boolean(j['prompt']) && <div className="pl-3 text-mf-text-4">prompt: {String(j['prompt'])}</div>}
+            {Boolean(j['prompt']) && <div className="pl-3 text-mf-text-3">prompt: {String(j['prompt'])}</div>}
           </div>
         ))}
       </div>
@@ -195,7 +195,7 @@ function buildScheduleCard(kind: ScheduleKind): ToolCallMessagePartComponent {
         onClick={toggle}
         testId={`chat-schedule-${kind.toLowerCase()}-pill`}
       >
-        <span className="font-mono text-caption text-mf-text-3">{label}</span>
+        <span className="font-mono text-label text-muted-foreground">{label}</span>
       </MarkerPill>
     );
 

--- a/packages/ui/src/features/chat/tools/cards/SearchCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SearchCard.tsx
@@ -43,7 +43,7 @@ function PlainBody({ resultText }: { resultText: string }) {
   return (
     <pre
       data-testid="search-card-plain-body"
-      className="font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 text-muted-foreground"
+      className="font-mono text-label whitespace-pre-wrap break-words px-3 py-2 text-muted-foreground"
     >
       {resultText}
     </pre>
@@ -84,7 +84,7 @@ export const SearchCard: ToolCallMessagePartComponent = ({ toolName, toolCallId,
       <span className="text-mf-text-4 shrink-0">·</span>
       <TruncatedWithTooltip
         text={`"${pattern}"`}
-        className="font-mono text-caption text-muted-foreground min-w-0 max-w-[200px]"
+        className="font-mono text-label text-muted-foreground min-w-0 max-w-[200px]"
         contentClassName="font-mono break-all"
       />
     </>
@@ -92,7 +92,9 @@ export const SearchCard: ToolCallMessagePartComponent = ({ toolName, toolCallId,
 
   const trailing = (
     <>
-      {matchCount !== null && <span className="font-mono text-micro text-mf-text-3 shrink-0">· {matchCount}</span>}
+      {matchCount !== null && (
+        <span className="font-mono text-caption text-muted-foreground shrink-0">· {matchCount}</span>
+      )}
       <StatusDot result={result} isError={isError} />
     </>
   );
@@ -103,7 +105,7 @@ export const SearchCard: ToolCallMessagePartComponent = ({ toolName, toolCallId,
         <TooltipTrigger asChild>
           <span
             data-testid="search-card-path"
-            className="font-mono text-micro text-mf-text-4 truncate block cursor-default"
+            className="font-mono text-caption text-muted-foreground truncate block cursor-default"
             tabIndex={0}
           >
             in {searchPath}

--- a/packages/ui/src/features/chat/tools/cards/SkillLoadedCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SkillLoadedCard.tsx
@@ -25,7 +25,7 @@ export function SkillLoadedCard({ skillName, path = '', content = '' }: SkillLoa
   const expandable = content.length > 0;
 
   const pillLabel = (
-    <span className="font-mono text-caption text-mf-text-3">
+    <span className="font-mono text-label text-muted-foreground">
       Using skill: <span className="text-primary">{skillName}</span>
     </span>
   );
@@ -50,7 +50,7 @@ export function SkillLoadedCard({ skillName, path = '', content = '' }: SkillLoa
           <TooltipTrigger asChild>
             <span>{pill}</span>
           </TooltipTrigger>
-          <TooltipContent side="top" className="font-mono text-caption max-w-xs break-all">
+          <TooltipContent side="top" className="font-mono text-label max-w-xs break-all">
             {path}
           </TooltipContent>
         </Tooltip>

--- a/packages/ui/src/features/chat/tools/cards/SlashCommandCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/SlashCommandCard.tsx
@@ -28,7 +28,7 @@ export const SlashCommandCard: ToolCallMessagePartComponent = ({ args }) => {
             <span
               data-testid="chat-slash-command-args"
               tabIndex={0}
-              className="font-mono text-caption text-mf-text-3 truncate min-w-0 cursor-default"
+              className="font-mono text-caption text-muted-foreground truncate min-w-0 cursor-default"
             >
               {skillArgs}
             </span>

--- a/packages/ui/src/features/chat/tools/cards/TaskCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/TaskCard.tsx
@@ -55,7 +55,7 @@ function TaskHeader({ agentName, model, description, fullPrompt, isRunning, isEr
       />
 
       {/* Model (mono, muted) */}
-      {model && <TruncatedWithTooltip text={model} className="font-mono text-caption text-mf-text-4" />}
+      {model && <TruncatedWithTooltip text={model} className="font-mono text-caption text-mf-text-3" />}
 
       {/* Description / prompt */}
       {description && (

--- a/packages/ui/src/features/chat/tools/cards/TaskProgressCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/TaskProgressCard.tsx
@@ -89,7 +89,7 @@ function TaskStatusIcon({ status }: { status: string }) {
     return <span className="h-3.5 w-3.5 shrink-0 animate-pulse rounded-sm border border-primary bg-primary" />;
   }
   // pending / unknown
-  return <span className="h-3.5 w-3.5 shrink-0 rounded-sm border border-mf-text-4" />;
+  return <span className="h-3.5 w-3.5 shrink-0 rounded-sm border border-mf-text-3" />;
 }
 
 // ── Single task row ───────────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ function TaskRow({ task }: { task: TaskState }) {
               'truncate text-body',
               isCompleted && 'text-muted-foreground line-through',
               isInProgress && 'text-foreground',
-              !isCompleted && !isInProgress && 'text-mf-text-3',
+              !isCompleted && !isInProgress && 'text-muted-foreground',
             )}
             tabIndex={0}
           >
@@ -137,7 +137,7 @@ export const TaskProgressCard: ToolCallMessagePartComponent = (part) => {
         className="flex w-full items-center gap-1.5 py-0.5 text-caption text-muted-foreground hover:text-foreground transition-colors"
       >
         <span className="font-medium">Tasks</span>
-        <span className="text-mf-text-4">({tasks.length})</span>
+        <span className="text-mf-text-3">({tasks.length})</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="space-y-0.5 py-0.5">

--- a/packages/ui/src/features/chat/tools/cards/WebFetchCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/WebFetchCard.tsx
@@ -53,7 +53,7 @@ function UrlRow({ url }: { url: string }) {
         type="button"
         data-testid="web-fetch-card-url"
         onClick={open}
-        className="font-mono text-caption text-primary truncate min-w-0 hover:underline cursor-pointer text-left"
+        className="font-mono text-label text-primary truncate min-w-0 hover:underline cursor-pointer text-left"
       >
         {url}
       </button>
@@ -67,7 +67,10 @@ function UrlRow({ url }: { url: string }) {
 
 function SummaryBody({ text }: { text: string }) {
   return (
-    <p data-testid="web-fetch-card-summary" className="px-3 pb-2 pt-1.5 text-label text-muted-foreground leading-normal">
+    <p
+      data-testid="web-fetch-card-summary"
+      className="px-3 pb-2 pt-1.5 text-label text-muted-foreground leading-normal"
+    >
       {text}
     </p>
   );
@@ -92,9 +95,10 @@ export const WebFetchCard: ToolCallMessagePartComponent = ({ toolName, args, res
     </FamilyTile>
   );
 
-  const target = isSearch && query ? (
-    <span className="font-mono text-caption text-muted-foreground min-w-0 truncate">&quot;{query}&quot;</span>
-  ) : undefined;
+  const target =
+    isSearch && query ? (
+      <span className="font-mono text-label text-muted-foreground min-w-0 truncate">&quot;{query}&quot;</span>
+    ) : undefined;
 
   const trailing = <StatusDot result={result} isError={isError} />;
 

--- a/packages/ui/src/features/chat/tools/cards/WorktreeStatusPillCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/WorktreeStatusPillCard.tsx
@@ -75,7 +75,7 @@ function buildWorktreeCard(kind: 'EnterWorktree' | 'ExitWorktree'): ToolCallMess
         expandable={false}
         testId={`chat-worktree-${isEnter ? 'enter' : 'exit'}-pill`}
       >
-        <span className="font-mono text-caption text-mf-text-3">{label}</span>
+        <span className="font-mono text-label text-muted-foreground">{label}</span>
       </MarkerPill>
     );
 
@@ -86,7 +86,7 @@ function buildWorktreeCard(kind: 'EnterWorktree' | 'ExitWorktree'): ToolCallMess
             <TooltipTrigger asChild>
               <span>{pill}</span>
             </TooltipTrigger>
-            <TooltipContent side="top" className="font-mono text-caption max-w-xs break-all">
+            <TooltipContent side="top" className="font-mono text-label max-w-xs break-all">
               {tooltip}
             </TooltipContent>
           </Tooltip>

--- a/packages/ui/src/features/chat/tools/cards/WriteFileCard.tsx
+++ b/packages/ui/src/features/chat/tools/cards/WriteFileCard.tsx
@@ -32,14 +32,14 @@ import { useChatId } from '../chat-tool-context';
 function AllAddLines({ content }: { content: string }) {
   const lines = content.split('\n');
   return (
-    <div className="font-mono text-caption leading-5 overflow-x-auto bg-mf-code-bg">
+    <div className="font-mono text-label leading-5 overflow-x-auto bg-mf-code-bg">
       {lines.map((line, i) => (
         <div
           key={i}
           className="flex border-l-2 border-l-mf-diff-add-border bg-mf-diff-add-bg hover:brightness-95 transition-colors"
         >
-          <span className="shrink-0 w-8 select-none text-mf-text-4 text-right pr-1" />
-          <span className="shrink-0 w-8 select-none text-mf-text-4 text-right pr-2">{i + 1}</span>
+          <span className="shrink-0 w-8 select-none text-mf-text-3 text-right pr-1" />
+          <span className="shrink-0 w-8 select-none text-mf-text-3 text-right pr-2">{i + 1}</span>
           <span className="shrink-0 w-5 select-none text-mf-diff-add-text text-center font-bold">+</span>
           <span className="select-text whitespace-pre-wrap break-all pr-3 text-mf-diff-add-text">{line}</span>
         </div>
@@ -88,7 +88,7 @@ function WriteCardBody({
           ) : (
             <pre
               data-testid="chat-write-error-text"
-              className="text-caption font-mono overflow-x-auto whitespace-pre-wrap text-muted-foreground"
+              className="text-label font-mono overflow-x-auto whitespace-pre-wrap text-muted-foreground"
             >
               {resultText}
             </pre>
@@ -127,7 +127,7 @@ export const WriteFileCard: ToolCallMessagePartComponent = (part) => {
   const trailing = (
     <>
       {stats?.added != null && (
-        <span className="font-mono tabular-nums text-micro shrink-0 font-semibold text-mf-diff-add-text">
+        <span className="font-mono tabular-nums text-caption shrink-0 font-semibold text-muted-foreground">
           +{stats.added}
         </span>
       )}

--- a/packages/ui/src/features/chat/tools/cards/marker-pill.tsx
+++ b/packages/ui/src/features/chat/tools/cards/marker-pill.tsx
@@ -3,8 +3,8 @@
  *
  * Design contract (10-chatcards.jsx MarkerWrap/MarkerPill/MarkerBody):
  *   - Centered column wrapper (MarkerWrap) — `flex flex-col items-center`
- *   - Pill: bg-mf-content2, border-border, rounded-full, font-mono text-caption
- *     text-mf-text-3. Error: red-tinted border + bg. Pending: pulsing dot.
+ *   - Pill: bg-mf-content2, border-border, rounded-full, font-mono text-label
+ *     text-muted-foreground. Error: red-tinted border + bg. Pending: pulsing dot.
  *   - Expandable: chevron right/down; disclosure body below (rounded-lg, bg-mf-content2).
  *   - Accent token via text-primary for the meaningful name.
  *
@@ -61,7 +61,7 @@ export function MarkerPill({
         onClick={clickable ? onClick : undefined}
         className={cn(
           'inline-flex items-center gap-1.5 rounded-full pt-[4px] pr-[11px] pb-[4px] pl-[9px]',
-          'font-mono text-caption text-mf-text-3 select-none',
+          'font-mono text-label text-muted-foreground select-none',
           'border border-border bg-mf-content2',
           'transition-colors duration-100',
           clickable && 'hover:bg-accent cursor-pointer',
@@ -70,15 +70,15 @@ export function MarkerPill({
           'max-w-full overflow-hidden',
         )}
       >
-        <span className="shrink-0 text-mf-text-4">{icon}</span>
+        <span className="shrink-0 text-muted-foreground">{icon}</span>
         <span className="truncate min-w-0">{children}</span>
         {isPending && <span className="w-1.5 h-1.5 rounded-full bg-mf-text-4 animate-pulse shrink-0" />}
         {isError && <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />}
         {clickable &&
           (open ? (
-            <ChevronDownIcon size={11} className="text-mf-text-4 shrink-0" />
+            <ChevronDownIcon size={12} className="text-muted-foreground shrink-0" />
           ) : (
-            <ChevronRightIcon size={11} className="text-mf-text-4 shrink-0" />
+            <ChevronRightIcon size={12} className="text-muted-foreground shrink-0" />
           ))}
       </button>
     </Hint>
@@ -110,7 +110,7 @@ export function MarkerBody({
 
 /** ARGUMENTS / RESULT section label inside a MarkerBody. */
 export function MarkerCapsLabel({ children }: { children: React.ReactNode }) {
-  return <div className="text-micro font-bold tracking-wide uppercase text-mf-text-3 mb-1">{children}</div>;
+  return <div className="text-caption font-medium text-muted-foreground mb-1">{children}</div>;
 }
 
 // ── MarkerPre ─────────────────────────────────────────────────────────────────
@@ -120,8 +120,8 @@ export function MarkerPre({ children, muted = false }: { children: React.ReactNo
   return (
     <pre
       className={cn(
-        'font-mono text-caption whitespace-pre-wrap break-words leading-snug',
-        muted ? 'text-mf-text-3' : 'text-foreground',
+        'font-mono text-label whitespace-pre-wrap break-words leading-snug',
+        muted ? 'text-muted-foreground' : 'text-foreground',
       )}
     >
       {children}

--- a/packages/ui/src/features/chat/tools/shared/card-shell.tsx
+++ b/packages/ui/src/features/chat/tools/shared/card-shell.tsx
@@ -62,7 +62,7 @@ export function ErrorBody({ text, testId }: ErrorBodyProps) {
       <div className="absolute inset-0 bg-destructive opacity-10 pointer-events-none" aria-hidden />
       <pre
         data-testid={testId}
-        className="relative font-mono text-caption whitespace-pre-wrap break-words px-3 py-2 text-destructive"
+        className="relative font-mono text-label whitespace-pre-wrap break-words px-3 py-2 text-destructive"
       >
         {text}
       </pre>

--- a/packages/ui/src/features/chat/tools/shared/diff.tsx
+++ b/packages/ui/src/features/chat/tools/shared/diff.tsx
@@ -114,14 +114,14 @@ function DiffLineRow({ kind, content, oldNum = '', newNum = '', rowKey }: DiffLi
 
   const addSign = <span className="shrink-0 w-5 select-none text-mf-diff-add-text text-center">+</span>;
   const delSign = <span className="shrink-0 w-5 select-none text-mf-diff-del-text text-center">-</span>;
-  const ctxSign = <span className="shrink-0 w-5 select-none text-mf-text-4 text-center"> </span>;
+  const ctxSign = <span className="shrink-0 w-5 select-none text-mf-text-3 text-center"> </span>;
 
   return (
     <div key={rowKey} className={rowClass}>
       {/* old line number */}
-      <span className="shrink-0 w-8 select-none text-mf-text-4 text-right pr-1">{kind === 'add' ? '' : oldNum}</span>
+      <span className="shrink-0 w-8 select-none text-mf-text-3 text-right pr-1">{kind === 'add' ? '' : oldNum}</span>
       {/* new line number */}
-      <span className="shrink-0 w-8 select-none text-mf-text-4 text-right pr-2">{kind === 'del' ? '' : newNum}</span>
+      <span className="shrink-0 w-8 select-none text-mf-text-3 text-right pr-2">{kind === 'del' ? '' : newNum}</span>
       {/* sign column */}
       {kind === 'add' ? addSign : kind === 'del' ? delSign : ctxSign}
       {/* content */}
@@ -159,7 +159,7 @@ function HunkSeparator() {
 
 export function DiffFromPatch({ hunks }: { hunks: DiffHunk[] }) {
   return (
-    <div className="font-mono text-caption leading-5 overflow-x-auto bg-mf-code-bg">
+    <div className="font-mono text-label leading-5 overflow-x-auto bg-mf-code-bg">
       {hunks.map((hunk, hi) => (
         <React.Fragment key={hi}>
           {hi > 0 && <HunkSeparator />}
@@ -211,7 +211,7 @@ export function DiffFallback({
   const hasLineNums = startLine !== null;
 
   return (
-    <div className="font-mono text-caption leading-5 overflow-x-auto bg-mf-code-bg">
+    <div className="font-mono text-label leading-5 overflow-x-auto bg-mf-code-bg">
       {oldLines.map((line, i) => (
         <DiffLineRow
           key={`old-${i}`}

--- a/packages/ui/src/features/context-panel/AgentsList.tsx
+++ b/packages/ui/src/features/context-panel/AgentsList.tsx
@@ -4,8 +4,8 @@ import { ScopedListRow } from './ScopedListRow';
 
 export function AgentsList() {
   const { agents, loading } = useSidebarSkills();
-  if (loading) return <div className="py-4 text-center text-caption text-mf-text-3">Loading…</div>;
-  if (agents.length === 0) return <div className="py-4 text-center text-caption text-mf-text-3">No agents</div>;
+  if (loading) return <div className="py-4 text-center text-caption text-muted-foreground">Loading…</div>;
+  if (agents.length === 0) return <div className="py-4 text-center text-caption text-muted-foreground">No agents</div>;
   return (
     <div className="py-1">
       {agents.map((a) => (

--- a/packages/ui/src/features/context-panel/BottomPanel.tsx
+++ b/packages/ui/src/features/context-panel/BottomPanel.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import { FileText, Wand2, Bot } from 'lucide-react';
 import { useUiPrefs, type BottomPanelTab } from '@/store/ui-prefs';
+import { CountBadge } from '@/components/ui/count-badge';
 import { useSessionContext } from './use-session-context';
 import { useSidebarSkills } from './use-sidebar-skills';
 import { sessionItemCount } from './derive-session-items';
@@ -42,17 +43,15 @@ export function BottomPanel() {
                 type="button"
                 data-testid={`sidebar-bottom-tab-${t.id}`}
                 onClick={() => setTab(t.id)}
-                className={`inline-flex flex-1 items-center justify-center gap-[5px] rounded-[5px] px-[6px] py-[4px] text-caption ${
+                className={`inline-flex flex-1 items-center justify-center gap-[5px] rounded-[5px] px-[6px] py-[4px] text-label ${
                   active
                     ? 'bg-mf-tab-active font-semibold text-foreground shadow-[var(--mf-shadow-rail-active)]'
                     : 'font-medium text-muted-foreground hover:bg-accent'
                 }`}
               >
-                <Icon size={11} className={active ? 'text-primary' : 'text-muted-foreground'} aria-hidden />
+                <Icon size={14} className={active ? 'text-primary' : 'text-muted-foreground'} aria-hidden />
                 <span>{t.label}</span>
-                <span className={`text-micro font-semibold ${active ? 'text-primary' : 'text-mf-text-4'}`}>
-                  {t.count}
-                </span>
+                <CountBadge count={t.count} variant={active ? 'unread' : 'info'} />
               </button>
             );
           })}

--- a/packages/ui/src/features/context-panel/ContextFileItem.tsx
+++ b/packages/ui/src/features/context-panel/ContextFileItem.tsx
@@ -11,7 +11,7 @@ interface ContextFileItemProps {
 /** Per-badge-type text color: '@'=accent, auto=muted, plan=amber, skill=violet. */
 const BADGE_COLOR_CLASS: Record<string, string> = {
   '@': 'text-primary',
-  auto: 'text-mf-text-3',
+  auto: 'text-muted-foreground',
   plan: 'text-mf-accent-amber',
   skill: 'text-mf-accent-violet',
 };
@@ -31,7 +31,7 @@ const BADGE_BG_CLASS: Record<string, string> = {
  */
 export function ContextFileItem({ path, displayName, badge }: ContextFileItemProps) {
   const fileName = displayName ?? path.split('/').pop() ?? path;
-  const badgeColorClass = badge ? (BADGE_COLOR_CLASS[badge] ?? 'text-mf-text-3') : '';
+  const badgeColorClass = badge ? (BADGE_COLOR_CLASS[badge] ?? 'text-muted-foreground') : '';
   const badgeBgClass = badge ? (BADGE_BG_CLASS[badge] ?? 'bg-mf-text-3/[0.20]') : '';
   return (
     <Tooltip>
@@ -41,13 +41,13 @@ export function ContextFileItem({ path, displayName, badge }: ContextFileItemPro
           data-testid={`sidebar-context-item-${path}`}
           aria-label={path}
           onClick={() => emitSurfaceIntent({ type: 'open-file', path })}
-          className="flex w-full min-w-0 items-center gap-2 rounded-md py-[3px] pl-[24px] pr-[14px] text-left text-caption text-foreground hover:bg-accent"
+          className="flex w-full min-w-0 items-center gap-2 rounded-md py-[3px] pl-[24px] pr-[14px] text-left text-label text-foreground hover:bg-accent"
         >
-          <FileText size={10} className="shrink-0 text-mf-text-3" aria-hidden />
+          <FileText size={12} className="shrink-0 text-muted-foreground" aria-hidden />
           <span className="flex-1 truncate">{fileName}</span>
           {badge && (
             <span
-              className={`shrink-0 rounded-[4px] px-1.5 font-mono text-micro font-semibold uppercase ${badgeColorClass} ${badgeBgClass}`}
+              className={`shrink-0 rounded-[4px] px-1.5 font-mono text-caption font-semibold ${badgeColorClass} ${badgeBgClass}`}
             >
               {badge}
             </span>

--- a/packages/ui/src/features/context-panel/ContextInspector.tsx
+++ b/packages/ui/src/features/context-panel/ContextInspector.tsx
@@ -8,7 +8,7 @@ import { TasksSection } from './TasksSection';
 import { useSessionTodos } from '@/store/session-todos';
 
 function Muted({ text }: { text: string }) {
-  return <div className="py-4 text-center text-caption text-mf-text-3">{text}</div>;
+  return <div className="py-4 text-center text-caption text-muted-foreground">{text}</div>;
 }
 
 /** Context tab body: Global / Project / Session file groups (Tasks live elsewhere). */
@@ -44,7 +44,7 @@ export function ContextInspector() {
         ))}
         {context.attachments.length > 0 && (
           <div className="mt-1 px-[12px]">
-            <div className="mb-1 text-micro uppercase tracking-wide text-mf-text-3">Attachments</div>
+            <div className="mb-1 text-caption font-medium text-muted-foreground">Attachments</div>
             <SessionAttachmentsGrid chatId={chatId} attachments={context.attachments} />
           </div>
         )}

--- a/packages/ui/src/features/context-panel/ContextSection.tsx
+++ b/packages/ui/src/features/context-panel/ContextSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { ChevronDown } from 'lucide-react';
+import { CountBadge } from '@/components/ui/count-badge';
 
 interface ContextSectionProps {
   icon: LucideIcon;
@@ -13,7 +14,14 @@ interface ContextSectionProps {
 }
 
 /** Collapsible context group: chevron + icon + title + count chip (or a trailing slot), then children. */
-export function ContextSection({ icon: Icon, title, count, trailing, defaultOpen = false, children }: ContextSectionProps) {
+export function ContextSection({
+  icon: Icon,
+  title,
+  count,
+  trailing,
+  defaultOpen = false,
+  children,
+}: ContextSectionProps) {
   const [open, setOpen] = useState(defaultOpen);
   return (
     <div className="mb-1">
@@ -24,20 +32,17 @@ export function ContextSection({ icon: Icon, title, count, trailing, defaultOpen
         className="flex w-full items-center gap-1.5 px-[12px] py-1.5 text-left"
       >
         <ChevronDown
-          size={9}
+          size={14}
           aria-hidden
-          className={`shrink-0 text-mf-text-3 transition-transform ${open ? '' : '-rotate-90'}`}
+          className={`shrink-0 text-muted-foreground transition-transform ${open ? '' : '-rotate-90'}`}
         />
-        <Icon size={11} className="shrink-0 text-muted-foreground" aria-hidden />
+        <Icon size={14} className="shrink-0 text-muted-foreground" aria-hidden />
         <span
-          className={`text-micro font-semibold text-foreground ${trailing != null ? 'flex-none' : 'min-w-0 flex-1 truncate'}`}
+          className={`text-caption font-medium text-muted-foreground ${trailing != null ? 'flex-none' : 'min-w-0 flex-1 truncate'}`}
         >
           {title}
         </span>
-        {trailing ??
-          (count != null && (
-            <span className="shrink-0 rounded-md bg-mf-chip px-1.5 font-mono text-micro text-mf-text-3">{count}</span>
-          ))}
+        {trailing ?? (count != null && <CountBadge count={count} variant="info" showZero className="shrink-0" />)}
       </button>
       {open && <div className="pb-1">{children}</div>}
     </div>

--- a/packages/ui/src/features/context-panel/ScopedListRow.tsx
+++ b/packages/ui/src/features/context-panel/ScopedListRow.tsx
@@ -20,16 +20,14 @@ export function ScopedListRow({ testId, icon: Icon, name, description, scope, fi
       onClick={() => emitSurfaceIntent({ type: 'open-file', path: filePath })}
       className="grid w-full grid-cols-[14px_1fr_auto] items-center gap-[7px] px-[12px] py-[4px] text-left hover:bg-accent"
     >
-      <Icon size={11} className="text-primary" aria-hidden />
+      <Icon size={14} className="text-primary" aria-hidden />
       <div className="min-w-0">
-        <div className="truncate text-caption font-medium text-foreground">{name}</div>
+        <div className="truncate text-label font-medium text-foreground">{name}</div>
         {description && (
-          <TruncatedWithTooltip text={description} tabIndex={0} className="block text-micro text-mf-text-3" />
+          <TruncatedWithTooltip text={description} tabIndex={0} className="block text-caption text-muted-foreground" />
         )}
       </div>
-      <span className="rounded-[8px] bg-mf-chip px-[5px] py-[1px] text-micro uppercase tracking-wide text-mf-text-3">
-        {scope}
-      </span>
+      <span className="rounded-[8px] bg-mf-chip px-[5px] py-[1px] text-caption text-muted-foreground">{scope}</span>
     </button>
   );
 }

--- a/packages/ui/src/features/context-panel/SessionAttachmentsGrid.tsx
+++ b/packages/ui/src/features/context-panel/SessionAttachmentsGrid.tsx
@@ -63,12 +63,12 @@ export function SessionAttachmentsGrid({ chatId, attachments }: Props) {
                   className="h-full w-full rounded-sm object-cover"
                 />
               ) : (
-                <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-1 text-mf-text-3">
+                <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-1 text-muted-foreground">
                   <FileText size={16} aria-hidden />
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span
-                        className="h-7 w-full overflow-hidden break-all text-center text-micro leading-tight"
+                        className="h-7 w-full overflow-hidden break-all text-center text-caption leading-tight"
                         tabIndex={0}
                       >
                         {att.name}

--- a/packages/ui/src/features/context-panel/SkillsList.tsx
+++ b/packages/ui/src/features/context-panel/SkillsList.tsx
@@ -4,8 +4,8 @@ import { ScopedListRow } from './ScopedListRow';
 
 export function SkillsList() {
   const { skills, loading } = useSidebarSkills();
-  if (loading) return <div className="py-4 text-center text-caption text-mf-text-3">Loading…</div>;
-  if (skills.length === 0) return <div className="py-4 text-center text-caption text-mf-text-3">No skills</div>;
+  if (loading) return <div className="py-4 text-center text-caption text-muted-foreground">Loading…</div>;
+  if (skills.length === 0) return <div className="py-4 text-center text-caption text-muted-foreground">No skills</div>;
   return (
     <div className="py-1">
       {skills.map((s) => (

--- a/packages/ui/src/features/context-panel/TasksSection.tsx
+++ b/packages/ui/src/features/context-panel/TasksSection.tsx
@@ -24,7 +24,7 @@ export function TasksSection({ todos }: { todos: readonly TodoItem[] }): React.R
                 style={{ width: `${pct}%` }}
               />
             </span>
-            <span className="shrink-0 font-mono text-micro tabular-nums text-mf-text-3">
+            <span className="shrink-0 font-mono text-caption tabular-nums text-muted-foreground">
               {completed}/{total}
             </span>
           </>
@@ -43,12 +43,14 @@ export function TasksSection({ todos }: { todos: readonly TodoItem[] }): React.R
                 <span
                   className={cn(
                     'flex size-[12px] shrink-0 items-center justify-center rounded-[4px] border-[1.5px]',
-                    done ? 'border-mf-success bg-mf-success' : 'border-mf-text-4',
+                    done ? 'border-mf-success bg-mf-success' : 'border-mf-text-3',
                   )}
                 >
                   {done && <Check className="size-[8px] text-white" strokeWidth={3} />}
                 </span>
-                <span className={cn('flex-1 truncate', done ? 'text-mf-text-3 line-through' : 'text-foreground')}>
+                <span
+                  className={cn('flex-1 truncate', done ? 'text-muted-foreground line-through' : 'text-foreground')}
+                >
                   {label}
                 </span>
               </div>

--- a/packages/ui/src/features/editor/DiffHeader.tsx
+++ b/packages/ui/src/features/editor/DiffHeader.tsx
@@ -46,20 +46,20 @@ export function DiffHeader({ fileName, changeCount, additions, deletions, filePa
       className="flex h-[28px] shrink-0 items-center gap-2 border-b border-border bg-mf-content2 px-3"
     >
       {/* Leading git branch icon */}
-      <GitBranch size={11} className="shrink-0 text-mf-text-3" aria-hidden />
+      <GitBranch size={14} className="shrink-0 text-mf-text-3" aria-hidden />
 
       {/* Truncated file path */}
-      <span className="min-w-0 flex-1 truncate font-mono text-micro text-mf-text-4">{fileName}</span>
+      <span className="min-w-0 flex-1 truncate font-mono text-label text-muted-foreground">{fileName}</span>
 
       {/* Separate +N / −N counts */}
       {additions !== undefined && (
-        <span className="font-semibold text-mf-success tabular-nums text-caption">+{additions}</span>
+        <span className="font-semibold text-mf-diff-add-text tabular-nums text-caption">+{additions}</span>
       )}
       {deletions !== undefined && (
-        <span className="font-semibold text-destructive tabular-nums text-caption">−{deletions}</span>
+        <span className="font-semibold text-mf-diff-del-text tabular-nums text-caption">−{deletions}</span>
       )}
       {additions === undefined && deletions === undefined && (
-        <span className="text-caption text-mf-text-3 tabular-nums">{changeCount} changes</span>
+        <span className="text-caption text-muted-foreground tabular-nums">{changeCount} changes</span>
       )}
 
       {/* Prev / Next buttons using chevron icons */}
@@ -69,9 +69,9 @@ export function DiffHeader({ fileName, changeCount, additions, deletions, filePa
         disabled={disabled}
         onClick={onPrev}
         aria-label="Previous change"
-        className="flex h-5 w-5 items-center justify-center rounded text-mf-text-3 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+        className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
       >
-        <ChevronUp size={13} aria-hidden />
+        <ChevronUp size={14} aria-hidden />
       </button>
       <button
         type="button"
@@ -79,9 +79,9 @@ export function DiffHeader({ fileName, changeCount, additions, deletions, filePa
         disabled={disabled}
         onClick={onNext}
         aria-label="Next change"
-        className="flex h-5 w-5 items-center justify-center rounded text-mf-text-3 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+        className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
       >
-        <ChevronDown size={13} aria-hidden />
+        <ChevronDown size={14} aria-hidden />
       </button>
 
       {/* Reveal button */}
@@ -93,7 +93,7 @@ export function DiffHeader({ fileName, changeCount, additions, deletions, filePa
           aria-label="Reveal in file tree"
           className="inline-flex h-[20px] w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[6px] border-none bg-transparent text-muted-foreground transition-colors hover:bg-accent"
         >
-          <Crosshair size={12} aria-hidden />
+          <Crosshair size={14} aria-hidden />
         </button>
       )}
     </div>

--- a/packages/ui/src/features/editor/MarkdownPreview.tsx
+++ b/packages/ui/src/features/editor/MarkdownPreview.tsx
@@ -46,7 +46,7 @@ interface CodeBlockProps {
 }
 
 const CODE_PRE_CLASS =
-  'my-2 overflow-x-auto rounded-md border border-border bg-mf-code-bg p-3 font-mono text-caption text-mf-code-fg';
+  'my-2 overflow-x-auto rounded-md border border-border bg-mf-code-bg p-3 font-mono text-label text-mf-code-fg';
 
 /** Fenced code block with shiki highlighting. Renders plain until shiki resolves. */
 function CodeBlock({ className, children }: CodeBlockProps) {
@@ -81,7 +81,7 @@ const components = {
     return (
       <code
         {...props}
-        className="rounded-sm border border-border bg-mf-raised px-1.5 py-0.5 font-mono text-caption text-mf-code-cmt"
+        className="rounded-sm border border-border bg-mf-raised px-1.5 py-0.5 font-mono text-label text-mf-code-cmt"
       >
         {children}
       </code>

--- a/packages/ui/src/features/editor/SaveStatusChip.tsx
+++ b/packages/ui/src/features/editor/SaveStatusChip.tsx
@@ -4,18 +4,24 @@ export function SaveStatusChip({ dirty }: { dirty: boolean }) {
     return (
       <span
         data-testid="editor-save-status"
-        className="rounded-[4px] bg-mf-warning-tint px-[5px] py-[1px] font-mono text-micro text-mf-warning"
+        className="rounded-[4px] bg-mf-warning-tint px-[5px] py-[1px] font-mono text-caption text-foreground"
       >
-        ● unsaved
+        <span className="text-mf-warning" aria-hidden>
+          ●
+        </span>{' '}
+        unsaved
       </span>
     );
   }
   return (
     <span
       data-testid="editor-save-status"
-      className="rounded-[4px] bg-mf-success-tint px-[5px] py-[1px] font-mono text-micro text-mf-success"
+      className="rounded-[4px] bg-mf-success-tint px-[5px] py-[1px] font-mono text-caption text-muted-foreground"
     >
-      ● saved
+      <span className="text-mf-success" aria-hidden>
+        ●
+      </span>{' '}
+      saved
     </span>
   );
 }

--- a/packages/ui/src/features/editor/editor-banners.tsx
+++ b/packages/ui/src/features/editor/editor-banners.tsx
@@ -8,7 +8,7 @@ export function ReadOnlyBanner({ external }: { external: boolean }) {
   return (
     <div
       data-testid="editor-tab-readonly"
-      className="flex-shrink-0 bg-mf-tab-bar px-3 py-0.5 text-caption text-mf-text-3"
+      className="flex-shrink-0 bg-mf-tab-bar px-3 py-0.5 text-caption text-muted-foreground"
     >
       {external ? 'Read-only — outside the project' : 'Read-only'}
     </div>
@@ -30,7 +30,7 @@ export function DiskConflictBanner({ onReload, onKeepMine }: { onReload: () => v
   return (
     <div
       data-testid="editor-tab-disk-conflict"
-      className="flex flex-shrink-0 items-center gap-2 bg-mf-warning-tint px-3 py-1 text-caption text-mf-warning"
+      className="flex flex-shrink-0 items-center gap-2 bg-mf-warning-tint px-3 py-1 text-caption text-foreground"
     >
       <span className="flex-1">File changed on disk</span>
       <button data-testid="editor-tab-reload" onClick={onReload} className="rounded px-2 py-0.5 hover:opacity-80">

--- a/packages/ui/src/features/editor/inline-comments/InlineCommentWidget.tsx
+++ b/packages/ui/src/features/editor/inline-comments/InlineCommentWidget.tsx
@@ -9,7 +9,7 @@
  * Design per EditorCommentWidget (03-content.jsx):
  *   Header row (6px pad, hairline bottom):
  *     Sparkles icon (text-primary) + "Review comment" (caption semibold
- *     text-muted-foreground) + range label (mono micro text-mf-text-4) + close X
+ *     text-muted-foreground) + range label (mono caption text-mf-text-3) + close X
  *   Snippet block (when lineContent provided):
  *     bg-mf-raised, hairline bottom border, SnippetLines with numbered rows
  *   Card: shadow-pop, accent border when editing (focus-within:border-primary/40)
@@ -93,7 +93,7 @@ export function InlineCommentWidget({
     <div data-testid="editor-comment-widget" className="flex py-[5px] pl-[14px] pr-[14px] font-sans">
       {/* Sparkles gutter indicator */}
       <div className="mr-[10px] flex w-[12px] shrink-0 items-start pt-[9px]">
-        <Sparkles size={11} className="text-primary" aria-hidden />
+        <Sparkles size={12} className="text-primary" aria-hidden />
       </div>
 
       {/* Card */}
@@ -101,7 +101,7 @@ export function InlineCommentWidget({
         {/* Header */}
         <div className="flex items-center gap-[6px] [border-bottom:0.5px_solid_var(--border)] px-[10px] py-[6px]">
           <span className="text-caption font-semibold text-muted-foreground">Review comment</span>
-          {lineLabel !== null && <span className="font-mono text-micro text-mf-text-4">{lineLabel}</span>}
+          {lineLabel !== null && <span className="font-mono text-caption text-mf-text-3">{lineLabel}</span>}
           <div className="flex-1" />
           <Hint label="Close">
             <button
@@ -110,7 +110,7 @@ export function InlineCommentWidget({
               onClick={onClose}
               className="inline-flex h-[18px] w-[18px] items-center justify-center rounded-[4px] border-none bg-transparent text-mf-text-3 hover:bg-accent"
             >
-              <X size={10} aria-hidden />
+              <X size={14} aria-hidden />
             </button>
           </Hint>
         </div>
@@ -139,13 +139,13 @@ export function InlineCommentWidget({
 
         {/* Footer */}
         <div className="flex items-center gap-[6px] [border-top:0.5px_solid_var(--border)] px-[9px] py-[6px]">
-          <span className="font-mono text-micro text-mf-text-4">⌘↩ to add</span>
+          <span className="font-mono text-caption text-mf-text-3">⌘↩ to add</span>
           <div className="flex-1" />
           <button
             data-testid="editor-comment-widget-cancel"
             type="button"
             onClick={onClose}
-            className="h-[24px] rounded-[6px] px-[8px] text-caption text-muted-foreground [border:0.5px_solid_var(--border)] bg-transparent hover:bg-accent transition-colors"
+            className="h-[24px] rounded-[6px] px-[8px] text-label text-muted-foreground [border:0.5px_solid_var(--border)] bg-transparent hover:bg-accent transition-colors"
           >
             Cancel
           </button>
@@ -154,7 +154,7 @@ export function InlineCommentWidget({
             type="button"
             onClick={handleSave}
             disabled={!text.trim()}
-            className="h-[24px] rounded-[6px] border-none bg-primary px-[8px] text-caption font-semibold text-white disabled:opacity-40 transition-opacity"
+            className="h-[24px] rounded-[6px] border-none bg-primary px-[8px] text-label font-semibold text-primary-foreground disabled:opacity-40 transition-opacity"
           >
             Add context
           </button>
@@ -164,9 +164,9 @@ export function InlineCommentWidget({
               type="button"
               onClick={handleSend}
               disabled={!text.trim()}
-              className="inline-flex h-[24px] items-center gap-[4px] rounded-[6px] border-none bg-primary px-[8px] text-caption font-semibold text-white disabled:opacity-40 transition-opacity"
+              className="inline-flex h-[24px] items-center gap-[4px] rounded-[6px] border-none bg-primary px-[8px] text-label font-semibold text-primary-foreground disabled:opacity-40 transition-opacity"
             >
-              <Send size={10} aria-hidden />
+              <Send size={14} aria-hidden />
               Send
             </button>
           )}

--- a/packages/ui/src/features/editor/lsp/references-panel.tsx
+++ b/packages/ui/src/features/editor/lsp/references-panel.tsx
@@ -108,9 +108,7 @@ export function ReferencesPanel({ locations, symbolName, onSelectRange, onClose 
                   onClick={() => handleRowClick(loc)}
                   className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
                 >
-                  <span className="min-w-0 flex-1 truncate font-mono text-caption text-foreground">
-                    {basename(path)}
-                  </span>
+                  <span className="min-w-0 flex-1 truncate font-mono text-label text-foreground">{basename(path)}</span>
                   <span className="shrink-0 text-caption text-muted-foreground">:{line}</span>
                 </button>
               </li>

--- a/packages/ui/src/features/files/ChangesPanel.tsx
+++ b/packages/ui/src/features/files/ChangesPanel.tsx
@@ -36,7 +36,7 @@ const SCOPE_MODES: { id: ScopeMode; label: string }[] = [
   { id: 'branch', label: 'Branch' },
 ];
 
-const SCOPE_BTN = 'flex h-[18px] flex-1 items-center justify-center rounded-[4px] text-micro transition-colors';
+const SCOPE_BTN = 'flex h-[18px] flex-1 items-center justify-center rounded-[4px] text-label transition-colors';
 
 /** Semantic kind → full-word label. */
 const KIND_WORD: Record<string, string> = {
@@ -50,11 +50,11 @@ const KIND_WORD: Record<string, string> = {
 const KIND_CLASS: Record<string, string> = {
   added: 'text-mf-diff-add-text',
   deleted: 'text-mf-diff-del-text',
-  modified: 'text-mf-warning',
-  renamed: 'text-mf-warning',
+  modified: 'text-muted-foreground',
+  renamed: 'text-muted-foreground',
 };
 
-const statusClass = (code: string): string => KIND_CLASS[gitStatusKind(code)] ?? 'text-mf-warning';
+const statusClass = (code: string): string => KIND_CLASS[gitStatusKind(code)] ?? 'text-muted-foreground';
 const statusWord = (code: string): string => KIND_WORD[gitStatusKind(code)] ?? 'Modified';
 const basename = (path: string): string =>
   path.lastIndexOf('/') === -1 ? path : path.slice(path.lastIndexOf('/') + 1);
@@ -167,19 +167,19 @@ export function ChangesPanel({ port, projectId, chatId }: ChangesPanelProps) {
             onClick={bump}
             className="inline-flex h-[20px] w-[20px] flex-shrink-0 items-center justify-center rounded-[4px] border-none bg-transparent hover:bg-accent"
           >
-            <RotateCw size={11} className="text-mf-text-3" />
+            <RotateCw size={14} className="text-muted-foreground" />
           </button>
         </Hint>
       </div>
 
       {/* Count + (branch comparison, right-aligned) */}
       <div className="flex flex-shrink-0 items-center gap-[6px] px-[12px] pb-[6px]">
-        <span className="text-micro text-mf-text-3">
+        <span className="text-caption text-muted-foreground">
           {rows !== null && !sessionNoChat ? `${rows.length} changed ${rows.length === 1 ? 'file' : 'files'}` : ''}
         </span>
         <div className="flex-1" />
         {mode === 'branch' && branch?.branch && branch?.baseBranch && (
-          <span className="truncate font-mono text-micro text-primary">
+          <span className="truncate font-mono text-caption text-primary">
             {branch.branch} ↔ {branch.baseBranch}
           </span>
         )}
@@ -206,18 +206,18 @@ export function ChangesPanel({ port, projectId, chatId }: ChangesPanelProps) {
               onClick={() => emitSurfaceIntent({ type: 'open-diff', path: f.path })}
               className="flex h-[22px] w-full items-center gap-[7px] rounded-[4px] border-none bg-transparent px-[6px] py-[4px] text-left hover:bg-accent hover:text-foreground"
             >
-              <File size={10} className="flex-shrink-0 text-mf-text-3" />
+              <File size={12} className="flex-shrink-0 text-mf-text-3" />
               <TruncatedWithTooltip
                 text={basename(f.path)}
                 tooltip={f.path}
-                className="flex-1 text-caption text-foreground"
+                className="flex-1 text-label text-foreground"
                 contentClassName="font-mono break-all"
               />
-              <span className="truncate font-mono text-micro text-mf-text-3">{dirname(f.path)}</span>
+              <span className="truncate font-mono text-caption text-muted-foreground">{dirname(f.path)}</span>
               {f.status && (
                 <span
                   data-testid={`changes-status-${f.path}`}
-                  className={`flex-shrink-0 font-bold text-micro [letter-spacing:0.3px] ${statusClass(f.status)}`}
+                  className={`flex-shrink-0 font-medium text-caption ${statusClass(f.status)}`}
                 >
                   {statusWord(f.status)}
                 </span>

--- a/packages/ui/src/features/files/FileTree.tsx
+++ b/packages/ui/src/features/files/FileTree.tsx
@@ -138,7 +138,7 @@ function TreeNode({ entry, depth, port, projectId, chatId, base, revealPath, act
             .join(' ')}
         >
           <span className="w-[9px] flex-shrink-0" />
-          <File size={11} className="flex-shrink-0 text-mf-text-3" />
+          <File size={12} className="flex-shrink-0 text-mf-text-3" />
           <TruncatedWithTooltip
             text={entry.name}
             tooltip={fullPath}
@@ -162,7 +162,7 @@ function TreeNode({ entry, depth, port, projectId, chatId, base, revealPath, act
           className="flex h-[22px] w-full items-center gap-[5px] border-none bg-transparent pr-[12px] text-left text-label font-medium text-foreground hover:bg-accent"
         >
           <ChevronRight
-            size={9}
+            size={12}
             className={`flex-shrink-0 text-mf-text-3 transition-transform ${open ? 'rotate-90' : ''}`}
           />
           <Folder size={12} className="flex-shrink-0 fill-current text-primary" />
@@ -259,7 +259,7 @@ export function FileTree({ port, projectId, chatId }: FileTreeProps) {
       {/* Header row: workspace-root label (right-clickable) + refresh button */}
       <div className="flex h-[20px] items-center px-[12px] py-[4px]">
         <FileTreeRowMenu entry={{ name: '.', path: '.', type: 'directory' }} fullPath={base ?? projectId}>
-          <span className="flex-1 truncate font-mono text-micro font-semibold uppercase text-mf-text-3 [letter-spacing:0.6px]">
+          <span className="flex-1 truncate font-mono text-caption font-medium text-muted-foreground">
             {lastSegment(base ?? projectId)}
           </span>
         </FileTreeRowMenu>
@@ -270,7 +270,7 @@ export function FileTree({ port, projectId, chatId }: FileTreeProps) {
             onClick={() => setRefreshKey((k) => k + 1)}
             className="inline-flex h-[20px] w-[20px] flex-shrink-0 items-center justify-center rounded-[4px] border-none bg-transparent hover:bg-accent"
           >
-            <RotateCw size={11} className="text-mf-text-3" />
+            <RotateCw size={14} className="text-muted-foreground" />
           </button>
         </Hint>
       </div>

--- a/packages/ui/src/features/files/InspectorPane.tsx
+++ b/packages/ui/src/features/files/InspectorPane.tsx
@@ -11,6 +11,7 @@ import { onSurfaceIntent } from '@/store/surface-intents';
 import { cn } from '@/lib/utils';
 import { useTheme } from '@/store/theme';
 import { windowStyleGeometry } from '@/lib/appearance/window-style';
+import { CountBadge } from '@/components/ui/count-badge';
 import { ChangesPanel } from './ChangesPanel';
 import { FileTree } from './FileTree';
 import { TasksDrawer } from '../tasks/TasksDrawer';
@@ -20,7 +21,7 @@ import { useChangesCount } from './use-changes-count';
 type Tab = 'files' | 'changes';
 
 const SEG_BASE =
-  'flex h-[22px] flex-1 items-center justify-center gap-[5px] rounded-[6px] text-caption transition-colors';
+  'flex h-[22px] flex-1 items-center justify-center gap-[5px] rounded-[6px] text-label transition-colors';
 
 export function InspectorPane({ port }: { port: number }) {
   const { projectId, chatId } = useActiveIdentity();
@@ -59,7 +60,7 @@ export function InspectorPane({ port }: { port: number }) {
                 : 'font-medium text-muted-foreground hover:text-foreground'
             }`}
           >
-            <Folder size={11} />
+            <Folder size={14} />
             Files
           </button>
           <button
@@ -73,9 +74,9 @@ export function InspectorPane({ port }: { port: number }) {
                 : 'font-medium text-muted-foreground hover:text-foreground'
             }`}
           >
-            <GitCompare size={11} />
+            <GitCompare size={14} />
             Changes
-            {changesCount > 0 && <span className="font-mono text-micro text-mf-text-3">{changesCount}</span>}
+            <CountBadge count={changesCount} variant="info" />
           </button>
         </div>
       </div>

--- a/packages/ui/src/features/files/__tests__/ChangesPanel.test.tsx
+++ b/packages/ui/src/features/files/__tests__/ChangesPanel.test.tsx
@@ -52,12 +52,12 @@ describe('ChangesPanel status tokens', () => {
     expect(badge.className).toContain('text-mf-diff-add-text');
   });
 
-  it('modified file (status M) uses text-mf-warning', async () => {
+  it('modified file (status M) uses text-muted-foreground', async () => {
     mockGetGitStatus.mockResolvedValue([{ path: 'modified.ts', status: 'M' }]);
     render(<ChangesPanel {...BASE_PROPS} />);
     const badge = await screen.findByTestId('changes-status-modified.ts');
-    expect(badge.className).toContain('text-mf-warning');
-    expect(badge.className).not.toContain('text-mf-surface-files');
+    expect(badge.className).toContain('text-muted-foreground');
+    expect(badge.className).not.toContain('text-mf-warning');
   });
 
   it('deleted file (status D) uses text-mf-diff-del-text', async () => {

--- a/packages/ui/src/features/files/use-file-search.tsx
+++ b/packages/ui/src/features/files/use-file-search.tsx
@@ -43,7 +43,7 @@ export function FileRow({
     >
       <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="text-body font-medium truncate">{result.name}</span>
-      <span className="text-caption text-muted-foreground truncate ml-auto">{dir}</span>
+      <span className="text-label text-muted-foreground truncate ml-auto">{dir}</span>
     </button>
   );
 }

--- a/packages/ui/src/features/git/BranchGroupSection.tsx
+++ b/packages/ui/src/features/git/BranchGroupSection.tsx
@@ -36,9 +36,9 @@ function PrefixGroup({
       <button
         data-testid={`git-branch-group-toggle-${prefix}`}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-1 px-2 py-0.5 text-caption text-muted-foreground hover:text-foreground"
+        className="w-full flex items-center gap-1 px-2 py-0.5 text-caption font-medium text-muted-foreground hover:text-foreground"
       >
-        {expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         <span>{prefix}</span>
       </button>
       {expanded &&
@@ -73,9 +73,9 @@ export function BranchGroupSection({
       <button
         data-testid={`git-branch-section-toggle-${title.toLowerCase().replace(/\s+/g, '-')}`}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full h-[26px] flex items-center gap-[5px] px-2 text-micro font-bold text-mf-text-3 uppercase tracking-wide"
+        className="w-full h-[26px] flex items-center gap-[5px] px-2 text-caption font-medium text-muted-foreground"
       >
-        {expanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
+        {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         {title}
       </button>
 

--- a/packages/ui/src/features/git/BranchRow.tsx
+++ b/packages/ui/src/features/git/BranchRow.tsx
@@ -19,19 +19,19 @@ export interface BranchRowProps {
 
 function BranchDivergence({ ahead, behind }: { ahead?: number; behind?: number }) {
   if (!ahead && !behind) {
-    return <span className="text-caption text-mf-text-4 shrink-0">up to date</span>;
+    return <span className="text-caption text-mf-text-3 shrink-0">up to date</span>;
   }
   return (
-    <span className="inline-flex items-center gap-[7px] font-mono text-caption text-mf-text-3 shrink-0">
+    <span className="inline-flex items-center gap-[7px] font-mono text-caption text-foreground shrink-0">
       {(ahead ?? 0) > 0 && (
-        <span className="inline-flex items-center gap-[1px] text-mf-success">
-          <ArrowUp size={9} className="text-mf-success" />
+        <span className="inline-flex items-center gap-[1px]">
+          <ArrowUp size={12} className="text-mf-success" />
           {ahead}
         </span>
       )}
       {(behind ?? 0) > 0 && (
-        <span className="inline-flex items-center gap-[1px] text-mf-warning">
-          <ArrowDown size={9} className="text-mf-warning" />
+        <span className="inline-flex items-center gap-[1px]">
+          <ArrowDown size={12} className="text-mf-warning" />
           {behind}
         </span>
       )}
@@ -80,7 +80,7 @@ export function BranchRow({
         {displayName}
       </span>
       {!isRemote && <BranchDivergence ahead={ahead} behind={behind} />}
-      <ChevronRight size={11} className="shrink-0 text-mf-text-4" />
+      <ChevronRight size={12} className="shrink-0 text-mf-text-3" />
     </button>
   );
 }

--- a/packages/ui/src/features/git/BranchSubmenu.tsx
+++ b/packages/ui/src/features/git/BranchSubmenu.tsx
@@ -201,12 +201,12 @@ export function BranchSubmenu(props: BranchSubmenuProps) {
           re-clicking the already-selected branch row, wired in BranchPopover. */}
       <div className="px-1.5 py-1.5 border-b border-border flex items-center gap-1.5">
         {props.isRemote ? (
-          <Globe size={12} className="text-mf-text-3 shrink-0" />
+          <Globe size={12} className="text-muted-foreground shrink-0" />
         ) : (
-          <GitBranch size={12} className="text-mf-text-3 shrink-0" />
+          <GitBranch size={12} className="text-muted-foreground shrink-0" />
         )}
         <span className="flex-1 truncate font-mono text-label font-semibold text-foreground">{branch}</span>
-        {busy && <Loader2 size={11} className="animate-spin text-muted-foreground shrink-0" />}
+        {busy && <Loader2 size={12} className="animate-spin text-muted-foreground shrink-0" />}
       </div>
       <div className="py-1">
         {items.map((item, idx) => {

--- a/packages/ui/src/features/git/ConflictView.tsx
+++ b/packages/ui/src/features/git/ConflictView.tsx
@@ -61,7 +61,7 @@ export function ConflictView({ conflictFiles, activeOperation, onAbort, aborting
           </div>
 
           <div className="px-3 py-2 border-t border-border">
-            <p className="text-caption text-muted-foreground leading-relaxed">
+            <p className="text-label text-muted-foreground leading-relaxed">
               Ask an agent to resolve the conflicts, or use an external editor. Once resolved, stage and commit to
               complete the operation.
             </p>

--- a/packages/ui/src/features/git/NewBranchDialog.tsx
+++ b/packages/ui/src/features/git/NewBranchDialog.tsx
@@ -86,12 +86,12 @@ export function NewBranchDialog({
             placeholder="feature/my-branch"
             disabled={creating}
             className={cn(
-              'w-full h-[30px] px-[9px] rounded-md border-[0.5px] bg-background font-mono text-caption text-foreground',
+              'w-full h-[30px] px-[9px] rounded-md border-[0.5px] bg-background font-mono text-body text-foreground',
               'focus:outline-none focus:ring-1 focus:ring-primary',
               error ? 'border-destructive' : 'border-border',
             )}
           />
-          {error && <p className="mt-1 text-caption text-destructive">{error}</p>}
+          {error && <p className="mt-1 text-label text-destructive">{error}</p>}
         </div>
 
         <div>
@@ -101,7 +101,7 @@ export function NewBranchDialog({
             value={startPoint}
             onChange={(e) => setStartPoint(e.target.value)}
             disabled={creating}
-            className="w-full h-[30px] px-[9px] rounded-md border-[0.5px] border-border bg-background font-mono text-caption text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            className="w-full h-[30px] px-[9px] rounded-md border-[0.5px] border-border bg-background font-mono text-body text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
           >
             <optgroup label="Local">
               {localBranches.map((b) => (

--- a/packages/ui/src/features/git/RenameBranchView.tsx
+++ b/packages/ui/src/features/git/RenameBranchView.tsx
@@ -33,7 +33,7 @@ export function RenameBranchView({ target, value, onChange, onSubmit, onCancel, 
           <ArrowLeft size={14} />
         </button>
         <span className="text-body font-medium text-foreground">Rename Branch</span>
-        {target && <span className="text-caption text-muted-foreground truncate ml-1">'{target}'</span>}
+        {target && <span className="text-label text-muted-foreground truncate ml-1">'{target}'</span>}
       </div>
 
       <input
@@ -66,7 +66,7 @@ export function RenameBranchView({ target, value, onChange, onSubmit, onCancel, 
             (busy || !value.trim()) && 'opacity-40 cursor-not-allowed',
           )}
         >
-          {busy && <Loader2 size={11} className="animate-spin" />}
+          {busy && <Loader2 size={12} className="animate-spin" />}
           Rename
         </button>
       </div>

--- a/packages/ui/src/features/git/WorktreeSection.tsx
+++ b/packages/ui/src/features/git/WorktreeSection.tsx
@@ -39,10 +39,10 @@ export function WorktreeSection({
         <button
           data-testid={`git-worktree-toggle-${name}`}
           onClick={() => setExpanded((v) => !v)}
-          className="flex-1 h-[26px] flex items-center gap-[5px] px-2 text-micro font-bold text-mf-text-3 uppercase tracking-wide"
+          className="flex-1 h-[26px] flex items-center gap-[5px] px-2 text-caption font-medium text-muted-foreground"
         >
-          {expanded ? <ChevronDown size={9} /> : <ChevronRight size={9} />}
-          <GitFork size={11} className="text-mf-warning shrink-0" />
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          <GitFork size={12} className="text-mf-warning shrink-0" />
           {name}
         </button>
         {onNewSession && (
@@ -58,7 +58,7 @@ export function WorktreeSection({
                 )}
                 aria-label={`New session on worktree ${name}`}
               >
-                <Plus size={11} />
+                <Plus size={12} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">New session on this worktree</TooltipContent>
@@ -77,7 +77,7 @@ export function WorktreeSection({
                 )}
                 aria-label={`Delete worktree ${name}`}
               >
-                {isDeleting ? <Loader2 size={11} className="animate-spin" /> : <Trash2 size={11} />}
+                {isDeleting ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
               </button>
             </TooltipTrigger>
             <TooltipContent side="top">{isDeleting ? 'Deleting…' : 'Delete worktree'}</TooltipContent>

--- a/packages/ui/src/features/preview/CaptureAnnotationPopover.tsx
+++ b/packages/ui/src/features/preview/CaptureAnnotationPopover.tsx
@@ -37,10 +37,10 @@ export function CaptureAnnotationPopover({
               className="w-full rounded-md border border-border object-contain"
               style={{ maxHeight: 80 }}
             />
-            {capture.selector && <span className="text-caption text-muted-foreground">{capture.selector}</span>}
+            {capture.selector && <span className="text-label text-muted-foreground">{capture.selector}</span>}
             <Textarea
               data-testid={`preview-annotation-input-${capture.id}`}
-              className="min-h-[44px] px-2 py-1.5 text-caption"
+              className="min-h-[44px] px-2 py-1.5 text-body"
               rows={2}
               placeholder="Add a note..."
               defaultValue={capture.annotation ?? ''}

--- a/packages/ui/src/features/preview/PreviewBodyState.tsx
+++ b/packages/ui/src/features/preview/PreviewBodyState.tsx
@@ -42,8 +42,8 @@ export function PreviewBodyState({
             <span className="w-2 h-2 rounded-full bg-destructive" />
             <span className="text-body text-muted-foreground">Preview tunnel unavailable</span>
           </div>
-          {tunnelError && <span className="line-clamp-2 font-mono text-micro text-mf-text-4">{tunnelError}</span>}
-          <span className="text-micro text-mf-text-4">Process logs are in the console below</span>
+          {tunnelError && <span className="line-clamp-2 font-mono text-caption text-mf-text-3">{tunnelError}</span>}
+          <span className="text-caption text-muted-foreground">Process logs are in the console below</span>
         </div>
       </div>
     );
@@ -53,8 +53,8 @@ export function PreviewBodyState({
     return (
       <div data-testid="preview-tunnel-pending" className="absolute inset-0 grid place-items-center bg-card">
         <div className="flex items-center gap-[8px]">
-          <Loader2 size={12} className="animate-spin text-mf-text-3" />
-          <span className="text-label text-mf-text-3">Starting tunnel…</span>
+          <Loader2 size={12} className="animate-spin text-muted-foreground" />
+          <span className="text-label text-muted-foreground">Starting tunnel…</span>
         </div>
       </div>
     );
@@ -70,12 +70,12 @@ export function PreviewBodyState({
           className="group flex flex-col items-center gap-2.5 px-[26px] py-[20px] rounded-xl border-none bg-transparent cursor-pointer hover:bg-accent transition-colors"
         >
           <div className="w-10 h-10 rounded-full border border-border flex items-center justify-center transition-[border-color] duration-[120ms] group-hover:border-mf-success">
-            <Play size={15} className="fill-current text-mf-success" />
+            <Play size={16} className="fill-current text-mf-success" />
           </div>
           <span className="text-label text-muted-foreground font-medium tracking-tight">
             Run {configName || 'server'}
           </span>
-          <span className="font-mono text-micro text-mf-text-4">launches localhost:{port ?? '…'}</span>
+          <span className="font-mono text-caption text-mf-text-3">launches localhost:{port ?? '…'}</span>
         </button>
       </div>
     );
@@ -85,8 +85,8 @@ export function PreviewBodyState({
     return (
       <div data-testid="preview-body-starting" className="absolute inset-0 grid place-items-center bg-card">
         <div className="flex items-center gap-[8px]">
-          <Loader2 size={12} className="animate-spin text-mf-text-3" />
-          <span className="text-label text-mf-text-3">Waiting for localhost:{port ?? '…'}…</span>
+          <Loader2 size={12} className="animate-spin text-muted-foreground" />
+          <span className="text-label text-muted-foreground">Waiting for localhost:{port ?? '…'}…</span>
         </div>
       </div>
     );
@@ -97,9 +97,9 @@ export function PreviewBodyState({
     const inspectBadge = inspectActive ? (
       <div
         data-testid="preview-inspect-active-indicator"
-        className="absolute top-[8px] left-[8px] z-10 rounded-[6px] bg-primary px-[7px] py-[2px] font-mono text-micro font-bold text-white"
+        className="absolute top-[8px] left-[8px] z-10 rounded-[6px] bg-primary px-[7px] py-[2px] font-mono text-caption font-semibold text-primary-foreground"
       >
-        CLICK AN ELEMENT
+        Click an element
       </div>
     ) : null;
     return (

--- a/packages/ui/src/features/preview/PreviewCaptureCluster.tsx
+++ b/packages/ui/src/features/preview/PreviewCaptureCluster.tsx
@@ -25,8 +25,8 @@ export function PreviewCaptureCluster({
         isRunning ? 'bg-primary/[0.055] border-[0.5px] border-primary/20' : 'opacity-40 pointer-events-none'
       }`}
     >
-      <ArrowUp size={9} strokeWidth={2.4} className="text-primary" />
-      <span className="text-micro font-bold text-primary uppercase [letter-spacing:0.3px] mr-0.5">Chat</span>
+      <ArrowUp size={12} strokeWidth={2.4} className="text-primary" />
+      <span className="text-caption font-semibold text-primary mr-0.5">Chat</span>
       <PreviewIconButton
         testId="preview-toolbar-inspect"
         title="Inspect element"
@@ -34,7 +34,7 @@ export function PreviewCaptureCluster({
         active={inspectActive}
         className="w-[24px]"
       >
-        <Crosshair size={13} />
+        <Crosshair size={14} />
       </PreviewIconButton>
       <PreviewIconButton
         testId="preview-toolbar-capture"
@@ -42,7 +42,7 @@ export function PreviewCaptureCluster({
         onClick={onCaptureClick}
         className="w-[24px]"
       >
-        <Camera size={13} />
+        <Camera size={14} />
       </PreviewIconButton>
       <PreviewIconButton
         testId="preview-toolbar-region"
@@ -51,7 +51,7 @@ export function PreviewCaptureCluster({
         active={regionActive}
         className="w-[24px]"
       >
-        <Frame size={13} />
+        <Frame size={14} />
       </PreviewIconButton>
     </div>
   );

--- a/packages/ui/src/features/preview/PreviewRunControl.tsx
+++ b/packages/ui/src/features/preview/PreviewRunControl.tsx
@@ -23,9 +23,9 @@ export function PreviewRunControl({ status, onRun, onStop, onRestart }: PreviewR
       <button
         data-testid="preview-run-start"
         onClick={onRun}
-        className="inline-flex h-[24px] flex-shrink-0 items-center gap-1.5 rounded-md bg-mf-success pl-[9px] pr-[11px] text-label font-semibold text-white"
+        className="inline-flex h-[24px] flex-shrink-0 items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card pl-[9px] pr-[11px] text-label font-semibold text-foreground"
       >
-        <Play size={11} className="fill-current" />
+        <Play size={12} className="fill-current text-mf-success" />
         Run
       </button>
     );
@@ -39,12 +39,12 @@ export function PreviewRunControl({ status, onRun, onStop, onRestart }: PreviewR
           onClick={onStop}
           className="inline-flex h-[24px] items-center gap-1.5 rounded-md border-[0.5px] border-border bg-card pl-[8px] pr-[10px] text-label font-semibold text-foreground"
         >
-          <Square size={10} className="fill-current text-destructive" />
+          <Square size={12} className="fill-current text-destructive" />
           Stop
         </button>
       </Hint>
       <PreviewIconButton testId="preview-run-restart" title="Restart server" onClick={onRestart} className="w-[24px]">
-        <RefreshCw size={13} />
+        <RefreshCw size={14} />
       </PreviewIconButton>
     </div>
   );

--- a/packages/ui/src/features/preview/PreviewUrlBar.tsx
+++ b/packages/ui/src/features/preview/PreviewUrlBar.tsx
@@ -57,7 +57,7 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         onClick={handleReload}
         disabled={!isRunning}
       >
-        <RotateCw size={13} />
+        <RotateCw size={14} />
       </PreviewIconButton>
 
       <span
@@ -78,12 +78,12 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
           setInvalid(false);
         }}
         onKeyDown={handleKeyDown}
-        className={`flex-1 min-w-0 bg-transparent outline-none font-mono text-caption px-[4px] ${
+        className={`flex-1 min-w-0 bg-transparent outline-none font-mono text-body px-[4px] ${
           invalid
             ? 'text-destructive ring-1 ring-destructive rounded-sm'
             : isRunning
               ? 'text-foreground'
-              : 'text-mf-text-4'
+              : 'text-muted-foreground'
         }`}
       />
 
@@ -92,9 +92,8 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         title="Open in browser"
         onClick={handleOpenBrowser}
         disabled={!isRunning}
-        className="text-mf-text-3"
       >
-        <ExternalLink size={12} />
+        <ExternalLink size={14} />
       </PreviewIconButton>
 
       <PreviewIconButton
@@ -102,9 +101,8 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         title="Clear cache"
         onClick={handleClearCache}
         disabled={!isRunning}
-        className="text-mf-text-3"
       >
-        <Eraser size={13} />
+        <Eraser size={14} />
       </PreviewIconButton>
     </div>
   );

--- a/packages/ui/src/features/review/ReviewCommitRail.tsx
+++ b/packages/ui/src/features/review/ReviewCommitRail.tsx
@@ -48,7 +48,7 @@ export function ReviewCommitRail({
             <Check size={22} strokeWidth={2.4} className="text-mf-success" aria-hidden />
           </span>
           <div className="text-body font-semibold text-foreground">Changes committed</div>
-          <div className="font-mono text-caption text-mf-text-3">
+          <div className="font-mono text-caption text-muted-foreground">
             {fileCount} {fileCount === 1 ? 'file' : 'files'} · {totalLines} lines
           </div>
           <button
@@ -78,7 +78,7 @@ export function ReviewCommitRail({
                 type="button"
                 data-testid={`review-commit-suggestion-${s.trim().replace(/[^a-z]/gi, '')}`}
                 onClick={() => onMessageChange(s)}
-                className="rounded-[13px] border border-border bg-background px-[9px] py-[4px] text-micro text-muted-foreground transition-colors hover:border-primary"
+                className="rounded-[13px] border border-border bg-background px-[9px] py-[4px] text-caption text-muted-foreground transition-colors hover:border-primary"
               >
                 {s.trim()}
               </button>
@@ -90,15 +90,15 @@ export function ReviewCommitRail({
               data-testid="review-commit-unviewed-warning"
               className="mb-[12px] flex items-start gap-[8px] rounded-md border border-mf-warning/30 bg-mf-warning/10 px-[10px] py-[9px]"
             >
-              <TriangleAlert size={13} className="mt-px shrink-0 text-mf-warning" aria-hidden />
-              <span className="text-caption leading-snug text-mf-warning">
+              <TriangleAlert size={14} className="mt-px shrink-0 text-mf-warning" aria-hidden />
+              <span className="text-label leading-snug text-foreground">
                 {unviewedCount} {unviewedCount === 1 ? 'file' : 'files'} not yet reviewed.
               </span>
             </div>
           )}
 
           {error && (
-            <div data-testid="review-commit-error" className="mb-[12px] text-caption text-destructive">
+            <div data-testid="review-commit-error" className="mb-[12px] text-label text-destructive">
               {error}
             </div>
           )}
@@ -113,7 +113,7 @@ export function ReviewCommitRail({
             className={`mb-[8px] inline-flex h-[36px] items-center justify-center gap-1.5 rounded-md text-body font-bold tracking-tight transition-opacity ${
               canCommit
                 ? 'bg-primary text-primary-foreground shadow-[0_1px_3px_color-mix(in_oklab,var(--primary)_40%,transparent)] hover:opacity-90'
-                : 'cursor-not-allowed bg-mf-chip text-mf-text-3'
+                : 'cursor-not-allowed bg-mf-chip text-muted-foreground'
             }`}
           >
             <Check size={14} strokeWidth={2.4} aria-hidden />

--- a/packages/ui/src/features/review/ReviewFileToolbar.tsx
+++ b/packages/ui/src/features/review/ReviewFileToolbar.tsx
@@ -28,10 +28,10 @@ export function ReviewFileToolbar({
   return (
     <div className="flex h-[40px] shrink-0 items-center gap-[10px] border-b border-border bg-mf-content2 px-[14px]">
       <span className="shrink-0 font-mono text-label font-semibold text-foreground">{name}</span>
-      {dir && <span className="min-w-0 truncate font-mono text-caption text-mf-text-4">{dir}/</span>}
+      {dir && <span className="min-w-0 truncate font-mono text-caption text-muted-foreground">{dir}/</span>}
       <span className="inline-flex gap-[7px] font-mono text-caption">
-        <span className="font-semibold text-mf-success">+{additions}</span>
-        <span className="font-semibold text-destructive">−{deletions}</span>
+        <span className="font-semibold text-mf-diff-add-text">+{additions}</span>
+        <span className="font-semibold text-mf-diff-del-text">−{deletions}</span>
       </span>
 
       <div className="flex-1" />
@@ -57,12 +57,12 @@ export function ReviewFileToolbar({
       >
         <span
           className={`inline-flex h-[15px] w-[15px] items-center justify-center rounded-[4px] border-[1.5px] ${
-            viewed ? 'border-mf-success bg-mf-success' : 'border-mf-text-4 bg-transparent'
+            viewed ? 'border-mf-success bg-mf-success' : 'border-mf-text-3 bg-transparent'
           }`}
         >
           {viewed && <Check size={10} strokeWidth={2.6} className="text-white" aria-hidden />}
         </span>
-        <span className={`text-caption font-semibold ${viewed ? 'text-mf-success' : 'text-muted-foreground'}`}>
+        <span className={`text-caption font-semibold ${viewed ? 'text-foreground' : 'text-muted-foreground'}`}>
           Viewed
         </span>
       </button>

--- a/packages/ui/src/features/review/ReviewFileTree.tsx
+++ b/packages/ui/src/features/review/ReviewFileTree.tsx
@@ -7,6 +7,7 @@
  * brand selection tint; viewed (non-active) rows dim and strike through.
  */
 import { KIND_LABEL } from '@/lib/git-status-kind';
+import { SectionHeader } from '@/components/ui/section-header';
 import type { ReviewFile } from './git-status-to-files';
 
 /**
@@ -15,10 +16,10 @@ import type { ReviewFile } from './git-status-to-files';
  * not the previous /15 approximation.
  */
 const BADGE_CLASS: Record<ReviewFile['status'], string> = {
-  added: 'text-mf-success bg-mf-success/[12.16%]',
-  modified: 'text-mf-warning bg-mf-warning/[12.16%]',
-  deleted: 'text-mf-diff-del-text bg-mf-diff-del-text/[12.16%]',
-  renamed: 'text-mf-warning bg-mf-warning/[12.16%]',
+  added: 'text-foreground bg-mf-success/[12.16%]',
+  modified: 'text-foreground bg-mf-warning/[12.16%]',
+  deleted: 'text-foreground bg-mf-diff-del-text/[12.16%]',
+  renamed: 'text-foreground bg-mf-warning/[12.16%]',
 };
 
 interface ReviewFileTreeProps {
@@ -43,7 +44,7 @@ function StatMeter({ path, additions, deletions }: { path: string; additions: nu
             : frac <= delFrac + 0.0001 && addFrac < frac
               ? 'bg-mf-diff-del-text'
               : 'bg-mf-chip';
-        return <span key={i} className={`size-[7px] rounded-[2px] ${color}`} />;
+        return <span key={i} className={`size-[9px] rounded-[2px] ${color}`} />;
       })}
     </span>
   );
@@ -52,9 +53,7 @@ function StatMeter({ path, additions, deletions }: { path: string; additions: nu
 export function ReviewFileTree({ files, selectedFile, onSelectFile, viewedFiles }: ReviewFileTreeProps) {
   return (
     <div className="flex h-full flex-col">
-      <div className="px-3.5 pb-1.5 pt-[12px] text-micro font-bold uppercase tracking-wide text-mf-text-3">
-        Changed files
-      </div>
+      <SectionHeader className="px-3.5 pb-1.5 pt-[12px]">Changed files</SectionHeader>
       {files.length === 0 ? (
         <div data-testid="review-file-tree-empty" className="px-3.5 py-4 text-caption text-muted-foreground">
           No changes to review
@@ -77,7 +76,7 @@ export function ReviewFileTree({ files, selectedFile, onSelectFile, viewedFiles 
                 } ${isViewed && !isSelected ? 'opacity-55' : ''}`}
               >
                 <span
-                  className={`inline-flex size-[16px] shrink-0 items-center justify-center rounded font-mono text-micro font-extrabold ${BADGE_CLASS[f.status]}`}
+                  className={`inline-flex size-[16px] shrink-0 items-center justify-center rounded font-mono text-caption font-extrabold ${BADGE_CLASS[f.status]}`}
                 >
                   {KIND_LABEL[f.status]}
                 </span>
@@ -88,7 +87,7 @@ export function ReviewFileTree({ files, selectedFile, onSelectFile, viewedFiles 
                   >
                     {fileName}
                   </span>
-                  {dirPath && <span className="truncate text-micro text-mf-text-3">{dirPath}</span>}
+                  {dirPath && <span className="truncate text-caption text-muted-foreground">{dirPath}</span>}
                 </span>
                 <StatMeter path={f.path} additions={f.additions} deletions={f.deletions} />
               </button>

--- a/packages/ui/src/features/review/ReviewPanelHeader.tsx
+++ b/packages/ui/src/features/review/ReviewPanelHeader.tsx
@@ -34,7 +34,7 @@ export function ReviewPanelHeader({
         className="inline-flex size-[30px] shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
         aria-label="Close review"
       >
-        <X className="size-[15px]" />
+        <X className="size-[16px]" />
       </button>
 
       <div className="flex items-center gap-2.5">
@@ -47,24 +47,24 @@ export function ReviewPanelHeader({
           data-testid="review-branch-badge"
           className="inline-flex items-center gap-1.5 rounded-md bg-mf-chip px-2.5 py-1"
         >
-          <GitBranch className="size-[11px] text-mf-text-3" aria-hidden />
+          <GitBranch className="size-[12px] text-mf-text-3" aria-hidden />
           <span className="font-mono text-caption text-muted-foreground">{branch}</span>
         </span>
       )}
 
       <div className="flex-1" />
 
-      <span data-testid="review-file-counts" className="text-caption text-mf-text-3">
+      <span data-testid="review-file-counts" className="text-caption text-muted-foreground">
         {fileCount} {fileCount === 1 ? 'file' : 'files'} ·{' '}
-        <span className="font-semibold text-mf-success">+{totalAdditions}</span>{' '}
+        <span className="font-semibold text-mf-diff-add-text">+{totalAdditions}</span>{' '}
         <span className="font-semibold text-mf-diff-del-text">−{totalDeletions}</span>
       </span>
 
       <span
         data-testid="review-viewed-counter"
-        className={`inline-flex items-center gap-1.5 text-caption ${allViewed ? 'text-mf-success' : 'text-mf-text-3'}`}
+        className="inline-flex items-center gap-1.5 text-caption text-muted-foreground"
       >
-        {allViewed && <Check className="size-[12px]" strokeWidth={2.4} aria-hidden />}
+        {allViewed && <Check className="size-[12px] text-mf-success" strokeWidth={2.4} aria-hidden />}
         {viewedCount}/{fileCount} viewed
       </span>
     </div>

--- a/packages/ui/src/features/run/ConsolePane.tsx
+++ b/packages/ui/src/features/run/ConsolePane.tsx
@@ -96,7 +96,7 @@ function LogLines({ entries, scrollRef }: { entries: LogEntry[]; scrollRef: Reac
     <div
       ref={scrollRef}
       data-testid="run-console-log-lines"
-      className="mf-editor-selectable min-h-0 flex-1 overflow-y-auto pl-[12px] pr-[12px] pt-0 pb-[10px] font-mono text-caption leading-relaxed"
+      className="mf-editor-selectable min-h-0 flex-1 overflow-y-auto pl-[12px] pr-[12px] pt-0 pb-[10px] font-mono text-body leading-relaxed"
     >
       {entries.length === 0 ? (
         <span className="text-muted-foreground">No output yet.</span>
@@ -118,7 +118,7 @@ function LogLines({ entries, scrollRef }: { entries: LogEntry[]; scrollRef: Reac
 function LogCountChip({ count }: { count: number }) {
   if (count === 0) return null;
   return (
-    <span className="flex-shrink-0 rounded-md bg-mf-chip px-[6px] py-[1px] font-mono text-micro text-mf-text-4">
+    <span className="flex-shrink-0 rounded-md bg-mf-chip px-[6px] py-[1px] font-mono text-caption text-muted-foreground">
       {count} logs
     </span>
   );
@@ -134,7 +134,7 @@ function ClearButton({ onClear }: { onClear: () => void }) {
       aria-label="Clear console"
       onClick={onClear}
     >
-      <Trash2 size={10} />
+      <Trash2 size={12} />
     </Button>
   );
 }
@@ -178,9 +178,11 @@ export function ConsolePane({ scopeKey, processName, variant = 'full' }: Console
               size={11}
               className={`flex-shrink-0 text-muted-foreground transition-transform ${expanded ? '' : '-rotate-90'}`}
             />
-            <span className="flex-shrink-0 text-caption font-semibold text-muted-foreground">Console</span>
+            <span className="flex-shrink-0 text-label font-semibold text-muted-foreground">Console</span>
             <LogCountChip count={entries.length} />
-            {!expanded && <span className="min-w-0 flex-1 truncate font-mono text-micro text-mf-text-4">{tail}</span>}
+            {!expanded && (
+              <span className="min-w-0 flex-1 truncate font-mono text-caption text-muted-foreground">{tail}</span>
+            )}
           </button>
           <span className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
             <ClearButton onClear={onClear} />
@@ -203,7 +205,7 @@ export function ConsolePane({ scopeKey, processName, variant = 'full' }: Console
     <div data-testid="run-console-pane" className="flex h-full min-h-0 flex-col bg-card">
       <div className="flex h-[28px] flex-shrink-0 items-center justify-between [border-bottom:0.5px_solid_var(--border)] pl-[12px] pr-[6px]">
         <div className="flex min-w-0 items-center gap-[8px]">
-          <span className="flex-shrink-0 text-caption font-semibold text-muted-foreground">Console</span>
+          <span className="flex-shrink-0 text-label font-semibold text-muted-foreground">Console</span>
           <LogCountChip count={entries.length} />
         </div>
         <ClearButton onClear={onClear} />

--- a/packages/ui/src/features/sessions/filter/TagFilterBar.tsx
+++ b/packages/ui/src/features/sessions/filter/TagFilterBar.tsx
@@ -128,7 +128,7 @@ export function TagFilterBar({ items, filterProjectId, registry }: Props): React
       data-testid="sessions-tag-filter-bar"
       className={`flex w-full min-w-0 flex-shrink-0 items-center gap-1.5 px-[12px] pb-[7px] pt-1.5 ${expanded ? 'flex-wrap' : 'flex-nowrap overflow-hidden'}`}
     >
-      <span className="shrink-0 select-none text-micro font-semibold uppercase tracking-wide text-mf-text-3">Tags</span>
+      <span className="shrink-0 select-none text-caption font-medium text-muted-foreground">Tags</span>
       {shownTags.map((name) => (
         <TagPill
           key={name}

--- a/packages/ui/src/features/sessions/new-thread/FirstRunState.tsx
+++ b/packages/ui/src/features/sessions/new-thread/FirstRunState.tsx
@@ -33,12 +33,14 @@ export function FirstRunState() {
         type="button"
         data-testid="sessions-firstrun-add-project"
         onClick={() => void addProject()}
-        className="inline-flex h-[30px] items-center gap-1.5 rounded-[8px] bg-primary px-3.5 text-caption font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        className="inline-flex h-[30px] items-center gap-1.5 rounded-[8px] bg-primary px-3.5 text-label font-semibold text-primary-foreground transition-opacity hover:opacity-90"
       >
         <FolderPlus size={14} />
         Add project…
       </button>
-      <p className="text-micro text-mf-text-4">Your files stay on disk — Mainframe only tracks session metadata.</p>
+      <p className="text-caption text-muted-foreground">
+        Your files stay on disk — Mainframe only tracks session metadata.
+      </p>
     </div>
   );
 }

--- a/packages/ui/src/features/sessions/new-thread/SuggestionRow.tsx
+++ b/packages/ui/src/features/sessions/new-thread/SuggestionRow.tsx
@@ -43,13 +43,13 @@ export function SuggestionRow({
       </span>
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-body font-medium text-foreground">{suggestion.title}</span>
-        <span className="truncate text-micro text-mf-text-3">{suggestion.meta}</span>
+        <span className="truncate text-caption text-muted-foreground">{suggestion.meta}</span>
       </span>
       <span
         data-testid={`sessions-welcome-suggestion-insert-${index}`}
-        className="flex flex-shrink-0 items-center gap-1 text-micro text-mf-text-3 opacity-0 transition-opacity group-hover:opacity-100"
+        className="flex flex-shrink-0 items-center gap-1 text-caption text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
       >
-        <CornerDownLeft size={11} /> insert
+        <CornerDownLeft size={12} /> insert
       </span>
     </button>
   );

--- a/packages/ui/src/features/sessions/new-thread/WelcomeState.tsx
+++ b/packages/ui/src/features/sessions/new-thread/WelcomeState.tsx
@@ -47,7 +47,7 @@ export function WelcomeState({ projectId }: { projectId: string }) {
         <div className="flex items-center gap-2">
           <ProjectChip projectId={projectId} name={projectName} size={18} />
           {branch != null && (
-            <span className="inline-flex items-center gap-1 text-caption text-mf-text-3">
+            <span className="inline-flex items-center gap-1 text-caption text-muted-foreground">
               <GitBranch size={12} />
               <span className="font-mono">{branch}</span>
             </span>
@@ -61,7 +61,7 @@ export function WelcomeState({ projectId }: { projectId: string }) {
 
         {suggestions.length > 0 && (
           <div className="flex flex-col gap-2">
-            <div className="text-micro font-bold tracking-wide text-muted-foreground">FROM THE REPO</div>
+            <div className="text-caption font-medium text-muted-foreground">From the repo</div>
             {suggestions.map((s, i) => (
               <SuggestionRow key={`${s.icon}-${s.title}`} suggestion={s} index={i} onInsert={insert} />
             ))}

--- a/packages/ui/src/features/sessions/new-thread/__tests__/WelcomeState.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/WelcomeState.test.tsx
@@ -35,16 +35,16 @@ describe('WelcomeState', () => {
     await waitFor(() => expect(screen.getByText('main')).toBeInTheDocument());
   });
 
-  it('does not render the FROM THE REPO section when there are no suggestions', () => {
+  it('does not render the From the repo section when there are no suggestions', () => {
     render(<WelcomeState projectId="proj-a" />);
-    expect(screen.queryByText('FROM THE REPO')).toBeNull();
+    expect(screen.queryByText('From the repo')).toBeNull();
     expect(screen.queryByTestId('sessions-welcome-suggestion-0')).toBeNull();
   });
 
   it('renders suggestion rows and prefills the composer on click (no auto-send)', () => {
     __suggestions = [S(), S({ title: 'Clean up TODOs', tint: 'amber', prefill: 'Fix TODOs.' })];
     render(<WelcomeState projectId="proj-a" />);
-    expect(screen.getByText('FROM THE REPO')).toBeInTheDocument();
+    expect(screen.getByText('From the repo')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('sessions-welcome-suggestion-1'));
     expect(setText).toHaveBeenCalledWith('Fix TODOs.');
   });

--- a/packages/ui/src/features/sessions/sidebar/ArchivedSessionsDialog.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ArchivedSessionsDialog.tsx
@@ -42,7 +42,7 @@ function ArchivedSessionRow({ id, title, projectName, updatedAt, restoring, onRe
       <div className="min-w-0 flex-1">
         <TruncatedWithTooltip text={title} side="left" className="block text-body font-medium text-foreground" />
         {projectName !== null && (
-          <div className="mt-0.5 flex items-center gap-1 text-caption text-mf-text-3">
+          <div className="mt-0.5 flex items-center gap-1 text-caption text-muted-foreground">
             <TruncatedWithTooltip text={projectName} side="left" className="max-w-[140px]" />
           </div>
         )}
@@ -64,7 +64,7 @@ function ArchivedSessionRow({ id, title, projectName, updatedAt, restoring, onRe
             'Restore'
           )}
         </button>
-        <div className="flex items-center gap-1 whitespace-nowrap text-caption text-mf-text-3">
+        <div className="flex items-center gap-1 whitespace-nowrap text-caption text-muted-foreground">
           <Clock className="size-2.5 shrink-0" />
           <span>{when}</span>
         </div>

--- a/packages/ui/src/features/sessions/sidebar/DraftSessionRow.tsx
+++ b/packages/ui/src/features/sessions/sidebar/DraftSessionRow.tsx
@@ -49,7 +49,7 @@ export function DraftSessionRow({
       data-active={selected ? 'true' : 'false'}
       onClick={onSelect}
       onKeyDown={onKeyDown}
-      className="group relative flex w-full items-center gap-[9px] border-l-2 border-l-transparent pb-[9px] pl-2.5 pr-[12px] pt-[8px] text-left transition-colors hover:bg-accent data-[active=true]:border-l-primary data-[active=true]:bg-accent"
+      className="group relative flex w-full items-center gap-[9px] rounded-md pb-[9px] pl-2.5 pr-[12px] pt-[8px] text-left transition-colors hover:bg-accent data-[active=true]:bg-mf-chip"
     >
       <span
         aria-hidden
@@ -63,21 +63,23 @@ export function DraftSessionRow({
           >
             New Session
           </span>
-          <span className="flex-shrink-0 text-micro tabular-nums text-mf-text-3 group-hover:hidden">now</span>
+          <span className="flex-shrink-0 text-caption tabular-nums text-muted-foreground group-hover:hidden">now</span>
           <Hint label="Discard draft">
             <button
               type="button"
               data-testid="sessions-draft-row-discard"
               onClick={discard}
-              className="hidden size-5 flex-shrink-0 items-center justify-center rounded-xs text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
+              className="hidden size-5 flex-shrink-0 items-center justify-center rounded-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground group-hover:inline-flex"
             >
-              <XIcon className="size-[11px]" />
+              <XIcon className="size-3.5" />
             </button>
           </Hint>
         </div>
         <div className="mt-[4px] flex min-w-0 items-center gap-[6px] @max-[220px]:hidden">
           {showProject && <ProjectChip projectId={projectId} name={projectName} size={16} />}
-          <span className="truncate text-micro text-mf-text-4">draft — clears if you leave without sending</span>
+          <span className="truncate text-caption text-muted-foreground">
+            draft — clears if you leave without sending
+          </span>
         </div>
       </div>
     </div>

--- a/packages/ui/src/features/sessions/sidebar/ExternalSessionRow.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ExternalSessionRow.tsx
@@ -48,7 +48,7 @@ export function ExternalSessionRow({
           text={session.title ?? (session.firstPrompt ? cleanPromptDisplay(session.firstPrompt) : 'Untitled session')}
           className="block text-body font-medium text-foreground"
         />
-        <div className="mt-0.5 flex items-center gap-1 text-caption text-mf-text-3">
+        <div className="mt-0.5 flex items-center gap-1 text-caption text-muted-foreground">
           {session.gitBranch && (
             <>
               <GitBranch className="size-2.5 shrink-0" />
@@ -89,7 +89,7 @@ export function ExternalSessionRow({
             'Import'
           )}
         </button>
-        <div className="flex items-center gap-1 whitespace-nowrap text-caption text-mf-text-3">
+        <div className="flex items-center gap-1 whitespace-nowrap text-caption text-muted-foreground">
           <Clock className="size-2.5 shrink-0" />
           <span>{formatIsoRelative(session.modifiedAt)}</span>
         </div>

--- a/packages/ui/src/features/sessions/sidebar/FilterPill.tsx
+++ b/packages/ui/src/features/sessions/sidebar/FilterPill.tsx
@@ -5,6 +5,8 @@
  * TagFilterBar's own TagPill, which paints inline via TAG_DOT_STYLE; this pill
  * carries no swatch.
  */
+import { CountBadge } from '@/components/ui/count-badge';
+
 export interface FilterPillProps {
   label: string;
   active: boolean;
@@ -22,21 +24,13 @@ export function FilterPill({ label, active, testId, onClick, badgeCount = 0, bad
       onClick={onClick}
       type="button"
       className={[
-        'inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] px-2.5 text-caption font-medium tracking-normal transition-colors',
+        'inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] px-2.5 text-label font-medium tracking-normal transition-colors',
         active ? 'bg-primary text-primary-foreground' : 'bg-accent text-muted-foreground hover:text-foreground',
       ].join(' ')}
     >
-      <span className="max-w-[140px] truncate">{label}</span>
-      {badgeCount > 0 && badgeTestId != null && (
-        <span
-          data-testid={badgeTestId}
-          className={[
-            'inline-flex h-[16px] min-w-[16px] items-center justify-center rounded-lg px-1 text-micro font-bold leading-none text-white',
-            active ? 'bg-white/25' : 'bg-primary',
-          ].join(' ')}
-        >
-          {badgeCount}
-        </span>
+      <span className="max-w-[160px] truncate">{label}</span>
+      {badgeTestId != null && (
+        <CountBadge count={badgeCount} variant="unread" onAccent={active} data-testid={badgeTestId} />
       )}
     </button>
   );

--- a/packages/ui/src/features/sessions/sidebar/ImportSessionsDialog.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ImportSessionsDialog.tsx
@@ -38,9 +38,7 @@ function ProjectPicker({
 
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="px-2 pb-1.5 pt-0.5 text-micro font-bold uppercase tracking-wide text-mf-text-3">
-        Select project
-      </div>
+      <div className="px-2 pb-1.5 pt-0.5 text-caption font-medium text-muted-foreground">Select project</div>
       {sorted.map((project) => (
         <Tooltip key={project.id}>
           <TooltipTrigger asChild>
@@ -164,7 +162,7 @@ export function SessionList({ port, projectId, projectPath, onDone, onBack }: Se
         onClick={onBack}
         className="mb-2 flex items-center gap-0.5 text-caption text-muted-foreground transition-colors hover:text-foreground"
       >
-        <ChevronLeft className="size-3" />
+        <ChevronLeft className="size-3.5" />
         Back
       </button>
     ) : null;
@@ -173,7 +171,7 @@ export function SessionList({ port, projectId, projectPath, onDone, onBack }: Se
     return (
       <>
         {backButton}
-        <div className="flex items-center justify-center gap-2 py-8 text-mf-text-3">
+        <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
           <Loader2 className="size-3.5 animate-spin" />
           <span className="text-body">Loading sessions…</span>
         </div>
@@ -227,7 +225,7 @@ export function SessionList({ port, projectId, projectPath, onDone, onBack }: Se
             <div
               ref={sentinelRef}
               data-testid="sessions-import-load-more"
-              className="flex items-center justify-center gap-2 py-3 text-mf-text-3"
+              className="flex items-center justify-center gap-2 py-3 text-muted-foreground"
             >
               <Loader2 className="size-3.5 animate-spin" />
               <span className="text-caption">Loading more…</span>

--- a/packages/ui/src/features/sessions/sidebar/NewSessionPickerPopover.tsx
+++ b/packages/ui/src/features/sessions/sidebar/NewSessionPickerPopover.tsx
@@ -71,9 +71,7 @@ export function NewSessionPickerPopover({
         sideOffset={4}
         className="w-auto min-w-[216px] p-1.5"
       >
-        <div className="px-2 py-1 text-micro font-bold uppercase tracking-wide text-muted-foreground">
-          New session in…
-        </div>
+        <div className="px-2 py-1 text-caption font-medium text-muted-foreground">New session in…</div>
         {projects.map((p) => (
           <button
             key={p.id}
@@ -86,7 +84,9 @@ export function NewSessionPickerPopover({
             className={rowClass}
           >
             <ProjectChip projectId={p.id} name={p.name} size={16} className="min-w-0 flex-1" />
-            <span className="flex-shrink-0 text-micro text-mf-text-3">{countLabel(sessionCounts[p.id] ?? 0)}</span>
+            <span className="flex-shrink-0 text-caption text-muted-foreground">
+              {countLabel(sessionCounts[p.id] ?? 0)}
+            </span>
           </button>
         ))}
         <div className="my-1 h-px bg-border" />
@@ -99,7 +99,7 @@ export function NewSessionPickerPopover({
           }}
           className={rowClass}
         >
-          <FolderPlus className="size-[13px] flex-shrink-0 text-mf-text-3" aria-hidden />
+          <FolderPlus className="size-3.5 flex-shrink-0 text-muted-foreground" aria-hidden />
           <span className="text-muted-foreground">Add project…</span>
         </button>
       </PopoverContent>

--- a/packages/ui/src/features/sessions/sidebar/ProjectFilterPillBar.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ProjectFilterPillBar.tsx
@@ -112,7 +112,7 @@ export function ProjectFilterPillBar({
           data-testid="sessions-add-project"
           type="button"
           onClick={onAddProject}
-          className="inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] border border-dashed border-mf-border-hover px-2.5 text-caption font-semibold tracking-normal text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground"
+          className="inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] border border-dashed border-mf-border-hover px-2.5 text-caption font-semibold tracking-normal text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
           <FolderPlus className="size-[12px]" aria-hidden />
           <span>Add project</span>

--- a/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
@@ -2,6 +2,7 @@ import type { Project } from '@qlan-ro/mainframe-types';
 import { forwardRef, type HTMLAttributes } from 'react';
 import { PencilIcon, Trash2Icon } from 'lucide-react';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu';
+import { CountBadge } from '@/components/ui/count-badge';
 import { DismissibleHint } from '@/components/ui/hint';
 import { useUiPrefs } from '@/store/ui-prefs';
 
@@ -27,18 +28,8 @@ const RENAME_LABEL = 'Rename Project';
 const HINT_LABEL = 'Right-click for options';
 
 function ProjectPillBadge({ active, count, testId }: { active: boolean; count: number; testId?: string }) {
-  if (count <= 0 || testId == null) return null;
-  const className = [
-    'inline-flex h-4 min-w-4 items-center justify-center rounded-lg px-1 text-micro font-bold leading-none text-white',
-    active ? 'bg-white/25' : 'bg-primary',
-  ]
-    .filter(Boolean)
-    .join(' ');
-  return (
-    <span data-testid={testId} className={className}>
-      {count}
-    </span>
-  );
+  if (testId == null) return null;
+  return <CountBadge count={count} variant="unread" onAccent={active} data-testid={testId} />;
 }
 
 function ProjectRemoveContextItem({ projectId, onRemoveProject }: { projectId: string; onRemoveProject: () => void }) {
@@ -46,7 +37,6 @@ function ProjectRemoveContextItem({ projectId, onRemoveProject }: { projectId: s
     <ContextMenuItem
       data-testid={`sessions-project-remove-${projectId}`}
       variant="destructive"
-      className="text-caption"
       onSelect={onRemoveProject}
     >
       <Trash2Icon className="mr-2 size-3.5" />
@@ -57,7 +47,7 @@ function ProjectRemoveContextItem({ projectId, onRemoveProject }: { projectId: s
 
 function ProjectRenameContextItem({ projectId }: { projectId: string }) {
   return (
-    <ContextMenuItem data-testid={`sessions-project-rename-${projectId}`} disabled className="text-caption">
+    <ContextMenuItem data-testid={`sessions-project-rename-${projectId}`} disabled>
       <PencilIcon className="mr-2 size-3.5" />
       {RENAME_LABEL}
     </ContextMenuItem>
@@ -69,7 +59,7 @@ const ProjectPillBody = forwardRef<HTMLSpanElement, ProjectPillBodyProps>(functi
   ref,
 ) {
   const containerClass = [
-    'inline-flex h-[24px] shrink-0 items-center overflow-hidden rounded-[12px] text-caption font-medium tracking-normal transition-colors',
+    'inline-flex h-[24px] shrink-0 items-center overflow-hidden rounded-[12px] text-label font-medium tracking-normal transition-colors',
     active ? 'bg-primary text-primary-foreground' : 'bg-accent text-muted-foreground hover:text-foreground',
     className,
   ]
@@ -85,7 +75,7 @@ const ProjectPillBody = forwardRef<HTMLSpanElement, ProjectPillBodyProps>(functi
         type="button"
         className="inline-flex h-full min-w-0 items-center gap-1.5 px-3"
       >
-        <span className="max-w-[140px] truncate">{project.name}</span>
+        <span className="max-w-[160px] truncate">{project.name}</span>
         <ProjectPillBadge active={active} count={badgeCount} testId={badgeTestId} />
       </button>
     </span>

--- a/packages/ui/src/features/sessions/sidebar/SessionGroupHeader.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionGroupHeader.tsx
@@ -14,10 +14,10 @@ export function SessionGroupHeader({ label }: { label: string }) {
   return (
     <div
       data-testid={`sessions-group-header-${label}`}
-      className="flex items-center gap-[4px] bg-mf-glass px-[12px] pb-[3px] pt-[7px] text-micro font-bold uppercase tracking-wide text-mf-text-3 backdrop-blur-[40px] backdrop-saturate-[1.8]"
+      className="flex items-center gap-[4px] bg-mf-glass px-[12px] pb-[3px] pt-[7px] text-caption font-medium text-muted-foreground backdrop-blur-[40px] backdrop-saturate-[1.8]"
     >
       {inPinnedGroup && (
-        <PinIcon data-testid="sessions-group-pin-glyph" className="size-[9px] flex-shrink-0 text-primary" />
+        <PinIcon data-testid="sessions-group-pin-glyph" className="size-[12px] flex-shrink-0 text-primary" />
       )}
       {label}
     </div>

--- a/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
@@ -45,7 +45,7 @@ function workingLogoAnimation(adapterId: string): string {
 function statusLogoClass(badge: SessionBadge, adapterId: string): string {
   const base = 'inline-flex size-8 flex-shrink-0 items-center justify-center';
   const active = badge.base === 'working' || badge.base === 'waiting';
-  const visual = badge.unread || active ? 'text-primary' : 'text-mf-text-4 opacity-50';
+  const visual = badge.unread || active ? 'text-primary' : 'text-mf-text-3';
   switch (badge.base) {
     case 'worktree-missing':
     case 'transcript-missing':
@@ -90,7 +90,7 @@ function RelativeTime({ updatedAt }: { updatedAt: number }) {
   return (
     <span
       data-testid="sessions-row-relative-time"
-      className="flex-shrink-0 text-micro tabular-nums text-mf-text-3 group-hover:hidden"
+      className="flex-shrink-0 text-caption tabular-nums text-muted-foreground group-hover:hidden"
     >
       {text}
     </span>
@@ -113,7 +113,7 @@ function RowHoverActions({
   onArchive: () => void;
 }) {
   const btn =
-    'inline-flex size-[22px] items-center justify-center rounded-xs text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground';
+    'inline-flex size-[22px] items-center justify-center rounded-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
   const stop = (fn: () => void) => (e: MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -132,17 +132,17 @@ function RowHoverActions({
             onTags(e.currentTarget.getBoundingClientRect());
           }}
         >
-          <TagIcon className="size-[11px]" />
+          <TagIcon className="size-3.5" />
         </button>
       </Hint>
       <Hint label="Rename">
         <button data-testid="sessions-row-action-rename" type="button" className={btn} onClick={stop(onRename)}>
-          <PaperclipIcon className="size-[11px]" />
+          <PaperclipIcon className="size-3.5" />
         </button>
       </Hint>
       <Hint label="Archive">
         <button data-testid="sessions-row-action-archive" type="button" className={btn} onClick={stop(onArchive)}>
-          <XIcon className="size-[11px]" />
+          <XIcon className="size-3.5" />
         </button>
       </Hint>
     </div>
@@ -239,7 +239,7 @@ function SessionRowInner({
       <ThreadListItemPrimitive.Root
         data-testid="sessions-row"
         data-chat-id={item.id}
-        className="group relative border-l-2 border-l-transparent transition-colors hover:bg-accent data-[active=true]:border-l-primary data-[active=true]:bg-accent"
+        className="group relative rounded-md transition-colors hover:bg-accent data-[active=true]:bg-mf-chip"
       >
         {/* Whole-row select target: the entire row body is the trigger, so a click
             anywhere (title, status dot, meta row, empty space) changes the active

--- a/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRowMeta.tsx
@@ -43,9 +43,9 @@ function DegradedMarker({ causes }: { causes: string[] }) {
       <span
         data-testid="sessions-row-meta-degraded"
         aria-label={label}
-        className="inline-flex flex-shrink-0 items-center text-mf-text-3"
+        className="inline-flex flex-shrink-0 items-center text-muted-foreground"
       >
-        <AlertTriangle size={9} aria-hidden />
+        <AlertTriangle size={12} aria-hidden />
       </span>
     </Hint>
   );
@@ -69,11 +69,11 @@ export function SessionRowMeta({
   ];
 
   return (
-    <div className="flex min-w-0 items-center gap-[8px] text-micro tracking-normal text-mf-text-3">
+    <div className="flex min-w-0 items-center gap-[8px] text-caption tracking-normal text-muted-foreground">
       {projectName != null && chipColor != null && (
         <span
           data-testid="sessions-row-meta-project"
-          className="inline-flex h-[15px] max-w-[124px] flex-shrink-0 items-center gap-[4px] rounded-[4px] pl-[5px] pr-[6px] text-micro font-semibold"
+          className="inline-flex h-[15px] max-w-[124px] flex-shrink-0 items-center gap-[4px] rounded-[4px] pl-[5px] pr-[6px] text-caption font-semibold"
           style={{
             backgroundColor: `color-mix(in oklch, ${chipColor} 10%, transparent)`,
             color: chipColor,
@@ -97,7 +97,7 @@ export function SessionRowMeta({
               worktreeMissing ? 'text-destructive' : 'text-muted-foreground',
             ].join(' ')}
           >
-            <GitFork size={9} className="flex-shrink-0 text-mf-text-3" aria-hidden />
+            <GitFork size={12} className="flex-shrink-0" aria-hidden />
             <span className="max-w-[8rem] truncate">{worktreeBasename(worktreePath)}</span>
           </span>
         </Hint>

--- a/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
@@ -22,6 +22,7 @@
 import { memo, useCallback, useMemo, type ReactNode } from 'react';
 import { useAssistantRuntime, useAuiState } from '@assistant-ui/react';
 import { mfToast } from '@/lib/toast';
+import { CountBadge } from '@/components/ui/count-badge';
 import type { SessionItem } from '../view-model/chat-to-thread-custom';
 import { regularThreadItemsToSessionItems } from '../view-model/chat-to-thread-custom';
 import { arrangeSessions } from '../view-model/group-sessions';
@@ -50,7 +51,7 @@ import { resolveProjectSession } from './resolve-project-session';
 
 function EmptyState({ hasFilters }: { hasFilters: boolean }) {
   return (
-    <div data-testid="sessions-empty-state" className="px-3 py-5 text-center text-caption text-mf-text-3">
+    <div data-testid="sessions-empty-state" className="px-3 py-5 text-center text-body text-muted-foreground">
       {hasFilters ? 'No sessions match these filters.' : 'No sessions yet'}
     </div>
   );
@@ -67,8 +68,8 @@ function SessionsGroupHeader({ count, newButton }: { count: number; newButton: R
   const { sortMode, setSortMode } = useSessionFilters();
   return (
     <div className="flex items-center gap-[4px] px-[12px] pb-1 pt-[8px]">
-      <span className="text-micro font-bold uppercase tracking-wide text-muted-foreground">Sessions</span>
-      <span className="text-micro text-mf-text-3">{count}</span>
+      <span className="text-caption font-medium text-muted-foreground">Sessions</span>
+      <CountBadge count={count} variant="info" />
       <div className="flex-1" />
       {newButton}
       <SessionSortMenu mode={sortMode} onChange={setSortMode} />

--- a/packages/ui/src/features/sessions/sidebar/SessionSortMenu.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionSortMenu.tsx
@@ -29,9 +29,9 @@ export function SessionSortMenu({ mode, onChange }: SessionSortMenuProps) {
           <button
             data-testid="sessions-sort-button"
             type="button"
-            className="inline-flex size-[22px] items-center justify-center rounded-md text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+            className="inline-flex size-[22px] items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
           >
-            <ChevronsUpDownIcon className="size-[11px]" />
+            <ChevronsUpDownIcon className="size-3.5" />
           </button>
         </PopoverTrigger>
       </Hint>

--- a/packages/ui/src/features/sessions/sidebar/SessionsMoreMenu.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionsMoreMenu.tsx
@@ -30,7 +30,7 @@ import { Hint } from '@/components/ui/hint';
 import { ArchivedSessionsDialog } from './ArchivedSessionsDialog';
 
 const ICON_BTN =
-  'inline-flex size-[22px] items-center justify-center rounded-md text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground';
+  'inline-flex size-[22px] items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground';
 
 export function SessionsMoreMenu() {
   const port = useDaemonPort();
@@ -48,7 +48,7 @@ export function SessionsMoreMenu() {
         <Hint label="More">
           <DropdownMenuTrigger asChild>
             <button data-testid="sessions-more-button" type="button" className={ICON_BTN}>
-              <MoreHorizontalIcon className="size-[11px]" />
+              <MoreHorizontalIcon className="size-3.5" />
             </button>
           </DropdownMenuTrigger>
         </Hint>

--- a/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
@@ -27,7 +27,7 @@ import { NewSessionPickerPopover } from './NewSessionPickerPopover';
 import { useNewSessionPickerTarget } from './use-new-session-picker-target';
 
 const ICON_BTN =
-  'inline-flex size-[22px] items-center justify-center rounded-[6px] text-mf-text-3 transition-colors hover:bg-accent hover:text-foreground';
+  'inline-flex size-[22px] items-center justify-center rounded-[6px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
 
 interface SessionsNewButtonProps {
   filterProjectId: string | null;
@@ -63,7 +63,7 @@ export function SessionsNewButton({
           }}
         >
           <button data-testid="sessions-new-button" data-tut="sessions" type="button" className={ICON_BTN}>
-            <PlusIcon className="size-[12px]" />
+            <PlusIcon className="size-3.5" />
           </button>
         </ThreadListPrimitive.New>
       </Hint>

--- a/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
@@ -449,8 +449,8 @@ describe('ProjectFilterPillBar — project action affordance', () => {
     fireEvent.contextMenu(screen.getByTestId('sessions-filter-pill-p1-wrap'));
     expect(screen.getByTestId('sessions-project-rename-p1').textContent).toContain('Rename Project');
     expect(screen.getByTestId('sessions-project-rename-p1')).toHaveAttribute('data-disabled');
-    expect(screen.getByTestId('sessions-project-rename-p1').className).toContain('text-caption');
-    expect(screen.getByTestId('sessions-project-remove-p1').className).toContain('text-caption');
+    expect(screen.getByTestId('sessions-project-rename-p1').className).toContain('text-label');
+    expect(screen.getByTestId('sessions-project-remove-p1').className).toContain('text-label');
     await userEvent.click(screen.getByTestId('sessions-project-remove-p1'));
 
     expect(handleRemove).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
@@ -350,8 +350,8 @@ describe('session row badge presentation', () => {
   it('idle + read → muted provider logo, no pill', () => {
     render(<StatusDot badge={{ base: 'idle', unread: false }} adapterId="opencode" />);
     const dot = screen.getByTestId('sessions-row-status-dot');
-    expect(dot.className).toContain('text-mf-text-4');
-    expect(dot.className).toContain('opacity-50');
+    expect(dot.className).toContain('text-mf-text-3');
+    expect(dot.className).not.toContain('opacity-50');
     expect(dot.className).not.toContain('grayscale');
     expect(dot.className).not.toContain('animate-pulse');
     expect(screen.getByTestId('sessions-row-provider-logo')).toHaveAttribute('data-provider-id', 'opencode');
@@ -377,7 +377,7 @@ describe('session row badge presentation', () => {
     render(<StatusDot badge={{ base: 'worktree-missing', unread: false }} adapterId="claude" />);
     const dot = screen.getByTestId('sessions-row-status-dot');
     expect(dot.className).not.toContain('text-destructive');
-    expect(dot.className).toContain('opacity-50');
+    expect(dot.className).not.toContain('opacity-50');
     expect(dot.className).not.toContain('grayscale');
   });
 });

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.unread-store.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.unread-store.test.tsx
@@ -91,13 +91,15 @@ describe('SessionRow — unread store integration', () => {
     render(<SessionRow item={makeItem({ id: 'chat-1', remoteId: 'chat-1' })} />);
 
     const logo = screen.getByTestId('sessions-row-status-dot');
-    expect(logo.className).toContain('opacity-50');
+    expect(logo.className).toContain('text-mf-text-3');
+    expect(logo.className).not.toContain('text-primary');
 
     act(() => {
       useUnreadStore.getState().markUnread('chat-1');
     });
 
-    expect(logo.className).not.toContain('opacity-50');
+    expect(logo.className).toContain('text-primary');
+    expect(logo.className).not.toContain('text-mf-text-3');
     expect(screen.getByTestId('sessions-row-title').className).toContain('font-bold');
   });
 
@@ -108,7 +110,7 @@ describe('SessionRow — unread store integration', () => {
       useUnreadStore.getState().markUnread('chat-1');
     });
 
-    expect(screen.getByTestId('sessions-row-status-dot').className).not.toContain('opacity-50');
+    expect(screen.getByTestId('sessions-row-status-dot').className).toContain('text-primary');
     expect(screen.getByTestId('sessions-row-title').className).toContain('font-bold');
   });
 });

--- a/packages/ui/src/features/sessions/tags/TagRecolorPanel.tsx
+++ b/packages/ui/src/features/sessions/tags/TagRecolorPanel.tsx
@@ -26,9 +26,7 @@ export function TagRecolorPanel({ tagName, onPick, onClose }: Props): React.Reac
         if (e.key === 'Escape') onClose();
       }}
     >
-      <div className="text-caption text-muted-foreground uppercase tracking-wide px-1 pb-1">
-        Recolor &quot;{tagName}&quot;
-      </div>
+      <div className="text-caption font-medium text-muted-foreground px-1 pb-1">Recolor &quot;{tagName}&quot;</div>
       <div className="grid grid-cols-5 gap-1">
         {TAG_PALETTE.map((c) => (
           <button

--- a/packages/ui/src/features/settings/SettingsSidebar.tsx
+++ b/packages/ui/src/features/settings/SettingsSidebar.tsx
@@ -61,7 +61,7 @@ function ProviderSubItems({ activeProvider }: { activeProvider: string | null })
           >
             <span
               className={cn(
-                'inline-flex size-[15px] shrink-0 items-center justify-center rounded-xs text-micro font-bold text-white ring-1 ring-inset ring-black/10',
+                'inline-flex size-[15px] shrink-0 items-center justify-center rounded-xs text-caption font-bold text-white ring-1 ring-inset ring-black/10',
                 providerDot(adapter.id),
               )}
             >

--- a/packages/ui/src/features/settings/panes/about/AboutPane.tsx
+++ b/packages/ui/src/features/settings/panes/about/AboutPane.tsx
@@ -49,7 +49,7 @@ export function AboutPane() {
               i < rows.length - 1 && 'border-b-[0.5px] border-border',
             )}
           >
-            <span className="w-20 shrink-0 text-label text-mf-text-3">{row.label}</span>
+            <span className="w-20 shrink-0 text-label text-muted-foreground">{row.label}</span>
             <TruncatedWithTooltip
               text={row.value}
               data-testid={row.testId}

--- a/packages/ui/src/features/settings/panes/general/GeneralPane.tsx
+++ b/packages/ui/src/features/settings/panes/general/GeneralPane.tsx
@@ -36,12 +36,12 @@ export function GeneralPane({ port }: { port: number }) {
       <h2 className="text-title font-bold text-foreground">General</h2>
 
       <section className="flex flex-col gap-3">
-        <h3 className="text-label font-semibold text-mf-text-3">Appearance</h3>
+        <h3 className="text-label font-semibold text-muted-foreground">Appearance</h3>
         <AppearanceControls />
       </section>
 
       <section className="flex flex-col gap-3">
-        <h3 className="text-label font-semibold text-mf-text-3">Worktree directory</h3>
+        <h3 className="text-label font-semibold text-muted-foreground">Worktree directory</h3>
         <p className="text-label text-muted-foreground">
           Relative path where worktrees are created inside project roots.
         </p>

--- a/packages/ui/src/features/settings/panes/providers/ConfigConflictsWarning.tsx
+++ b/packages/ui/src/features/settings/panes/providers/ConfigConflictsWarning.tsx
@@ -15,7 +15,7 @@ export function ConfigConflictsWarning({ conflicts }: ConfigConflictsWarningProp
       className="flex items-start gap-2 px-3 py-2 rounded-md bg-mf-warning-tint border border-mf-warning/30"
     >
       <AlertTriangle size={14} className="text-mf-warning shrink-0 mt-0.5" />
-      <p className="text-label text-mf-warning">
+      <p className="text-label text-foreground">
         Claude Code settings.json defines {conflicts.join(', ')}. Mainframe flags will take precedence when launching
         sessions.
       </p>

--- a/packages/ui/src/features/settings/panes/providers/ProvidersPane.tsx
+++ b/packages/ui/src/features/settings/panes/providers/ProvidersPane.tsx
@@ -25,7 +25,7 @@ function ProviderHeader({ adapter }: { adapter: AdapterInfo }) {
         <h3 className="text-title font-bold text-foreground">{adapter.name}</h3>
         <div className="flex items-center gap-1.5">
           <span className={cn('size-1.5 rounded-full', adapter.installed ? 'bg-mf-success' : 'bg-mf-text-3')} />
-          <span className="text-caption text-muted-foreground">
+          <span className="text-label text-muted-foreground">
             {adapter.installed ? 'Detected on PATH' : 'Not installed'}
           </span>
         </div>

--- a/packages/ui/src/features/settings/panes/remote-access/DevicesSection.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/DevicesSection.tsx
@@ -54,7 +54,7 @@ export function DevicesSection({ port }: DevicesSectionProps): React.ReactElemen
           Loading...
         </div>
       ) : devices.length === 0 ? (
-        <p className="text-micro text-muted-foreground">No paired devices.</p>
+        <p className="text-label text-muted-foreground">No paired devices.</p>
       ) : (
         <div className="space-y-1.5">
           {devices.map((device) => (
@@ -70,8 +70,10 @@ function DeviceRow({ device, onRemove }: { device: Device; onRemove: (id: string
   return (
     <div className="flex items-center justify-between p-2.5 bg-card border border-border rounded-md">
       <div>
-        <span className="text-caption text-foreground">{device.deviceName}</span>
-        <span className="text-micro text-muted-foreground ml-2">{new Date(device.createdAt).toLocaleDateString()}</span>
+        <span className="text-label text-foreground">{device.deviceName}</span>
+        <span className="text-caption text-muted-foreground ml-2">
+          {new Date(device.createdAt).toLocaleDateString()}
+        </span>
       </div>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/packages/ui/src/features/settings/panes/remote-access/NamedTunnelSection.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/NamedTunnelSection.tsx
@@ -57,7 +57,7 @@ export function NamedTunnelSection({
     <div data-testid="settings-remote-access-named-tunnel-section" className="space-y-3">
       <div>
         <label className="text-label font-semibold text-muted-foreground">Named Tunnel</label>
-        <p className="text-micro text-muted-foreground mt-0.5">
+        <p className="text-label text-muted-foreground mt-0.5">
           Use a Cloudflare connector token for a persistent URL.
         </p>
       </div>
@@ -102,25 +102,23 @@ function NamedTunnelConfigured({
     <div className="space-y-2">
       {tunnel.state === 'idle' || tunnel.state === 'error' ? (
         <div className="flex items-center gap-2 p-2.5 bg-card border border-border rounded-md">
-          <span className="w-2 h-2 rounded-full bg-muted-foreground opacity-60 shrink-0" />
-          <code className="text-caption text-muted-foreground truncate flex-1">{savedUrl}</code>
-          <span className="text-micro text-muted-foreground shrink-0">
+          <span className="w-2 h-2 rounded-full bg-muted-foreground shrink-0" />
+          <code className="text-label text-muted-foreground truncate flex-1">{savedUrl}</code>
+          <span className="text-caption text-muted-foreground shrink-0">
             {tunnel.state === 'error' ? 'Stopped (error)' : 'Stopped'}
           </span>
         </div>
       ) : (
         <TunnelStatusRow state={tunnel.state} url={tunnel.url ?? savedUrl} onRetryVerify={tunnel.retryVerify} />
       )}
-      {tunnel.state === 'error' && tunnel.errorMsg && (
-        <p className="text-caption text-destructive">{tunnel.errorMsg}</p>
-      )}
-      {saveError && <p className="text-caption text-destructive">{saveError}</p>}
+      {tunnel.state === 'error' && tunnel.errorMsg && <p className="text-label text-destructive">{tunnel.errorMsg}</p>}
+      {saveError && <p className="text-label text-destructive">{saveError}</p>}
       <div className="flex items-center gap-2">
         <button
           data-testid="named-tunnel-toggle"
           onClick={onStartStop}
           disabled={tunnel.togglingAction !== null}
-          className={`inline-flex h-[30px] items-center justify-center px-[11px] text-caption rounded-md transition-colors disabled:opacity-50 ${
+          className={`inline-flex h-[30px] items-center justify-center px-[11px] text-label rounded-md transition-colors disabled:opacity-50 ${
             tunnel.running
               ? 'bg-accent text-foreground border border-border hover:bg-accent/80'
               : 'bg-primary text-primary-foreground hover:opacity-90'
@@ -141,7 +139,7 @@ function NamedTunnelConfigured({
           data-testid="named-tunnel-clear-config"
           onClick={onClear}
           disabled={tunnel.togglingAction === 'stop'}
-          className="inline-flex h-[30px] items-center justify-center px-[11px] text-caption text-muted-foreground bg-accent border border-border rounded-md hover:bg-accent/80 disabled:opacity-50 transition-colors"
+          className="inline-flex h-[30px] items-center justify-center px-[11px] text-label text-muted-foreground bg-accent border border-border rounded-md hover:bg-accent/80 disabled:opacity-50 transition-colors"
         >
           Clear Configuration
         </button>
@@ -175,7 +173,7 @@ function NamedTunnelSetup({
         value={token}
         onChange={(e) => onTokenChange(e.target.value)}
         placeholder="Cloudflare connector token"
-        className="h-[30px] w-full px-[11px] text-caption bg-card border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary"
+        className="h-[30px] w-full px-[11px] text-body bg-card border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary"
       />
       <input
         data-testid="named-tunnel-url-input"
@@ -183,14 +181,14 @@ function NamedTunnelSetup({
         value={url}
         onChange={(e) => onUrlChange(e.target.value)}
         placeholder="https://mainframe.example.com"
-        className="h-[30px] w-full px-[11px] text-caption bg-card border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary"
+        className="h-[30px] w-full px-[11px] text-body bg-card border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary"
       />
-      {saveError && <p className="text-caption text-destructive">{saveError}</p>}
+      {saveError && <p className="text-label text-destructive">{saveError}</p>}
       <button
         data-testid="named-tunnel-save"
         onClick={onSave}
         disabled={togglingStart || !token.trim() || !url.trim()}
-        className="inline-flex h-[30px] items-center justify-center px-[11px] text-caption bg-primary text-primary-foreground rounded-md hover:opacity-90 disabled:opacity-50 transition-opacity"
+        className="inline-flex h-[30px] items-center justify-center px-[11px] text-label bg-primary text-primary-foreground rounded-md hover:opacity-90 disabled:opacity-50 transition-opacity"
       >
         {togglingStart ? (
           <span className="flex items-center gap-1.5">

--- a/packages/ui/src/features/settings/panes/remote-access/PairingSection.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/PairingSection.tsx
@@ -61,7 +61,7 @@ export function PairingSection({ port }: PairingSectionProps): React.ReactElemen
     <div data-testid="settings-remote-access-pairing-section" className="space-y-3">
       <div>
         <label className="text-label font-semibold text-muted-foreground">Mobile Pairing</label>
-        <p className="text-micro text-muted-foreground mt-0.5">Generate a code to pair a mobile device.</p>
+        <p className="text-label text-muted-foreground mt-0.5">Generate a code to pair a mobile device.</p>
       </div>
 
       {code ? (
@@ -77,7 +77,7 @@ export function PairingSection({ port }: PairingSectionProps): React.ReactElemen
           data-testid="pairing-generate-code"
           onClick={handleGenerate}
           disabled={generating}
-          className="inline-flex h-[30px] items-center justify-center px-[11px] text-caption bg-primary text-primary-foreground rounded-md hover:opacity-90 disabled:opacity-50 transition-opacity"
+          className="inline-flex h-[30px] items-center justify-center px-[11px] text-label bg-primary text-primary-foreground rounded-md hover:opacity-90 disabled:opacity-50 transition-opacity"
         >
           {generating ? (
             <span className="flex items-center gap-1.5">
@@ -115,7 +115,7 @@ function PairingCodeDisplay({
         <CopyButton text={code} testId="pairing-code-copy" />
       </div>
       <div className="flex items-center justify-between">
-        <span className="text-micro text-muted-foreground">
+        <span className="text-caption text-muted-foreground">
           Expires in {minutes}:{seconds.toString().padStart(2, '0')}
         </span>
         <button

--- a/packages/ui/src/features/settings/panes/remote-access/QuickTunnelSection.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/QuickTunnelSection.tsx
@@ -18,7 +18,7 @@ export function QuickTunnelSection({ tunnel }: QuickTunnelSectionProps): React.R
       <div className="flex items-center justify-between">
         <div>
           <label className="text-label font-semibold text-muted-foreground">Quick Tunnel</label>
-          <p className="text-micro text-muted-foreground mt-0.5">
+          <p className="text-label text-muted-foreground mt-0.5">
             Ephemeral tunnel via trycloudflare.com (new URL each start).
           </p>
         </div>
@@ -26,7 +26,7 @@ export function QuickTunnelSection({ tunnel }: QuickTunnelSectionProps): React.R
           data-testid="quick-tunnel-toggle"
           onClick={handleToggle}
           disabled={tunnel.togglingAction !== null}
-          className={`inline-flex h-[30px] items-center justify-center px-[11px] text-caption rounded-md transition-colors disabled:opacity-50 ${
+          className={`inline-flex h-[30px] items-center justify-center px-[11px] text-label rounded-md transition-colors disabled:opacity-50 ${
             tunnel.running
               ? 'bg-accent text-foreground border border-border hover:bg-accent/80'
               : 'bg-primary text-primary-foreground hover:opacity-90'
@@ -46,9 +46,7 @@ export function QuickTunnelSection({ tunnel }: QuickTunnelSectionProps): React.R
       </div>
 
       <TunnelStatusRow state={tunnel.state} url={tunnel.url} onRetryVerify={tunnel.retryVerify} />
-      {tunnel.state === 'error' && tunnel.errorMsg && (
-        <p className="text-caption text-destructive">{tunnel.errorMsg}</p>
-      )}
+      {tunnel.state === 'error' && tunnel.errorMsg && <p className="text-label text-destructive">{tunnel.errorMsg}</p>}
     </div>
   );
 }

--- a/packages/ui/src/features/settings/panes/remote-access/RemoteAccessPane.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/RemoteAccessPane.tsx
@@ -13,7 +13,7 @@ export function RemoteAccessPane({ port }: RemoteAccessPaneProps): React.ReactEl
     return (
       <div data-testid="settings-pane-remote-access" className="space-y-6">
         <h3 className="text-title font-bold text-foreground">Remote Access</h3>
-        <div className="flex items-center gap-2 text-caption text-muted-foreground">
+        <div className="flex items-center gap-2 text-label text-muted-foreground">
           <RotateCw size={14} className="animate-spin" />
           Loading...
         </div>

--- a/packages/ui/src/features/settings/panes/remote-access/TunnelStatusRow.tsx
+++ b/packages/ui/src/features/settings/panes/remote-access/TunnelStatusRow.tsx
@@ -20,7 +20,7 @@ export function TunnelStatusRow({ state, url, onRetryVerify }: TunnelStatusRowPr
     return (
       <div className="flex items-center gap-2 p-2.5 bg-card border border-border rounded-md">
         <RotateCw size={12} className="animate-spin text-mf-warning shrink-0" />
-        <span className="text-caption text-muted-foreground flex-1">
+        <span className="text-label text-muted-foreground flex-1">
           {state === 'starting' ? 'Starting tunnel…' : 'Verifying DNS…'}
         </span>
       </div>
@@ -31,7 +31,7 @@ export function TunnelStatusRow({ state, url, onRetryVerify }: TunnelStatusRowPr
     return (
       <div className="flex items-center gap-2 p-2.5 bg-card border border-border rounded-md">
         <RotateCw size={12} className="animate-spin text-mf-warning shrink-0" />
-        <span className="text-caption text-muted-foreground flex-1">
+        <span className="text-label text-muted-foreground flex-1">
           Verifying DNS for <code className="text-foreground">{url}</code>…
         </span>
       </div>
@@ -42,7 +42,7 @@ export function TunnelStatusRow({ state, url, onRetryVerify }: TunnelStatusRowPr
     return (
       <div className="flex items-center gap-2 p-2.5 bg-card border border-border rounded-md">
         <span className="w-2 h-2 rounded-full bg-mf-success shrink-0" />
-        <code className="text-caption text-foreground truncate flex-1">{url}</code>
+        <code className="text-label text-foreground truncate flex-1">{url}</code>
         <CopyButton text={url} testId="tunnel-url-copy-ready" />
       </div>
     );
@@ -53,11 +53,11 @@ export function TunnelStatusRow({ state, url, onRetryVerify }: TunnelStatusRowPr
       <div className="space-y-2">
         <div className="flex items-center gap-2 p-2.5 bg-card border border-border rounded-md">
           <span className="w-2 h-2 rounded-full bg-mf-warning shrink-0" />
-          <code className="text-caption text-muted-foreground truncate flex-1">{url}</code>
+          <code className="text-label text-muted-foreground truncate flex-1">{url}</code>
           <CopyButton text={url} testId="tunnel-url-copy-unreachable" />
         </div>
         <div className="flex items-center justify-between">
-          <p className="text-micro text-mf-warning">
+          <p className="text-label text-muted-foreground">
             DNS not yet propagated — tunnel may not be reachable. Pairing disabled.
           </p>
           <button

--- a/packages/ui/src/features/settings/panes/shared/SettingGroup.tsx
+++ b/packages/ui/src/features/settings/panes/shared/SettingGroup.tsx
@@ -8,7 +8,7 @@ interface SettingGroupProps {
 export function SettingGroup({ title, children }: SettingGroupProps) {
   return (
     <div className="flex flex-col gap-1">
-      <h4 className="mb-1 text-micro font-bold uppercase tracking-wide text-mf-text-3">{title}</h4>
+      <h4 className="mb-1 text-caption font-medium text-muted-foreground">{title}</h4>
       <div className="divide-y divide-border">{children}</div>
     </div>
   );

--- a/packages/ui/src/features/tasks/DependencyPicker.tsx
+++ b/packages/ui/src/features/tasks/DependencyPicker.tsx
@@ -70,7 +70,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
 
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-caption text-muted-foreground">Depends on</label>
+      <label className="text-label text-muted-foreground">Depends on</label>
       {selected.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {selected.map((t) => (
@@ -87,7 +87,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
                 className="hover:text-foreground transition-colors"
                 aria-label={`Remove dependency on #${t.number}`}
               >
-                <X size={10} />
+                <X size={12} />
               </button>
             </span>
           ))}
@@ -99,7 +99,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
             type="button"
             data-testid="tasks-dep-input"
             className={cn(
-              'flex items-center gap-1 text-caption text-muted-foreground cursor-pointer',
+              'flex items-center gap-1 text-label text-muted-foreground cursor-pointer',
               'w-full px-2 py-1 rounded-md border border-border bg-background hover:bg-muted transition-colors',
             )}
             onClick={() => setOpen(!open)}
@@ -115,7 +115,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
                   ref={searchRef}
                   data-noring=""
                   type="text"
-                  className="bg-transparent text-caption text-foreground placeholder:text-muted-foreground focus:outline-none w-full"
+                  className="bg-transparent text-label text-foreground placeholder:text-muted-foreground focus:outline-none w-full"
                   placeholder="Search tasks…"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
@@ -130,7 +130,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
                     <button
                       type="button"
                       data-testid={`tasks-dep-opt-${t.number}`}
-                      className="w-full text-left px-2 py-1.5 text-caption text-foreground hover:bg-muted transition-colors"
+                      className="w-full text-left px-2 py-1.5 text-label text-foreground hover:bg-muted transition-colors"
                       onClick={() => addDep(t.number)}
                     >
                       <span className="text-muted-foreground">#{t.number}</span>{' '}
@@ -144,7 +144,7 @@ export function DependencyPicker({ currentNumber, allTodos, value, onChange }: P
         </div>
       )}
       {available.length === 0 && value.length === 0 && (
-        <span className="text-caption text-muted-foreground opacity-60">No other tasks available</span>
+        <span className="text-caption text-muted-foreground">No other tasks available</span>
       )}
     </div>
   );

--- a/packages/ui/src/features/tasks/FilterMenu.tsx
+++ b/packages/ui/src/features/tasks/FilterMenu.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { ChevronDown, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { CountBadge } from '@/components/ui/count-badge';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -56,14 +57,14 @@ export function FilterMenu({ label, options, selected, onChange }: Props): React
         >
           {label}
           {hasSelection && (
-            <span
+            <CountBadge
+              count={selected.length}
+              variant="unread"
+              className="ml-0.5"
               data-testid={`tasks-filter-${toKebab(label)}-count`}
-              className="ml-0.5 rounded-[6px] bg-primary/[18%] px-[5px] font-mono text-micro font-bold text-primary"
-            >
-              {selected.length}
-            </span>
+            />
           )}
-          <ChevronDown size={11} className="ml-0.5" />
+          <ChevronDown size={12} className="ml-0.5" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[160px] max-h-64 overflow-y-auto p-1">
@@ -86,7 +87,7 @@ export function FilterMenu({ label, options, selected, onChange }: Props): React
                   isSelected ? 'bg-primary border-primary text-primary-foreground' : 'border-border',
                 )}
               >
-                {isSelected && <Check size={9} strokeWidth={3} />}
+                {isSelected && <Check size={12} strokeWidth={3} />}
               </span>
               <span className="flex-1 capitalize">{opt.label.replace('_', ' ')}</span>
               {opt.count > 0 && <span className="text-caption text-muted-foreground tabular-nums">{opt.count}</span>}

--- a/packages/ui/src/features/tasks/LabelAutocomplete.tsx
+++ b/packages/ui/src/features/tasks/LabelAutocomplete.tsx
@@ -83,7 +83,7 @@ export function LabelAutocomplete({ value, onChange, allLabels }: Props): React.
               className="ml-0.5 hover:text-foreground transition-colors"
               aria-label={`Remove ${label}`}
             >
-              <X size={10} />
+              <X size={12} />
             </button>
           </span>
         ))}
@@ -99,15 +99,15 @@ export function LabelAutocomplete({ value, onChange, allLabels }: Props): React.
             }}
             onKeyDown={handleKeyDown}
             placeholder={value.length === 0 ? 'Add labels…' : ''}
-            className="w-full bg-transparent text-caption text-foreground focus:outline-none"
+            className="w-full bg-transparent text-label text-foreground focus:outline-none"
           />
           {ghostSuggestion && (
             <span
-              className="absolute inset-0 pointer-events-none text-caption select-none whitespace-nowrap overflow-hidden flex items-center"
+              className="absolute inset-0 pointer-events-none text-label select-none whitespace-nowrap overflow-hidden flex items-center"
               aria-hidden="true"
             >
               <span className="invisible">{inputValue}</span>
-              <span className="text-muted-foreground opacity-40">{ghostSuggestion.slice(inputValue.length)}</span>
+              <span className="text-mf-text-3">{ghostSuggestion.slice(inputValue.length)}</span>
             </span>
           )}
         </span>

--- a/packages/ui/src/features/tasks/QuickTaskDialog.tsx
+++ b/packages/ui/src/features/tasks/QuickTaskDialog.tsx
@@ -32,14 +32,14 @@ interface PendingFile {
 // Physical padding avoids Chromium scroll-clip bug.
 const inputCls = cn(
   'bg-background border border-border rounded-md pl-3 pr-3 py-1.5',
-  'text-caption text-foreground placeholder:text-muted-foreground',
+  'text-label text-foreground placeholder:text-muted-foreground',
   'focus:outline-none focus:ring-1 focus:ring-ring w-full',
 );
 const textareaWrap = cn(
   'bg-background border border-border rounded-md pl-3 pr-3 py-1.5 focus-within:ring-1 focus-within:ring-ring',
 );
 const textareaInner = cn(
-  'w-full bg-transparent border-0 p-0 resize-none text-caption text-foreground outline-none focus:outline-none focus-visible:outline-none',
+  'w-full bg-transparent border-0 p-0 resize-none text-label text-foreground outline-none focus:outline-none focus-visible:outline-none',
 );
 const pillBase = cn('px-3 py-1 text-caption rounded-full border transition-colors cursor-pointer');
 
@@ -229,7 +229,7 @@ export function QuickTaskDialog({ port, projectId, open, onClose }: Props) {
                 onKeyDown={handleModEnter}
               />
             </div>
-            <span className="text-caption text-muted-foreground opacity-60">Paste image to attach</span>
+            <span className="text-caption text-muted-foreground">Paste image to attach</span>
           </div>
 
           {/* Pending attachments */}
@@ -251,7 +251,7 @@ export function QuickTaskDialog({ port, projectId, open, onClose }: Props) {
                     className="absolute top-0.5 right-0.5 p-0.5 rounded bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity"
                     aria-label={`Remove ${f.filename}`}
                   >
-                    <X size={10} />
+                    <X size={12} />
                   </button>
                 </div>
               ))}
@@ -260,7 +260,7 @@ export function QuickTaskDialog({ port, projectId, open, onClose }: Props) {
 
           {/* Priority pills */}
           <div className="flex items-center gap-2">
-            <span className="text-caption text-muted-foreground">Priority</span>
+            <span className="text-label text-muted-foreground">Priority</span>
             <div className="flex gap-1">
               {(['low', 'medium', 'high'] as const).map((p) => (
                 <TypePill
@@ -286,7 +286,7 @@ export function QuickTaskDialog({ port, projectId, open, onClose }: Props) {
             onClick={() => void handleSubmit()}
             disabled={!title.trim() || submitting}
             className={cn(
-              'px-3 py-1.5 text-caption rounded-md transition-colors',
+              'px-3 py-1.5 text-label rounded-md transition-colors',
               'bg-primary text-primary-foreground hover:opacity-90',
               'disabled:opacity-50 disabled:cursor-not-allowed',
             )}

--- a/packages/ui/src/features/tasks/SortMenu.tsx
+++ b/packages/ui/src/features/tasks/SortMenu.tsx
@@ -58,7 +58,7 @@ export function SortMenu({ sort, onChange }: Props): React.ReactElement {
             'border border-border bg-background text-muted-foreground hover:text-foreground',
           )}
         >
-          <ArrowUpDown size={11} />
+          <ArrowUpDown size={12} />
           <span>
             {current?.label} {dirArrow(sort.dir)}
           </span>
@@ -79,7 +79,7 @@ export function SortMenu({ sort, onChange }: Props): React.ReactElement {
               )}
             >
               <span className="w-3.5 shrink-0">
-                {active && <Check size={11} strokeWidth={2.5} className="text-primary" />}
+                {active && <Check size={12} strokeWidth={2.5} className="text-primary" />}
               </span>
               <span className="flex-1">{label}</span>
               {active && <span className="text-primary">{dirArrow(sort.dir)}</span>}

--- a/packages/ui/src/features/tasks/TaskAttachments.tsx
+++ b/packages/ui/src/features/tasks/TaskAttachments.tsx
@@ -175,7 +175,7 @@ export function TaskAttachments({ port, todoId, pending, onPendingChange, onReje
 
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-caption text-muted-foreground">Attachments</label>
+      <label className="text-label text-muted-foreground">Attachments</label>
       {allItems.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {allItems.map((att) => {
@@ -214,7 +214,7 @@ export function TaskAttachments({ port, todoId, pending, onPendingChange, onReje
                   )}
                   aria-label={`Remove ${att.filename}`}
                 >
-                  <X size={10} />
+                  <X size={12} />
                 </button>
               </div>
             );
@@ -229,7 +229,7 @@ export function TaskAttachments({ port, todoId, pending, onPendingChange, onReje
         disabled={uploading}
         onClick={() => inputRef.current?.click()}
         className={cn(
-          'flex items-center gap-1 w-fit px-2 py-1 rounded-md text-caption',
+          'flex items-center gap-1 w-fit px-2 py-1 rounded-md text-label',
           'text-muted-foreground hover:text-foreground hover:bg-muted transition-colors',
           'disabled:opacity-40',
         )}

--- a/packages/ui/src/features/tasks/TaskCard.tsx
+++ b/packages/ui/src/features/tasks/TaskCard.tsx
@@ -63,7 +63,7 @@ export const TaskCard = React.memo(function TaskCard({
     >
       {/* Row 1: #number + title + type badge */}
       <div className="flex items-start gap-1.5 min-w-0">
-        <span className="shrink-0 font-mono text-caption font-medium text-primary leading-5">#{todo.number}</span>
+        <span className="shrink-0 font-mono text-label font-medium text-primary leading-5">#{todo.number}</span>
         <span className="flex-1 min-w-0">
           <span
             className={cn(
@@ -86,7 +86,7 @@ export const TaskCard = React.memo(function TaskCard({
 
       {/* Dependencies line */}
       {todo.dependencies.length > 0 && (
-        <div className="text-caption text-muted-foreground">
+        <div className="text-label text-muted-foreground">
           Depends on {todo.dependencies.map((n) => `#${n}`).join(', ')}
         </div>
       )}
@@ -108,7 +108,7 @@ export const TaskCard = React.memo(function TaskCard({
         <span className="flex-1" />
         <Hint label={`Updated ${new Date(todo.updated_at).toLocaleDateString()}`}>
           <span className="inline-flex items-center gap-1 text-caption text-muted-foreground shrink-0 whitespace-nowrap">
-            <Clock size={10} aria-hidden />
+            <Clock size={12} aria-hidden />
             {relativeTime(todo.updated_at)}
           </span>
         </Hint>
@@ -124,7 +124,7 @@ export const TaskCard = React.memo(function TaskCard({
           ))}
           {attachmentCount != null && attachmentCount > 0 && (
             <span className="flex items-center gap-0.5 text-caption text-muted-foreground">
-              <Paperclip size={10} />
+              <Paperclip size={12} />
               {attachmentCount}
             </span>
           )}

--- a/packages/ui/src/features/tasks/TaskColumn.tsx
+++ b/packages/ui/src/features/tasks/TaskColumn.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState } from 'react';
 import { cn } from '@/lib/utils';
+import { CountBadge } from '@/components/ui/count-badge';
 import { TaskCard } from './TaskCard';
 import type { Todo, TodoStatus } from '@/lib/api/todos';
 
@@ -65,10 +66,8 @@ export function TaskColumn({
       {/* Column header — chip sits adjacent to the label at a 7px gap, not
           right-aligned (design: 12-todos.jsx:617, finding 9.15). */}
       <div className="flex shrink-0 items-center gap-[7px] px-3.5 pb-4 pt-2.5">
-        <span className="text-caption font-bold uppercase tracking-wide text-muted-foreground">
-          {STATUS_LABEL[status]}
-        </span>
-        <span className="rounded-md bg-mf-chip px-1.5 py-px font-mono text-micro text-mf-text-3">{todos.length}</span>
+        <span className="text-caption font-medium text-muted-foreground">{STATUS_LABEL[status]}</span>
+        <CountBadge count={todos.length} variant="info" />
       </div>
 
       {/* Cards — 9px gap per design (12-todos.jsx:621, finding 9.14) */}

--- a/packages/ui/src/features/tasks/TaskEditModal.tsx
+++ b/packages/ui/src/features/tasks/TaskEditModal.tsx
@@ -23,13 +23,13 @@ import type { Todo, TodoStatus, TodoType, TodoPriority } from '@/lib/api/todos';
 // Physical padding avoids Chromium scroll-clip on <input>.
 const inputCls = cn(
   'bg-mf-content2 border-[0.5px] border-border rounded-md pl-3 pr-3 py-1.5',
-  'text-caption text-foreground focus:outline-none focus:ring-1 focus:ring-ring w-full',
+  'text-label text-foreground focus:outline-none focus:ring-1 focus:ring-ring w-full',
 );
 const textareaWrap = cn(
   'bg-mf-content2 border-[0.5px] border-border rounded-md pl-3 pr-3 py-1.5 focus-within:ring-1 focus-within:ring-ring',
 );
 const textareaInner = cn(
-  'w-full bg-transparent border-0 p-0 resize-none text-caption text-foreground outline-none focus:outline-none focus-visible:outline-none',
+  'w-full bg-transparent border-0 p-0 resize-none text-label text-foreground outline-none focus:outline-none focus-visible:outline-none',
 );
 
 interface Props {
@@ -176,7 +176,7 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <div className="p-4 space-y-3 overflow-y-auto flex-1 min-h-0">
             <div className="flex flex-col gap-1">
-              <label className="text-caption text-muted-foreground">Title *</label>
+              <label className="text-label text-muted-foreground">Title *</label>
               <input
                 data-testid="tasks-edit-title"
                 className={inputCls}
@@ -199,8 +199,8 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
 
             <div className="flex flex-col gap-1">
               <div className="flex items-baseline justify-between">
-                <label className="text-caption text-muted-foreground">Description (markdown)</label>
-                <span className="text-caption text-muted-foreground opacity-60">Paste image to attach</span>
+                <label className="text-label text-muted-foreground">Description (markdown)</label>
+                <span className="text-caption text-muted-foreground">Paste image to attach</span>
               </div>
               <div className={textareaWrap}>
                 <textarea
@@ -215,7 +215,7 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
               </div>
             </div>
 
-            {attachErr && <p className="text-caption text-destructive">{attachErr}</p>}
+            {attachErr && <p className="text-label text-destructive">{attachErr}</p>}
 
             <TaskAttachments
               port={port}
@@ -260,9 +260,9 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
                   onStartSession(todo.id);
                   onClose();
                 }}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-caption bg-primary text-primary-foreground font-semibold hover:opacity-90 transition-opacity"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-label bg-primary text-primary-foreground font-semibold hover:opacity-90 transition-opacity"
               >
-                <Play size={12} aria-hidden />
+                <Play size={14} aria-hidden />
                 Start session
               </button>
             )}
@@ -270,7 +270,7 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
               type="button"
               data-testid="tasks-edit-cancel"
               onClick={onClose}
-              className="px-3 py-1.5 rounded-md text-caption text-muted-foreground hover:bg-muted transition-colors"
+              className="px-3 py-1.5 rounded-md text-label text-muted-foreground hover:bg-muted transition-colors"
             >
               Cancel
             </button>
@@ -278,7 +278,7 @@ export function TaskEditModal({ port, projectId, todo, allTodos, allLabels, onCl
               type="submit"
               data-testid="tasks-edit-save"
               disabled={!title.trim() || saving}
-              className="px-3 py-1.5 rounded-md text-caption bg-primary text-primary-foreground disabled:opacity-40 hover:opacity-90 transition-opacity"
+              className="px-3 py-1.5 rounded-md text-label bg-primary text-primary-foreground disabled:opacity-40 hover:opacity-90 transition-opacity"
             >
               {saving ? 'Saving…' : todo ? 'Save changes' : 'Create task'}
             </button>

--- a/packages/ui/src/features/tasks/TaskListRow.tsx
+++ b/packages/ui/src/features/tasks/TaskListRow.tsx
@@ -80,13 +80,13 @@ function StatusDot({ todo, onCycle }: { todo: Todo; onCycle: (id: string) => voi
       className={cn(
         'shrink-0 flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-full',
         status === 'done'
-          ? 'w-4 h-4 bg-mf-success'
+          ? 'w-3.5 h-3.5 bg-mf-success'
           : status === 'in_progress'
             ? 'w-[15px] h-[15px] rounded-full border-2 border-primary'
-            : 'w-3.5 h-3.5 rounded-full border-[1.6px] border-mf-text-4 hover:border-primary',
+            : 'w-3.5 h-3.5 rounded-full border-[1.6px] border-mf-text-3 hover:border-primary',
       )}
     >
-      {status === 'done' && <Check size={9} className="text-white" strokeWidth={3} />}
+      {status === 'done' && <Check size={10} className="text-white" strokeWidth={3} />}
       {status === 'in_progress' && (
         <span data-status-pulse className="w-[5px] h-[5px] rounded-full bg-primary animate-pulse" aria-hidden />
       )}
@@ -155,7 +155,7 @@ export function TaskListRow({
         <StatusDot todo={todo} onCycle={onCycle} />
 
         {/* Number */}
-        <span className="shrink-0 font-mono text-caption font-medium text-primary w-10 text-right">#{todo.number}</span>
+        <span className="shrink-0 font-mono text-label font-medium text-primary w-10 text-right">#{todo.number}</span>
 
         {/* Title */}
         <span
@@ -195,7 +195,7 @@ export function TaskListRow({
                   className="p-1.5 rounded text-primary hover:bg-accent transition-colors"
                   aria-label="Start in new session"
                 >
-                  <Play size={13} />
+                  <Play size={14} />
                 </button>
               </TooltipTrigger>
               <TooltipContent>Start session</TooltipContent>
@@ -212,7 +212,7 @@ export function TaskListRow({
                 className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                 aria-label="Edit task"
               >
-                <Edit size={13} />
+                <Edit size={14} />
               </button>
             </TooltipTrigger>
             <TooltipContent>Edit</TooltipContent>
@@ -228,7 +228,7 @@ export function TaskListRow({
                 className="p-1.5 rounded text-muted-foreground hover:text-destructive hover:bg-accent transition-colors"
                 aria-label="Delete task"
               >
-                <Trash2 size={13} />
+                <Trash2 size={14} />
               </button>
             </TooltipTrigger>
             <TooltipContent>Delete</TooltipContent>
@@ -239,9 +239,9 @@ export function TaskListRow({
       {/* Expanded detail panel */}
       {expanded && (
         <div className="px-10 pb-3 space-y-2 text-body text-muted-foreground bg-accent/50">
-          {todo.body && <p className="whitespace-pre-wrap text-foreground text-caption leading-relaxed">{todo.body}</p>}
+          {todo.body && <p className="whitespace-pre-wrap text-foreground text-label leading-relaxed">{todo.body}</p>}
 
-          <div className="flex flex-wrap gap-4 text-caption">
+          <div className="flex flex-wrap gap-4 text-label">
             {todo.milestone && (
               <span>
                 <span className="font-medium text-foreground">Milestone:</span> {todo.milestone}
@@ -260,7 +260,7 @@ export function TaskListRow({
             )}
           </div>
 
-          <div className="flex gap-4 text-caption text-muted-foreground">
+          <div className="flex gap-4 text-label text-muted-foreground">
             <span>Created {formatDate(todo.created_at)}</span>
             <span>Updated {formatDate(todo.updated_at)}</span>
           </div>
@@ -285,9 +285,9 @@ export function TaskListRow({
                   e.stopPropagation();
                   onStartSession(todo);
                 }}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-caption font-semibold hover:opacity-90 transition-opacity"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-label font-semibold hover:opacity-90 transition-opacity"
               >
-                <Play size={12} />
+                <Play size={14} />
                 {todo.status === 'in_progress' ? 'Resume session' : 'Start session'}
               </button>
             )}
@@ -297,9 +297,9 @@ export function TaskListRow({
                 e.stopPropagation();
                 onEdit(todo);
               }}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-muted-foreground text-caption font-medium hover:text-foreground transition-colors"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-card text-muted-foreground text-label font-medium hover:text-foreground transition-colors"
             >
-              <Edit size={12} />
+              <Edit size={14} />
               Edit
             </button>
           </div>

--- a/packages/ui/src/features/tasks/TaskListView.tsx
+++ b/packages/ui/src/features/tasks/TaskListView.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState, useCallback, useRef } from 'react';
 import { ChevronDown, ChevronRight, ListChecks } from 'lucide-react';
+import { CountBadge } from '@/components/ui/count-badge';
 import type { Todo, TodoStatus } from '@/lib/api/todos';
 import type { TodoFilters } from './todos-filters';
 import { useTodosStore } from './use-todos-store';
@@ -160,12 +161,12 @@ export function TaskListView({ port, projectId, todos, filters, onEdit, onStartS
               <button
                 type="button"
                 data-testid={`tasks-list-group-${status}`}
-                className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-b border-border bg-mf-content2 px-3 py-1.5 text-caption font-bold uppercase tracking-wide text-muted-foreground"
+                className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-b border-border bg-mf-content2 px-3 py-1.5 text-caption font-medium text-muted-foreground"
                 onClick={() => toggleGroup(status)}
               >
                 {collapsedGroups.has(status) ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
                 {GROUP_LABEL[status]}
-                <span className="ml-1 font-normal text-muted-foreground/70">{items.length}</span>
+                <CountBadge count={items.length} variant="info" className="ml-1" />
               </button>
 
               {/* Rows */}
@@ -202,7 +203,7 @@ export function TaskListView({ port, projectId, todos, filters, onEdit, onStartS
             <kbd className="rounded-sm border-[0.5px] border-border bg-card px-1.5 py-0.5 font-mono text-caption leading-none text-muted-foreground">
               {key}
             </kbd>
-            <span className="text-caption text-mf-text-3">{label}</span>
+            <span className="text-caption text-muted-foreground">{label}</span>
           </span>
         ))}
       </div>

--- a/packages/ui/src/features/tasks/TaskMetaFields.tsx
+++ b/packages/ui/src/features/tasks/TaskMetaFields.tsx
@@ -12,7 +12,7 @@ import type { Todo } from '@/lib/api/todos';
 // Physical padding shorthand avoids the Chromium scroll-clip bug on <input>.
 const inputCls = cn(
   'bg-background border border-border rounded-md pl-3 pr-3 py-1.5',
-  'text-caption text-foreground focus:outline-none focus:ring-1 focus:ring-ring',
+  'text-label text-foreground focus:outline-none focus:ring-1 focus:ring-ring',
   'w-full',
 );
 
@@ -46,12 +46,12 @@ export function TaskMetaFields({
   return (
     <>
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Labels</label>
+        <label className="text-label text-muted-foreground">Labels</label>
         <LabelAutocomplete value={labelList} onChange={onLabelChange} allLabels={allLabels} />
       </div>
 
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Assignees (comma-separated)</label>
+        <label className="text-label text-muted-foreground">Assignees (comma-separated)</label>
         <input
           data-testid="tasks-edit-assignees"
           className={inputCls}
@@ -62,7 +62,7 @@ export function TaskMetaFields({
       </div>
 
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Milestone</label>
+        <label className="text-label text-muted-foreground">Milestone</label>
         <input
           data-testid="tasks-edit-milestone"
           className={inputCls}

--- a/packages/ui/src/features/tasks/TaskSelectFields.tsx
+++ b/packages/ui/src/features/tasks/TaskSelectFields.tsx
@@ -32,9 +32,9 @@ export function TaskSelectFields({ type, onTypeChange, priority, onPriorityChang
   return (
     <div className="grid grid-cols-3 gap-3">
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Type</label>
+        <label className="text-label text-muted-foreground">Type</label>
         <Select value={type} onValueChange={(v) => onTypeChange(v as TodoType)}>
-          <SelectTrigger data-testid="tasks-edit-type" className="text-caption h-8">
+          <SelectTrigger data-testid="tasks-edit-type" className="text-label h-8">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -47,9 +47,9 @@ export function TaskSelectFields({ type, onTypeChange, priority, onPriorityChang
         </Select>
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Priority</label>
+        <label className="text-label text-muted-foreground">Priority</label>
         <Select value={priority} onValueChange={(v) => onPriorityChange(v as TodoPriority)}>
-          <SelectTrigger data-testid="tasks-edit-priority" className="text-caption h-8">
+          <SelectTrigger data-testid="tasks-edit-priority" className="text-label h-8">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -62,9 +62,9 @@ export function TaskSelectFields({ type, onTypeChange, priority, onPriorityChang
         </Select>
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-caption text-muted-foreground">Status</label>
+        <label className="text-label text-muted-foreground">Status</label>
         <Select value={status} onValueChange={(v) => onStatusChange(v as TodoStatus)}>
-          <SelectTrigger data-testid="tasks-edit-status" className="text-caption h-8">
+          <SelectTrigger data-testid="tasks-edit-status" className="text-label h-8">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/packages/ui/src/features/tasks/TasksBoard.tsx
+++ b/packages/ui/src/features/tasks/TasksBoard.tsx
@@ -82,7 +82,7 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
         </button>
         <ListChecks size={15} className="shrink-0 text-primary" aria-hidden />
         <span className="text-body font-semibold text-foreground">Tasks</span>
-        <span className="font-mono text-caption text-mf-text-3 bg-mf-chip rounded-md px-[8px] py-0.5">
+        <span className="font-mono text-caption text-muted-foreground bg-mf-chip rounded-md px-[8px] py-0.5">
           {activeCount} active · {doneCount} done
         </span>
 
@@ -94,7 +94,7 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
             onClick={() => setView('list')}
             aria-pressed={view === 'list'}
             className={cn(
-              'flex items-center gap-1 px-2 py-1 rounded text-caption transition-colors',
+              'flex items-center gap-1 px-2 py-1 rounded text-label transition-colors',
               view === 'list'
                 ? 'bg-background text-foreground shadow-sm'
                 : 'text-muted-foreground hover:text-foreground',
@@ -109,7 +109,7 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
             onClick={() => setView('board')}
             aria-pressed={view === 'board'}
             className={cn(
-              'flex items-center gap-1 px-2 py-1 rounded text-caption transition-colors',
+              'flex items-center gap-1 px-2 py-1 rounded text-label transition-colors',
               view === 'board'
                 ? 'bg-background text-foreground shadow-sm'
                 : 'text-muted-foreground hover:text-foreground',
@@ -125,9 +125,9 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
           data-testid="tasks-board-new"
           type="button"
           onClick={handleNew}
-          className="flex items-center gap-1 px-2 py-1.5 rounded-md bg-primary text-primary-foreground text-caption hover:opacity-90 transition-opacity"
+          className="flex items-center gap-1 px-2 py-1.5 rounded-md bg-primary text-primary-foreground text-label hover:opacity-90 transition-opacity"
         >
-          <Plus size={12} />
+          <Plus size={14} />
           New task
         </button>
       </div>

--- a/packages/ui/src/features/tasks/TasksDrawer.tsx
+++ b/packages/ui/src/features/tasks/TasksDrawer.tsx
@@ -12,6 +12,7 @@
  */
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { ExternalLink, Plus, CircleDashed } from 'lucide-react';
+import { CountBadge } from '@/components/ui/count-badge';
 import { useTodosStore } from './use-todos-store';
 import { useTasksModal } from './use-tasks-modal';
 import { TasksDrawerList } from './TasksDrawerList';
@@ -113,21 +114,11 @@ export function TasksDrawer({ port, projectId, onStartSession }: Props): React.R
 
       {/* Header */}
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 shrink-0 [border-bottom:0.5px_solid_var(--border)]">
-        <CircleDashed size={11} className="text-muted-foreground flex-shrink-0" aria-hidden />
-        <span
-          data-testid="tasks-drawer-label"
-          className="text-caption font-semibold uppercase tracking-wide text-muted-foreground"
-        >
+        <CircleDashed size={12} className="text-muted-foreground flex-shrink-0" aria-hidden />
+        <span data-testid="tasks-drawer-label" className="text-caption font-medium text-muted-foreground">
           Tasks
         </span>
-        {activeCount > 0 && (
-          <span
-            data-testid="tasks-drawer-count"
-            className="font-mono text-micro text-mf-text-3 bg-mf-chip rounded-md px-1.5 py-px tabular-nums"
-          >
-            {activeCount}
-          </span>
-        )}
+        <CountBadge count={activeCount} variant="info" data-testid="tasks-drawer-count" />
         <div className="ml-auto flex items-center gap-0.5">
           <button
             data-testid="tasks-drawer-new"
@@ -136,7 +127,7 @@ export function TasksDrawer({ port, projectId, onStartSession }: Props): React.R
             className="inline-flex h-[22px] w-[22px] items-center justify-center rounded-[4px] border-none bg-transparent text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
             aria-label="New task"
           >
-            <Plus size={11} />
+            <Plus size={14} />
           </button>
           <button
             data-testid="tasks-drawer-expand"
@@ -145,7 +136,7 @@ export function TasksDrawer({ port, projectId, onStartSession }: Props): React.R
             className="inline-flex h-[22px] w-[22px] items-center justify-center rounded-[4px] border-none bg-transparent text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
             aria-label="Open full Tasks view"
           >
-            <ExternalLink size={13} />
+            <ExternalLink size={14} />
           </button>
         </div>
       </div>

--- a/packages/ui/src/features/tasks/TasksDrawerList.tsx
+++ b/packages/ui/src/features/tasks/TasksDrawerList.tsx
@@ -56,8 +56,8 @@ export function TasksDrawerList({ port, projectId, onStartSession }: Props): Rea
               )}
             >
               <span className={cn('shrink-0 w-1.5 h-1.5 rounded-full', statusDotColor(todo.status))} />
-              <span className="shrink-0 font-mono text-caption text-primary">#{todo.number}</span>
-              <span className="flex-1 min-w-0 text-caption text-foreground truncate">{todo.title}</span>
+              <span className="shrink-0 font-mono text-label text-primary">#{todo.number}</span>
+              <span className="flex-1 min-w-0 text-body text-foreground truncate">{todo.title}</span>
             </button>
           ))
         )}

--- a/packages/ui/src/features/tasks/TasksFilterBar.tsx
+++ b/packages/ui/src/features/tasks/TasksFilterBar.tsx
@@ -105,7 +105,7 @@ export function TasksFilterBar({ filters, onChange, allLabels, sort, onSortChang
             value={filters.search}
             onChange={(e) => onChange({ ...filters, search: e.target.value })}
             placeholder="Search tasks…"
-            className="h-[30px] w-[230px] pl-6 pr-6 text-caption"
+            className="h-[30px] w-[230px] pl-6 pr-6 text-label"
           />
           {filters.search && (
             <button
@@ -113,7 +113,7 @@ export function TasksFilterBar({ filters, onChange, allLabels, sort, onSortChang
               className="absolute right-1.5 text-muted-foreground hover:text-foreground"
               aria-label="Clear search"
             >
-              <X size={11} />
+              <X size={12} />
             </button>
           )}
         </div>
@@ -140,12 +140,12 @@ export function TasksFilterBar({ filters, onChange, allLabels, sort, onSortChang
             data-testid="tasks-filter-clear"
             onClick={clearAll}
             className={cn(
-              'flex items-center gap-1 px-2 py-1 rounded text-caption font-medium transition-colors',
+              'flex items-center gap-1 px-2 py-1 rounded text-label font-medium transition-colors',
               'text-primary hover:underline',
             )}
             type="button"
           >
-            <X size={11} />
+            <X size={12} />
             Clear
           </button>
         )}

--- a/packages/ui/src/features/tasks/__tests__/FilterMenu.test.tsx
+++ b/packages/ui/src/features/tasks/__tests__/FilterMenu.test.tsx
@@ -29,7 +29,7 @@ describe('FilterMenu — selected-count pill (finding 9.12)', () => {
     render(<FilterMenu label="Type" options={OPTIONS} selected={['bug']} onChange={() => {}} />);
     const pill = screen.getByTestId('tasks-filter-type-count');
     expect(pill.textContent).toBe('1');
-    expect(pill.className).toContain('font-mono');
+    expect(pill.className).toContain('tabular-nums');
   });
 
   it('does NOT render a parenthetical "(1)" text node', () => {

--- a/packages/ui/src/features/tasks/__tests__/TasksDrawer.test.tsx
+++ b/packages/ui/src/features/tasks/__tests__/TasksDrawer.test.tsx
@@ -117,28 +117,22 @@ describe('TasksDrawer — key testids are rendered', () => {
     expect(screen.getByTestId('tasks-drawer')).toBeTruthy();
   });
 
-  it('renders the "Tasks" header label uppercase via CSS (text stays "Tasks", class applies uppercase transform)', () => {
+  it('renders the "Tasks" header label as a sentence-case muted eyebrow (no uppercase/tracking)', () => {
     renderDrawer();
     const label = screen.getByTestId('tasks-drawer-label');
     expect(label.textContent).toBe('Tasks');
-    expect(label.className).toContain('uppercase');
-    expect(label.className).toContain('tracking-wide');
     expect(label.className).toContain('text-muted-foreground');
+    expect(label.className).not.toContain('uppercase');
+    expect(label.className).not.toContain('tracking-wide');
   });
 
-  it('renders the active-count badge as a chip (tasks-drawer-count) with chip background and tabular-nums', () => {
+  it('renders the active-count badge (tasks-drawer-count) as capsule-less muted numerals', () => {
     renderDrawer([OPEN_TODO]);
     const badge = screen.getByTestId('tasks-drawer-count');
     expect(badge.textContent).toBe('1');
-    expect(badge.className).toContain('bg-mf-chip');
     expect(badge.className).toContain('tabular-nums');
-  });
-
-  it('renders the active-count badge with an 8px radius (design parity)', () => {
-    renderDrawer([OPEN_TODO]);
-    const badge = screen.getByTestId('tasks-drawer-count');
-    expect(badge.className).toContain('rounded-md');
-    expect(badge.className).not.toContain('rounded-sm');
+    expect(badge.className).toContain('text-muted-foreground');
+    expect(badge.className).not.toContain('bg-mf-chip');
   });
 
   it('does NOT render the count badge when there are zero active todos', () => {

--- a/packages/ui/src/features/tasks/__tests__/task-palettes.test.ts
+++ b/packages/ui/src/features/tasks/__tests__/task-palettes.test.ts
@@ -27,17 +27,17 @@ import { typeTint, priorityTint, priorityDotClass } from '../task-palettes';
 describe('typeTint — semantic type tokens (design: 12-todos.jsx:12-20)', () => {
   it('bug: task-type-bug token @ 10%', () => {
     expect(typeTint('bug')).toContain('bg-mf-task-type-bug/10');
-    expect(typeTint('bug')).toContain('text-mf-task-type-bug');
+    expect(typeTint('bug')).toContain('text-foreground');
   });
 
   it('feature: accent (primary) tint', () => {
     expect(typeTint('feature')).toContain('bg-primary/10');
-    expect(typeTint('feature')).toContain('text-primary');
+    expect(typeTint('feature')).toContain('text-foreground');
   });
 
   it('enhancement: task-type-enhancement token @ 10%', () => {
     expect(typeTint('enhancement')).toContain('bg-mf-task-type-enhancement/10');
-    expect(typeTint('enhancement')).toContain('text-mf-task-type-enhancement');
+    expect(typeTint('enhancement')).toContain('text-foreground');
   });
 
   it('documentation: chip tint (design has no bespoke hue)', () => {
@@ -46,29 +46,29 @@ describe('typeTint — semantic type tokens (design: 12-todos.jsx:12-20)', () =>
 
   it('question: task-type-question token @ 12%', () => {
     expect(typeTint('question')).toContain('bg-mf-task-type-question/[0.12]');
-    expect(typeTint('question')).toContain('text-mf-task-type-question');
+    expect(typeTint('question')).toContain('text-foreground');
   });
 
   it('duplicate: task-type-duplicate token @ 10%', () => {
     expect(typeTint('duplicate')).toContain('bg-mf-task-type-duplicate/10');
-    expect(typeTint('duplicate')).toContain('text-mf-task-type-duplicate');
+    expect(typeTint('duplicate')).toContain('text-foreground');
   });
 });
 
 describe('priorityTint — semantic priority tokens (design: 12-todos.jsx:21-26)', () => {
   it('critical: priority-critical token @ 10%', () => {
     expect(priorityTint('critical')).toContain('bg-mf-priority-critical/10');
-    expect(priorityTint('critical')).toContain('text-mf-priority-critical');
+    expect(priorityTint('critical')).toContain('text-foreground');
   });
 
   it('high: priority-high token @ 10%', () => {
     expect(priorityTint('high')).toContain('bg-mf-priority-high/10');
-    expect(priorityTint('high')).toContain('text-mf-priority-high');
+    expect(priorityTint('high')).toContain('text-foreground');
   });
 
   it('medium: priority-medium token @ 12%', () => {
     expect(priorityTint('medium')).toContain('bg-mf-priority-medium/[0.12]');
-    expect(priorityTint('medium')).toContain('text-mf-priority-medium');
+    expect(priorityTint('medium')).toContain('text-foreground');
   });
 
   it('low: chip tint (no bespoke hue)', () => {

--- a/packages/ui/src/features/tasks/task-palettes.ts
+++ b/packages/ui/src/features/tasks/task-palettes.ts
@@ -31,46 +31,48 @@ export function statusTint(status: TodoStatus): string {
 }
 
 /**
- * Background + text tint for a todo type badge.
- * Matches the design's TD_TYPE palette (12-todos.jsx:12-20).
+ * Tint background for a todo type badge; the hue lives on the background only,
+ * the label ink stays neutral (foreground/muted) for contrast in every theme.
+ * Background matches the design's TD_TYPE palette (12-todos.jsx:12-20).
  */
 export function typeTint(type: TodoType): string {
   switch (type) {
     case 'bug':
-      return 'bg-mf-task-type-bug/10 text-mf-task-type-bug';
+      return 'bg-mf-task-type-bug/10 text-foreground';
     case 'feature':
-      return 'bg-primary/10 text-primary';
+      return 'bg-primary/10 text-foreground';
     case 'enhancement':
-      return 'bg-mf-task-type-enhancement/10 text-mf-task-type-enhancement';
+      return 'bg-mf-task-type-enhancement/10 text-foreground';
     case 'documentation':
       return 'bg-mf-chip text-muted-foreground';
     case 'question':
-      return 'bg-mf-task-type-question/[0.12] text-mf-task-type-question';
+      return 'bg-mf-task-type-question/[0.12] text-foreground';
     case 'wont_fix':
-      return 'bg-mf-chip text-mf-text-3';
+      return 'bg-mf-chip text-muted-foreground';
     case 'duplicate':
-      return 'bg-mf-task-type-duplicate/10 text-mf-task-type-duplicate';
+      return 'bg-mf-task-type-duplicate/10 text-foreground';
     case 'invalid':
-      return 'bg-mf-chip text-mf-text-3';
+      return 'bg-mf-chip text-muted-foreground';
     default:
       return 'bg-mf-chip text-muted-foreground';
   }
 }
 
 /**
- * Background + text tint for a priority pill.
- * Matches the design's TD_PRI palette (12-todos.jsx:21-26).
+ * Tint background for a priority pill; the hue is carried by the background and
+ * the leading dot only, the label ink stays neutral for contrast.
+ * Background matches the design's TD_PRI palette (12-todos.jsx:21-26).
  */
 export function priorityTint(priority: TodoPriority): string {
   switch (priority) {
     case 'critical':
-      return 'bg-mf-priority-critical/10 text-mf-priority-critical';
+      return 'bg-mf-priority-critical/10 text-foreground';
     case 'high':
-      return 'bg-mf-priority-high/10 text-mf-priority-high';
+      return 'bg-mf-priority-high/10 text-foreground';
     case 'medium':
-      return 'bg-mf-priority-medium/[0.12] text-mf-priority-medium';
+      return 'bg-mf-priority-medium/[0.12] text-foreground';
     case 'low':
-      return 'bg-mf-chip text-mf-text-3';
+      return 'bg-mf-chip text-muted-foreground';
     default:
       return 'bg-mf-chip text-muted-foreground';
   }

--- a/packages/ui/src/features/tour/WsTourLabel.tsx
+++ b/packages/ui/src/features/tour/WsTourLabel.tsx
@@ -41,7 +41,7 @@ export function WsTourLabel({ step, idx, total, onBack, onNext, style }: WsTourL
           <span className="inline-flex w-[20px] h-[20px] rounded-[6px] bg-primary/12 text-primary items-center justify-center">
             <Sparkles size={12} />
           </span>
-          <span className="text-caption font-semibold text-mf-text-3 uppercase" style={{ letterSpacing: '0.5px' }}>
+          <span className="text-caption font-medium text-muted-foreground">
             Step {idx + 1} of {total}
           </span>
         </div>
@@ -89,7 +89,7 @@ export function WsTourLabel({ step, idx, total, onBack, onNext, style }: WsTourL
           <button
             data-testid="tour-next-btn"
             onClick={onNext}
-            className="h-[28px] px-[14px] rounded-[8px] bg-primary text-white text-label font-semibold"
+            className="h-[28px] px-[14px] rounded-[8px] bg-primary text-primary-foreground text-label font-semibold"
           >
             {isLast ? 'Done' : 'Next'}
           </button>

--- a/packages/ui/src/layout/FilesTabStrip.tsx
+++ b/packages/ui/src/layout/FilesTabStrip.tsx
@@ -39,13 +39,13 @@ function tabGlyph(tab: EditorTabModel, isActive: boolean) {
 
   if (tab.kind === 'diff') {
     const color = isActive ? 'text-mf-accent-amber' : 'text-mf-text-3';
-    return <GitCompare size={11} className={`flex-shrink-0 ${color}`} />;
+    return <GitCompare size={12} className={`flex-shrink-0 ${color}`} />;
   }
   if (tab.kind === 'code') {
-    return <Code2 size={11} className={cls} />;
+    return <Code2 size={12} className={cls} />;
   }
   // viewer / unknown
-  return <FileText size={11} className={cls} />;
+  return <FileText size={12} className={cls} />;
 }
 
 // ── Single tab pill ──────────────────────────────────────────────────────────
@@ -70,7 +70,7 @@ function TabPill({ tab, isActive, onActivate, onClose, onPromote }: TabPillProps
         'rounded-[7px] tracking-tight transition-colors duration-[120ms]',
         isActive
           ? 'bg-mf-chip font-semibold text-foreground'
-          : 'font-medium text-mf-text-3 hover:bg-accent hover:text-foreground',
+          : 'font-medium text-muted-foreground hover:bg-accent hover:text-foreground',
       ].join(' ')}
       onClick={() => onActivate(tab.id)}
       onDoubleClick={() => onPromote(tab.id)}
@@ -104,7 +104,7 @@ function TabPill({ tab, isActive, onActivate, onClose, onPromote }: TabPillProps
             onClose(tab.id);
           }}
         >
-          <X size={9} />
+          <X size={12} />
         </button>
       </Hint>
     </div>
@@ -142,7 +142,7 @@ export function FilesTabStrip() {
 
       {/* Surface icon */}
       <div className="flex-shrink-0 px-[4px]">
-        <EditorGlyph size={11} className="text-mf-surface-files" />
+        <EditorGlyph size={12} className="text-mf-surface-files" />
       </div>
 
       {/* Tab pills */}
@@ -167,7 +167,7 @@ export function FilesTabStrip() {
           onClick={() => emitSurfaceIntent({ type: 'open-file-picker' })}
           className={`${ACTION_BTN} ml-0.5`}
         >
-          <Plus size={11} className="text-mf-text-3" />
+          <Plus size={12} className="text-mf-text-3" />
         </button>
       </Hint>
 

--- a/packages/ui/src/layout/MainToolbar.tsx
+++ b/packages/ui/src/layout/MainToolbar.tsx
@@ -33,7 +33,7 @@ const ICON_BTN =
   'inline-flex h-[24px] w-[28px] flex-shrink-0 items-center justify-center rounded-[6px] border-none bg-transparent text-muted-foreground cursor-pointer transition-[background] duration-[120ms] hover:bg-accent';
 
 const CHIP_BASE =
-  'inline-flex h-[22px] min-w-0 max-w-[230px] items-center gap-[5px] rounded-[6px] border-[0.5px] border-solid px-[6px] font-mono text-caption font-normal';
+  'inline-flex h-[22px] min-w-0 max-w-[230px] items-center gap-[5px] rounded-[6px] border-[0.5px] border-solid px-[6px] font-mono text-label font-normal';
 
 /**
  * Worktree vs main-repo chip styling — mirrors the Workspace Surfaces artboard
@@ -53,20 +53,20 @@ function BranchChipContent({ branch, isWorktree }: { branch: string; isWorktree:
   return (
     <>
       {isWorktree ? (
-        <GitFork size={11} className="flex-shrink-0 text-primary" />
+        <GitFork size={12} className="flex-shrink-0 text-primary" />
       ) : (
-        <GitBranch size={11} className="flex-shrink-0 text-mf-text-3" />
+        <GitBranch size={12} className="flex-shrink-0 text-mf-text-3" />
       )}
       <span className="truncate">{branch}</span>
       {isWorktree && (
         <span
           data-testid="main-toolbar-branch-wt"
-          className="ml-[1px] inline-flex h-[14px] flex-shrink-0 items-center rounded-[4px] bg-primary/12 px-[5px] text-micro font-semibold uppercase tracking-wide text-primary"
+          className="ml-[1px] inline-flex h-[14px] flex-shrink-0 items-center rounded-[4px] bg-primary/12 px-[5px] text-caption font-semibold uppercase tracking-wide text-primary"
         >
           wt
         </span>
       )}
-      <ChevronDown size={8} className="flex-shrink-0 text-mf-text-4" />
+      <ChevronDown size={12} className="flex-shrink-0 text-mf-text-3" />
     </>
   );
 }

--- a/packages/ui/src/layout/RunTabPill.tsx
+++ b/packages/ui/src/layout/RunTabPill.tsx
@@ -28,10 +28,10 @@ function tabGlyph(tab: RunTab, isActive: boolean) {
         ? 'text-mf-surface-run'
         : 'text-foreground';
   const cls = `flex-shrink-0 ${color}`;
-  if (tab.kind === 'preview') return <Eye size={11} className={cls} />;
-  if (tab.kind === 'console') return <SquareTerminal size={11} className={cls} />;
-  if (tab.kind === 'terminal') return <Terminal size={11} className={cls} />;
-  return <FileText size={11} className={cls} />;
+  if (tab.kind === 'preview') return <Eye size={12} className={cls} />;
+  if (tab.kind === 'console') return <SquareTerminal size={12} className={cls} />;
+  if (tab.kind === 'terminal') return <Terminal size={12} className={cls} />;
+  return <FileText size={12} className={cls} />;
 }
 
 interface RunTabPillProps {
@@ -63,7 +63,7 @@ export function RunTabPill({ pane, tab, configs, scopeStatuses, onStop }: RunTab
         'rounded-[7px] tracking-tight transition-colors duration-[120ms]',
         isActive
           ? 'bg-mf-chip font-semibold text-foreground'
-          : 'font-medium text-mf-text-3 hover:bg-accent hover:text-foreground',
+          : 'font-medium text-muted-foreground hover:bg-accent hover:text-foreground',
       ].join(' ')}
     >
       {tabGlyph(tab, isActive)}
@@ -81,7 +81,7 @@ export function RunTabPill({ pane, tab, configs, scopeStatuses, onStop }: RunTab
               onStop(config);
             }}
           >
-            <Square size={9} className="text-destructive" fill="currentColor" />
+            <Square size={12} className="text-destructive" fill="currentColor" />
           </button>
         </Hint>
       )}
@@ -95,7 +95,7 @@ export function RunTabPill({ pane, tab, configs, scopeStatuses, onStop }: RunTab
             closeRunTab(pane.id, tab.id);
           }}
         >
-          <X size={9} />
+          <X size={12} />
         </button>
       </Hint>
     </div>

--- a/packages/ui/src/layout/RunTabStrip.tsx
+++ b/packages/ui/src/layout/RunTabStrip.tsx
@@ -57,7 +57,7 @@ function RunAddMenu({ paneId, configs, onLaunch }: RunAddMenuProps) {
             type="button"
             className={`${ACTION_BTN} ml-0.5 data-[state=open]:bg-mf-chip`}
           >
-            <Plus size={11} className="text-mf-text-3" />
+            <Plus size={12} className="text-mf-text-3" />
           </button>
         </PopoverTrigger>
       </Hint>
@@ -135,7 +135,7 @@ export function RunTabStrip({ pane, primary }: { pane: RunPane; primary: boolean
       )}
 
       <div className={`flex-shrink-0 ${primary ? 'px-[4px]' : 'pl-[10px] pr-[4px]'}`}>
-        <Play size={11} className="text-mf-surface-run" fill="currentColor" />
+        <Play size={12} className="text-mf-surface-run" fill="currentColor" />
       </div>
 
       <div className="flex h-full min-w-0 flex-initial items-center gap-[2px] overflow-x-auto pr-[2px] [scrollbar-width:none]">

--- a/packages/ui/src/layout/SidebarFooter.tsx
+++ b/packages/ui/src/layout/SidebarFooter.tsx
@@ -8,14 +8,14 @@ import { DaemonFooterStatus } from '@/features/daemon/DaemonFooterStatus';
 const COUNT_META: { key: keyof BaseStatusCounts; label: string; dot: string; text: string }[] = [
   { key: 'working', label: 'Working', dot: 'bg-primary animate-pulse', text: 'text-primary' },
   { key: 'waiting', label: 'Waiting for you', dot: 'bg-mf-warning', text: 'text-mf-warning' },
-  { key: 'idle', label: 'Idle', dot: 'bg-mf-text-4', text: 'text-mf-text-3' },
+  { key: 'idle', label: 'Idle', dot: 'bg-mf-text-4', text: 'text-muted-foreground' },
 ];
 
 export function SidebarFooterView({ counts }: { counts: BaseStatusCounts }) {
   return (
     <div
       data-testid="sidebar-footer"
-      className="flex h-[25px] flex-shrink-0 items-center gap-2 px-[12px] text-micro text-mf-text-3"
+      className="flex h-[25px] flex-shrink-0 items-center gap-2 px-[12px] text-caption text-muted-foreground"
     >
       <DaemonFooterStatus />
       <span className="flex-1" />

--- a/packages/ui/src/layout/SurfacePicker.tsx
+++ b/packages/ui/src/layout/SurfacePicker.tsx
@@ -30,8 +30,8 @@ function PickerRow({ testid, icon, label, hint, chevron, onClick, disabled, titl
     >
       {icon}
       <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{label}</span>
-      {hint && <span className="flex-shrink-0 font-mono text-micro text-mf-text-4">{hint}</span>}
-      {chevron && <ChevronRight size={10} className="flex-shrink-0 text-mf-text-4" />}
+      {hint && <span className="flex-shrink-0 font-mono text-caption text-muted-foreground">{hint}</span>}
+      {chevron && <ChevronRight size={12} className="flex-shrink-0 text-mf-text-3" />}
     </button>
   );
 }
@@ -126,7 +126,7 @@ export function SurfacePicker({ surface }: Props) {
         <div className="max-h-[300px] overflow-y-auto p-[4px]">
           {surface === 'files' ? <FilesPickerContent /> : <RunPickerContent />}
         </div>
-        <div className="[border-top:0.5px_solid_var(--border)] px-3.5 py-[7px] font-mono text-micro text-mf-text-4">
+        <div className="[border-top:0.5px_solid_var(--border)] px-3.5 py-[7px] font-mono text-caption text-muted-foreground">
           {surface === 'files' ? 'opens route here automatically' : 'spawns a running surface'}
         </div>
       </div>

--- a/packages/ui/src/layout/SurfaceRail.tsx
+++ b/packages/ui/src/layout/SurfaceRail.tsx
@@ -46,7 +46,7 @@ export function SurfaceRail() {
                 .filter(Boolean)
                 .join(' ')}
             >
-              <Icon size={12} className={on ? activeColor : 'text-mf-text-4'} />
+              <Icon size={12} className={on ? activeColor : 'text-mf-text-3'} />
             </button>
           </Hint>
         );

--- a/packages/ui/src/layout/UpdatePill.tsx
+++ b/packages/ui/src/layout/UpdatePill.tsx
@@ -52,9 +52,9 @@ export function UpdatePill() {
       type="button"
       onClick={handleClick}
       disabled={status.state === 'downloading'}
-      className="inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] bg-primary/[0.08] px-2.5 text-caption font-semibold tracking-normal text-primary transition-colors hover:bg-primary/[0.14] disabled:cursor-default"
+      className="inline-flex h-[22px] shrink-0 items-center gap-[5px] rounded-[11px] bg-primary/[0.08] px-2.5 text-label font-semibold tracking-normal text-primary transition-colors hover:bg-primary/[0.14] disabled:cursor-default"
     >
-      <Download className="size-[11px]" aria-hidden />
+      <Download className="size-[12px]" aria-hidden />
       <span>{label}</span>
     </button>
   );

--- a/packages/ui/src/layout/__tests__/SidebarFooter.test.tsx
+++ b/packages/ui/src/layout/__tests__/SidebarFooter.test.tsx
@@ -194,7 +194,7 @@ describe('SidebarFooter — design-parity findings 1.7/1.10/1.11/1.12', () => {
     expect(waitingCount.className).toContain('font-semibold');
   });
 
-  it('idle count digit carries text-mf-text-3 + font-semibold (finding 1.12)', () => {
+  it('idle count digit carries a legible muted-foreground + font-semibold', () => {
     render(
       <SidebarFooterView
         counts={{ 'worktree-missing': 0, 'transcript-missing': 0, working: 0, waiting: 0, idle: 1 }}
@@ -204,7 +204,7 @@ describe('SidebarFooter — design-parity findings 1.7/1.10/1.11/1.12', () => {
       },
     );
     const idleCount = screen.getByTestId('sidebar-footer-count-idle');
-    expect(idleCount.className).toContain('text-mf-text-3');
+    expect(idleCount.className).toContain('text-muted-foreground');
     expect(idleCount.className).toContain('font-semibold');
   });
 });

--- a/packages/ui/src/store/__tests__/theme.test.ts
+++ b/packages/ui/src/store/__tests__/theme.test.ts
@@ -173,10 +173,10 @@ describe('theme store — uiScale axis', () => {
     expect(setZoomMock).toHaveBeenCalledWith(UI_SCALE_FACTORS.large);
   });
 
-  it('applyStoredScale calls host.setZoom with 1 for compact', async () => {
+  it('applyStoredScale calls host.setZoom with the compact factor', async () => {
     localStorage.setItem('mf-ui-scale', 'compact');
-    const { applyStoredScale } = await import('../theme');
+    const { applyStoredScale, UI_SCALE_FACTORS } = await import('../theme');
     applyStoredScale();
-    expect(setZoomMock).toHaveBeenCalledWith(1);
+    expect(setZoomMock).toHaveBeenCalledWith(UI_SCALE_FACTORS.compact);
   });
 });

--- a/packages/ui/src/store/theme.ts
+++ b/packages/ui/src/store/theme.ts
@@ -15,11 +15,13 @@ const SCHEMES: readonly ColorScheme[] = ['classic', 'ocean', 'velvet'];
 const WINDOW_STYLES: readonly WindowStyle[] = ['unified', 'split', 'glass'];
 const UI_SCALES: readonly UiScale[] = ['compact', 'normal', 'large'];
 
-/** Provisional — tuned so Normal dominant text ≈ 13px, Large ≈ 15px. */
+/** Native page-zoom factors. Normal is crisp un-zoomed (dominant text = the raw
+ *  13px body token); Compact/Large nudge the whole surface so dominant text
+ *  reads ≈ 12 / 13 / 15 px across compact / normal / large. */
 export const UI_SCALE_FACTORS: Record<UiScale, number> = {
-  compact: 1,
-  normal: 1.15,
-  large: 1.3,
+  compact: 0.92,
+  normal: 1.0,
+  large: 1.15,
 };
 
 function readMode(): ThemeMode {

--- a/packages/ui/src/styles/__tests__/contrast.test.ts
+++ b/packages/ui/src/styles/__tests__/contrast.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+/**
+ * Contrast guardrail — the CI encoding of the typography/legibility audit
+ * (docs/architecture/2026-07-11-typography-legibility-audit.md §7).
+ *
+ * Parses the six appearance blocks in globals.css, resolves each token through
+ * the real cascade (ocean/velvet LIGHT inherit `--background` from :root, dark
+ * blocks layer `.dark` under the scheme selector), composites alpha inks over
+ * their true backdrops, and asserts the WCAG floors the Foundation values were
+ * solved to. If a future token re-tint regresses below 4.5:1 this test fails
+ * before it ships.
+ *
+ * mf-text-3 was solved to *exactly* 4.5:1 worst-case (light glass), so the
+ * threshold is 4.49 to absorb float noise rather than flake on the boundary.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const WCAG_MIN = 4.49;
+
+const css = readFileSync(new URL('../globals.css', import.meta.url), 'utf8');
+
+type Decls = Record<string, string>;
+
+/** Parse every top-level rule into { selector -> { --token: value } }, comments stripped. */
+function parseRules(source: string): Map<string, Decls> {
+  const clean = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rules = new Map<string, Decls>();
+  let depth = 0;
+  let buf = '';
+  let selector = '';
+  for (const ch of clean) {
+    if (ch === '{') {
+      // A top-level rule's selector is the text after any preceding statement
+      // terminator (e.g. the leading `@import "tailwindcss";` before `:root`).
+      if (depth === 0) selector = buf.split(';').pop()!.trim().replace(/\s+/g, ' ');
+      depth += 1;
+      buf = '';
+      continue;
+    }
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        const decls: Decls = {};
+        for (const stmt of buf.split(';')) {
+          const m = stmt.match(/^\s*(--[a-z0-9-]+)\s*:\s*(.+?)\s*$/i);
+          if (m) decls[m[1]!] = m[2]!.trim();
+        }
+        const prev = rules.get(selector) ?? {};
+        rules.set(selector, { ...prev, ...decls });
+      }
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  return rules;
+}
+
+const rules = parseRules(css);
+
+/** Cascade layering per theme (later selectors win); mirrors the globals.css header. */
+const THEMES: Record<string, string[]> = {
+  'classic-light': [':root'],
+  'classic-dark': [':root', '.dark'],
+  'ocean-light': [':root', '[data-scheme="ocean"]'],
+  'ocean-dark': [':root', '.dark', '[data-scheme="ocean"]', '.dark[data-scheme="ocean"]'],
+  'velvet-light': [':root', '[data-scheme="velvet"]'],
+  'velvet-dark': [':root', '.dark', '[data-scheme="velvet"]', '.dark[data-scheme="velvet"]'],
+};
+
+function resolve(theme: string): Decls {
+  const layers = THEMES[theme];
+  if (!layers) throw new Error(`unknown theme "${theme}"`);
+  const out: Decls = {};
+  for (const sel of layers) {
+    const decls = rules.get(sel);
+    if (!decls) throw new Error(`missing block for selector "${sel}" (theme ${theme})`);
+    Object.assign(out, decls);
+  }
+  return out;
+}
+
+/** Read a required token, failing loudly if a re-tint dropped it. */
+function req(t: Decls, token: string): string {
+  const v = t[token];
+  if (v === undefined) throw new Error(`missing token ${token}`);
+  return v;
+}
+
+type RGBA = { r: number; g: number; b: number; a: number };
+
+function parseColor(value: string): RGBA {
+  const hex = value.match(/^#([0-9a-f]{6})$/i);
+  if (hex) {
+    const n = parseInt(hex[1]!, 16);
+    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255, a: 1 };
+  }
+  const rgba = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)$/i);
+  if (rgba) {
+    return { r: +rgba[1]!, g: +rgba[2]!, b: +rgba[3]!, a: rgba[4] === undefined ? 1 : +rgba[4] };
+  }
+  throw new Error(`unsupported color value: "${value}"`);
+}
+
+/** Composite a (possibly translucent) foreground color over an opaque backdrop. */
+function composite(fg: RGBA, bg: RGBA): RGBA {
+  return {
+    r: fg.r * fg.a + bg.r * (1 - fg.a),
+    g: fg.g * fg.a + bg.g * (1 - fg.a),
+    b: fg.b * fg.a + bg.b * (1 - fg.a),
+    a: 1,
+  };
+}
+
+function srgbToLinear(c: number): number {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance({ r, g, b }: RGBA): number {
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+function contrast(a: RGBA, b: RGBA): number {
+  const l1 = relativeLuminance(a);
+  const l2 = relativeLuminance(b);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** The three backdrops every readable ink is checked against. */
+function backdrops(t: Decls): Record<string, RGBA> {
+  const glass = composite(parseColor(req(t, '--mf-glass')), parseColor(req(t, '--mf-window')));
+  return {
+    glass,
+    background: parseColor(req(t, '--background')),
+    card: parseColor(req(t, '--card')),
+  };
+}
+
+const ALL = Object.keys(THEMES);
+const LIGHT = ALL.filter((t) => t.endsWith('-light'));
+
+describe('globals.css contrast guardrail', () => {
+  it.each(ALL)('muted-foreground clears 4.5:1 on glass/background/card — %s', (theme) => {
+    const t = resolve(theme);
+    const ink = parseColor(req(t, '--muted-foreground'));
+    for (const [name, bg] of Object.entries(backdrops(t))) {
+      expect(contrast(ink, bg), `muted-foreground on ${name} (${theme})`).toBeGreaterThanOrEqual(WCAG_MIN);
+    }
+  });
+
+  it.each(ALL)('mf-text-3 clears 4.5:1 on glass/background/card — %s', (theme) => {
+    const t = resolve(theme);
+    const ink = parseColor(req(t, '--mf-text-3'));
+    for (const [name, bg] of Object.entries(backdrops(t))) {
+      expect(contrast(ink, bg), `mf-text-3 on ${name} (${theme})`).toBeGreaterThanOrEqual(WCAG_MIN);
+    }
+  });
+
+  it.each(LIGHT)('mf-success/mf-warning clear 4.5:1 as text on background — %s', (theme) => {
+    const t = resolve(theme);
+    const bg = parseColor(req(t, '--background'));
+    expect(
+      contrast(parseColor(req(t, '--mf-success')), bg),
+      `mf-success on background (${theme})`,
+    ).toBeGreaterThanOrEqual(WCAG_MIN);
+    expect(
+      contrast(parseColor(req(t, '--mf-warning')), bg),
+      `mf-warning on background (${theme})`,
+    ).toBeGreaterThanOrEqual(WCAG_MIN);
+  });
+
+  it('resolves ocean/velvet light background by inheritance from :root', () => {
+    // Guards the cascade model itself: these blocks do NOT redeclare --background.
+    expect(resolve('ocean-light')['--background']).toBe('#ffffff');
+    expect(resolve('velvet-light')['--background']).toBe('#ffffff');
+  });
+});

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -54,7 +54,7 @@
   --mf-raised: #f3efe7;
   --mf-tab-bar: #f3f0ea;
   --mf-tab-active: #ffffff;
-  --mf-text-3: #92918d;
+  --mf-text-3: #6c6b68;
   --mf-text-4: #bcbab5;
   --mf-chip: rgba(0,0,0,0.05);
   --mf-selection: rgba(10,132,255,0.10);
@@ -62,8 +62,8 @@
      editor-search convention), defined once in :root; no scheme overrides them. */
   --mf-find-tint: rgba(251,191,36,0.32);
   --mf-find-active: rgba(251,146,60,0.60);
-  --mf-warning: #d97706;
-  --mf-success: #28a745;
+  --mf-warning: #a15804;
+  --mf-success: #1d7b33;
 
   /* Editor syntax — Xcode-ish on warm paper */
   --mf-code-bg: #fbfaf7;
@@ -244,7 +244,7 @@
   --mf-raised: #313447;
   --mf-tab-bar: #21232e;
   --mf-tab-active: #373a4d;
-  --mf-text-3: #7d8099;
+  --mf-text-3: #8b8ea4;
   --mf-text-4: #555870;
   --mf-chip: rgba(255,255,255,0.07);
   --mf-selection: rgba(138,112,245,0.30);
@@ -301,6 +301,27 @@
   --mf-tool-web: #2bd6c2;
   --mf-tool-web-tint: rgba(43, 214, 194, 0.14);
   --mf-code-inline-fg: #e0a878;
+
+  /* Semantic hue overrides for dark cards. The task-type/priority/auto glyph +
+     tint-foreground colors are declared once in :root at light-tuned L; on dark
+     surfaces they clip, so lighten L (hue/sat preserved) to ~4.5:1 on the
+     darkest card. Design-constant across schemes → identical in all 3 dark
+     blocks. Icon/tint use only, never body text. medium/low priority dots
+     already pass on dark and stay inherited. */
+  --mf-task-type-bug: #e17a76;
+  --mf-task-type-enhancement: #a982f7;
+  --mf-task-type-question: #d38810;
+  --mf-task-type-duplicate: #f3721b;
+  --mf-priority-critical: #e17a76;
+  --mf-priority-high: #f3721b;
+  --mf-priority-medium: #d2890f;
+  --mf-priority-critical-dot: #e17a76;
+  --mf-priority-high-dot: #ef770f;
+  --mf-auto-violet: #ac8bc6;
+  --mf-auto-kind-question: #f3721b;
+  --mf-auto-kind-loop: #27ad72;
+  --mf-auto-kind-parallel: #ec771b;
+  --mf-auto-kind-call: #6798e5;
 
   --mf-shadow-panel: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.22);
   --mf-shadow-panel-soft: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.18);
@@ -361,12 +382,12 @@
   --mf-raised: #eaf1f1;
   --mf-tab-bar: #edf3f4;
   --mf-tab-active: #ffffff;
-  --mf-text-3: #89989d;
+  --mf-text-3: #5f6d72;
   --mf-text-4: #b6c3c7;
   --mf-chip: rgba(10,50,55,0.05);
   --mf-selection: rgba(14,152,136,0.11);
-  --mf-warning: #c07a12;
-  --mf-success: #1e9e58;
+  --mf-warning: #955f0e;
+  --mf-success: #177a44;
 
   --mf-code-bg: #f6fafa;
   --mf-code-fg: #1d262b;
@@ -455,7 +476,7 @@
   --mf-raised: #2a3545;
   --mf-tab-bar: #1b222e;
   --mf-tab-active: #303d4f;
-  --mf-text-3: #76869b;
+  --mf-text-3: #7e8da1;
   --mf-text-4: #4d5a6b;
   --mf-chip: rgba(255,255,255,0.07);
   --mf-selection: rgba(47,198,183,0.26);
@@ -510,6 +531,24 @@
   --mf-tool-web: #2fc6b7;
   --mf-tool-web-tint: rgba(47, 198, 183, 0.14);
   --mf-code-inline-fg: #e0a878;
+
+  /* Semantic hue overrides for dark cards (see classic-dark block for rationale) —
+     design-constant, identical across all 3 dark blocks. */
+  --mf-task-type-bug: #e17a76;
+  --mf-task-type-enhancement: #a982f7;
+  --mf-task-type-question: #d38810;
+  --mf-task-type-duplicate: #f3721b;
+  --mf-priority-critical: #e17a76;
+  --mf-priority-high: #f3721b;
+  --mf-priority-medium: #d2890f;
+  --mf-priority-critical-dot: #e17a76;
+  --mf-priority-high-dot: #ef770f;
+  --mf-auto-violet: #ac8bc6;
+  --mf-auto-kind-question: #f3721b;
+  --mf-auto-kind-loop: #27ad72;
+  --mf-auto-kind-parallel: #ec771b;
+  --mf-auto-kind-call: #6798e5;
+
   --mf-shadow-panel: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.22);
   --mf-shadow-panel-soft: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.18);
   --mf-shadow-panel-ambient: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.18), 0 6px 18px rgba(0, 0, 0, 0.22);
@@ -561,12 +600,12 @@
   --mf-raised: #f3ecf3;
   --mf-tab-bar: #f2edf2;
   --mf-tab-active: #ffffff;
-  --mf-text-3: #94899c;
+  --mf-text-3: #72677b;
   --mf-text-4: #c0b6c6;
   --mf-chip: rgba(70,20,60,0.05);
   --mf-selection: rgba(214,72,143,0.10);
-  --mf-warning: #c0741f;
-  --mf-success: #1f9e54;
+  --mf-warning: #9a5d19;
+  --mf-success: #187b41;
 
   --mf-code-bg: #fbf8fb;
   --mf-code-fg: #271d2e;
@@ -653,7 +692,7 @@
   --mf-raised: #382c48;
   --mf-tab-bar: #251d30;
   --mf-tab-active: #3d2f4f;
-  --mf-text-3: #877b97;
+  --mf-text-3: #9287a1;
   --mf-text-4: #594f6a;
   --mf-chip: rgba(255,255,255,0.07);
   --mf-selection: rgba(240,107,179,0.24);
@@ -708,6 +747,24 @@
   --mf-tool-web: #2bd6c2;
   --mf-tool-web-tint: rgba(43, 214, 194, 0.14);
   --mf-code-inline-fg: #e0a878;
+
+  /* Semantic hue overrides for dark cards (see classic-dark block for rationale) —
+     design-constant, identical across all 3 dark blocks. */
+  --mf-task-type-bug: #e17a76;
+  --mf-task-type-enhancement: #a982f7;
+  --mf-task-type-question: #d38810;
+  --mf-task-type-duplicate: #f3721b;
+  --mf-priority-critical: #e17a76;
+  --mf-priority-high: #f3721b;
+  --mf-priority-medium: #d2890f;
+  --mf-priority-critical-dot: #e17a76;
+  --mf-priority-high-dot: #ef770f;
+  --mf-auto-violet: #ac8bc6;
+  --mf-auto-kind-question: #f3721b;
+  --mf-auto-kind-loop: #27ad72;
+  --mf-auto-kind-parallel: #ec771b;
+  --mf-auto-kind-call: #6798e5;
+
   --mf-shadow-panel: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.22);
   --mf-shadow-panel-soft: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.18);
   --mf-shadow-panel-ambient: 0 0 0 0.5px var(--border), 0 1px 2px rgba(0, 0, 0, 0.18), 0 6px 18px rgba(0, 0, 0, 0.22);
@@ -854,6 +911,17 @@
   --text-title: 1.0625rem;   /* 17px */
   --text-display: 1.375rem;  /* 22px */
   --text-hero: 1.75rem;      /* 28px */
+
+  /* Paired leading (Tailwind v4 --text-<name>--line-height): looser for body
+     copy, tighter for large display rungs. */
+  --text-micro--line-height: 1.3;
+  --text-caption--line-height: 1.35;
+  --text-label--line-height: 1.4;
+  --text-body--line-height: 1.5;
+  --text-heading--line-height: 1.3;
+  --text-title--line-height: 1.25;
+  --text-display--line-height: 1.2;
+  --text-hero--line-height: 1.15;
 
   /* Letter spacing + line-height */
   --tracking-tight: -0.02em;


### PR DESCRIPTION
## Summary

Applies the 2026-07-11 typography/legibility audit of `packages/ui` — root-cause fixes, not per-site patches. The trigger was the project-picker pills (barely readable in compact mode, an effectively invisible count badge) and session rows reading as black/washed-black instead of a macOS-style label hierarchy. A full static audit + measured WCAG math found these were instances of a handful of systemic causes.

Design decisions (chosen up-front): all phases in one branch · Finder-style **neutral-fill** row selection · **capsule-less gray** counts · **sentence-case muted** eyebrows · `mf-text-4` ornament-only · re-anchor scale factors.

## What changed

**Foundation (tokens + scale)**
- Re-tint `mf-text-3` / `mf-success` / `mf-warning` across all six themes to clear WCAG 4.5:1 (hue preserved). `mf-text-3` was failing 2.5–4.4:1 everywhere; `mf-text-4` (1.5–2.3:1) is reclassified as ornament-only.
- Add paired `--text-*--line-height` tokens and dark-theme overrides for the fixed semantic hues.
- Re-anchor `UI_SCALE_FACTORS` to **0.92 / 1.0 / 1.15** so normal renders a crisp un-zoomed 13px and compact stays legible.

**Shared primitives**
- Fix `button.tsx`'s `[&_svg]:size-4` (rendered 8px on the compressed spacing scale *and* overrode child sizes) → 14px default that respects overrides.
- Menu/dropdown/command/context eyebrows → sentence-case `caption` `muted-foreground` (drops 10px bold-uppercase-tracking on failing gray). Tooltip `caption`→`label`.
- New `CountBadge` (capsule-less counts) and `SectionHeader` primitives, with tests.

**Sweep (12 clusters)**
- Promote must-read text off 10–11px; move semantic hues off text onto icons/tints; replace the invisible white-on-accent count badges; give session-row selection a macOS-style neutral fill; normalize meaningful icons onto a 12/14/16 grid (fixing several `size-3`=6px / `size-4`=8px traps and two icons that were larger than their box).

**Guardrail**
- New `src/styles/__tests__/contrast.test.ts` parses `globals.css`, composites the real backdrops, and fails CI if any re-tint drops a readable ink below 4.5:1 across the six themes.

## Verification

- **Typecheck:** clean.
- **Tests:** 4642 UI tests pass. Six tests had pinned the old buggy values (uppercase eyebrows, `compact:1`, `mf-text-3` idle count, `opacity-50` idle glyph) and were updated to assert the corrected behavior.
- **Contrast guardrail:** green on all six themes.
- **Live render:** verified in-browser against the daemon in light + dark — idle glyph now computes to the exact solved per-theme value at full opacity, metadata is `muted-foreground`, pills are `text-label`, selection is a rounded neutral fill. No console errors, no layout regressions.

## Notes for review

- ~190 files, +743/−711 — token/size swaps, no structural changes; `data-testid`s preserved.
- Docs: `docs/architecture/2026-07-11-typography-legibility-{audit,findings}.md` carry the full diagnosis + per-file worklist.
- The native page-zoom re-anchor (compact/normal/large) is covered by the unit test; it can't be exercised in browser dev mode (it's a Tauri/Electron host call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)