### PR TITLE
fix(ui): reclaim the sidebar's phantom scrollbar gutter

### DIFF
--- a/.changeset/sidebar-density-polish.md
+++ b/.changeset/sidebar-density-polish.md
@@ -3,3 +3,9 @@
 ---
 
 Overhaul the left sidebar's visual density and information architecture: unified per-level indentation across Projects/Sessions/Tasks/Tags (matching macOS outline conventions, full-width selection highlights on indented rows), all four root sections now independently collapsible and persisted, Context/Skills/Agents moved into the right inspector while Tasks moved into the left sidebar as its own section (per HIG, contextual detail vs. navigable collections), colored tag pills replacing neutral chips with color dots, a redesigned daemon selector card matching the mobile app's pattern, and numerous row-height/padding/font/scroll-behavior fixes throughout.
+
+The Tasks section now shows at most five tasks with a "View all N tasks" row, and sits in the bottom cluster below the flexible spacer. Project rows reserve full-strength foreground for the unread signal instead of using it at rest, matching the session-row convention.
+
+The sessions list no longer reserves layout width for a scrollbar that is invisible at rest. A global `scrollbar-width: thin` made WebKit render a classic, space-reserving bar, shrinking every row by 13px to line a gutter whose thumb is transparent until hover; the list now uses a Radix ScrollArea, whose absolutely-positioned thumb overlays the rows at no layout cost.
+
+Fixes a latent bug in the shared `ScrollArea`: its `[&>div]:!block` rule used Tailwind v3's important-prefix syntax, which compiles to nothing under Tailwind v4, so the rule had never taken effect. Radix's `display: table` viewport wrapper now gets a viewport-bounded width as intended, restoring `truncate` on flex rows in every ScrollArea.

--- a/.changeset/sidebar-density-polish.md
+++ b/.changeset/sidebar-density-polish.md
@@ -3,9 +3,3 @@
 ---
 
 Overhaul the left sidebar's visual density and information architecture: unified per-level indentation across Projects/Sessions/Tasks/Tags (matching macOS outline conventions, full-width selection highlights on indented rows), all four root sections now independently collapsible and persisted, Context/Skills/Agents moved into the right inspector while Tasks moved into the left sidebar as its own section (per HIG, contextual detail vs. navigable collections), colored tag pills replacing neutral chips with color dots, a redesigned daemon selector card matching the mobile app's pattern, and numerous row-height/padding/font/scroll-behavior fixes throughout.
-
-The Tasks section now shows at most five tasks with a "View all N tasks" row, and sits in the bottom cluster below the flexible spacer. Project rows reserve full-strength foreground for the unread signal instead of using it at rest, matching the session-row convention.
-
-The sessions list no longer reserves layout width for a scrollbar that is invisible at rest. A global `scrollbar-width: thin` made WebKit render a classic, space-reserving bar, shrinking every row by 13px to line a gutter whose thumb is transparent until hover; the list now uses a Radix ScrollArea, whose absolutely-positioned thumb overlays the rows at no layout cost.
-
-Fixes a latent bug in the shared `ScrollArea`: its `[&>div]:!block` rule used Tailwind v3's important-prefix syntax, which compiles to nothing under Tailwind v4, so the rule had never taken effect. Radix's `display: table` viewport wrapper now gets a viewport-bounded width as intended, restoring `truncate` on flex rows in every ScrollArea.

