### PR TITLE
fix(ui): stop toasts flickering on hover

### DIFF
--- a/.changeset/olive-pans-shake.md
+++ b/.changeset/olive-pans-shake.md
@@ -1,0 +1,10 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix toasts flickering when hovered.
+
+Sonner's default collapsed stack clamps every toast to the front toast's height and re-lays the
+stack out on hover. Our toast cards vary in height, so hovering moved a stacked toast ~314px out
+from under the pointer, which un-hovered it, which moved it back — a visible flicker loop. The
+toast stack is now always expanded, so hover changes no geometry.

--- a/packages/ui/src/components/ui/__tests__/sonner.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/sonner.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Toaster (sonner wrapper) regression test.
+ *
+ * Context: sonner's default collapsed stack clamps every toast to the front
+ * toast's height and re-lays the stack out on hover. Our WsToastCards vary a
+ * lot in height (a "Read more"-expanded error toast is ~306px), so without
+ * `expand` a hovered stacked toast moved 314px — out from under the pointer,
+ * which un-hovered it, which moved it back: a ~10Hz flicker loop. With
+ * `expand`, hover-induced movement measures 0px.
+ *
+ * jsdom has no layout engine, so we can't reproduce the pixel movement here.
+ * Instead we assert the contract that prevents it: `Toaster` must pass
+ * `expand` (plus the other stack-geometry props) to sonner's `Toaster`. If
+ * `expand` is ever dropped while tidying props, this test fails even though
+ * nothing else would catch it.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+const sonnerToasterMock = vi.fn((_props: Record<string, unknown>) => null);
+
+vi.mock('sonner', () => ({
+  Toaster: (props: Record<string, unknown>) => sonnerToasterMock(props),
+}));
+
+import { Toaster } from '../sonner';
+
+describe('Toaster', () => {
+  it('passes expand and the stack geometry props to sonner', () => {
+    render(<Toaster />);
+
+    expect(sonnerToasterMock).toHaveBeenCalledWith({
+      position: 'bottom-right',
+      offset: 18,
+      gap: 9,
+      visibleToasts: 5,
+      expand: true,
+    });
+  });
+});

--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -12,5 +12,10 @@
 import { Toaster as SonnerToaster } from 'sonner';
 
 export function Toaster() {
-  return <SonnerToaster position="bottom-right" offset={18} gap={9} visibleToasts={5} />;
+  // `expand` is load-bearing, not cosmetic: sonner's default collapsed stack clamps every
+  // toast to the front toast's height and re-lays the stack out on hover. Our cards vary in
+  // height (a "Read more"-expanded error is ~300px), so hovering moved a stacked toast by
+  // ~314px — out from under the pointer, which un-hovered it, which moved it back: a flicker
+  // loop. Always-expanded means hover changes no geometry.
+  return <SonnerToaster position="bottom-right" offset={18} gap={9} visibleToasts={5} expand />;
 }


### PR DESCRIPTION
Found while investigating **#237** — visible in the reporter's screen recording of the Codex failure toasts.

## Root cause

Sonner's default **collapsed** stack clamps every toast to the *front* toast's height (`height: var(--front-toast-height)`) and re-lays the whole stack out when the pointer enters it (`data-expanded` flips → `height: var(--initial-height)`).

Our `WsToastCard`s vary a lot in height — an error toast whose description has been expanded via the existing "Read more" toggle is ~300px. So when a second toast arrives while you're hovering the first, hovering **moves the toast you're pointing at**:

pointer enters → stack expands → the toast jumps ~314px → it's no longer under the pointer → un-hover → stack collapses → the toast lands back under the pointer → re-hover → …

That's the ~10Hz flicker in the recording.

## Fix

One prop: `expand` on the `Toaster`. Always-expanded means hover changes no geometry, so the loop can't start.

Verified in a real browser (Playwright), pointer parked and **never moved** after the second toast arrives:

| config | hover-induced movement |
|---|---|
| before (`expand=false`) | **314px** |
| after (`expand`) | **0px** |

Capping the card height was also measured and is **not** a fix on its own (still 203px of movement) — and isn't needed anyway: descriptions already clamp to 3 lines behind "Read more", so the tall toast only exists when the user deliberately expands it.

## Test plan

- [x] Repro'd and measured in a real browser before/after (numbers above) — jsdom has no layout engine, so the pixel loop can't be asserted in unit tests
- [x] New `sonner.test.tsx` guards the contract that prevents it: `expand` must reach sonner. It's load-bearing config, not cosmetics — dropping it while tidying props would silently bring the flicker back, and nothing else would catch it
- [x] `ws-toast.test.tsx` — 28 tests, no regression
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)