### PR TITLE
fix(codex): stop treating codex stderr as a fatal run error (#237)

### DIFF
--- a/.changeset/olive-buttons-repeat.md
+++ b/.changeset/olive-buttons-repeat.md
@@ -1,0 +1,14 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix Codex sessions failing to start when a configured MCP server needs authentication.
+
+The codex binary writes tracing logs to stderr as normal operation, and the adapter escalated
+every stderr line to a fatal run error. An unauthenticated remote MCP server makes codex log an
+`rmcp` ERROR on every startup, so each Codex session died instantly with "Agent run failed"
+while the underlying run was healthy.
+
+stderr is now treated as a log stream. Real failures still surface: an unexpected non-zero exit
+reports its code along with the tail of recent stderr, so genuine startup crashes keep their
+diagnostics.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/jsonrpc.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/jsonrpc.rs
@@ -23,6 +23,7 @@ use crate::types::{
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
 const STDERR_TAIL_LINES: usize = 20;
+const STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
@@ -144,6 +145,7 @@ impl JsonRpcClient {
         let close_notify = Arc::new(Notify::new());
         let kill_notify = Arc::new(Notify::new());
         let recent_stderr: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let saw_panic = Arc::new(AtomicBool::new(false));
         let handlers = Arc::new(handlers);
 
         let stdin = child.stdin.take();
@@ -198,14 +200,19 @@ impl JsonRpcClient {
         // every startup while the run proceeds fine. stderr is a log stream, never an error
         // channel: a real failure arrives as a JSON-RPC error or a non-zero exit (reported by
         // the exit watcher, which replays this tail as the reason).
-        if let Some(stderr) = stderr {
+        let stderr_reader = stderr.map(|stderr| {
             let recent_stderr = recent_stderr.clone();
+            let saw_panic = saw_panic.clone();
             tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     let message = line.trim();
                     if message.is_empty() {
                         continue;
+                    }
+
+                    if is_panic_line(message) {
+                        saw_panic.store(true, Ordering::SeqCst);
                     }
 
                     let mut tail = recent_stderr.lock().unwrap_or_else(|e| e.into_inner());
@@ -221,8 +228,8 @@ impl JsonRpcClient {
                         tracing::warn!(module = "codex:jsonrpc", stderr = message, "codex stderr");
                     }
                 }
-            });
-        }
+            })
+        });
 
         // Exit watcher — resolve on process exit (or an explicit kill request);
         // reject pending + fire close.