--- a/.changeset/sidebar-scrollbar-gutter.md
+++ b/.changeset/sidebar-scrollbar-gutter.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+The sessions list no longer reserves layout width for a scrollbar that is invisible at rest. A global `scrollbar-width: thin` made WebKit render a classic, space-reserving bar, shrinking every row by 13px to line a gutter whose thumb is transparent until hover; the list now uses a Radix ScrollArea, whose absolutely-positioned thumb overlays the rows at no layout cost.
+
+Fixes a latent bug in the shared `ScrollArea`: its `[&>div]:!block` rule used Tailwind v3's important-prefix syntax, which compiles to nothing under Tailwind v4, so the rule had never taken effect. Radix's `display: table` viewport wrapper now gets a viewport-bounded width as intended, restoring `truncate` on flex rows in every ScrollArea.
+
+The Tasks section now shows at most five tasks with a "View all N tasks" row, and sits in the bottom cluster below the flexible spacer. Project rows reserve full-strength foreground for the unread signal instead of using it at rest, matching the session-row convention.

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -15,8 +15,12 @@ function ScrollArea({
         on flex rows — they grow past the viewport and trailing controls get clipped by
         the root's `overflow-hidden`. Forcing that wrapper to `block` gives it a definite
         viewport-bounded width so truncation works. All our ScrollAreas are vertical.
+
+        `block!`, not `!block`: Tailwind v4 moved the important modifier to a suffix, so
+        the v3 prefix form compiles to nothing — this rule silently did nothing until
+        2026-07-16.
       */}
-      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
+      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:block!">
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />

--- a/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
@@ -43,13 +43,24 @@ const ProjectRowBody = forwardRef<HTMLDivElement, ProjectRowBodyProps>(function 
   { project, active, badgeCount, badgeTestId, avatarColor, onSelect, className, ...props },
   ref,
 ) {
+  // Mirrors SessionRow's title convention: full-strength foreground is the
+  // UNREAD signal, never the resting state. Rest is muted (matching the "All"
+  // and "Add project" rows above); a project with unread sessions goes bold
+  // foreground; active wins over both.
+  const hasUnread = badgeCount > 0;
   const containerClass = [
     'flex h-[28px] w-full items-center rounded-md transition-colors',
-    active ? 'bg-mf-selection text-primary' : 'text-foreground hover:bg-accent',
+    active ? 'bg-mf-selection' : 'hover:bg-accent',
     className,
   ]
     .filter(Boolean)
     .join(' ');
+
+  const nameClass = active
+    ? 'text-primary font-medium'
+    : hasUnread
+      ? 'text-foreground font-bold'
+      : 'text-muted-foreground font-medium';
 
   return (
     <div ref={ref} data-testid={`sessions-filter-pill-${project.id}-wrap`} className={containerClass} {...props}>
@@ -58,12 +69,12 @@ const ProjectRowBody = forwardRef<HTMLDivElement, ProjectRowBodyProps>(function 
         aria-pressed={active}
         onClick={onSelect}
         type="button"
-        className="flex h-full min-w-0 flex-1 items-center gap-[9px] px-[12px] text-label font-medium tracking-normal"
+        className="flex h-full min-w-0 flex-1 items-center gap-[9px] px-[12px] text-label tracking-normal"
       >
         <span data-testid={`sessions-filter-pill-avatar-${project.id}`}>
           <ProjectAvatar name={project.name} color={avatarColor} />
         </span>
-        <span className="min-w-0 flex-1 truncate text-left">{project.name}</span>
+        <span className={`min-w-0 flex-1 truncate text-left ${nameClass}`}>{project.name}</span>
         {badgeTestId != null && (
           <CountBadge count={badgeCount} variant="unread" onAccent={active} data-testid={badgeTestId} />
         )}

--- a/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
@@ -125,10 +125,14 @@ export function SessionListVirtuoso({ groups, showProject, renderItem }: Session
   const [contentHeight, setContentHeight] = useState<number>();
 
   return (
-    // pb only: top padding on the scroller opens a see-through band above the
-    // pinned group header (sticky pins to the content edge, below the padding).
+    // mb, not pb: the scroller is capped at `maxHeight: contentHeight`, so bottom
+    // PADDING is subtracted from the viewport inside that cap — leaving the list
+    // permanently 2px short of its own content and Radix painting a thumb for an
+    // overflow that isn't real. A margin sits outside the cap and buys the same
+    // gap for free. Bottom only: a top gap on the scroller opens a see-through
+    // band above the pinned group header (sticky pins to the content edge).
     <GroupedVirtuoso
-      className="min-h-0 flex-[9999_1_0%] pb-0.5"
+      className="mb-0.5 min-h-0 flex-[9999_1_0%]"
       style={contentHeight != null ? { maxHeight: contentHeight } : undefined}
       totalListHeightChanged={setContentHeight}
       groupCounts={groupCounts}

--- a/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionListVirtuoso.tsx
@@ -20,9 +20,11 @@
  */
 import { forwardRef, useMemo, useState, type ComponentPropsWithoutRef, type ReactNode } from 'react';
 import { GroupedVirtuoso } from 'react-virtuoso';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import type { SessionGroupResult } from '../view-model/group-sessions';
 import type { SessionItem } from '../view-model/chat-to-thread-custom';
 import { SessionGroupHeader } from './SessionGroupHeader';
+import { ScrollBar } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 
 export interface SessionListVirtuosoProps {
@@ -32,24 +34,53 @@ export interface SessionListVirtuosoProps {
 }
 
 // The scroll viewport. Carries the list test hook; forwardRef is required —
-// Virtuoso attaches its scroll listener to this node. Defined at module scope
-// so its identity is stable across renders (an inline component would remount
-// the scroller every render).
-const SessionsScroller = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
-  function SessionsScroller(props, ref) {
-    const { className, ...rest } = props;
-    return (
-      <div
+// Virtuoso attaches its scroll listener to this node (hence the ref lands on the
+// Radix Viewport, the element that actually scrolls — not the Root). Defined at
+// module scope so its identity is stable across renders (an inline component
+// would remount the scroller every render).
+//
+// Radix ScrollArea rather than a plain div: globals.css sets `scrollbar-width:
+// thin` universally, which WebKit renders as a CLASSIC, space-reserving bar — so
+// rows lost width to a permanent gutter whose thumb is transparent until hover.
+// No CSS fixes that (the standard props can't be mixed with ::-webkit-scrollbar
+// rules, and scrollbar-gutter only ever reserves more). Radix hides the native
+// bar and paints an absolutely-positioned thumb instead: it overlays the rows, so
+// it costs no layout width. `type="hover"` keeps the old reveal-on-hover feel.
+//
+// Splitting Virtuoso's props across the two elements is load-bearing. The Root is
+// the flex child the sidebar lays out, so it takes the className (flex sizing) and
+// the `maxHeight` content cap. Everything else in Virtuoso's style — crucially
+// `overflow-y: auto` — must stay on the Viewport: handing it to the Root instead
+// makes the Root a SECOND scroll container, and since Virtuoso's ref/listener is
+// on the Viewport, the list then scrolls on an element Virtuoso never measures and
+// rows past the fold become unreachable.
+const SessionsScroller = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(function SessionsScroller(
+  { className, style, children, ...rest },
+  ref,
+) {
+  const { maxHeight, ...viewportStyle } = style ?? {};
+  return (
+    <ScrollAreaPrimitive.Root type="hover" className={cn('relative overflow-hidden', className)} style={{ maxHeight }}>
+      <ScrollAreaPrimitive.Viewport
         ref={ref}
-        className={cn('overscroll-contain bg-transparent', className)}
         {...rest}
+        style={viewportStyle}
+        // `[&>div]:block!`: Radix wraps viewport children in a `display:table`
+        // div. Left as a table it also shrink-wraps Virtuoso's item list, which
+        // collapses the measured content height to a single row.
+        className="size-full overscroll-contain bg-transparent [&>div]:block!"
         // After {...rest}: Virtuoso injects its own data-testid ("virtuoso-scroller")
         // which must not override the list's test hook.
         data-testid="sessions-list-scroll"
-      />
-    );
-  },
-);
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      {/* w-[9px], not the shared ScrollBar's w-2: integer spacing is compressed here
+            (w-2 = 4px), which after the border and padding leaves a 1px thumb. */}
+      <ScrollBar className="w-[9px]" />
+    </ScrollAreaPrimitive.Root>
+  );
+});
 
 // The pinned group-header host. Its SessionGroupHeader child paints translucent
 // glass, but WKWebView's backdrop-filter does not reliably sample sibling rows

--- a/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionSidebar.tsx
@@ -5,9 +5,9 @@
  *   header → ProjectFilterPillBar (the project switcher — "All projects" is
  *   its own top row, so no separate "Projects" section title is needed) →
  *   "Sessions" group header (chevron + count + new/sort/more) → scrollable
- *   TIME-grouped list (flex-1) → TasksSidebarSection (a second navigable
- *   collection, right after Sessions) → TagFilterBar pinned at the BOTTOM
- *   (border-t, flex-shrink-0)
+ *   TIME-grouped list (flex-1) → flexible spacer → bottom utility cluster:
+ *   TasksSidebarSection (capped backlog preview) → TagFilterBar, glued to
+ *   the daemon selector footer below
  *
  * Grouping is by TIME, not project (Pinned / Today / Yesterday / Earlier), with a
  * Sort By menu (Recent / Name / Status) — per the artboard `arrangeSessions`.
@@ -270,12 +270,8 @@ function SessionSidebarImpl() {
         </>
       )}
 
-      {/* Tasks — a navigable collection like Sessions, per HIG; sits right after the
-          session list, before the tag filter footer. */}
-      <TasksSidebarSection />
-
       {/* Flexible gap (not a fixed margin): absorbs whatever vertical space
-          Projects/Sessions/Tasks don't use, so Tags + the daemon selector
+          Projects/Sessions don't use, so Tasks + Tags + the daemon selector
           (SidebarFooter, rendered by SidebarShell right after this component)
           stay glued together as one bottom-anchored cluster instead of the
           footer floating up flush against Tags on a short list. A fixed
@@ -283,6 +279,12 @@ function SessionSidebarImpl() {
           shrinks below itself, so it always leaves a footer-sized dead zone
           either above or below the cluster depending on content length. */}
       <div className="min-h-3 flex-1" aria-hidden="true" />
+
+      {/* Bottom utility cluster: navigation (Projects/Sessions) flows from the
+          top; secondary project sections (Tasks backlog preview, tag filters)
+          anchor at the bottom with the daemon selector — the Finder/Mail
+          split of primary collections vs. end-of-sidebar utility sections. */}
+      <TasksSidebarSection />
 
       <TagFilterBar items={allItems} filterProjectId={filterProjectId} registry={registry} />
     </>

--- a/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
@@ -107,6 +107,56 @@ describe('ProjectFilterPillBar — attention badge', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Name color convention — mirrors SessionRow's title: full-strength foreground
+// is the UNREAD signal only. A project with no unread sessions must render its
+// name muted, never black.
+// ---------------------------------------------------------------------------
+
+describe('ProjectFilterPillBar — project name color signals unread, not rest state', () => {
+  /** p1's name span — the element carrying the color/weight classes. */
+  const nameSpan = (): HTMLElement => screen.getByText('mainframe');
+
+  it('renders a project with no unread sessions muted, not foreground', () => {
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId={null}
+        attentionCounts={{ p1: 0, p2: 0 }}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(nameSpan().className).toContain('text-muted-foreground');
+    expect(nameSpan().className).not.toContain('text-foreground');
+  });
+
+  it('renders a project WITH unread sessions bold foreground', () => {
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId={null}
+        attentionCounts={{ p1: 3, p2: 0 }}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(nameSpan().className).toContain('text-foreground');
+    expect(nameSpan().className).toContain('font-bold');
+  });
+
+  it('renders the active project in the selection color, not the unread black', () => {
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId="p1"
+        attentionCounts={{ p1: 3, p2: 0 }}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(nameSpan().className).toContain('text-primary');
+    expect(nameSpan().className).not.toContain('font-bold');
+  });
+});
+
 describe('ProjectFilterPillBar — single-select click semantics', () => {
   it('clicking an inactive project row calls onSelect with its id', async () => {
     const handleSelect = vi.fn();

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
@@ -34,12 +34,14 @@ import type { SessionGroupResult } from '../../view-model/group-sessions';
 
 vi.mock('react-virtuoso', () => ({
   GroupedVirtuoso: (props: {
+    className?: string;
+    style?: React.CSSProperties;
     groupCounts: number[];
     components: { Scroller: React.ComponentType<React.HTMLAttributes<HTMLDivElement>> };
     groupContent: (groupIndex: number) => React.ReactNode;
     itemContent: (index: number, groupIndex: number) => React.ReactNode;
   }) => {
-    const { groupCounts, components, groupContent, itemContent } = props;
+    const { className, style, groupCounts, components, groupContent, itemContent } = props;
     const Scroller = components.Scroller;
     const rows: React.ReactNode[] = [];
     let flatIndex = 0;
@@ -50,7 +52,15 @@ vi.mock('react-virtuoso', () => ({
         flatIndex++;
       }
     });
-    return <Scroller className="virtuoso-scroller">{rows}</Scroller>;
+    // Real Virtuoso forwards the className/style it was given down to the Scroller
+    // component (alongside its own marker class), which is how SessionListVirtuoso's
+    // layout classes reach the ScrollArea Root. Mirror that, or the mock silently
+    // swallows the very props some tests assert on.
+    return (
+      <Scroller className={['virtuoso-scroller', className].filter(Boolean).join(' ')} style={style}>
+        {rows}
+      </Scroller>
+    );
   },
 }));
 
@@ -131,6 +141,29 @@ describe('SessionListVirtuoso — scroller test hook is present', () => {
     );
     const viewport = screen.getByTestId('sessions-list-scroll');
     expect(viewport.hasAttribute('data-radix-scroll-area-viewport')).toBe(true);
+  });
+
+  // Regression: the scroller's bottom gap must not be padding. The Root is capped at
+  // `maxHeight: contentHeight` (Virtuoso's own measured content height) and is
+  // border-box, so bottom padding is subtracted from the viewport INSIDE that cap:
+  // a 272px Root gave a 270px viewport holding 272px of content (measured live:
+  // vpOffsetH 270, vpScrollH 272, overflowBy 2). Radix read that phantom 2px
+  // overflow as "scrollable" and painted a near-full-height thumb on a list that
+  // comfortably fit. A margin sits outside the cap and buys the same gap for free.
+  // jsdom does no layout, so pin the cause: no bottom padding on the Root, gap via margin.
+  it('gives the scroller its bottom gap with a margin, never padding that fakes an overflow', () => {
+    render(
+      <SessionListVirtuoso
+        groups={[TODAY_GROUP]}
+        showProject
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+      />,
+    );
+    // Virtuoso's className lands on the ScrollArea Root — the viewport's parent.
+    const root = screen.getByTestId('sessions-list-scroll').parentElement;
+    const rootClasses = root?.className.split(/\s+/) ?? [];
+    expect(rootClasses).toContain('mb-0.5');
+    expect(rootClasses.filter((c) => /^-?pb-/.test(c))).toEqual([]);
   });
 });
 

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionListVirtuoso.test.tsx
@@ -107,8 +107,30 @@ describe('SessionListVirtuoso — scroller test hook is present', () => {
         renderItem={(item) => <div key={item.id}>{item.id}</div>}
       />,
     );
-    expect(screen.getByTestId('sessions-list-scroll').className).toContain('bg-transparent');
-    expect(screen.getByTestId('sessions-list-scroll').className).toContain('virtuoso-scroller');
+    const viewport = screen.getByTestId('sessions-list-scroll');
+    expect(viewport.className).toContain('bg-transparent');
+    // Virtuoso passes the Scroller's className to the ScrollArea Root (the outermost
+    // node it lays out), not to the Viewport that carries the test hook.
+    expect(viewport.parentElement?.className).toContain('virtuoso-scroller');
+  });
+
+  // Regression: globals.css sets `scrollbar-width: thin` on `*`, which WebKit renders as a
+  // CLASSIC, space-reserving scrollbar — the session list permanently lost a 13px gutter and rows
+  // shrank (326px instead of 339px), even though the thumb is transparent at rest. Radix ScrollArea
+  // is the fix: it hides the native bar and paints an absolutely-positioned thumb that overlays the
+  // rows at zero layout cost. jsdom renders no scrollbars, so pin the structure that guarantees it —
+  // Radix stamps `data-radix-scroll-area-viewport` on the viewport (and ships the scoped
+  // `scrollbar-width:none` rule keyed off that attribute). A plain-div scroller has no such attr.
+  it('renders the scroller as a Radix ScrollArea viewport so the native gutter is suppressed', () => {
+    render(
+      <SessionListVirtuoso
+        groups={[TODAY_GROUP]}
+        showProject
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+      />,
+    );
+    const viewport = screen.getByTestId('sessions-list-scroll');
+    expect(viewport.hasAttribute('data-radix-scroll-area-viewport')).toBe(true);
   });
 });
 

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionSidebar.test.tsx
@@ -622,8 +622,8 @@ describe('SessionSidebar — archived sessions are excluded from the list', () =
 // 8. TagFilterBar is mounted (sessions-tag-filter-bar present)
 // Per the warm-chrome artboard it is now pinned at the BOTTOM, AFTER the
 // scrollable session list — assert it renders AND comes after the list region.
-// TasksSidebarSection sits between the two: right after the session list,
-// before the tag filter footer.
+// TasksSidebarSection is part of the bottom utility cluster: after the
+// flexible spacer, directly above the tag filter footer.
 // ---------------------------------------------------------------------------
 
 describe('SessionSidebar — TagFilterBar is mounted at the bottom, after the list', () => {
@@ -640,7 +640,7 @@ describe('SessionSidebar — TagFilterBar is mounted at the bottom, after the li
     expect(pills.compareDocumentPosition(tagBar) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('renders the tasks section right after the session list, before the tag filter bar', () => {
+  it('renders the tasks section in the bottom cluster, directly before the tag filter bar', () => {
     render(<SessionSidebar />);
     const tasks = screen.getByTestId('tasks-sidebar-section-stub');
     const tagBar = screen.getByTestId('sessions-tag-filter-bar');

--- a/packages/ui/src/features/tasks/TasksSidebarList.tsx
+++ b/packages/ui/src/features/tasks/TasksSidebarList.tsx
@@ -7,8 +7,11 @@
  * edge — the two loaders don't race, both go through the store's `_loadSeq`
  * staleness guard.
  *
- * Filters to active tasks (status !== 'done'). Click → opens TaskEditModal
- * via local state (section-local; does not use the modal store).
+ * Filters to active tasks (status !== 'done') and shows at most
+ * VISIBLE_TASKS rows — no internal scroll region (macOS sidebars keep one
+ * scroll container; long collections link out instead). Overflow ends the
+ * section with a "View all N tasks" row that opens the full Tasks view.
+ * Click on a row → opens TaskEditModal via local state (section-local).
  *
  * Row treatment mirrors SessionRow (mx-2 rounded-md hover:bg-accent), not the
  * old bordered-list drawer rows, so it reads as a sibling of the Sessions list.
@@ -18,6 +21,7 @@
 import React, { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useTodosStore } from './use-todos-store';
+import { useTasksModal } from './use-tasks-modal';
 import { TaskEditModal } from './TaskEditModal';
 import type { Todo } from '@/lib/api/todos';
 import { extractAllLabels } from './todos-filters';
@@ -25,6 +29,9 @@ import { SIDEBAR_INDENT_STEP_PX } from '@/layout/sidebar-indent';
 
 /** Level 1 — same depth as "+ New task" (no task sub-grouping exists yet). */
 const TASK_ROW_INDENT_PX = SIDEBAR_INDENT_STEP_PX;
+
+/** Sidebar preview size; the full backlog lives in the Tasks modal. */
+const VISIBLE_TASKS = 5;
 
 interface Props {
   port: number;
@@ -34,6 +41,7 @@ interface Props {
 
 export function TasksSidebarList({ port, projectId, onStartSession }: Props): React.ReactElement {
   const { load, todos } = useTodosStore();
+  const openModal = useTasksModal((s) => s.openModal);
   const [editTodo, setEditTodo] = useState<Todo | null | undefined>(undefined);
 
   // SINGLE loader owner: this component is always mounted when projectId is set.
@@ -42,6 +50,7 @@ export function TasksSidebarList({ port, projectId, onStartSession }: Props): Re
   }, [port, projectId, load]);
 
   const active = todos.filter((t) => t.status !== 'done');
+  const shown = active.slice(0, VISIBLE_TASKS);
   const allLabels = extractAllLabels(todos);
 
   return (
@@ -52,7 +61,7 @@ export function TasksSidebarList({ port, projectId, onStartSession }: Props): Re
             No active tasks.
           </div>
         ) : (
-          active.map((todo) => (
+          shown.map((todo) => (
             <button
               key={todo.id}
               type="button"
@@ -68,6 +77,17 @@ export function TasksSidebarList({ port, projectId, onStartSession }: Props): Re
               <span className="flex-1 min-w-0 text-body text-foreground truncate">{todo.title}</span>
             </button>
           ))
+        )}
+        {active.length > VISIBLE_TASKS && (
+          <button
+            data-testid="tasks-sidebar-view-all"
+            type="button"
+            onClick={openModal}
+            style={{ marginLeft: TASK_ROW_INDENT_PX }}
+            className="mr-2 flex h-[24px] items-center px-[12px] text-left text-caption font-semibold tracking-normal text-primary transition-colors hover:underline"
+          >
+            View all {active.length} tasks
+          </button>
         )}
       </div>
 

--- a/packages/ui/src/features/tasks/TasksSidebarSection.tsx
+++ b/packages/ui/src/features/tasks/TasksSidebarSection.tsx
@@ -12,9 +12,9 @@
  * active project via useActiveIdentity and renders nothing without one
  * (matches the old `{projectId && <TasksDrawer .../>}` guard).
  *
- * Capped own-scroll height (not flex-1) so a long task list can't crowd the
- * Sessions list off the visible sidebar — plain section, no manual resize
- * handle, closer to "just like Sessions" than the old resizable drawer.
+ * No internal scroll region: TasksSidebarList caps itself at a few rows and
+ * ends with a "View all N tasks" row into the full Tasks view, so a long
+ * backlog can't crowd the Sessions list off the visible sidebar.
  *
  * data-testid="tasks-sidebar-section".
  */
@@ -42,8 +42,6 @@ const ROW_BTN =
 /** Matches SessionsMoreMenu's ICON_BTN, for a consistent header icon-button look. */
 const ICON_BTN =
   'inline-flex size-[22px] items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
-
-const LIST_MAX_HEIGHT = 240;
 
 export function TasksSidebarSection() {
   const { projectId } = useActiveIdentity();
@@ -104,9 +102,7 @@ export function TasksSidebarSection() {
             </button>
           </div>
 
-          <div className="overflow-y-auto" style={{ maxHeight: LIST_MAX_HEIGHT }}>
-            <TasksSidebarList port={port} projectId={projectId} onStartSession={(t) => void startTodoSession(t.id)} />
-          </div>
+          <TasksSidebarList port={port} projectId={projectId} onStartSession={(t) => void startTodoSession(t.id)} />
         </>
       )}
 

--- a/packages/ui/src/features/tasks/__tests__/TasksSidebarSection.test.tsx
+++ b/packages/ui/src/features/tasks/__tests__/TasksSidebarSection.test.tsx
@@ -16,6 +16,8 @@
  *  8.  Done todos do NOT appear as rows.
  *  9.  Clicking Expand calls useTasksModal.openModal.
  *  10. Clicking New opens the TaskEditModal (create flow).
+ *  11. Overflow: at most 5 task rows render; a "View all N tasks" row appears
+ *      past 5 and opens the full Tasks view (no internal scroll region).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
@@ -214,7 +216,50 @@ describe('TasksSidebarSection — New button opens the create modal', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 11. Section is collapsible
+// 11. Overflow — cap at 5 rows + "View all N tasks"
+// ---------------------------------------------------------------------------
+
+describe('TasksSidebarSection — caps visible rows and offers View all', () => {
+  const sevenActive = Array.from({ length: 7 }, (_, i) =>
+    makeTodo({ id: `todo-${i + 1}`, number: i + 1, title: `Task ${i + 1}`, status: 'open' }),
+  );
+
+  it('renders only the first 5 rows when there are 7 active todos', () => {
+    renderSection(sevenActive);
+    expect(screen.getByTestId('tasks-sidebar-row-5')).toBeTruthy();
+    expect(screen.queryByTestId('tasks-sidebar-row-6')).toBeNull();
+    expect(screen.queryByTestId('tasks-sidebar-row-7')).toBeNull();
+  });
+
+  it('renders "View all 7 tasks" when there are 7 active todos', () => {
+    renderSection(sevenActive);
+    expect(screen.getByTestId('tasks-sidebar-view-all').textContent).toBe('View all 7 tasks');
+  });
+
+  it('does NOT render the View all row at exactly 5 active todos', () => {
+    renderSection(sevenActive.slice(0, 5));
+    expect(screen.getByTestId('tasks-sidebar-row-5')).toBeTruthy();
+    expect(screen.queryByTestId('tasks-sidebar-view-all')).toBeNull();
+  });
+
+  it('does not count done todos toward the cap or the View all total', () => {
+    const fiveActivePlusDone = [
+      ...sevenActive.slice(0, 5),
+      makeTodo({ id: 'todo-done', number: 99, title: 'Done', status: 'done' }),
+    ];
+    renderSection(fiveActivePlusDone);
+    expect(screen.queryByTestId('tasks-sidebar-view-all')).toBeNull();
+  });
+
+  it('clicking View all opens the full Tasks view', async () => {
+    renderSection(sevenActive);
+    await userEvent.click(screen.getByTestId('tasks-sidebar-view-all'));
+    expect(mockOpenModal).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Section is collapsible
 // ---------------------------------------------------------------------------
 
 describe('TasksSidebarSection — collapsible', () => {

--- a/packages/ui/src/layout/__tests__/SidebarShell.test.tsx
+++ b/packages/ui/src/layout/__tests__/SidebarShell.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 
 // The shell composes chrome around the sessions list; mock the heavy children so
 // this test asserts only composition + DOM order (list → footer). SessionSidebar
-// itself now composes TasksSidebarSection + TagFilterBar right after its list —
-// covered by SessionSidebar's own tests, not the shell's.
+// itself now composes TasksSidebarSection + TagFilterBar as a bottom cluster
+// below its list — covered by SessionSidebar's own tests, not the shell's.
 vi.mock('@/features/sessions/sidebar/SessionSidebar', () => ({
   SessionSidebar: () => <div data-testid="session-list-stub" />,
 }));


### PR DESCRIPTION
Follow-up polish to #470, on the surfaces that PR left rough.

## The scrollbar gutter

The sessions list reserved 13px of layout width for a scrollbar nobody could see. `globals.css` sets `scrollbar-width: thin` on `*`, which WebKit renders as a **classic, space-reserving** bar — so every row shrank to line a gutter whose thumb is transparent until hover.

CSS alone can't undo this: setting either standard scrollbar property makes WebKit ignore `::-webkit-scrollbar` rules, and `scrollbar-gutter` only ever reserves *more*. So the list now uses a Radix ScrollArea, which hides the native bar and paints an absolutely-positioned thumb that overlays the rows at no layout cost.

Measured live in the Tauri webview:

| | before | after |
|---|---|---|
| gutter | 13px | 0 |
| row width | 326px | 339px |
| thumb | invisible at rest | 6px, overlays rows, reveals on hover |

Splitting Virtuoso's props across Root and Viewport is load-bearing and commented as such: the Viewport must keep `overflow-y`, or the Root becomes a second scroll container that Virtuoso never measures and rows past the fold become unreachable.

## The phantom 2px overflow

Caught in testing after the above: resize until the list scrolls, then resize back, and the thumb stayed — spanning nearly the full track with room to spare.

The scroller is capped at `maxHeight: contentHeight` (Virtuoso's measured content height) and Radix's Root is `border-box`, so the list's `pb-0.5` was subtracted from the viewport *inside* that cap: a 272px Root gave a 270px viewport to hold 272px of content. `overflowBy: 2`, permanently — Radix rightly called that scrollable and sized a thumb for a 2px overflow.

Padding is the wrong tool inside a content-height cap; any of it steals from the viewport. `mb-0.5` sits outside the box and buys the same gap free. Verified: `overflowBy: 0` at rest, `overflowBy: 173` with scrolling intact at a small window, rows 339px throughout.

## Latent Tailwind v4 bug in the shared ScrollArea

`[&>div]:!block` used Tailwind **v3**'s important-*prefix* syntax. v4 moved it to a *suffix*, so the rule compiled to nothing and had never taken effect. Its own comment explains it exists to stop Radix's `display: table` viewport wrapper from defeating `truncate` on flex rows.

Fixed to `[&>div]:block!`. This is the behavior the rule always intended, but it now genuinely applies to every `ScrollArea` consumer — SettingsDialog, ChatThread, ArchivedSessionsDialog, ImportSessionsDialog, TagFilterBar. Worth a reviewer's eye; typecheck and tests are both blind to phantom classes.

## Sidebar polish

- Tasks capped at five with a "View all N tasks" row, moved into the bottom cluster below the flexible spacer.
- Project rows no longer spend full-strength foreground at rest — reserved for the unread signal, matching the session-row convention.

## Testing

- `SessionListVirtuoso` suite 9/9, including a guard that the scroller carries no bottom-padding utility (proven to fail on a `pb-0.5` revert). jsdom can't measure layout, so it pins the structural cause rather than the symptom.
- UI typecheck clean.
- Manual QA of the sidebar changes: 6/6 pass, no surface defects. That run predates the scroller rewrite; the scrollbar behavior above was verified by direct measurement in the live webview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)