### PR TITLE
fix(ui): ask before archiving, not after

### DIFF
--- a/.changeset/archive-session-flow.md
+++ b/.changeset/archive-session-flow.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix the session archive flow. Archiving a session with no git worktree no longer raises a confirm dialog — there was nothing to decide, since the dialog exists only to ask what should happen to the worktree.
+
+Sessions with a worktree are now asked before anything moves, not after. assistant-ui switches the active thread away the moment `archive()` is called, so prompting from inside the adapter changed the selected session while the dialog was still open, and cancelling stranded the user on an empty draft instead of returning them to the session they had just chosen to keep. The row now settles the question first and only then archives, so a cancel leaves both the session and the selection untouched.
+
+Project rows offer a remove button on hover, alongside the existing right-click menu item. The session row's archive action uses an archive icon instead of an X.

--- a/packages/e2e/tests-tauri/sessions.spec.ts
+++ b/packages/e2e/tests-tauri/sessions.spec.ts
@@ -18,8 +18,7 @@
  *   sessions-row-action-archive   — hover action: archive
  *   sessions-rename-input         — inline rename input
  *   sessions-row-title            — the title span
- *   sessions-archive-confirm-dialog — dialog root (no-worktree + worktree chats)
- *   sessions-archive-confirm      — Archive button (no-worktree chat)
+ *   sessions-archive-confirm-dialog — dialog root (worktree-backed chats only)
  *   sessions-archived-dialog      — archived sessions dialog
  *   archived-session-item         — row inside archived dialog
  *   restore-session-btn           — restore button in archived dialog
@@ -29,8 +28,8 @@
  *   import-session-btn            — Import button on each external-session row
  *   sessions-new-picker           — sidebar "New" project picker (no filter pill active)
  *   daemon-footer-trigger         — sidebar footer daemon status (used for readiness waits)
- *   sessions-archive-keep-worktree   — ArchiveWorktreeDialog "Keep worktree" button (hasWorktree=true)
- *   sessions-archive-delete-worktree — ArchiveWorktreeDialog "Delete worktree" button (hasWorktree=true)
+ *   sessions-archive-keep-worktree   — ArchiveWorktreeDialog "Keep worktree" button
+ *   sessions-archive-delete-worktree — ArchiveWorktreeDialog "Delete worktree" button
  *   sessions-import-load-more     — ImportSessionsDialog infinite-scroll sentinel (IntersectionObserver)
  *   sessions-import-retry         — ImportSessionsDialog "Try again" button (fetch error state)
  */
@@ -170,13 +169,9 @@ test.describe('§45 Sessions panel', () => {
       .first()
       .evaluate((el) => (el as HTMLElement).click());
 
-    // The ArchiveWorktreeDialog opens — for a chat with NO git worktree, click Archive.
-    const confirmDialog = page.getByTestId('sessions-archive-confirm-dialog');
-    await confirmDialog.waitFor({ timeout: 5_000 });
-    await page.getByTestId('sessions-archive-confirm').click();
-
-    // The row should disappear from the active list.
+    // A chat with NO worktree has nothing to decide, so it archives with no prompt.
     await expect(rows).toHaveCount(countBefore - 1, { timeout: 10_000 });
+    await expect(page.getByTestId('sessions-archive-confirm-dialog')).toHaveCount(0);
   });
 
   // SP9: view and restore an archived session.
