### PR TITLE
Add update channel setting (stable / pre-release)

### DIFF
--- a/.changeset/update-channel-setting.md
+++ b/.changeset/update-channel-setting.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-core': minor
+'@qlan-ro/mainframe-ui': minor
+'@qlan-ro/mainframe-app-electron': minor
+'@qlan-ro/mainframe-app-tauri': minor
+---
+
+Add an update channel setting (Stable / Pre-release) in Settings → General. Electron respects it via `electron-updater`'s `allowPrerelease`; Tauri resolves the newest published GitHub release directly for the pre-release channel, since its updater has no built-in concept of channels.

--- a/docs/architecture/2026-07-13-update-channel-setting-design.md
+++ b/docs/architecture/2026-07-13-update-channel-setting-design.md
@@ -1,0 +1,76 @@
+# Update channel setting (stable / pre-release)
+
+## Problem
+
+Both desktop shells (Electron, Tauri) have working auto-update pipelines, but neither can ever offer a pre-release (rc) build: Electron's `autoUpdater.allowPrerelease` defaults to `false`, and Tauri's updater endpoint is a static URL pointing at GitHub's `/releases/latest`, which excludes prereleases entirely. There is no user-facing way to opt into rc builds.
+
+## Goal
+
+Add a per-machine "update channel" preference (`stable` / `prerelease`) that a user can toggle in Settings, and wire both shells' update-check logic to respect it.
+
+## Out of scope
+
+- Fixing the CI release workflow leaving rc releases as unpublished drafts (`.github/workflows/release.yml`, `draft: true` with no publish step). The channel setting is inert until releases are published, by whatever means; that's separate, existing work.
+- Any change to `release.yml` release/tag strategy.
+
+## Data model
+
+`packages/types/src/settings.ts`:
+
+```ts
+export const UPDATE_CHANNELS = ['stable', 'prerelease'] as const;
+export type UpdateChannel = (typeof UPDATE_CHANNELS)[number];
+
+export interface GeneralConfig {
+  worktreeDir: string;
+  notifications: NotificationConfig;
+  updateChannel: UpdateChannel;
+}
+
+export const GENERAL_DEFAULTS: GeneralConfig = {
+  worktreeDir: '.worktrees',
+  notifications: NOTIFICATION_DEFAULTS,
+  updateChannel: 'stable',
+};
+```
+
+Default is always `'stable'`, even if the currently-installed build is itself an rc — no auto-detection, explicit opt-in only.
+
+## Daemon
+
+No new endpoint. `updateChannel` is a scalar field in the existing `general` settings category, handled by the existing generic loop in `packages/core/src/server/routes/settings.ts` (`PUT /api/settings/general`). Only change: add `updateChannel: z.enum(UPDATE_CHANNELS).optional()` to `UpdateGeneralSettingsBody` in `packages/core/src/server/routes/schemas.ts`. `GET /api/settings/general` already spreads `GENERAL_DEFAULTS` first, so existing rows read back as `'stable'`.
+
+## UI
+
+`packages/ui/src/features/settings/panes/general/GeneralPane.tsx` gains an "Updates" section, using the same `PickerRow` component `AppearanceControls.tsx` already uses for Mode/Color Scheme/Window Style — a two-option instant-save row: "Stable" / "Pre-release (RC)". Saved via the existing `updateGeneralSettings(port, { updateChannel })` call, same pattern as other scalar fields. No separate Save button (matches the instant-save picker convention, unlike the free-text worktree-dir field).
+
+## Electron (`packages/app-electron/src/main/auto-updater.ts`)
+
+Precedent: `idle-reporter.ts` already calls the daemon directly from the main process (`fetch(`${DAEMON_URL}/api/device/activity`)`).
+
+- `initAutoUpdater` takes the daemon port (same as `DaemonStatusTracker` in `index.ts:255`).
+- Before every check — both scheduled timers in `scheduleChecks()` and `checkForUpdatesManual()` — fetch `GET /api/settings/general` from the daemon, read `updateChannel`, and set `autoUpdater.allowPrerelease = updateChannel === 'prerelease'` immediately before calling `checkForUpdates()`.
+- If the fetch fails (daemon briefly unreachable), default to `allowPrerelease = false` (stable) rather than blocking the check.
+- No other changes — electron-updater's GitHub provider already lists releases and filters by `allowPrerelease` internally once that flag is set.
+
+## Tauri (`packages/app-tauri/src-tauri/src/updater.rs`)
+
+Precedent: `presence.rs` already POSTs to the daemon from Rust via `ureq`.
+
+- Add `resolve_channel(daemon_port: u16) -> UpdateChannel`: `ureq` GET `/api/settings/general`, parse `updateChannel`, default to `Stable` on any error (offline daemon, malformed response, etc).
+- **Stable path is unchanged**: `app.updater()` keeps using the static endpoint from `tauri.conf.json` (already correct for stable once a release is published).
+- **Prerelease path only**: add `resolve_prerelease_endpoint() -> Option<Url>` — `ureq` GET `https://api.github.com/repos/qlan-ro/mainframe/releases` (unauthenticated, newest-first), skip entries with `draft: true`, take the first remaining entry regardless of its `prerelease` flag, and read its `latest.json` asset's `browser_download_url`. Build the updater via `app.updater_builder().endpoints(vec![url]).build()` instead of `app.updater()`.
+- If the GitHub lookup fails (offline, rate-limited, no matching asset), fall back to the static default endpoint so a check never hard-fails — it just behaves like the stable channel for that attempt.
+- Applies to `updater_check`, `updater_download`, `updater_install`, and `schedule_update_checks` — all resolve the channel/endpoint the same way before calling into the updater.
+
+## Testing
+
+- `GENERAL_DEFAULTS`/zod schema: new field defaults and validates correctly.
+- `GeneralPane` test: selecting "Pre-release" fires `PATCH` with `updateChannel: 'prerelease'`; selecting "Stable" fires it with `'stable'`.
+- Electron: unit test around the allowPrerelease-selection logic (given a fetched channel, is the flag set correctly), and the fetch-failure fallback to `false`.
+- Tauri: unit test for the release-filtering logic (skip drafts, take newest regardless of prerelease flag) against a fixture JSON array, mirroring how `error_classifier.rs` is tested today — same style as existing Rust unit tests in this file's neighborhood.
+
+## Risks / notes
+
+- Until the separate CI draft-publish gap is fixed, toggling to "Pre-release" has no visible effect (nothing published to fetch). This is expected and was explicitly descoped.
+- The Tauri prerelease path adds an unauthenticated call to the public GitHub API on every prerelease-channel check (10s startup + every 4h) — low volume, well under GitHub's unauthenticated rate limit for a single-repo, single-user query.