@@ -234,6 +241,7 @@ impl JsonRpcClient {
             let exited = exited.clone();
             let closed = closed.clone();
             let recent_stderr = recent_stderr.clone();
+            let saw_panic = saw_panic.clone();
             let handlers = handlers.clone();
             tokio::spawn(async move {
                 let code = tokio::select! {
@@ -248,8 +256,23 @@ impl JsonRpcClient {
                     &pending,
                     JsonRpcError(format!("Process exited with code {code:?}")),
                 );
-                if !closed.load(Ordering::SeqCst) && code.is_some_and(|c| c != 0) {
-                    let code = code.unwrap_or_default();
+
+                // `child.wait()` only means the PID is gone — the stderr pipe can still hold
+                // the very lines that say why (a panic backtrace). Let the reader drain to EOF
+                // before snapshotting the tail, bounded so a wedged pipe can't hang the exit.
+                if let Some(reader) = stderr_reader {
+                    let _ = tokio::time::timeout(STDERR_DRAIN_TIMEOUT, reader).await;
+                }
+
+                let panicked = saw_panic.load(Ordering::SeqCst);
+                let clean = code == Some(0) && !panicked;
+                if !closed.load(Ordering::SeqCst) && !clean {
+                    // A signal death (including an aborting panic) reports no code at all.
+                    let reason = match (code, panicked) {
+                        (Some(c), _) => format!("exited with code {c}"),
+                        (None, true) => "panicked".to_string(),
+                        (None, false) => "was killed by a signal".to_string(),
+                    };
                     let tail: Vec<String> = recent_stderr
                         .lock()
                         .unwrap_or_else(|e| e.into_inner())
@@ -257,9 +280,9 @@ impl JsonRpcClient {
                         .cloned()
                         .collect();
                     (handlers.on_error)(if tail.is_empty() {
-                        format!("codex exited with code {code}")
+                        format!("codex {reason}")
                     } else {
-                        format!("codex exited with code {code}:\n{}", tail.join("\n"))
+                        format!("codex {reason}:\n{}", tail.join("\n"))
                     });
                 }
                 for listener in close_listeners
@@ -453,25 +476,71 @@ fn reject_all_pending(pending: &Arc<Mutex<HashMap<RequestId, PendingTx>>>, err: 
     }
 }
 
+/// `2026-07-13T13:10:39.248771Z` — mirrors the TS `^\d{4}-\d{2}-\d{2}T[\d:.]+Z` prefix.
+fn is_rfc3339_prefix(ts: &str) -> bool {
+    let b = ts.as_bytes();
+    // yyyy-mm-ddT + at least one time char + Z
+    b.len() > 12
+        && b.ends_with(b"Z")
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[7] == b'-'
+        && b[8..10].iter().all(u8::is_ascii_digit)
+        && b[10] == b'T'
+        && b[11..b.len() - 1]
+            .iter()
+            .all(|c| c.is_ascii_digit() || *c == b':' || *c == b'.')
+}
+
 /// `<rfc3339> <LEVEL> <target>: <message>` — the codex binary's tracing format.
-/// Hand-rolled (no regex crate): a timestamp-shaped first token, then a level.
+/// Hand-rolled (no regex crate); kept in parity with `TRACING_LINE` in the TS adapter,
+/// which also requires something to follow the level.
 fn is_tracing_line(message: &str) -> bool {
     let mut parts = message.split_whitespace();
     let Some(ts) = parts.next() else {
         return false;
     };
-    if !ts.ends_with('Z') || !ts.starts_with(|c: char| c.is_ascii_digit()) || !ts.contains('T') {
+    if !is_rfc3339_prefix(ts) {
         return false;
     }
-    matches!(
+    if !matches!(
         parts.next(),
         Some("TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR")
-    )
+    ) {
+        return false;
+    }
+    parts.next().is_some()
+}
+
+/// The app-server discards panicked task handles and can still exit 0, so a panic is only
+/// detectable on stderr. Latched during the run and reported at exit, never mid-run.
+fn is_panic_line(message: &str) -> bool {
+    message.starts_with("thread '") && message.contains("panicked")
 }
 
 #[cfg(test)]
 mod stderr_tests {
-    use super::is_tracing_line;
+    use super::{is_panic_line, is_tracing_line};
+
+    #[test]
+    fn latches_a_rust_panic_line() {
+        assert!(is_panic_line(
+            "thread 'tokio-runtime-worker' panicked at src/foo.rs:1:1"
+        ));
+        // The #237 line is an ordinary tracing ERROR, not a panic — it must NOT latch.
+        assert!(!is_panic_line(
+            "2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal: \
+             Transport channel closed, when AuthRequired(AuthRequiredError { .. })"
+        ));
+        assert!(!is_panic_line("all good here"));
+    }
+
+    #[test]
+    fn rejects_timestamp_shaped_garbage() {
+        assert!(!is_tracing_line("2TgarbageZ ERROR foo: bar"));
+        assert!(!is_tracing_line("2026-07-13T13:10:39.248771Z ERROR"));
+    }
 
     // The #237 repro: an unauthenticated remote MCP server makes codex log this on every
     // startup while the run itself proceeds fine.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/jsonrpc.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/jsonrpc.rs
@@ -5,7 +5,7 @@
 //! copied exactly from the TS). 30s request timeout; notification + server-request
 //! handlers; close listeners.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
@@ -22,6 +22,7 @@ use crate::types::{
 };
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
+const STDERR_TAIL_LINES: usize = 20;
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
@@ -142,6 +143,7 @@ impl JsonRpcClient {
         let close_listeners: Arc<Mutex<Vec<CloseListener>>> = Arc::new(Mutex::new(Vec::new()));
         let close_notify = Arc::new(Notify::new());
         let kill_notify = Arc::new(Notify::new());
+        let recent_stderr: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
         let handlers = Arc::new(handlers);
 
         let stdin = child.stdin.take();
@@ -191,18 +193,33 @@ impl JsonRpcClient {
             });
         }
 
-        // Stderr reader task — filter noise, surface the rest.
+        // Stderr reader task. codex is a Rust binary that writes tracing logs to stderr as
+        // normal operation — an unauthenticated remote MCP server alone emits ERROR lines on
+        // every startup while the run proceeds fine. stderr is a log stream, never an error
+        // channel: a real failure arrives as a JSON-RPC error or a non-zero exit (reported by
+        // the exit watcher, which replays this tail as the reason).
         if let Some(stderr) = stderr {
-            let handlers = handlers.clone();
+            let recent_stderr = recent_stderr.clone();
             tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     let message = line.trim();
-                    if message.is_empty() || is_stderr_noise(message) {
+                    if message.is_empty() {
                         continue;
                     }
-                    tracing::warn!(module = "codex:jsonrpc", stderr = message, "codex stderr");
-                    (handlers.on_error)(message.to_string());
+
+                    let mut tail = recent_stderr.lock().unwrap_or_else(|e| e.into_inner());
+                    tail.push_back(message.to_string());
+                    while tail.len() > STDERR_TAIL_LINES {
+                        tail.pop_front();
+                    }
+                    drop(tail);
+
+                    if is_tracing_line(message) {
+                        tracing::debug!(module = "codex:jsonrpc", stderr = message, "codex stderr");
+                    } else {
+                        tracing::warn!(module = "codex:jsonrpc", stderr = message, "codex stderr");
+                    }
                 }
             });
         }
@@ -215,6 +232,8 @@ impl JsonRpcClient {
             let close_notify = close_notify.clone();
             let kill_notify = kill_notify.clone();
             let exited = exited.clone();
+            let closed = closed.clone();
+            let recent_stderr = recent_stderr.clone();
             let handlers = handlers.clone();
             tokio::spawn(async move {
                 let code = tokio::select! {
@@ -229,6 +248,20 @@ impl JsonRpcClient {
                     &pending,
                     JsonRpcError(format!("Process exited with code {code:?}")),
                 );
+                if !closed.load(Ordering::SeqCst) && code.is_some_and(|c| c != 0) {
+                    let code = code.unwrap_or_default();
+                    let tail: Vec<String> = recent_stderr
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .iter()
+                        .cloned()
+                        .collect();
+                    (handlers.on_error)(if tail.is_empty() {
+                        format!("codex exited with code {code}")
+                    } else {
+                        format!("codex exited with code {code}:\n{}", tail.join("\n"))
+                    });
+                }
                 for listener in close_listeners
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
@@ -420,15 +453,55 @@ fn reject_all_pending(pending: &Arc<Mutex<HashMap<RequestId, PendingTx>>>, err: 
     }
 }
 
-/// The stderr noise filter (`STDERR_NOISE`) — hand-rolled (no regex crate).
-fn is_stderr_noise(message: &str) -> bool {
-    let lower = message.to_lowercase();
-    lower.starts_with("debugger")
-        || lower.starts_with("warning:")
-        || message.starts_with("DeprecationWarning")
-        || message.starts_with("ExperimentalWarning")
-        || (message.starts_with("(node:") && message.contains(')'))
-        || (message.starts_with("thread '") && message.contains("panicked"))
+/// `<rfc3339> <LEVEL> <target>: <message>` — the codex binary's tracing format.
+/// Hand-rolled (no regex crate): a timestamp-shaped first token, then a level.
+fn is_tracing_line(message: &str) -> bool {
+    let mut parts = message.split_whitespace();
+    let Some(ts) = parts.next() else {
+        return false;
+    };
+    if !ts.ends_with('Z') || !ts.starts_with(|c: char| c.is_ascii_digit()) || !ts.contains('T') {
+        return false;
+    }
+    matches!(
+        parts.next(),
+        Some("TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR")
+    )
+}
+
+#[cfg(test)]
+mod stderr_tests {
+    use super::is_tracing_line;
+
+    // The #237 repro: an unauthenticated remote MCP server makes codex log this on every
+    // startup while the run itself proceeds fine.
+    #[test]
+    fn classifies_the_rmcp_auth_required_error_as_a_tracing_line() {
+        assert!(is_tracing_line(
+            "2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal: \
+             Transport channel closed, when AuthRequired(AuthRequiredError { .. })"
+        ));
+    }
+
+    #[test]
+    fn classifies_every_tracing_level() {
+        for level in ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"] {
+            assert!(is_tracing_line(&format!(
+                "2026-07-13T13:10:39.248771Z {level} codex_core::config: loaded"
+            )));
+        }
+    }
+
+    #[test]
+    fn rejects_lines_that_are_not_tracing_output() {
+        assert!(!is_tracing_line(
+            "thread 'main' panicked at src/main.rs:1:1"
+        ));
+        assert!(!is_tracing_line("error: unexpected argument '--nope'"));
+        assert!(!is_tracing_line(""));
+        assert!(!is_tracing_line("2026-07-13T13:10:39.248771Z"));
+        assert!(!is_tracing_line("ERROR rmcp: no leading timestamp"));
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/src/__tests__/codex-jsonrpc.test.ts
+++ b/packages/core/src/__tests__/codex-jsonrpc.test.ts
@@ -291,5 +291,80 @@ describe('JsonRpcClient', () => {
 
       expect(onError).not.toHaveBeenCalled();
     });
+
+    it('calls onError once naming the signal when the process dies by signal without a client-initiated close', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-07-13T13:10:00.000000Z ERROR codex_core: fatal condition\n'));
+      proc.emit('close', null, 'SIGKILL');
+
+      expect(onError).toHaveBeenCalledOnce();
+      const [message] = onError.mock.calls[0]!;
+      expect(message).toContain('SIGKILL');
+      expect(message).toContain('fatal condition');
+    });
+
+    it('does not call onError for a signal death after the client itself initiated the close', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      const client = createClient(proc, { onError });
+
+      client.close(); // mock proc.kill() emits close(0) synchronously
+      proc.emit('close', null, 'SIGKILL');
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('calls onError when a Rust panic line was seen even though the process exits 0', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from("thread 'tokio-runtime-worker' panicked at src/foo.rs:1:1\n"));
+      proc.emit('close', 0);
+
+      expect(onError).toHaveBeenCalledOnce();
+      const [message] = onError.mock.calls[0]!;
+      expect(message).toContain("thread 'tokio-runtime-worker' panicked at src/foo.rs:1:1");
+    });
+
+    it('does not call onError on a clean exit with code 0 and no panic line', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-07-13T13:10:00.000000Z INFO codex_core: starting\n'));
+      proc.emit('close', 0);
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not call onError when only the rmcp AuthRequired line was seen and the process exits 0', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      const line =
+        '2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\\"https://mcp.slack.com/.well-known/oauth-protected-resource\\"" })';
+      proc.stderr!.emit('data', Buffer.from(line + '\n'));
+      proc.emit('close', 0);
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('includes the final unterminated stderr line in the exit report', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from("thread 'main' panicked at src/lib.rs:9:1"));
+      proc.emit('close', 1);
+
+      expect(onError).toHaveBeenCalledOnce();
+      const [message] = onError.mock.calls[0]!;
+      expect(message).toContain("thread 'main' panicked at src/lib.rs:9:1");
+    });
   });
 });

--- a/packages/core/src/__tests__/codex-jsonrpc.test.ts
+++ b/packages/core/src/__tests__/codex-jsonrpc.test.ts
@@ -200,4 +200,96 @@ describe('JsonRpcClient', () => {
     proc.emit('close', 1);
     expect(onExit).toHaveBeenCalledWith(1);
   });
+
+  describe('stderr handling (#237)', () => {
+    it('does not call onError for the rmcp AuthRequired stderr line', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      const line =
+        '2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\\"https://mcp.slack.com/.well-known/oauth-protected-resource\\"" })';
+      proc.stderr!.emit('data', Buffer.from(line + '\n'));
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not call onError for a plain informational stderr line', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-07-13T13:10:00.000000Z INFO codex_core: starting session\n'));
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not call onError for any line in a chunk carrying multiple stderr lines', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      const chunk =
+        [
+          '2026-07-13T13:10:38.000000Z INFO codex_core: loaded config',
+          '2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { www_authenticate_header: "Bearer resource_metadata=\\"https://mcp.slack.com/.well-known/oauth-protected-resource\\"" })',
+          '2026-07-13T13:10:40.000000Z INFO codex_core: session ready',
+        ].join('\n') + '\n';
+      proc.stderr!.emit('data', Buffer.from(chunk));
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not call onError when a stderr line arrives split across two chunks', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-01-01T00:00:00.0Z INFO foo: hel'));
+      proc.stderr!.emit('data', Buffer.from('lo\n'));
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('calls onError once with the exit code and stderr tail when the process exits non-zero unexpectedly', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-07-13T13:10:00.000000Z INFO codex_core: starting\n'));
+      proc.stderr!.emit('data', Buffer.from('2026-07-13T13:10:01.000000Z ERROR codex_core: panic: bad config file\n'));
+
+      proc.emit('close', 1);
+
+      expect(onError).toHaveBeenCalledOnce();
+      const [message] = onError.mock.calls[0]!;
+      expect(message).toContain('1');
+      expect(message).toContain('panic: bad config file');
+    });
+
+    it('includes the fully reassembled split-chunk line in exit diagnostics', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      createClient(proc, { onError });
+
+      proc.stderr!.emit('data', Buffer.from('2026-01-01T00:00:00.0Z INFO foo: hel'));
+      proc.stderr!.emit('data', Buffer.from('lo\n'));
+
+      proc.emit('close', 1);
+
+      expect(onError).toHaveBeenCalledOnce();
+      const [message] = onError.mock.calls[0]!;
+      expect(message).toContain('foo: hello');
+    });
+
+    it('does not call onError when the client itself initiated the close', () => {
+      const onError = vi.fn();
+      const proc = createMockProcess();
+      const client = createClient(proc, { onError });
+
+      client.close();
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/plugins/builtin/codex/jsonrpc.ts
+++ b/packages/core/src/plugins/builtin/codex/jsonrpc.ts
@@ -13,6 +13,10 @@ const STDERR_TAIL_LINES = 20;
 // `<rfc3339> <LEVEL> <target>: <message>` — the codex binary's tracing format.
 const TRACING_LINE = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s/;
 
+// The app-server discards panicked task handles and can still exit 0, so a panic is
+// only detectable on stderr. Latched here and reported at exit, never mid-run.
+const PANIC_LINE = /^thread '.*' panicked/;
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -77,6 +81,7 @@ export class JsonRpcClient {
   private nextId = 1;
   private buffer = '';
   private stderrBuffer = '';
+  private sawPanic = false;
   private readonly recentStderr: string[] = [];
   private pending = new Map<RequestId, PendingRequest>();
   private closed = false;
@@ -89,9 +94,9 @@ export class JsonRpcClient {
   ) {
     process.stdout?.on('data', (chunk: Buffer) => this.handleStdout(chunk));
     process.stderr?.on('data', (chunk: Buffer) => this.handleStderr(chunk));
-    process.on('close', (code: number | null) => {
+    process.on('close', (code: number | null, signal?: NodeJS.Signals | null) => {
       this.rejectAllPending(new Error(`Process exited with code ${code}`));
-      this.reportUnexpectedExit(code);
+      this.reportUnexpectedExit(code, signal ?? null);
       for (const listener of this.closeListeners) listener();
       this.handlers.onExit(code);
     });
@@ -182,23 +187,36 @@ export class JsonRpcClient {
     this.stderrBuffer += chunk.toString();
     const lines = this.stderrBuffer.split('\n');
     this.stderrBuffer = lines.pop() ?? '';
-
-    for (const line of lines) {
-      const message = line.trim();
-      if (!message) continue;
-
-      this.recentStderr.push(message);
-      if (this.recentStderr.length > STDERR_TAIL_LINES) this.recentStderr.shift();
-
-      if (TRACING_LINE.test(message)) log.debug({ stderr: message }, 'codex stderr');
-      else log.warn({ stderr: message }, 'codex stderr');
-    }
+    for (const line of lines) this.recordStderr(line);
   }
 
-  private reportUnexpectedExit(code: number | null): void {
-    if (this.closed || code === 0 || code === null) return;
+  private recordStderr(line: string): void {
+    const message = line.trim();
+    if (!message) return;
+
+    if (PANIC_LINE.test(message)) this.sawPanic = true;
+
+    this.recentStderr.push(message);
+    if (this.recentStderr.length > STDERR_TAIL_LINES) this.recentStderr.shift();
+
+    if (TRACING_LINE.test(message)) log.debug({ stderr: message }, 'codex stderr');
+    else log.warn({ stderr: message }, 'codex stderr');
+  }
+
+  private reportUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): void {
+    if (this.closed) return;
+
+    // A dying process often omits the trailing newline on its last line — the very line
+    // that says why. Flush the partial before reading the tail.
+    this.recordStderr(this.stderrBuffer);
+    this.stderrBuffer = '';
+
+    if (code === 0 && signal === null && !this.sawPanic) return;
+
+    const reason =
+      signal !== null ? `was killed by ${signal}` : this.sawPanic ? 'panicked' : `exited with code ${code}`;
     const tail = this.recentStderr.join('\n');
-    this.handlers.onError(tail ? `codex exited with code ${code}:\n${tail}` : `codex exited with code ${code}`);
+    this.handlers.onError(tail ? `codex ${reason}:\n${tail}` : `codex ${reason}`);
   }
 
   private dispatch(msg: Record<string, unknown>): void {

--- a/packages/core/src/plugins/builtin/codex/jsonrpc.ts
+++ b/packages/core/src/plugins/builtin/codex/jsonrpc.ts
@@ -8,6 +8,11 @@ const log = createChildLogger('codex:jsonrpc');
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+const STDERR_TAIL_LINES = 20;
+
+// `<rfc3339> <LEVEL> <target>: <message>` — the codex binary's tracing format.
+const TRACING_LINE = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s/;
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -71,6 +76,8 @@ export interface JsonRpcHandlers {
 export class JsonRpcClient {
   private nextId = 1;
   private buffer = '';
+  private stderrBuffer = '';
+  private readonly recentStderr: string[] = [];
   private pending = new Map<RequestId, PendingRequest>();
   private closed = false;
   private closeListeners = new Set<() => void>();
@@ -84,6 +91,7 @@ export class JsonRpcClient {
     process.stderr?.on('data', (chunk: Buffer) => this.handleStderr(chunk));
     process.on('close', (code: number | null) => {
       this.rejectAllPending(new Error(`Process exited with code ${code}`));
+      this.reportUnexpectedExit(code);
       for (const listener of this.closeListeners) listener();
       this.handlers.onExit(code);
     });
@@ -166,21 +174,31 @@ export class JsonRpcClient {
     }
   }
 
-  private static readonly STDERR_NOISE = [
-    /^Debugger/i,
-    /^Warning:/i,
-    /^DeprecationWarning/i,
-    /^ExperimentalWarning/i,
-    /^\(node:\d+\)/,
-    /^thread '.*' panicked/,
-  ];
-
+  // codex is a Rust binary that writes tracing logs to stderr as normal operation —
+  // an unauthenticated remote MCP server alone emits ERROR lines on every startup while
+  // the run proceeds fine. stderr is a log stream, never an error channel: a real failure
+  // arrives as a JSON-RPC error, a process 'error', or a non-zero exit (reported below).
   private handleStderr(chunk: Buffer): void {
-    const message = chunk.toString().trim();
-    if (!message) return;
-    if (JsonRpcClient.STDERR_NOISE.some((p) => p.test(message))) return;
-    log.warn({ stderr: message }, 'codex stderr');
-    this.handlers.onError(message);
+    this.stderrBuffer += chunk.toString();
+    const lines = this.stderrBuffer.split('\n');
+    this.stderrBuffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const message = line.trim();
+      if (!message) continue;
+
+      this.recentStderr.push(message);
+      if (this.recentStderr.length > STDERR_TAIL_LINES) this.recentStderr.shift();
+
+      if (TRACING_LINE.test(message)) log.debug({ stderr: message }, 'codex stderr');
+      else log.warn({ stderr: message }, 'codex stderr');
+    }
+  }
+
+  private reportUnexpectedExit(code: number | null): void {
+    if (this.closed || code === 0 || code === null) return;
+    const tail = this.recentStderr.join('\n');
+    this.handlers.onError(tail ? `codex exited with code ${code}:\n${tail}` : `codex exited with code ${code}`);
   }
 
   private dispatch(msg: Record<string, unknown>): void {


### PR DESCRIPTION
Fixes todo **#237 — "Codex sessions dont start"** (Bug, Critical).

## Root cause

The Codex adapter's JSON-RPC client escalated **every** non-noise stderr line to `handlers.onError`, which the daemon emits as an `error` event and the UI renders as an "Agent run failed" toast (`chat-event-router.ts:64`) while flipping runState to `error`.

But `codex` is a Rust binary that writes tracing logs to stderr as *normal operation*. Any remote MCP server needing OAuth makes it log this at MCP-connect time — i.e. on **every session start**:

```
2026-07-13T13:10:39.248771Z ERROR rmcp::transport::worker: worker quit with fatal:
  Transport channel closed, when AuthRequired(AuthRequiredError { ... mcp.slack.com ... })
```

"fatal" there refers to that MCP transport worker, not the run. Verified: `codex exec` prints those exact lines and still **exits 0 with correct output**. So the run was always healthy — Mainframe just misread its logs as a crash, and every Codex session appeared to die on launch.

The reporter has `slack` and `claude_design` configured as remote MCP servers in `~/.codex/config.toml`, which is why it reproduced 100% for them.

## Fix

stderr is a **log stream, not an error channel**. For an app-server, real failures arrive as JSON-RPC errors, a process `error`, or a bad exit. Applied to **both** daemon implementations (Node + the Rust arm behind `MAINFRAME_DAEMON_IMPL`) — otherwise the bug would have stayed live for anyone on the Rust daemon.

Diagnostics are *not* lost. The last 20 stderr lines are buffered and replayed as the reason when the process dies unexpectedly:

- **non-zero exit** → reports the code + stderr tail
- **signal death** (SIGKILL/OOM/abort) → reported and names the signal. Kills we initiate are excluded via the existing `closed` flag.
- **panic that still exits 0** → the app-server discards panicked task handles ([`let _ = processor_handle.await`](https://github.com/openai/codex)), so a panic is only visible on stderr. `thread '...' panicked` is latched and reported *at exit* — keeping stderr non-fatal during the run. (The old noise filter ironically classified panics as noise and swallowed them.)
- the final **unterminated** stderr line — the one a dying process usually writes without a newline — is flushed into the tail before reporting.

Two latent defects fixed along the way:
- The TS classifier ran on the raw **chunk** with `^`-anchored regexes and no `m` flag, so only a chunk's first line was ever tested, and lines split across chunks were mangled. Now line-buffered.
- Rust: the exit watcher could snapshot the tail *before* the stderr reader drained the pipe — losing exactly the panic it exists to capture. It now awaits the reader, bounded by a 500ms timeout.

## Test plan

- [x] 13 new tests in `codex-jsonrpc.test.ts` (**84** codex TS tests pass) — the rmcp `AuthRequired` line is non-fatal; per-line + split-chunk buffering; exit code / signal / exit-0-panic / unterminated-line diagnostics; clean-exit and self-close regression guards
- [x] 5 new Rust tests (**37** crate tests pass); `cargo clippy` + `cargo fmt` clean
- [x] `tsc --noEmit` clean
- [x] **End-to-end against the real `codex` binary**: drove a real `CodexSession` with the reporter's unauthenticated MCP servers configured. codex emits the rmcp `AuthRequired` ERROR lines → **0 error events** (was: instant "Agent run failed") and the session replies normally.

## Note for the reporter

This makes Mainframe stop *misreporting* the MCP auth failure. The servers themselves are still unauthenticated, so `slack` and `claude_design` tools won't be available inside Codex until you authenticate them (or drop them from `~/.codex/config.toml`) — that part is codex-side config, not a Mainframe bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)