### PR TITLE
fix(app-tauri): stop WKWebView from caching stale frontend assets across updates

### DIFF
--- a/.changeset/webview-stale-asset-cache.md
+++ b/.changeset/webview-stale-asset-cache.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix stale frontend assets surviving app updates (root cause behind the "still broken" scrollbar reports on #438/#443/#446).
+
+Tauri's asset protocol sends no `Cache-Control`/`ETag`/`Last-Modified` headers, and since the `tauri://` origin never changes between app versions, WKWebView's disk cache could keep serving `index.html` and its referenced JS/CSS from a pre-update session after an in-place update — with no way to tell it was stale. Three separate scrollbar-CSS fixes shipped correctly but kept getting masked by this. The main window is now built manually (`"create": false` in config) with `on_web_resource_request` attaching `Cache-Control: no-store` to every asset response, so each request always hits the current bundle.

--- a/packages/app-tauri/src-tauri/src/lib.rs
+++ b/packages/app-tauri/src-tauri/src/lib.rs
@@ -136,6 +136,25 @@ pub fn run() {
             daemon_impl::daemon_impl_set,
         ])
         .setup(move |app| {
+            // Build the main window ourselves (config has `"create": false`) so we can
+            // attach `on_web_resource_request`. Tauri's asset protocol sends no
+            // Cache-Control/ETag/Last-Modified headers, and WKWebView's disk cache can
+            // keep serving bytes from a pre-update session across an in-place app
+            // update because the tauri:// origin never changes — a version bump alone
+            // doesn't invalidate it. `no-store` forces every asset request to hit the
+            // current bundle, at effectively zero cost since these are local reads.
+            let window_config = app.config().app.windows[0].clone();
+            tauri::WebviewWindowBuilder::from_config(app.handle(), &window_config)
+                .expect("invalid main window config")
+                .on_web_resource_request(|_request, response| {
+                    response.headers_mut().insert(
+                        tauri::http::header::CACHE_CONTROL,
+                        tauri::http::HeaderValue::from_static("no-store"),
+                    );
+                })
+                .build()
+                .expect("failed to create main window");
+
             // Build + set the native application menu. Errors are logged and the
             // app continues without a menu rather than panicking (degrade gracefully).
             match menu::build_menu(app.handle()) {

--- a/packages/app-tauri/src-tauri/tauri.conf.json
+++ b/packages/app-tauri/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
     "windows": [
       {
         "label": "main",
+        "create": false,
         "title": "Mainframe",
         "width": 1400,
         "height": 900,


### PR DESCRIPTION
## The bug

#446 ("still broken" per live report against rc.6) was the third scrollbar-CSS fix in a row (#438, #443, #446) — each one shipped genuinely correct CSS (verified: the rc.6 release build embeds byte-identical, correct CSS to what's on `main`), yet the packaged app kept showing the old native scrollbar. `tauri:dev` never reproduced it.

Root cause: Tauri's built-in `tauri://` asset protocol response builder sets no `Cache-Control`, `ETag`, or `Last-Modified` header on any response (verified against the `tauri` crate source, `protocol/tauri.rs`). Since that origin is static across every app version, WKWebView's disk cache had nothing telling it a new version invalidates old entries — an in-place update could leave the webview still serving `index.html` (and the JS/CSS it references) from a pre-update session indefinitely, surviving relaunches. Confirmed live: the production app's `~/Library/Caches/ro.qlan.mainframe/WebKit/NetworkCache` held entries spanning rc.5 through rc.6+ without ever being invalidated.

This is a real Tauri gotcha, not specific to the scrollbar CSS — any future frontend-only fix was equally at risk of being silently masked the same way.

## The fix

The main window is now built manually in `.setup()` (`tauri.conf.json` sets `"create": false` on it) with `on_web_resource_request` attaching `Cache-Control: no-store` to every asset response, so the webview always fetches from the current bundle. `no-store` is effectively free here since these are local reads, not real network round-trips.

## Verification

- `cargo check --features mcp-bridge` clean.
- Built a debug-profile bundle using the real embedded-asset code path (same as release, `tauri://` origin) with the mcp-bridge feature for inspection (release builds never ship the bridge). Via the debug bridge, confirmed live:
  - `fetch('tauri://localhost/index.html')` → `Cache-Control: no-store`
  - `fetch(cssAssetUrl)` → `Cache-Control: no-store`
  - Scrollbar CSS still computes correctly (`scrollbar-width: thin`, transparent colors) — this change doesn't touch the actual scrollbar fix from #446, only cache headers.
- Confirmed dev mode (`tauri:dev`) is unaffected — it loads directly from the Vite dev server, bypassing this code path entirely, which is also why the bug never reproduced there.

Note: this does not retroactively clear caches already on a user's machine — that's pre-existing state, not this change's job. It just guarantees no *future* update can get silently masked the same way. Existing installs self-heal once they update past this fix (or after `~/Library/Caches/ro.qlan.mainframe/WebKit` is cleared once, manually).

## Test plan

- [ ] `cargo check --features mcp-bridge` passes
- [ ] `pnpm tauri:dev` still launches the main window normally (menu, mcp-bridge capability, daemon status all still wire up through the "main" label)
- [ ] A packaged build served a stale cached `index.html`/CSS before this fix, and does not after (spot-check via an in-place update over an old install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)