--- a/packages/app-electron/src/main/auto-updater.test.ts
+++ b/packages/app-electron/src/main/auto-updater.test.ts
@@ -5,6 +5,7 @@ const listeners = new Map<string, ((arg?: unknown) => void)[]>();
 const mockAutoUpdater = {
   autoDownload: false,
   autoInstallOnAppQuit: false,
+  allowPrerelease: false,
   on: vi.fn((event: string, fn: (arg?: unknown) => void) => {
     const arr = listeners.get(event) ?? [];
     arr.push(fn);
@@ -54,7 +55,7 @@ afterEach(() => {
 describe('auto-updater manual check', () => {
   it('shows "up to date" dialog on update-not-available when manual', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     await mod.checkForUpdatesManual(mockWindow);
     emit('update-not-available');
     expect(showMessageBox).toHaveBeenCalledTimes(1);
@@ -63,14 +64,14 @@ describe('auto-updater manual check', () => {
 
   it('does NOT show dialog on update-not-available when scheduled', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     emit('update-not-available');
     expect(showMessageBox).not.toHaveBeenCalled();
   });
 
   it('shows error dialog on persistent error when manual', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     await mod.checkForUpdatesManual(mockWindow);
     emit('error', Object.assign(new Error('signature mismatch'), { code: 'EPERM' }));
     expect(showMessageBox).toHaveBeenCalledTimes(1);
@@ -79,7 +80,7 @@ describe('auto-updater manual check', () => {
 
   it('does NOT show dialog on transient error when manual, but clears in-flight flag', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     await mod.checkForUpdatesManual(mockWindow);
     emit('error', Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' }));
     expect(showMessageBox).not.toHaveBeenCalled();
@@ -88,7 +89,7 @@ describe('auto-updater manual check', () => {
 
   it('does NOT show dialog on update-available when manual (StatusBar handles it)', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     await mod.checkForUpdatesManual(mockWindow);
     emit('update-available', { version: '0.18.0' });
     expect(showMessageBox).not.toHaveBeenCalled();
@@ -97,7 +98,7 @@ describe('auto-updater manual check', () => {
 
   it('checkForUpdatesManual is a no-op when already in-flight', async () => {
     const mod = await import('./auto-updater.js');
-    mod.initAutoUpdater(mockWindow);
+    mod.initAutoUpdater(mockWindow, 31415);
     await mod.checkForUpdatesManual(mockWindow);
     await mod.checkForUpdatesManual(mockWindow);
     expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
@@ -107,7 +108,7 @@ describe('auto-updater manual check', () => {
     vi.useFakeTimers();
     try {
       const mod = await import('./auto-updater.js');
-      mod.initAutoUpdater(mockWindow);
+      mod.initAutoUpdater(mockWindow, 31415);
       await mod.checkForUpdatesManual(mockWindow);
       expect(mod.isManualCheckInFlight()).toBe(true);
       vi.advanceTimersByTime(60_000);
@@ -122,5 +123,54 @@ describe('auto-updater manual check', () => {
     const mod = await import('./auto-updater.js');
     await mod.checkForUpdatesManual(mockWindow);
     expect(mockAutoUpdater.checkForUpdates).not.toHaveBeenCalled();
+  });
+});
+
+describe('auto-updater update channel', () => {
+  let allowPrereleaseAtCheckTime: boolean | undefined;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    allowPrereleaseAtCheckTime = undefined;
+    mockAutoUpdater.checkForUpdates.mockImplementation(() => {
+      allowPrereleaseAtCheckTime = mockAutoUpdater.allowPrerelease;
+      return Promise.resolve(null);
+    });
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets allowPrerelease=true when the daemon reports the prerelease channel', async () => {
+    fetchMock.mockResolvedValue({
+      json: () => Promise.resolve({ success: true, data: { updateChannel: 'prerelease' } }),
+    });
+    const mod = await import('./auto-updater.js');
+    mod.initAutoUpdater(mockWindow, 31415);
+    await mod.checkForUpdatesManual(mockWindow);
+
+    expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:31415/api/settings/general');
+    expect(allowPrereleaseAtCheckTime).toBe(true);
+  });
+
+  it('sets allowPrerelease=false when the daemon reports the stable channel', async () => {
+    fetchMock.mockResolvedValue({ json: () => Promise.resolve({ success: true, data: { updateChannel: 'stable' } }) });
+    const mod = await import('./auto-updater.js');
+    mod.initAutoUpdater(mockWindow, 31415);
+    await mod.checkForUpdatesManual(mockWindow);
+
+    expect(allowPrereleaseAtCheckTime).toBe(false);
+  });
+
+  it('defaults to allowPrerelease=false without throwing when the daemon fetch fails', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    const mod = await import('./auto-updater.js');
+    mod.initAutoUpdater(mockWindow, 31415);
+    await expect(mod.checkForUpdatesManual(mockWindow)).resolves.toBeUndefined();
+
+    expect(allowPrereleaseAtCheckTime).toBe(false);
   });
 });

--- a/packages/app-electron/src/main/auto-updater.ts
+++ b/packages/app-electron/src/main/auto-updater.ts
@@ -1,10 +1,33 @@
 import { autoUpdater } from 'electron-updater';
 import type { UpdateInfo, ProgressInfo } from 'electron-updater';
 import { BrowserWindow, ipcMain, dialog, app } from 'electron';
+import type { UpdateChannel } from '@qlan-ro/mainframe-types';
 import { createMainLogger } from './logger.js';
 import { classifyUpdateError } from './auto-updater-error-classifier.js';
 
 const log = createMainLogger('electron:auto-updater');
+
+const DAEMON_HOST = process.env['DAEMON_HOST'] ?? '127.0.0.1';
+
+// Set once at startup by initAutoUpdater; every check re-reads the channel
+// setting from the daemon before calling checkForUpdates().
+let daemonPort: number | null = null;
+
+async function fetchUpdateChannel(): Promise<UpdateChannel> {
+  if (daemonPort === null) return 'stable';
+  try {
+    const res = await fetch(`http://${DAEMON_HOST}:${daemonPort}/api/settings/general`);
+    const body = (await res.json()) as { data?: { updateChannel?: unknown } };
+    return body.data?.updateChannel === 'prerelease' ? 'prerelease' : 'stable';
+  } catch (err) {
+    log.warn({ err }, 'failed to fetch update channel from daemon; defaulting to stable');
+    return 'stable';
+  }
+}
+
+async function applyUpdateChannel(): Promise<void> {
+  autoUpdater.allowPrerelease = (await fetchUpdateChannel()) === 'prerelease';
+}
 
 export type UpdateStatus =
   | { state: 'checking' }
@@ -112,24 +135,32 @@ function registerListeners(mainWindow: BrowserWindow): void {
 }
 
 function registerIPC(): void {
-  ipcMain.handle('update:check', () => autoUpdater.checkForUpdates());
+  ipcMain.handle('update:check', async () => {
+    await applyUpdateChannel();
+    return autoUpdater.checkForUpdates();
+  });
   ipcMain.handle('update:download', () => autoUpdater.downloadUpdate());
   ipcMain.handle('update:install', () => autoUpdater.quitAndInstall());
+}
+
+async function checkForUpdatesWithChannel(warnMessage: string): Promise<void> {
+  await applyUpdateChannel();
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch (err: unknown) {
+    log.warn({ err }, warnMessage);
+  }
 }
 
 function scheduleChecks(): void {
   // First check after 10 seconds on startup, then every 4 hours.
   setTimeout(() => {
-    autoUpdater.checkForUpdates().catch((err: unknown) => {
-      log.warn({ err }, 'scheduled update check failed');
-    });
+    void checkForUpdatesWithChannel('scheduled update check failed');
   }, 10_000);
 
   setInterval(
     () => {
-      autoUpdater.checkForUpdates().catch((err: unknown) => {
-        log.warn({ err }, 'periodic update check failed');
-      });
+      void checkForUpdatesWithChannel('periodic update check failed');
     },
     4 * 60 * 60 * 1_000,
   );
@@ -153,6 +184,7 @@ export async function checkForUpdatesManual(window: BrowserWindow): Promise<void
     log.warn('manual update check timed out without a terminal event; clearing flag');
     clearManualFlag();
   }, MANUAL_CHECK_TIMEOUT_MS);
+  await applyUpdateChannel();
   try {
     await autoUpdater.checkForUpdates();
   } catch (err: unknown) {
@@ -161,13 +193,14 @@ export async function checkForUpdatesManual(window: BrowserWindow): Promise<void
   }
 }
 
-export function initAutoUpdater(mainWindow: BrowserWindow): void {
+export function initAutoUpdater(mainWindow: BrowserWindow, port: number): void {
   // electron-updater only works in packaged builds; skip in development.
   if (process.env.NODE_ENV === 'development') {
     log.info('development mode: auto-updater disabled');
     return;
   }
 
+  daemonPort = port;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
 

--- a/packages/app-electron/src/main/index.ts
+++ b/packages/app-electron/src/main/index.ts
@@ -270,7 +270,7 @@ app.whenReady().then(() => {
   startIdleReporter();
   startRendererMemoryLogger(() => mainWindow);
 
-  if (mainWindow) initAutoUpdater(mainWindow);
+  if (mainWindow) initAutoUpdater(mainWindow, DAEMON_PORT);
 
   setupWebviewSandbox(denyUnneededPermissions, openExternalSafe);
 

--- a/packages/app-tauri/src-tauri/Cargo.lock
+++ b/packages/app-tauri/src-tauri/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ureq",
+ "url",
  "which",
 ]
 

--- a/packages/app-tauri/src-tauri/Cargo.toml
+++ b/packages/app-tauri/src-tauri/Cargo.toml
@@ -33,6 +33,8 @@ dirs = "5"
 which = "6"
 portable-pty = "0.9"
 ureq = { version = "2", default-features = false, features = ["json"] }
+# Matches the `url::Url` type tauri-plugin-updater's `endpoints()` builder expects.
+url = "2"
 # The platform credential-store backends are opt-in in keyring 3.x. Without an
 # explicit backend feature the crate silently falls back to an in-memory mock
 # store, so remote-daemon tokens never persist and every reconnect authenticates

--- a/packages/app-tauri/src-tauri/src/updater.rs
+++ b/packages/app-tauri/src-tauri/src/updater.rs
@@ -5,13 +5,43 @@
 //! `packages/app-electron/src/main/auto-updater.ts`. Signing keypair + CI release
 //! workflow are deferred (see `docs/architecture/2026-06-24-host-bridge-plan3-infra-todos.md`).
 
+pub mod channel;
 pub mod error_classifier;
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
-use tauri_plugin_updater::UpdaterExt;
+use tauri_plugin_updater::{Updater, UpdaterExt};
 
+use channel::UpdateChannel;
 use error_classifier::{classify, UpdateErrorKind};
+
+/// Resolve the updater for the current channel setting. Stable keeps using
+/// the static endpoint from `tauri.conf.json`; prerelease looks up the
+/// newest published GitHub release's `latest.json` asset and falls back to
+/// the stable endpoint if that lookup fails for any reason (never hard-fails
+/// the check). Used by `updater_check`/`updater_download`/`updater_install`,
+/// so `schedule_update_checks` (which calls `updater_check`) picks it up too.
+async fn resolve_updater(app: &AppHandle) -> Result<Updater, String> {
+    let daemon_port = crate::daemon_port();
+    let update_channel = tokio::task::spawn_blocking(move || channel::resolve_channel(daemon_port))
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if update_channel == UpdateChannel::Prerelease {
+        let endpoint = tokio::task::spawn_blocking(channel::resolve_prerelease_endpoint)
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Some(url) = endpoint {
+            return app
+                .updater_builder()
+                .endpoints(vec![url])
+                .map_err(|e| e.to_string())?
+                .build()
+                .map_err(|e| e.to_string());
+        }
+    }
+    app.updater().map_err(|e| e.to_string())
+}
 
 /// Contract-shaped status (serde tagged on `state`) — mirrors
 /// `UpdateStatusSchema` in `@qlan-ro/mainframe-types`. Plan 3, decision 1.
@@ -42,7 +72,7 @@ fn emit_status(app: &AppHandle, status: UpdateStatus) {
 #[tauri::command]
 pub async fn updater_check(app: AppHandle) -> Result<UpdateStatus, String> {
     emit_status(&app, UpdateStatus::Checking);
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = resolve_updater(&app).await?;
     match updater.check().await {
         Ok(Some(update)) => {
             let status = UpdateStatus::Available {
@@ -85,7 +115,7 @@ pub async fn updater_check(app: AppHandle) -> Result<UpdateStatus, String> {
 /// Bridge: `invoke('updater_download')` in `lib/tauri/bridge.ts`.
 #[tauri::command]
 pub async fn updater_download(app: AppHandle) -> Result<(), String> {
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = resolve_updater(&app).await?;
     let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
         return Err("no update available to download".to_string());
     };
@@ -116,7 +146,7 @@ pub async fn updater_download(app: AppHandle) -> Result<(), String> {
 /// Bridge: `invoke('updater_install')` in `lib/tauri/bridge.ts`.
 #[tauri::command]
 pub async fn updater_install(app: AppHandle) -> Result<(), String> {
-    let updater = app.updater().map_err(|e| e.to_string())?;
+    let updater = resolve_updater(&app).await?;
     let Some(update) = updater.check().await.map_err(|e| e.to_string())? else {
         return Err("no update available to install".to_string());
     };

--- a/packages/app-tauri/src-tauri/src/updater/channel.rs
+++ b/packages/app-tauri/src-tauri/src/updater/channel.rs
@@ -1,0 +1,192 @@
+//! Update-channel resolution — Plan: update-channel-setting design doc
+//! (docs/architecture/2026-07-13-update-channel-setting-design.md).
+//!
+//! Reads the daemon's `updateChannel` general setting and, for the
+//! prerelease channel, resolves the newest published GitHub release's
+//! `latest.json` asset URL directly (unauthenticated, newest-first).
+
+use std::time::Duration;
+
+use serde_json::Value;
+use url::Url;
+
+const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/qlan-ro/mainframe/releases";
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum UpdateChannel {
+    Stable,
+    Prerelease,
+}
+
+/// Read `updateChannel` from `GET /api/settings/general`. Defaults to
+/// `Stable` on any failure (offline daemon, non-200, malformed JSON, missing
+/// field) so a broken lookup never silently opts a user into prereleases.
+pub fn resolve_channel(daemon_port: u16) -> UpdateChannel {
+    fetch_channel(daemon_port).unwrap_or(UpdateChannel::Stable)
+}
+
+fn fetch_channel(daemon_port: u16) -> Result<UpdateChannel, String> {
+    let url = format!("http://127.0.0.1:{daemon_port}/api/settings/general");
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_millis(500))
+        .timeout_read(Duration::from_millis(500))
+        .build();
+    let body = agent
+        .get(&url)
+        .call()
+        .map_err(|e| e.to_string())?
+        .into_string()
+        .map_err(|e| e.to_string())?;
+    Ok(parse_channel_response(&body))
+}
+
+/// Pure parse of the `{ success, data: { updateChannel } }` envelope.
+/// Factored out from the network call so it's unit-testable without a daemon.
+fn parse_channel_response(body: &str) -> UpdateChannel {
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return UpdateChannel::Stable;
+    };
+    match value["data"]["updateChannel"].as_str() {
+        Some("prerelease") => UpdateChannel::Prerelease,
+        _ => UpdateChannel::Stable,
+    }
+}
+
+/// Resolve the prerelease update endpoint. Returns `None` on any failure
+/// (offline, rate-limited, no matching release/asset, parse error) — callers
+/// must fall back to the static stable endpoint rather than hard-failing.
+pub fn resolve_prerelease_endpoint() -> Option<Url> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(3))
+        .timeout_read(Duration::from_secs(3))
+        .build();
+    let body = agent
+        .get(GITHUB_RELEASES_URL)
+        .set("User-Agent", "mainframe-updater")
+        .call()
+        .ok()?
+        .into_string()
+        .ok()?;
+    let url_str = select_latest_json_url(&body)?;
+    Url::parse(&url_str).ok()
+}
+
+/// Pure selection logic: skip draft releases, take the first remaining entry
+/// regardless of its `prerelease` flag, and return its `latest.json` asset's
+/// `browser_download_url`. Kept separate from the network call for unit tests.
+fn select_latest_json_url(releases_json: &str) -> Option<String> {
+    let releases: Value = serde_json::from_str(releases_json).ok()?;
+    let release = releases
+        .as_array()?
+        .iter()
+        .find(|r| r["draft"].as_bool() != Some(true))?;
+    let asset = release["assets"]
+        .as_array()?
+        .iter()
+        .find(|a| a["name"].as_str() == Some("latest.json"))?;
+    asset["browser_download_url"].as_str().map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(draft: bool, prerelease: bool, assets: &str) -> String {
+        format!(
+            r#"{{"draft":{draft},"prerelease":{prerelease},"assets":{assets}}}"#
+        )
+    }
+
+    fn asset(name: &str, url: &str) -> String {
+        format!(r#"{{"name":"{name}","browser_download_url":"{url}"}}"#)
+    }
+
+    #[test]
+    fn parse_channel_response_reads_prerelease() {
+        let body = r#"{"success":true,"data":{"updateChannel":"prerelease"}}"#;
+        assert_eq!(parse_channel_response(body), UpdateChannel::Prerelease);
+    }
+
+    #[test]
+    fn parse_channel_response_reads_stable() {
+        let body = r#"{"success":true,"data":{"updateChannel":"stable"}}"#;
+        assert_eq!(parse_channel_response(body), UpdateChannel::Stable);
+    }
+
+    #[test]
+    fn parse_channel_response_defaults_stable_on_missing_field() {
+        assert_eq!(
+            parse_channel_response(r#"{"success":true,"data":{}}"#),
+            UpdateChannel::Stable
+        );
+    }
+
+    #[test]
+    fn parse_channel_response_defaults_stable_on_malformed_json() {
+        assert_eq!(parse_channel_response("not json"), UpdateChannel::Stable);
+    }
+
+    #[test]
+    fn select_latest_json_url_skips_drafts() {
+        let json = format!(
+            "[{},{}]",
+            release(true, false, &format!("[{}]", asset("latest.json", "https://example.com/draft.json"))),
+            release(false, false, &format!("[{}]", asset("latest.json", "https://example.com/real.json")))
+        );
+        assert_eq!(
+            select_latest_json_url(&json).as_deref(),
+            Some("https://example.com/real.json")
+        );
+    }
+
+    #[test]
+    fn select_latest_json_url_takes_first_regardless_of_prerelease_flag() {
+        let json = format!(
+            "[{},{}]",
+            release(false, true, &format!("[{}]", asset("latest.json", "https://example.com/rc.json"))),
+            release(false, false, &format!("[{}]", asset("latest.json", "https://example.com/stable.json")))
+        );
+        assert_eq!(
+            select_latest_json_url(&json).as_deref(),
+            Some("https://example.com/rc.json")
+        );
+    }
+
+    #[test]
+    fn select_latest_json_url_finds_asset_among_others() {
+        let assets = format!(
+            "[{},{}]",
+            asset("app.tar.gz", "https://example.com/app.tar.gz"),
+            asset("latest.json", "https://example.com/latest.json")
+        );
+        let json = format!("[{}]", release(false, false, &assets));
+        assert_eq!(
+            select_latest_json_url(&json).as_deref(),
+            Some("https://example.com/latest.json")
+        );
+    }
+
+    #[test]
+    fn select_latest_json_url_none_when_all_draft() {
+        let json = format!(
+            "[{}]",
+            release(true, false, &format!("[{}]", asset("latest.json", "https://example.com/draft.json")))
+        );
+        assert_eq!(select_latest_json_url(&json), None);
+    }
+
+    #[test]
+    fn select_latest_json_url_none_when_no_matching_asset() {
+        let json = format!(
+            "[{}]",
+            release(false, false, &format!("[{}]", asset("app.tar.gz", "https://example.com/app.tar.gz")))
+        );
+        assert_eq!(select_latest_json_url(&json), None);
+    }
+
+    #[test]
+    fn select_latest_json_url_none_on_malformed_json() {
+        assert_eq!(select_latest_json_url("not json"), None);
+        assert_eq!(select_latest_json_url("[]"), None);
+    }
+}

--- a/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
@@ -173,6 +173,10 @@ async fn get_general(State(ctx): State<Arc<AppCtx>>) -> Response {
         "worktreeDir".to_string(),
         Value::String(GeneralConfig::default().worktree_dir),
     );
+    data.insert(
+        "updateChannel".to_string(),
+        Value::String("stable".to_string()),
+    );
     for (k, v) in &raw {
         if k != "notifications" {
             data.insert(k.clone(), Value::String(v.clone()));
@@ -187,6 +191,8 @@ struct GeneralPatch {
     #[serde(rename = "worktreeDir")]
     worktree_dir: Option<String>,
     notifications: Option<NotificationPatch>,
+    #[serde(rename = "updateChannel")]
+    update_channel: Option<String>,
 }
 
 fn is_valid_worktree_dir(s: &str) -> bool {
@@ -215,10 +221,14 @@ async fn put_general(State(ctx): State<Arc<AppCtx>>, body: Bytes) -> Response {
             return fail(StatusCode::BAD_REQUEST, "Must be a simple directory name");
         }
     }
+    if !in_enum(&patch.update_channel, &["stable", "prerelease"]) {
+        return fail(StatusCode::BAD_REQUEST, "Invalid update channel");
+    }
 
     let GeneralPatch {
         worktree_dir,
         notifications,
+        update_channel,
     } = patch;
     let result = ctx
         .db
@@ -228,6 +238,13 @@ async fn put_general(State(ctx): State<Arc<AppCtx>>, body: Bytes) -> Response {
                     db.settings.delete("general", "worktreeDir")?;
                 } else {
                     db.settings.set("general", "worktreeDir", &wd)?;
+                }
+            }
+            if let Some(uc) = update_channel {
+                if uc == "stable" {
+                    db.settings.delete("general", "updateChannel")?;
+                } else {
+                    db.settings.set("general", "updateChannel", &uc)?;
                 }
             }
             if let Some(patch) = notifications {

--- a/packages/core-rs/crates/mainframe-server/tests/routes_settings.rs
+++ b/packages/core-rs/crates/mainframe-server/tests/routes_settings.rs
@@ -134,6 +134,55 @@ async fn general_put_rejects_empty_worktree_dir_with_joined_zod_message() {
     );
 }
 
+#[tokio::test]
+async fn general_put_persists_prerelease_channel() {
+    let server = spawn_test_server(None).await;
+    let resp = client()
+        .put(server.http_url("/api/settings/general"))
+        .json(&json!({ "updateChannel": "prerelease" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        get_setting(&server, "general", "updateChannel")
+            .await
+            .as_deref(),
+        Some("prerelease")
+    );
+    let body = get_json(&server, "/api/settings/general").await;
+    assert_eq!(body["data"]["updateChannel"], "prerelease");
+}
+
+#[tokio::test]
+async fn general_put_deletes_channel_key_when_set_to_default() {
+    let server = spawn_test_server(None).await;
+    set_setting(&server, "general", "updateChannel", "prerelease").await;
+    let resp = client()
+        .put(server.http_url("/api/settings/general"))
+        .json(&json!({ "updateChannel": "stable" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(get_setting(&server, "general", "updateChannel").await, None);
+}
+
+#[tokio::test]
+async fn general_put_rejects_invalid_update_channel() {
+    let server = spawn_test_server(None).await;
+    let resp = client()
+        .put(server.http_url("/api/settings/general"))
+        .json(&json!({ "updateChannel": "bogus" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["success"], false);
+    assert_eq!(body["error"], "Invalid update channel");
+}
+
 // ── providers PUT ────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/packages/core-rs/crates/mainframe-types/src/settings.rs
+++ b/packages/core-rs/crates/mainframe-types/src/settings.rs
@@ -159,11 +159,19 @@ pub struct NotificationConfig {
     pub other: NotificationOtherConfig,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateChannel {
+    Stable,
+    Prerelease,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneralConfig {
     pub worktree_dir: String,
     pub notifications: NotificationConfig,
+    pub update_channel: UpdateChannel,
 }
 
 /// Mirrors the exported `NOTIFICATION_DEFAULTS` constant (all channels on).
@@ -190,6 +198,7 @@ impl Default for GeneralConfig {
         Self {
             worktree_dir: ".worktrees".to_string(),
             notifications: NotificationConfig::default(),
+            update_channel: UpdateChannel::Stable,
         }
     }
 }
@@ -262,6 +271,18 @@ mod tests {
     #[test]
     fn general_defaults_match_ts_constant() {
         assert_eq!(GeneralConfig::default().worktree_dir, ".worktrees");
+        assert_eq!(
+            GeneralConfig::default().update_channel,
+            UpdateChannel::Stable
+        );
+    }
+
+    #[test]
+    fn update_channel_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&UpdateChannel::Prerelease).unwrap(),
+            "\"prerelease\""
+        );
     }
 }
 

--- a/packages/core/src/server/routes/schemas.ts
+++ b/packages/core/src/server/routes/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { EXECUTION_MODES } from '@qlan-ro/mainframe-types';
+import { EXECUTION_MODES, UPDATE_CHANNELS } from '@qlan-ro/mainframe-types';
 
 // --- HTTP Route Schemas ---
 
@@ -84,6 +84,7 @@ export const UpdateGeneralSettingsBody = z.object({
     .regex(/^[a-zA-Z0-9._-]+$/, 'Must be a simple directory name')
     .optional(),
   notifications: NotificationConfigSchema,
+  updateChannel: z.enum(UPDATE_CHANNELS).optional(),
 });
 
 // Filesystem browsing

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -50,9 +50,13 @@ export interface NotificationConfig {
   other: { plugin: boolean };
 }
 
+export const UPDATE_CHANNELS = ['stable', 'prerelease'] as const;
+export type UpdateChannel = (typeof UPDATE_CHANNELS)[number];
+
 export interface GeneralConfig {
   worktreeDir: string;
   notifications: NotificationConfig;
+  updateChannel: UpdateChannel;
 }
 
 export const NOTIFICATION_DEFAULTS: NotificationConfig = {
@@ -64,4 +68,5 @@ export const NOTIFICATION_DEFAULTS: NotificationConfig = {
 export const GENERAL_DEFAULTS: GeneralConfig = {
   worktreeDir: '.worktrees',
   notifications: NOTIFICATION_DEFAULTS,
+  updateChannel: 'stable',
 };

--- a/packages/ui/src/features/settings/panes/general/AppearanceControls.tsx
+++ b/packages/ui/src/features/settings/panes/general/AppearanceControls.tsx
@@ -24,7 +24,7 @@ const UI_SIZES: { id: UiScale; label: string }[] = [
   { id: 'large', label: 'Large' },
 ];
 
-function PickerRow<T extends string>({
+export function PickerRow<T extends string>({
   label,
   options,
   current,

--- a/packages/ui/src/features/settings/panes/general/GeneralPane.tsx
+++ b/packages/ui/src/features/settings/panes/general/GeneralPane.tsx
@@ -1,7 +1,13 @@
 import { useState } from 'react';
+import type { UpdateChannel } from '@qlan-ro/mainframe-types';
 import { useSettingsStore } from '../../../../store/settings';
 import { updateGeneralSettings } from '../../../../lib/api/settings';
-import { AppearanceControls } from './AppearanceControls';
+import { AppearanceControls, PickerRow } from './AppearanceControls';
+
+const UPDATE_CHANNEL_OPTIONS: { id: UpdateChannel; label: string }[] = [
+  { id: 'stable', label: 'Stable' },
+  { id: 'prerelease', label: 'Pre-release (RC)' },
+];
 
 export function GeneralPane({ port }: { port: number }) {
   const general = useSettingsStore((s) => s.general);
@@ -29,6 +35,12 @@ export function GeneralPane({ port }: { port: number }) {
         console.warn('[settings/GeneralPane]', err);
         setSaveError(err instanceof Error ? err.message : 'Save failed');
       });
+  }
+
+  function handleUpdateChannelSelect(updateChannel: UpdateChannel) {
+    updateGeneralSettings(port, { updateChannel })
+      .then(() => loadGeneral({ ...general, updateChannel }))
+      .catch((err: unknown) => console.warn('[settings/GeneralPane]', err));
   }
 
   return (
@@ -65,6 +77,17 @@ export function GeneralPane({ port }: { port: number }) {
           )}
         </div>
         {saveError !== null && <p className="text-label text-destructive">{saveError}</p>}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-label font-semibold text-muted-foreground">Updates</h3>
+        <PickerRow
+          label="Channel"
+          options={UPDATE_CHANNEL_OPTIONS}
+          current={general.updateChannel}
+          prefix="settings-updates-channel"
+          onSelect={handleUpdateChannelSelect}
+        />
       </section>
     </div>
   );

--- a/packages/ui/src/features/settings/panes/general/__tests__/GeneralPane.test.tsx
+++ b/packages/ui/src/features/settings/panes/general/__tests__/GeneralPane.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { GeneralPane } from '../GeneralPane';
 import { useSettingsStore } from '../../../../../store/settings';
 import { useTheme } from '../../../../../store/theme';
@@ -11,7 +11,11 @@ vi.mock('../../../../../lib/api/settings', () => ({
 
 beforeEach(() => {
   useSettingsStore.setState({
-    general: { worktreeDir: '.worktrees', notifications: useSettingsStore.getState().general.notifications },
+    general: {
+      worktreeDir: '.worktrees',
+      notifications: useSettingsStore.getState().general.notifications,
+      updateChannel: 'stable',
+    },
   });
   updateGeneralSettings.mockClear();
 });
@@ -60,5 +64,29 @@ describe('GeneralPane', () => {
     fireEvent.click(screen.getByTestId('settings-appearance-ui-scale-large'));
     expect(useTheme.getState().uiScale).toBe('large');
     expect(updateGeneralSettings).not.toHaveBeenCalled();
+  });
+
+  describe('update channel', () => {
+    it('renders the current channel as selected', () => {
+      render(<GeneralPane port={31415} />);
+      expect(screen.getByTestId('settings-updates-channel-stable').className).toContain('bg-accent text-foreground');
+      expect(screen.getByTestId('settings-updates-channel-prerelease').className).not.toContain(
+        'bg-accent text-foreground',
+      );
+    });
+
+    it('selecting Pre-release PUTs the patch and updates the displayed selection optimistically', async () => {
+      render(<GeneralPane port={31415} />);
+      fireEvent.click(screen.getByTestId('settings-updates-channel-prerelease'));
+      expect(updateGeneralSettings).toHaveBeenCalledWith(31415, { updateChannel: 'prerelease' });
+      await waitFor(() => {
+        expect(screen.getByTestId('settings-updates-channel-prerelease').className).toContain(
+          'bg-accent text-foreground',
+        );
+      });
+      expect(screen.getByTestId('settings-updates-channel-stable').className).not.toContain(
+        'bg-accent text-foreground',
+      );
+    });
   });
 });

--- a/packages/ui/src/features/settings/panes/notifications/__tests__/NotificationsPane.test.tsx
+++ b/packages/ui/src/features/settings/panes/notifications/__tests__/NotificationsPane.test.tsx
@@ -16,7 +16,9 @@ const NOTIF = {
   other: { plugin: true },
 };
 beforeEach(() => {
-  useSettingsStore.setState({ general: { worktreeDir: '.worktrees', notifications: structuredClone(NOTIF) } });
+  useSettingsStore.setState({
+    general: { worktreeDir: '.worktrees', notifications: structuredClone(NOTIF), updateChannel: 'stable' },
+  });
   updateGeneralSettings.mockClear();
 });
 afterEach(() => vi.clearAllMocks());


### PR DESCRIPTION
## Summary
- Adds an `updateChannel: 'stable' | 'prerelease'` field to `GeneralConfig`, surfaced as a "Channel" picker in Settings → General (defaults to `stable`).
- **Electron**: every update-check path (scheduled, manual, and the `update:check` IPC handler) reads the channel from the daemon and sets `autoUpdater.allowPrerelease` accordingly, defaulting to stable on any fetch failure.
- **Tauri**: the updater plugin has no built-in channel concept — stable keeps the static `tauri.conf.json` endpoint; pre-release resolves the newest published (non-draft) GitHub release's `latest.json` asset directly via the GitHub API, falling back to the stable endpoint on any lookup failure.
- **Rust daemon leg**: `packages/core-rs`'s `mainframe-server` (the in-progress Rust port of the Node daemon, gated by `MAINFRAME_DAEMON_IMPL=rust`) ports `GET`/`PUT /api/settings/general` 1:1 from Node — this was initially missed, so it's included here too (`GeneralConfig.update_channel`, validation, persistence, and integration tests) to keep the two daemon legs at parity.
- **CLAUDE.md**: documents `packages/core-rs` in Architecture and adds a golden rule — daemon changes need the matching Rust port in the same PR, until Node is retired. Added directly because of the parity gap this PR itself hit.
- Design doc: `docs/architecture/2026-07-13-update-channel-setting-design.md`

## Out of scope
The CI release workflow currently leaves rc releases as unpublished drafts (`release.yml`, `draft: true`, no publish step) — until that's fixed separately, toggling to "Pre-release" has no visible effect since nothing is published to fetch. This was explicitly descoped during design.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-app-electron exec vitest run src/main/auto-updater.test.ts` — 11/11 pass
- [x] `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/settings/panes/general/__tests__/GeneralPane.test.tsx` — 9/9 pass
- [x] `cargo test --lib updater::` (app-tauri) — 15/15 pass
- [x] `cargo test -p mainframe-types settings::` (core-rs) — 9/9 pass
- [x] `cargo test -p mainframe-server --test routes_settings` (core-rs) — 22/22 pass
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean
- [x] `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit` — clean
- [x] `cargo check` / `cargo clippy -D warnings` / `cargo fmt --check` (app-tauri, core-rs) — clean (only pre-existing, unrelated warnings)
- [x] CI green (a `mainframe-automations` conformance test flaked on one run, unrelated to this diff — passed on rerun)
- [ ] Manual: toggle the channel in Settings → General on both shells and confirm it persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)