@@ -208,18 +203,14 @@ test.describe('§45 Sessions panel', () => {
 
 // ─── §45 Sessions panel — archive dialog worktree branch ─────────────────────
 //
-// SP8 above covers the NO-worktree path: ArchiveWorktreeDialog renders only
-// `sessions-archive-confirm` (hasWorktree:false), which SP8 clicks. This block
-// covers the hasWorktree:true branch — the dialog swaps in
-// `sessions-archive-keep-worktree` / `sessions-archive-delete-worktree` instead
-// (ArchiveWorktreeDialog.tsx) — and exercises BOTH choices end to end, asserting
-// the worktree directory's fate on disk via node:fs (not just the dialog UI).
+// SP8 above covers the NO-worktree path, where archiving raises no dialog at all.
+// This block covers the only path that asks — a chat WITH a worktree, whose fate
+// is the question — and exercises BOTH answers end to end, asserting the worktree
+// directory's fate on disk via node:fs (not just the dialog UI).
 //
-// `hasWorktree` is derived by chats-remote-adapter.archiveWithConfirm from a
-// fresh `getChat` read of `chat.worktreePath` at archive-click time (not from
-// any cached list), so a chat REST-seeded with a worktree via `enable-worktree`
-// is picked up with no reload needed — same pattern as chat-header.spec.ts's
-// "review button (worktree gate)" block.
+// The row reads `custom.worktreePath` off its own thread-list entry (SessionRow →
+// useArchiveSession), so a chat REST-seeded with a worktree needs that entry
+// refreshed before the click: hence the reload in beforeAll.
 test.describe('§45 Sessions panel — archive dialog worktree branch', () => {
   let app: TauriAppFixture;
   let project: TauriProject;
@@ -252,6 +243,9 @@ test.describe('§45 Sessions panel — archive dialog worktree branch', () => {
     chatDelete = await createTauriChat(app.page, project.projectId, 'default');
     worktreePathKeep = await enableWorktree(chatKeep, 'e2e-archive-keep');
     worktreePathDelete = await enableWorktree(chatDelete, 'e2e-archive-delete');
+    // Re-derive the thread list so both rows carry the freshly-seeded worktreePath.
+    await app.page.reload();
+    await waitConnected(app.page);
   });
 
   test.afterAll(async () => {
@@ -259,7 +253,7 @@ test.describe('§45 Sessions panel — archive dialog worktree branch', () => {
     await closeTauriApp(app);
   });
 
-  test('a chat with a worktree shows keep/delete worktree buttons, not the single confirm', async () => {
+  test('a chat with a worktree is asked about it before archiving, and Keep spares the directory', async () => {
     const { page } = app;
     const sidebar = sessionsSidebar(page);
     const row = sidebar.row(chatKeep);
@@ -271,7 +265,8 @@ test.describe('§45 Sessions panel — archive dialog worktree branch', () => {
     await confirmDialog.waitFor({ timeout: 5_000 });
     await expect(page.getByTestId('sessions-archive-keep-worktree')).toBeVisible();
     await expect(page.getByTestId('sessions-archive-delete-worktree')).toBeVisible();
-    await expect(page.getByTestId('sessions-archive-confirm')).toHaveCount(0);
+    // The row is still in the list: nothing is archived until the question is answered.
+    await expect(row).toHaveCount(1);
 
     // Keep worktree — the row leaves the active list but the directory survives on disk.
     await page.getByTestId('sessions-archive-keep-worktree').click();

--- a/packages/ui/src/features/sessions/runtime/__tests__/archive-confirm-bridge.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/archive-confirm-bridge.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { useArchivePrompt, requestWorktreeArchiveChoice } from '../archive-confirm-bridge';
+import {
+  useArchivePrompt,
+  requestWorktreeArchiveChoice,
+  stageArchiveChoice,
+  takeArchiveChoice,
+} from '../archive-confirm-bridge';
 
 // ---------------------------------------------------------------------------
 // Reset zustand state between tests (the store is a module-level singleton)
@@ -7,10 +12,13 @@ import { useArchivePrompt, requestWorktreeArchiveChoice } from '../archive-confi
 
 afterEach(() => {
   useArchivePrompt.setState({ pending: null });
+  // Drain any staged choices left behind by a test so they don't leak.
+  takeArchiveChoice('chat-1');
+  takeArchiveChoice('chat-2');
 });
 
 // ---------------------------------------------------------------------------
-// archive-confirm-bridge
+// archive-confirm-bridge — request/resolve (the ASK)
 // ---------------------------------------------------------------------------
 
 describe('archive-confirm-bridge — initial state has no pending request', () => {
@@ -19,19 +27,16 @@ describe('archive-confirm-bridge — initial state has no pending request', () =
   });
 });
 
-describe('archive-confirm-bridge — request sets pending with provided fields', () => {
-  it('sets pending to { remoteId, hasWorktree } matching the call arguments', () => {
-    void requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
-    expect(useArchivePrompt.getState().pending).toEqual({
-      remoteId: 'chat-1',
-      hasWorktree: true,
-    });
+describe('archive-confirm-bridge — request sets pending with the remoteId', () => {
+  it('sets pending to { remoteId: "chat-1" }', () => {
+    void requestWorktreeArchiveChoice('chat-1');
+    expect(useArchivePrompt.getState().pending).toEqual({ remoteId: 'chat-1' });
   });
 });
 
 describe('archive-confirm-bridge — resolve with deleteWorktree:true fulfills the promise and clears pending', () => {
   it('awaited promise yields { deleteWorktree:true } and pending becomes null', async () => {
-    const promise = requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
+    const promise = requestWorktreeArchiveChoice('chat-1');
 
     useArchivePrompt.getState().resolve({ deleteWorktree: true });
 
@@ -43,7 +48,7 @@ describe('archive-confirm-bridge — resolve with deleteWorktree:true fulfills t
 
 describe('archive-confirm-bridge — resolve with deleteWorktree:false fulfills the promise', () => {
   it('awaited promise yields { deleteWorktree:false }', async () => {
-    const promise = requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
+    const promise = requestWorktreeArchiveChoice('chat-1');
 
     useArchivePrompt.getState().resolve({ deleteWorktree: false });
 
@@ -54,7 +59,7 @@ describe('archive-confirm-bridge — resolve with deleteWorktree:false fulfills 
 
 describe('archive-confirm-bridge — cancel: resolve with cancel fulfills the promise and clears pending', () => {
   it('awaited promise yields "cancel" and pending becomes null', async () => {
-    const promise = requestWorktreeArchiveChoice('chat-2', { hasWorktree: false });
+    const promise = requestWorktreeArchiveChoice('chat-2');
 
     useArchivePrompt.getState().resolve('cancel');
 
@@ -73,18 +78,15 @@ describe('archive-confirm-bridge — resolve with no pending is a no-op', () => 
 
 describe('archive-confirm-bridge — second request while first is pending overwrites pending (one prompt at a time)', () => {
   it('pending reflects the most-recent request after two overlapping requests', () => {
-    void requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
-    void requestWorktreeArchiveChoice('chat-2', { hasWorktree: false });
+    void requestWorktreeArchiveChoice('chat-1');
+    void requestWorktreeArchiveChoice('chat-2');
 
-    expect(useArchivePrompt.getState().pending).toEqual({
-      remoteId: 'chat-2',
-      hasWorktree: false,
-    });
+    expect(useArchivePrompt.getState().pending).toEqual({ remoteId: 'chat-2' });
   });
 
   it('resolving after the second request fulfills the second promise', async () => {
-    void requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
-    const second = requestWorktreeArchiveChoice('chat-2', { hasWorktree: false });
+    void requestWorktreeArchiveChoice('chat-1');
+    const second = requestWorktreeArchiveChoice('chat-2');
 
     useArchivePrompt.getState().resolve({ deleteWorktree: false });
 
@@ -94,14 +96,54 @@ describe('archive-confirm-bridge — second request while first is pending overw
   });
 
   it('resolves the displaced first promise with "cancel" (no stranded promise)', async () => {
-    const first = requestWorktreeArchiveChoice('chat-1', { hasWorktree: true });
-    const second = requestWorktreeArchiveChoice('chat-2', { hasWorktree: false });
+    const first = requestWorktreeArchiveChoice('chat-1');
+    const second = requestWorktreeArchiveChoice('chat-2');
 
     // The first promise must settle on its own — a second request strands it
-    // otherwise. It resolves to 'cancel' so its adapter.archive rolls back.
+    // otherwise. It resolves to 'cancel' so its caller abandons that archive.
     await expect(first).resolves.toBe('cancel');
 
     useArchivePrompt.getState().resolve({ deleteWorktree: false });
     await expect(second).resolves.toEqual({ deleteWorktree: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// archive-confirm-bridge — stageArchiveChoice / takeArchiveChoice (the HANDOFF)
+// ---------------------------------------------------------------------------
+
+describe('archive-confirm-bridge — takeArchiveChoice with nothing staged', () => {
+  it('returns undefined when no choice was staged for that remoteId', () => {
+    expect(takeArchiveChoice('chat-1')).toBeUndefined();
+  });
+});
+
+describe('archive-confirm-bridge — stageArchiveChoice then takeArchiveChoice hands off the staged value', () => {
+  it('returns { deleteWorktree: true } after staging it for chat-1', () => {
+    stageArchiveChoice('chat-1', { deleteWorktree: true });
+    expect(takeArchiveChoice('chat-1')).toEqual({ deleteWorktree: true });
+  });
+
+  it('returns { deleteWorktree: false } after staging it for chat-1', () => {
+    stageArchiveChoice('chat-1', { deleteWorktree: false });
+    expect(takeArchiveChoice('chat-1')).toEqual({ deleteWorktree: false });
+  });
+});
+
+describe('archive-confirm-bridge — takeArchiveChoice consumes the staged value', () => {
+  it('returns undefined on a second take for the same remoteId', () => {
+    stageArchiveChoice('chat-1', { deleteWorktree: true });
+    takeArchiveChoice('chat-1');
+    expect(takeArchiveChoice('chat-1')).toBeUndefined();
+  });
+});
+
+describe('archive-confirm-bridge — staged choices are keyed per remoteId', () => {
+  it('taking chat-2 does not consume or return chat-1s staged choice', () => {
+    stageArchiveChoice('chat-1', { deleteWorktree: true });
+    stageArchiveChoice('chat-2', { deleteWorktree: false });
+
+    expect(takeArchiveChoice('chat-2')).toEqual({ deleteWorktree: false });
+    expect(takeArchiveChoice('chat-1')).toEqual({ deleteWorktree: true });
   });
 });

--- a/packages/ui/src/features/sessions/runtime/__tests__/chats-remote-adapter.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/chats-remote-adapter.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../../../lib/api/chats', () => ({
 }));
 
 vi.mock('../archive-confirm-bridge', () => ({
-  requestWorktreeArchiveChoice: vi.fn(),
+  takeArchiveChoice: vi.fn(),
 }));
 
 vi.mock('../new-thread-coordinator', () => ({
@@ -68,7 +68,7 @@ vi.mock('../chat-controller-registry', () => ({
 // Import AFTER mocks so the module under test picks them up.
 import { makeChatsRemoteAdapter } from '../chats-remote-adapter';
 import { listChats, getChat, renameChat, archiveChat, unarchiveChat } from '../../../../lib/api/chats';
-import { requestWorktreeArchiveChoice } from '../archive-confirm-bridge';
+import { takeArchiveChoice } from '../archive-confirm-bridge';
 import { createForLocal } from '../new-thread-coordinator';
 
 // ---------------------------------------------------------------------------
@@ -80,9 +80,7 @@ const mockGetChat = getChat as MockedFunction<typeof getChat>;
 const mockRenameChat = renameChat as MockedFunction<typeof renameChat>;
 const mockArchiveChat = archiveChat as MockedFunction<typeof archiveChat>;
 const mockUnarchiveChat = unarchiveChat as MockedFunction<typeof unarchiveChat>;
-const mockRequestWorktreeArchiveChoice = requestWorktreeArchiveChoice as MockedFunction<
-  typeof requestWorktreeArchiveChoice
->;
+const mockTakeArchiveChoice = takeArchiveChoice as MockedFunction<typeof takeArchiveChoice>;
 const mockCreateForLocal = createForLocal as MockedFunction<typeof createForLocal>;
 
 // ---------------------------------------------------------------------------
@@ -216,64 +214,76 @@ describe('chats-remote-adapter — unarchive calls unarchiveChat once', () => {
 });
 
 // ---------------------------------------------------------------------------
-// chats-remote-adapter — archive awaits bridge then archives
+// chats-remote-adapter — archive consumes the staged choice, no prompt, no getChat
+//
+// The confirm dialog is asked (and can be cancelled) entirely upstream in the
+// sidebar row's handler — by the time archive() reaches the adapter, aui has
+// already started its optimistic switch, so the adapter never prompts and
+// never throws. It only reads whatever the row staged via stageArchiveChoice.
 // ---------------------------------------------------------------------------
 
-describe('chats-remote-adapter — archive awaits bridge then calls archiveChat', () => {
-  it('calls requestWorktreeArchiveChoice with hasWorktree:true when worktreePath is present', async () => {
-    mockGetChat.mockResolvedValueOnce(FIXTURE);
-    mockRequestWorktreeArchiveChoice.mockResolvedValueOnce({ deleteWorktree: false });
-    mockArchiveChat.mockResolvedValueOnce(undefined);
-    const adapter = makeChatsRemoteAdapter(31415);
-    await adapter.archive('chat-1');
-    expect(mockRequestWorktreeArchiveChoice).toHaveBeenCalledWith('chat-1', { hasWorktree: true });
-  });
-
-  it('calls archiveChat(31415, chat-1, false) when deleteWorktree is false', async () => {
-    mockGetChat.mockResolvedValueOnce(FIXTURE);
-    mockRequestWorktreeArchiveChoice.mockResolvedValueOnce({ deleteWorktree: false });
+describe('chats-remote-adapter — archive consumes the staged choice via takeArchiveChoice', () => {
+  it('calls archiveChat(31415, chat-1, false) when the staged choice is deleteWorktree:false', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce({ deleteWorktree: false });
     mockArchiveChat.mockResolvedValueOnce(undefined);
     const adapter = makeChatsRemoteAdapter(31415);
     await adapter.archive('chat-1');
     expect(mockArchiveChat).toHaveBeenCalledTimes(1);
     expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-1', false);
   });
+
+  it('calls archiveChat(31415, chat-1, true) when the staged choice is deleteWorktree:true', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce({ deleteWorktree: true });
+    mockArchiveChat.mockResolvedValueOnce(undefined);
+    const adapter = makeChatsRemoteAdapter(31415);
+    await adapter.archive('chat-1');
+    expect(mockArchiveChat).toHaveBeenCalledTimes(1);
+    expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-1', true);
+  });
+
+  it('calls archiveChat(31415, chat-1, false) when nothing was staged (the no-worktree path)', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce(undefined);
+    mockArchiveChat.mockResolvedValueOnce(undefined);
+    const adapter = makeChatsRemoteAdapter(31415);
+    await adapter.archive('chat-1');
+    expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-1', false);
+  });
+
+  it('calls takeArchiveChoice(chat-1) exactly once', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce({ deleteWorktree: false });
+    const adapter = makeChatsRemoteAdapter(31415);
+    await adapter.archive('chat-1');
+    expect(mockTakeArchiveChoice).toHaveBeenCalledTimes(1);
+    expect(mockTakeArchiveChoice).toHaveBeenCalledWith('chat-1');
+  });
+
+  it('does not call getChat', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce(undefined);
+    const adapter = makeChatsRemoteAdapter(31415);
+    await adapter.archive('chat-1');
+    expect(mockGetChat).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
-// chats-remote-adapter — archive cancel throws and does NOT call archiveChat
+// chats-remote-adapter — delete maps to archiveChat with the staged choice
 // ---------------------------------------------------------------------------
 
-describe('chats-remote-adapter — archive cancel throws and does not archive', () => {
-  it('rejects when requestWorktreeArchiveChoice resolves cancel', async () => {
-    mockGetChat.mockResolvedValueOnce(FIXTURE);
-    mockRequestWorktreeArchiveChoice.mockResolvedValueOnce('cancel');
-    const adapter = makeChatsRemoteAdapter(31415);
-    await expect(adapter.archive('chat-1')).rejects.toThrow();
-  });
-
-  it('does not call archiveChat when cancel is chosen', async () => {
-    mockGetChat.mockResolvedValueOnce(FIXTURE);
-    mockRequestWorktreeArchiveChoice.mockResolvedValueOnce('cancel');
-    const adapter = makeChatsRemoteAdapter(31415);
-    await expect(adapter.archive('chat-1')).rejects.toThrow();
-    expect(mockArchiveChat).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// chats-remote-adapter — delete maps to archive (calls archiveChat with deleteWorktree:true)
-// ---------------------------------------------------------------------------
-
-describe('chats-remote-adapter — delete maps to archiveChat with deleteWorktree:true', () => {
-  it('calls archiveChat(31415, chat-1, true) when deleteWorktree is true', async () => {
-    mockGetChat.mockResolvedValueOnce(FIXTURE);
-    mockRequestWorktreeArchiveChoice.mockResolvedValueOnce({ deleteWorktree: true });
+describe('chats-remote-adapter — delete consumes the staged choice via takeArchiveChoice', () => {
+  it('calls archiveChat(31415, chat-1, true) when the staged choice is deleteWorktree:true', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce({ deleteWorktree: true });
     mockArchiveChat.mockResolvedValueOnce(undefined);
     const adapter = makeChatsRemoteAdapter(31415);
     await adapter.delete('chat-1');
     expect(mockArchiveChat).toHaveBeenCalledTimes(1);
     expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-1', true);
+  });
+
+  it('does not call getChat', async () => {
+    mockTakeArchiveChoice.mockReturnValueOnce({ deleteWorktree: true });
+    const adapter = makeChatsRemoteAdapter(31415);
+    await adapter.delete('chat-1');
+    expect(mockGetChat).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/features/sessions/runtime/archive-confirm-bridge.ts
+++ b/packages/ui/src/features/sessions/runtime/archive-confirm-bridge.ts
@@ -1,15 +1,26 @@
 /**
- * Archive-confirm bridge (D10 / S5) — a zustand store the adapter and the
- * ArchiveWorktreeDialog share.
+ * Archive-confirm bridge (D10) — the seam between the archive confirm dialog,
+ * the row that triggers an archive, and the daemon adapter.
  *
- * Native ThreadListItemPrimitive.Archive calls adapter.archive(remoteId) with
- * NO payload, but our daemon archive takes a deleteWorktree flag. So the adapter
- * awaits this bridge: `request` sets `pending` (the dialog renders it) and
- * returns a promise; the user's button click calls `resolve(choice)`. A
- * 'cancel' makes the adapter throw so aui rolls back the optimistic archive (S5).
+ * Two halves, both needed because native ThreadListItemPrimitive.Archive calls
+ * adapter.archive(remoteId) with NO payload while our daemon archive takes a
+ * deleteWorktree flag:
  *
- * `hasWorktree` is passed in by the adapter caller (which derives it via getChat)
- * — the dialog uses it to decide whether to offer the "delete worktree" option.
+ *   - `request` / `resolve`: the ASK. The row calls `request` (sets `pending`,
+ *     which the dialog renders) and awaits the user's button click.
+ *   - `stageArchiveChoice` / `takeArchiveChoice`: the HANDOFF. The row stages the
+ *     answered choice under the chat id, then invokes aui's archive; the adapter
+ *     consumes it on its way to the daemon.
+ *
+ * The ask deliberately happens BEFORE aui's archive, not inside the adapter:
+ * aui switches the active thread away optimistically the moment archive() is
+ * called, so prompting from the adapter changed the user's selected session
+ * while the confirm dialog was still open — and cancelling then stranded them on
+ * an empty draft rather than the session they kept. Asking first means a cancel
+ * never reaches aui at all: nothing moves.
+ *
+ * Only worktree-backed sessions are ever asked (the question IS the worktree),
+ * so `pending` carries no hasWorktree flag — its presence means "has one".
  */
 import { create } from 'zustand';
 
@@ -17,12 +28,11 @@ export type ArchiveChoice = { deleteWorktree: boolean } | 'cancel';
 
 export interface PendingArchiveRequest {
   remoteId: string;
-  hasWorktree: boolean;
 }
 
 interface ArchivePromptState {
   pending: PendingArchiveRequest | null;
-  request: (remoteId: string, opts: { hasWorktree: boolean }) => Promise<ArchiveChoice>;
+  request: (remoteId: string) => Promise<ArchiveChoice>;
   resolve: (choice: ArchiveChoice) => void;
 }
 
@@ -30,14 +40,14 @@ let resolver: ((choice: ArchiveChoice) => void) | null = null;
 
 export const useArchivePrompt = create<ArchivePromptState>((set, get) => ({
   pending: null,
-  request: (remoteId, opts) => {
+  request: (remoteId) => {
     return new Promise<ArchiveChoice>((res) => {
       // One prompt at a time: a second request displaces the first. Resolve the
-      // stranded resolver with 'cancel' so its adapter.archive throws and aui
-      // rolls back the first optimistic archive (instead of hanging forever).
+      // stranded resolver with 'cancel' so its caller abandons that archive
+      // instead of hanging forever.
       const displaced = resolver;
       resolver = res;
-      set({ pending: { remoteId, hasWorktree: opts.hasWorktree } });
+      set({ pending: { remoteId } });
       displaced?.('cancel');
     });
   },
@@ -50,7 +60,21 @@ export const useArchivePrompt = create<ArchivePromptState>((set, get) => ({
   },
 }));
 
-/** Thin wrapper the adapter calls. Resolves with the dialog's choice. */
-export function requestWorktreeArchiveChoice(remoteId: string, opts: { hasWorktree: boolean }): Promise<ArchiveChoice> {
-  return useArchivePrompt.getState().request(remoteId, opts);
+/** Thin wrapper the row calls. Resolves with the dialog's choice. */
+export function requestWorktreeArchiveChoice(remoteId: string): Promise<ArchiveChoice> {
+  return useArchivePrompt.getState().request(remoteId);
+}
+
+const staged = new Map<string, { deleteWorktree: boolean }>();
+
+/** Record the answered choice for the archive aui is about to route to the adapter. */
+export function stageArchiveChoice(remoteId: string, choice: { deleteWorktree: boolean }): void {
+  staged.set(remoteId, choice);
+}
+
+/** Consume a staged choice. Undefined when the archive came from a path that never asks. */
+export function takeArchiveChoice(remoteId: string): { deleteWorktree: boolean } | undefined {
+  const choice = staged.get(remoteId);
+  staged.delete(remoteId);
+  return choice;
 }

--- a/packages/ui/src/features/sessions/runtime/chats-remote-adapter.ts
+++ b/packages/ui/src/features/sessions/runtime/chats-remote-adapter.ts
@@ -3,10 +3,11 @@
  *
  * - list/fetch project each daemon Chat → RemoteThreadMetadata via the pure
  *   chat-to-thread-custom mapper (all list signals ride in `custom`).
- * - archive AND delete both map to POST /archive (no hard-delete route, D5);
- *   both read hasWorktree from the chat, await the worktree-delete confirm
- *   bridge (D10), and a 'cancel' THROWS so aui rolls back its optimistic
- *   archive (S5).
+ * - archive AND delete both map to POST /archive (no hard-delete route, D5),
+ *   carrying the deleteWorktree flag the row staged on the confirm bridge (D10)
+ *   before it invoked archive. Nothing is asked here: aui switches the active
+ *   thread away the moment archive() is called, so a prompt at this depth ran
+ *   after the user's selection had already moved.
  * - generateTitle is a no-op empty stream — the daemon auto-titles; enqueuing
  *   would race it (invariant 4).
  * - initialize creates the daemon chat for a __LOCALID_* thread via the
@@ -26,7 +27,7 @@ import type { AssistantStreamChunk } from 'assistant-stream';
 import type { RemoteThreadListAdapter } from '@assistant-ui/react';
 import { listChats, getChat, renameChat, archiveChat, unarchiveChat } from '../../../lib/api/chats';
 import { chatToThreadCustom } from '../view-model/chat-to-thread-custom';
-import { requestWorktreeArchiveChoice } from './archive-confirm-bridge';
+import { takeArchiveChoice } from './archive-confirm-bridge';
 import { createForLocal } from './new-thread-coordinator';
 import { chatControllerRegistry } from './chat-controller-registry';
 
@@ -47,16 +48,11 @@ function toMetadata(chat: Parameters<typeof chatToThreadCustom>[0]): RemoteThrea
   return { ...result, custom };
 }
 
-async function archiveWithConfirm(port: number, remoteId: string): Promise<void> {
-  const chat = await getChat(port, remoteId);
-  const choice = await requestWorktreeArchiveChoice(remoteId, {
-    hasWorktree: !!chat.worktreePath,
-  });
-  if (choice === 'cancel') {
-    // Throw so aui rolls back its optimistic `archived` update (S5).
-    throw new Error('archive cancelled');
-  }
-  await archiveChat(port, remoteId, choice.deleteWorktree);
+async function archiveWithStagedChoice(port: number, remoteId: string): Promise<void> {
+  // Absent for an archive raised outside the sidebar row (which never has a
+  // worktree question to stage): keep the worktree, the safe default.
+  const choice = takeArchiveChoice(remoteId);
+  await archiveChat(port, remoteId, choice?.deleteWorktree ?? false);
 }
 
 export function makeChatsRemoteAdapter(port: number): RemoteThreadListAdapter {
@@ -73,10 +69,10 @@ export function makeChatsRemoteAdapter(port: number): RemoteThreadListAdapter {
       await renameChat(port, remoteId, newTitle);
     },
     async archive(remoteId: string): Promise<void> {
-      await archiveWithConfirm(port, remoteId);
+      await archiveWithStagedChoice(port, remoteId);
     },
     async delete(remoteId: string): Promise<void> {
-      await archiveWithConfirm(port, remoteId);
+      await archiveWithStagedChoice(port, remoteId);
     },
     async unarchive(remoteId: string): Promise<void> {
       await unarchiveChat(port, remoteId);

--- a/packages/ui/src/features/sessions/sidebar/ArchiveWorktreeDialog.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ArchiveWorktreeDialog.tsx
@@ -1,11 +1,11 @@
 /**
- * ArchiveWorktreeDialog — mounted confirm dialog that fulfills the archive bridge (D10/S5).
+ * ArchiveWorktreeDialog — mounted confirm dialog that fulfills the archive bridge (D10).
  *
- * Native ThreadListItemPrimitive.Archive → adapter.archive(remoteId) → the adapter
- * calls useArchivePrompt.getState().request(remoteId, { hasWorktree }). That sets
- * `pending` here; the user's button choice calls resolve(choice), settling the
- * adapter's awaited promise. A 'cancel' choice makes the adapter throw so aui
- * rolls back the optimistic archive (the row already left on the optimistic switch).
+ * Raised only for worktree-backed sessions, and only BEFORE the archive runs: the
+ * row awaits `requestWorktreeArchiveChoice`, which sets `pending` here; the user's
+ * button choice calls resolve(choice), settling that promise. Cancelling leaves
+ * the session — and the user's selection — exactly as they were. A session with no
+ * worktree has nothing to decide and is archived without a prompt.
  */
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -24,36 +24,26 @@ export function ArchiveWorktreeDialog() {
           <DialogTitle>Archive session</DialogTitle>
         </DialogHeader>
         <p className="text-body text-muted-foreground">
-          {pending.hasWorktree
-            ? 'This session has an associated worktree. Delete it too, or keep it on disk?'
-            : 'Archive this session?'}
+          This session has an associated worktree. Delete it too, or keep it on disk?
         </p>
         <DialogFooter className="gap-2">
           <Button data-testid="sessions-archive-cancel" variant="ghost" onClick={() => resolve('cancel')}>
             Cancel
           </Button>
-          {pending.hasWorktree ? (
-            <>
-              <Button
-                data-testid="sessions-archive-keep-worktree"
-                variant="outline"
-                onClick={() => resolve({ deleteWorktree: false })}
-              >
-                Keep worktree
-              </Button>
-              <Button
-                data-testid="sessions-archive-delete-worktree"
-                variant="destructive"
-                onClick={() => resolve({ deleteWorktree: true })}
-              >
-                Delete worktree
-              </Button>
-            </>
-          ) : (
-            <Button data-testid="sessions-archive-confirm" onClick={() => resolve({ deleteWorktree: false })}>
-              Archive
-            </Button>
-          )}
+          <Button
+            data-testid="sessions-archive-keep-worktree"
+            variant="outline"
+            onClick={() => resolve({ deleteWorktree: false })}
+          >
+            Keep worktree
+          </Button>
+          <Button
+            data-testid="sessions-archive-delete-worktree"
+            variant="destructive"
+            onClick={() => resolve({ deleteWorktree: true })}
+          >
+            Delete worktree
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
+++ b/packages/ui/src/features/sessions/sidebar/ProjectPillContextMenu.tsx
@@ -3,8 +3,10 @@
  * right-click Rename (disabled)/Remove menu. Restyled from a pill to a
  * full-width row (2026-07 rebuild) — a colored initial avatar replaces the
  * bare label, and the row fills the switcher list's width instead of
- * shrink-wrapping. `onRemoveProject` is optional: when omitted (no remove
- * handler wired up) the row renders bare, with no context-menu wrapper.
+ * shrink-wrapping. Remove is offered twice — a hover-revealed button on the row
+ * (the primary, discoverable entry point) and the right-click menu — both routed
+ * through the same handler. `onRemoveProject` is optional: when omitted (no
+ * remove handler wired up) the row renders bare, with neither affordance.
  */
 import type { Project } from '@qlan-ro/mainframe-types';
 import { forwardRef, type HTMLAttributes } from 'react';
@@ -33,6 +35,7 @@ interface ProjectRowBodyProps extends HTMLAttributes<HTMLDivElement> {
   badgeTestId?: string;
   avatarColor: string;
   onSelect: () => void;
+  onRemove?: () => void;
 }
 
 const REMOVE_LABEL = 'Remove Project';
@@ -40,11 +43,11 @@ const RENAME_LABEL = 'Rename Project';
 const HINT_LABEL = 'Right-click for options';
 
 const ProjectRowBody = forwardRef<HTMLDivElement, ProjectRowBodyProps>(function ProjectRowBody(
-  { project, active, badgeCount, badgeTestId, avatarColor, onSelect, className, ...props },
+  { project, active, badgeCount, badgeTestId, avatarColor, onSelect, onRemove, className, ...props },
   ref,
 ) {
   const containerClass = [
-    'flex h-[28px] w-full items-center rounded-md transition-colors',
+    'group flex h-[28px] w-full items-center rounded-md transition-colors',
     active ? 'bg-mf-selection text-primary' : 'text-foreground hover:bg-accent',
     className,
   ]
@@ -68,6 +71,23 @@ const ProjectRowBody = forwardRef<HTMLDivElement, ProjectRowBodyProps>(function 
           <CountBadge count={badgeCount} variant="unread" onAccent={active} data-testid={badgeTestId} />
         )}
       </button>
+      {onRemove != null && (
+        <button
+          data-testid={`sessions-project-remove-action-${project.id}`}
+          type="button"
+          aria-label={REMOVE_LABEL}
+          onClick={(e) => {
+            // The row's select button is a sibling, but the whole row is also the
+            // context-menu trigger — stop both from reacting to this click.
+            e.stopPropagation();
+            e.preventDefault();
+            onRemove();
+          }}
+          className="mr-[6px] hidden size-[22px] flex-shrink-0 items-center justify-center rounded-xs text-muted-foreground transition-colors group-hover:flex hover:bg-accent hover:text-destructive"
+        >
+          <Trash2Icon className="size-3.5" />
+        </button>
+      )}
     </div>
   );
 });
@@ -83,6 +103,7 @@ export function ProjectPillContextMenu({
 }: ProjectPillContextMenuProps) {
   const hintDismissed = useUiPrefs((s) => s.rightClickHintDismissed);
   const dismissHint = useUiPrefs((s) => s.dismissRightClickHint);
+  const removeProject = onRemoveProject == null ? undefined : () => onRemoveProject(project);
 
   const body = (
     <ProjectRowBody
@@ -92,11 +113,11 @@ export function ProjectPillContextMenu({
       badgeTestId={badgeTestId}
       avatarColor={avatarColor}
       onSelect={onSelect}
+      onRemove={removeProject}
     />
   );
 
-  if (onRemoveProject == null) return body;
-  const removeProject = () => onRemoveProject(project);
+  if (removeProject == null) return body;
 
   return (
     <ContextMenu>

--- a/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRow.tsx
@@ -39,6 +39,7 @@ import { useRowHoverCard } from './use-row-hover-card';
 import { SessionRowRename } from './SessionRowRename';
 import { SessionContextMenu } from './SessionContextMenu';
 import { useTagPopoverTarget } from '../tags/use-tag-popover-target';
+import { useArchiveSession } from './use-archive-session';
 import { sidebarIndentPx, SIDEBAR_ROW_GUTTER_PX } from '@/layout/sidebar-indent';
 
 /** Level 2 — one step deeper than SessionGroupHeader (level 1). Applied as the
@@ -95,6 +96,7 @@ function SessionRowInner({
   // popover at the cursor (same coordinates the context menu opened at) rather
   // than the host's default (0,0).
   const contextMenuPoint = useRef<{ x: number; y: number } | null>(null);
+  const handleArchive = useArchiveSession(item.remoteId ?? item.id, custom.worktreePath != null);
 
   const title = item.title ?? 'Untitled session';
 
@@ -153,7 +155,7 @@ function SessionRowInner({
             handleTags(p ? new DOMRect(p.x, p.y, 0, 0) : null);
           }, 0);
         }}
-        onArchive={() => void itemRuntime.archive()}
+        onArchive={handleArchive}
         claudeSessionId={custom.claudeSessionId}
       >
         <ThreadListItemPrimitive.Root
@@ -216,7 +218,7 @@ function SessionRowInner({
                 onPin={handlePin}
                 onUnpin={handleUnpin}
                 onTags={(rect) => handleTags(rect)}
-                onArchive={() => void itemRuntime.archive()}
+                onArchive={handleArchive}
               />
             </div>
           </ThreadListItemPrimitive.Trigger>

--- a/packages/ui/src/features/sessions/sidebar/SessionRowHoverActions.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionRowHoverActions.tsx
@@ -13,7 +13,7 @@
  * duplicate inline shortcut is redundant.
  */
 import type { MouseEvent } from 'react';
-import { PinIcon, PinOffIcon, TagIcon, XIcon } from 'lucide-react';
+import { ArchiveIcon, PinIcon, PinOffIcon, TagIcon } from 'lucide-react';
 import { Hint } from '@/components/ui/hint';
 
 export function RowHoverActions({
@@ -64,7 +64,7 @@ export function RowHoverActions({
       </Hint>
       <Hint label="Archive">
         <button data-testid="sessions-row-action-archive" type="button" className={btn} onClick={stop(onArchive)}>
-          <XIcon className="size-3.5" />
+          <ArchiveIcon className="size-3.5" />
         </button>
       </Hint>
     </div>

--- a/packages/ui/src/features/sessions/sidebar/__tests__/ArchiveWorktreeDialog.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/ArchiveWorktreeDialog.test.tsx
@@ -1,16 +1,19 @@
 /**
- * ArchiveWorktreeDialog — behavior tests (TDD red phase).
+ * ArchiveWorktreeDialog — behavior tests.
+ *
+ * The dialog is now only ever raised for worktree-backed sessions (the
+ * `!hasWorktree` "Archive this session?" branch is gone) — `pending` carries
+ * just `{ remoteId }`, and the dialog always renders the keep/delete-worktree
+ * choice. There is no more `sessions-archive-confirm` button.
  *
  * Behaviors covered:
  *  - pending=null → dialog root is absent from the DOM.
- *  - pending={ remoteId:'chat-1', hasWorktree:true } → dialog root present,
- *    heading text is "Archive session".
- *  - hasWorktree=true → keep/delete worktree buttons present; confirm absent.
- *  - hasWorktree=false → confirm button present; keep/delete buttons absent.
+ *  - pending={ remoteId:'chat-1' } → dialog root present, heading "Archive session".
+ *  - keep/delete worktree buttons are always present; the old single-confirm
+ *    button never renders.
  *  - Clicking sessions-archive-cancel calls resolve('cancel').
  *  - Clicking sessions-archive-keep-worktree calls resolve({ deleteWorktree:false }).
  *  - Clicking sessions-archive-delete-worktree calls resolve({ deleteWorktree:true }).
- *  - Clicking sessions-archive-confirm (hasWorktree=false) calls resolve({ deleteWorktree:false }).
  *
  * The archive-confirm-bridge module is mocked so tests control `pending` state
  * directly via useArchivePrompt.setState and spy on the `resolve` function.
@@ -27,7 +30,7 @@ import type { ArchiveChoice, PendingArchiveRequest } from '../../runtime/archive
 
 interface MockArchivePromptState {
   pending: PendingArchiveRequest | null;
-  request: (remoteId: string, opts: { hasWorktree: boolean }) => Promise<ArchiveChoice>;
+  request: (remoteId: string) => Promise<ArchiveChoice>;
   resolve: (choice: ArchiveChoice) => void;
 }
 
@@ -35,7 +38,7 @@ const mockResolve = vi.fn();
 
 const mockUseArchivePrompt = create<MockArchivePromptState>(() => ({
   pending: null,
-  request: (_remoteId, _opts) => Promise.resolve('cancel' as ArchiveChoice),
+  request: () => Promise.resolve('cancel' as ArchiveChoice),
   resolve: mockResolve,
 }));
 
@@ -82,7 +85,7 @@ describe('ArchiveWorktreeDialog — pending=null renders nothing', () => {
 
 describe('ArchiveWorktreeDialog — dialog root and heading when pending is set', () => {
   it('renders sessions-archive-confirm-dialog with heading "Archive session"', () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: true });
+    setPending({ remoteId: 'chat-1' });
     render(<ArchiveWorktreeDialog />);
 
     expect(screen.queryByTestId('sessions-archive-confirm-dialog')).not.toBeNull();
@@ -91,12 +94,13 @@ describe('ArchiveWorktreeDialog — dialog root and heading when pending is set'
 });
 
 // ---------------------------------------------------------------------------
-// 3. hasWorktree=true — keep/delete buttons present, confirm absent
+// 3. Worktree action buttons are always present; the old single-confirm
+// button (which required a hasWorktree=false branch) no longer exists.
 // ---------------------------------------------------------------------------
 
-describe('ArchiveWorktreeDialog — hasWorktree=true shows worktree action buttons', () => {
-  it('renders keep and delete worktree buttons but not the confirm button', () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: true });
+describe('ArchiveWorktreeDialog — always shows the worktree keep/delete choice', () => {
+  it('renders keep and delete worktree buttons and never the old confirm button', () => {
+    setPending({ remoteId: 'chat-1' });
     render(<ArchiveWorktreeDialog />);
 
     expect(screen.queryByTestId('sessions-archive-keep-worktree')).not.toBeNull();
@@ -106,27 +110,12 @@ describe('ArchiveWorktreeDialog — hasWorktree=true shows worktree action butto
 });
 
 // ---------------------------------------------------------------------------
-// 4. hasWorktree=false — confirm button present, keep/delete absent
-// ---------------------------------------------------------------------------
-
-describe('ArchiveWorktreeDialog — hasWorktree=false shows only confirm button', () => {
-  it('renders sessions-archive-confirm but not the keep/delete worktree buttons', () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: false });
-    render(<ArchiveWorktreeDialog />);
-
-    expect(screen.queryByTestId('sessions-archive-confirm')).not.toBeNull();
-    expect(screen.queryByTestId('sessions-archive-keep-worktree')).toBeNull();
-    expect(screen.queryByTestId('sessions-archive-delete-worktree')).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 5. Clicking cancel calls resolve('cancel')
+// 4. Clicking cancel calls resolve('cancel')
 // ---------------------------------------------------------------------------
 
 describe('ArchiveWorktreeDialog — cancel button calls resolve with "cancel"', () => {
   it('calls resolve exactly once with "cancel" when sessions-archive-cancel is clicked', async () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: true });
+    setPending({ remoteId: 'chat-1' });
     render(<ArchiveWorktreeDialog />);
 
     await userEvent.click(screen.getByTestId('sessions-archive-cancel'));
@@ -137,12 +126,12 @@ describe('ArchiveWorktreeDialog — cancel button calls resolve with "cancel"', 
 });
 
 // ---------------------------------------------------------------------------
-// 6. Clicking keep-worktree calls resolve({ deleteWorktree: false })
+// 5. Clicking keep-worktree calls resolve({ deleteWorktree: false })
 // ---------------------------------------------------------------------------
 
 describe('ArchiveWorktreeDialog — keep-worktree button calls resolve with deleteWorktree:false', () => {
   it('calls resolve with { deleteWorktree: false } when sessions-archive-keep-worktree is clicked', async () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: true });
+    setPending({ remoteId: 'chat-1' });
     render(<ArchiveWorktreeDialog />);
 
     await userEvent.click(screen.getByTestId('sessions-archive-keep-worktree'));
@@ -153,33 +142,17 @@ describe('ArchiveWorktreeDialog — keep-worktree button calls resolve with dele
 });
 
 // ---------------------------------------------------------------------------
-// 7. Clicking delete-worktree calls resolve({ deleteWorktree: true })
+// 6. Clicking delete-worktree calls resolve({ deleteWorktree: true })
 // ---------------------------------------------------------------------------
 
 describe('ArchiveWorktreeDialog — delete-worktree button calls resolve with deleteWorktree:true', () => {
   it('calls resolve with { deleteWorktree: true } when sessions-archive-delete-worktree is clicked', async () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: true });
+    setPending({ remoteId: 'chat-1' });
     render(<ArchiveWorktreeDialog />);
 
     await userEvent.click(screen.getByTestId('sessions-archive-delete-worktree'));
 
     expect(mockResolve).toHaveBeenCalledTimes(1);
     expect(mockResolve).toHaveBeenCalledWith({ deleteWorktree: true });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 8. Clicking confirm (hasWorktree=false) calls resolve({ deleteWorktree: false })
-// ---------------------------------------------------------------------------
-
-describe('ArchiveWorktreeDialog — confirm button calls resolve with deleteWorktree:false', () => {
-  it('calls resolve with { deleteWorktree: false } when sessions-archive-confirm is clicked', async () => {
-    setPending({ remoteId: 'chat-1', hasWorktree: false });
-    render(<ArchiveWorktreeDialog />);
-
-    await userEvent.click(screen.getByTestId('sessions-archive-confirm'));
-
-    expect(mockResolve).toHaveBeenCalledTimes(1);
-    expect(mockResolve).toHaveBeenCalledWith({ deleteWorktree: false });
   });
 });

--- a/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/ProjectFilterPillBar.test.tsx
@@ -316,6 +316,51 @@ describe('ProjectFilterPillBar — right-click project management', () => {
   });
 });
 
+describe('ProjectFilterPillBar — hover-revealed remove button on the project row', () => {
+  it('calls onRemoveProject with the project when the hover remove button is clicked', async () => {
+    const handleRemove = vi.fn();
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId={null}
+        attentionCounts={{}}
+        onSelect={() => undefined}
+        onRemoveProject={handleRemove}
+      />,
+    );
+    await userEvent.click(screen.getByTestId('sessions-project-remove-action-p2'));
+    expect(handleRemove).toHaveBeenCalledTimes(1);
+    expect(handleRemove).toHaveBeenCalledWith(PROJECTS[1]);
+  });
+
+  it('does not call onSelect when the hover remove button is clicked (stopPropagation)', async () => {
+    const handleSelect = vi.fn();
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId={null}
+        attentionCounts={{}}
+        onSelect={handleSelect}
+        onRemoveProject={() => undefined}
+      />,
+    );
+    await userEvent.click(screen.getByTestId('sessions-project-remove-action-p1'));
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not render the hover remove button when onRemoveProject is omitted', () => {
+    render(
+      <ProjectFilterPillBar
+        projects={PROJECTS}
+        filterProjectId={null}
+        attentionCounts={{}}
+        onSelect={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId('sessions-project-remove-action-p1')).toBeNull();
+  });
+});
+
 describe('ProjectFilterPillBar — collapsible', () => {
   it('renders a chevron next to the "Projects" label', () => {
     render(

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionRow.test.tsx
@@ -571,23 +571,23 @@ describe('StatusDot working provider logo size', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 17. Row hover-action glyphs match the artboard's literal (mismatched) icon
-// choice — xmark for Archive (finding 1.16, debatable but scope is full
-// parity with 02-chrome.jsx). The inline Rename shortcut was removed — the
-// right-click context menu (SessionContextMenu) already offers Rename.
+// 17. Row hover-action glyphs. The inline Rename shortcut was removed — the
+// right-click context menu (SessionContextMenu) already offers Rename. The
+// Archive hover action uses the ArchiveIcon glyph (was the xmark glyph before
+// the archive-confirm-flow rework).
 // ---------------------------------------------------------------------------
 
-describe('SessionRow hover-action glyphs match the artboard (finding 1.16)', () => {
+describe('SessionRow hover-action glyphs', () => {
   it('has no inline Rename hover-action button (right-click context menu covers it)', () => {
     render(<SessionRow item={makeItem()} />);
     expect(screen.queryByTestId('sessions-row-action-rename')).toBeNull();
   });
 
-  it('Archive action uses the xmark glyph, not ArchiveIcon', () => {
+  it('Archive action uses the ArchiveIcon glyph, not the xmark glyph', () => {
     render(<SessionRow item={makeItem()} />);
     const btn = screen.getByTestId('sessions-row-action-archive');
-    expect(btn.querySelector('svg.lucide-x')).toBeTruthy();
-    expect(btn.querySelector('svg.lucide-archive')).toBeNull();
+    expect(btn.querySelector('svg.lucide-archive')).toBeTruthy();
+    expect(btn.querySelector('svg.lucide-x')).toBeNull();
   });
 });
 

--- a/packages/ui/src/features/sessions/sidebar/__tests__/use-archive-session.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/use-archive-session.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * useArchiveSession — behavior tests.
+ *
+ * These lock in the archive-confirm-flow rework's core fix: cancelling the
+ * worktree dialog must not touch aui at all (previously the adapter threw
+ * AFTER aui's optimistic archive had already switched the active thread away,
+ * stranding the user on an empty draft). Asking BEFORE calling
+ * itemRuntime.archive() means a cancel never reaches aui — nothing moves.
+ *
+ * Behaviors covered:
+ *  1. hasWorktree=false — archives immediately, no prompt, stages deleteWorktree:false.
+ *  2. hasWorktree=true — asks first; itemRuntime.archive() is not called until answered.
+ *  3. hasWorktree=true, answer 'cancel' — stageArchiveChoice and itemRuntime.archive()
+ *     are never called.
+ *  4. hasWorktree=true, answer {deleteWorktree:false} — stages false, then archives.
+ *  5. hasWorktree=true, answer {deleteWorktree:true} — stages true, then archives.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+const archiveSpy = vi.fn();
+const requestWorktreeArchiveChoiceMock = vi.fn();
+const stageArchiveChoiceMock = vi.fn();
+
+vi.mock('@assistant-ui/react', () => ({
+  useThreadListItemRuntime: () => ({ archive: archiveSpy }),
+}));
+
+vi.mock('../../runtime/archive-confirm-bridge', () => ({
+  requestWorktreeArchiveChoice: (...args: unknown[]) => requestWorktreeArchiveChoiceMock(...args),
+  stageArchiveChoice: (...args: unknown[]) => stageArchiveChoiceMock(...args),
+}));
+
+import { useArchiveSession } from '../use-archive-session';
+
+beforeEach(() => {
+  archiveSpy.mockReset();
+  archiveSpy.mockResolvedValue(undefined);
+  requestWorktreeArchiveChoiceMock.mockReset();
+  stageArchiveChoiceMock.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// 1. No worktree — archive immediately, no prompt
+// ---------------------------------------------------------------------------
+
+describe('useArchiveSession — no worktree archives immediately with no prompt', () => {
+  it('stages deleteWorktree:false and calls itemRuntime.archive() without asking', async () => {
+    const { result } = renderHook(() => useArchiveSession('chat-1', false));
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+    });
+
+    expect(requestWorktreeArchiveChoiceMock).not.toHaveBeenCalled();
+    expect(stageArchiveChoiceMock).toHaveBeenCalledTimes(1);
+    expect(stageArchiveChoiceMock).toHaveBeenCalledWith('chat-1', { deleteWorktree: false });
+    expect(archiveSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Worktree present — asks first, archive() is not called before the
+// prompt resolves.
+// ---------------------------------------------------------------------------
+
+describe('useArchiveSession — worktree present asks before archiving', () => {
+  it('calls requestWorktreeArchiveChoice(chat-1) and does not call itemRuntime.archive() before it resolves', async () => {
+    let resolvePrompt: (choice: 'cancel' | { deleteWorktree: boolean }) => void = () => {};
+    requestWorktreeArchiveChoiceMock.mockReturnValueOnce(
+      new Promise((res) => {
+        resolvePrompt = res;
+      }),
+    );
+
+    const { result } = renderHook(() => useArchiveSession('chat-1', true));
+
+    act(() => {
+      result.current();
+    });
+
+    expect(requestWorktreeArchiveChoiceMock).toHaveBeenCalledWith('chat-1');
+    expect(archiveSpy).not.toHaveBeenCalled();
+    expect(stageArchiveChoiceMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolvePrompt({ deleteWorktree: false });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(archiveSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cancel — nothing moves: neither stageArchiveChoice nor archive() run.
+// ---------------------------------------------------------------------------
+
+describe('useArchiveSession — cancelling the worktree prompt does nothing', () => {
+  it('does not call stageArchiveChoice or itemRuntime.archive() when the answer is "cancel"', async () => {
+    requestWorktreeArchiveChoiceMock.mockResolvedValueOnce('cancel');
+    const { result } = renderHook(() => useArchiveSession('chat-1', true));
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(stageArchiveChoiceMock).not.toHaveBeenCalled();
+    expect(archiveSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4/5. Keep vs delete worktree choices stage the right flag before archiving.
+// ---------------------------------------------------------------------------
+
+describe('useArchiveSession — "keep worktree" answer stages deleteWorktree:false', () => {
+  it('calls stageArchiveChoice(chat-1, { deleteWorktree: false }) then archives', async () => {
+    requestWorktreeArchiveChoiceMock.mockResolvedValueOnce({ deleteWorktree: false });
+    const { result } = renderHook(() => useArchiveSession('chat-1', true));
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(stageArchiveChoiceMock).toHaveBeenCalledTimes(1);
+    expect(stageArchiveChoiceMock).toHaveBeenCalledWith('chat-1', { deleteWorktree: false });
+    expect(archiveSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useArchiveSession — "delete worktree" answer stages deleteWorktree:true', () => {
+  it('calls stageArchiveChoice(chat-1, { deleteWorktree: true }) then archives', async () => {
+    requestWorktreeArchiveChoiceMock.mockResolvedValueOnce({ deleteWorktree: true });
+    const { result } = renderHook(() => useArchiveSession('chat-1', true));
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(stageArchiveChoiceMock).toHaveBeenCalledTimes(1);
+    expect(stageArchiveChoiceMock).toHaveBeenCalledWith('chat-1', { deleteWorktree: true });
+    expect(archiveSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/sessions/sidebar/use-archive-session.ts
+++ b/packages/ui/src/features/sessions/sidebar/use-archive-session.ts
@@ -1,0 +1,30 @@
+/**
+ * useArchiveSession — the sidebar row's archive action.
+ *
+ * Asks about the worktree first (only when there IS one), then hands the answer
+ * to the adapter through the confirm bridge and lets aui run the archive. Order
+ * matters: aui switches the active thread away optimistically as soon as
+ * archive() is called, so the question has to be settled before that — otherwise
+ * the selection moves while the dialog is still open, and a cancel leaves the
+ * user on an empty draft instead of the session they chose to keep.
+ */
+import { useCallback } from 'react';
+import { useThreadListItemRuntime } from '@assistant-ui/react';
+import { requestWorktreeArchiveChoice, stageArchiveChoice } from '../runtime/archive-confirm-bridge';
+
+export function useArchiveSession(remoteId: string, hasWorktree: boolean): () => void {
+  const itemRuntime = useThreadListItemRuntime();
+
+  return useCallback(() => {
+    void (async () => {
+      let choice = { deleteWorktree: false };
+      if (hasWorktree) {
+        const answer = await requestWorktreeArchiveChoice(remoteId);
+        if (answer === 'cancel') return;
+        choice = answer;
+      }
+      stageArchiveChoice(remoteId, choice);
+      await itemRuntime.archive();
+    })();
+  }, [remoteId, hasWorktree, itemRuntime]);
+}


### PR DESCRIPTION
Four archive-flow complaints from testing, all in the sidebar.

## 1 & 2 — the confirm dialog asked too much, too late

`ThreadListItemPrimitive.Archive` calls `adapter.archive(remoteId)`, and assistant-ui switches the active thread away **optimistically, before that promise settles**. The worktree question lived inside the adapter, behind that call — so clicking archive moved your selection to a blank draft and *then* asked. Cancelling threw, which rolled back the `archived` flag but not the thread switch, and the router's fallback only fires for a thread that really is archived. So a cancel left you on the draft, with the session you kept sitting unselected in the list.

The ask now happens in the row, before the archive:

- `useArchiveSession(remoteId, hasWorktree)` reads `custom.worktreePath` off the row's own thread-list entry — no `getChat` round-trip — and prompts only when there is a worktree whose fate is genuinely in question. Cancel returns early and never invokes assistant-ui, so nothing moves at all.
- The answered choice is staged on the confirm bridge (`stageArchiveChoice`) and consumed by the adapter (`takeArchiveChoice`) on its way to `archiveChat`, which is how the flag crosses aui's payload-less `archive()`.
- A session with no worktree archives with no prompt.

Dead code removed in the same pass: the adapter's `getChat` + throw-to-roll-back, the dialog's `!hasWorktree` branch and its `sessions-archive-confirm` button, and `PendingArchiveRequest.hasWorktree` (the dialog is now only ever raised for worktree-backed sessions, so its presence *is* the flag).

## 3 — remove project on hover

The API was already there — `onRemoveProject` was wired to the right-click menu, with the confirm and the toast. Added the hover-revealed button (`sessions-project-remove-action-<id>`) that routes to the same handler, so remove is discoverable without a right-click.

## 4 — archive icon

`XIcon` → `ArchiveIcon` on the row's hover action. Testid unchanged.

## Verification

Live in the Tauri dev app (DOM-asserted, dev data restored afterwards):

| Behavior | Result |
|---|---|
| Archive a no-worktree session | No dialog; archived; selection untouched |
| Archive a worktree session | Dialog opens, row **stays in the list and stays selected** |
| Cancel | Nothing moved — session present, still selected |
| Hover icon | `lucide-archive` |
| Project rows | Remove button on all rows, `hidden` until `group-hover` |

Unit tests green per file: `use-archive-session` 5/5 (new — locks in "cancel calls neither `stageArchiveChoice` nor `archive()`"), `archive-confirm-bridge` 14/14, `chats-remote-adapter` 23/23, `ArchiveWorktreeDialog` 6/6, `SessionRow` 50/50, `ProjectFilterPillBar` 26/26, `App.integration` 12/12. Typecheck clean.

**Reviewer's eye welcome on:** the e2e `sessions.spec.ts` updates are not executed here. SP8 now asserts the *absence* of a dialog, and §45's worktree block gained a `page.reload()` in `beforeAll` — the row reads `worktreePath` from its thread-list entry rather than a fresh `getChat`, so a REST-seeded worktree needs the list re-derived before the click.

Branches off current `main`, independent of #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
