### PR TITLE
fix(ui): initialize new session drafts with effective defaults

### DIFF
--- a/.changeset/new-session-picker-no-draft.md
+++ b/.changeset/new-session-picker-no-draft.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix picking a project in the "All projects" view doing nothing. The picker read the draft thread's id before anything had created one — assistant-ui only mints that id inside `switchToNewThread`, and clears it again every time a draft is committed on first send — so the handler hit its null guard and returned silently. It now creates the draft first and seeds it afterwards.
+
+A new session started from the picker also honors the configured default adapter, matching the path taken when a project is already selected; it previously always started on Claude.

--- a/.changeset/snapshot-new-session-defaults.md
+++ b/.changeset/snapshot-new-session-defaults.md
@@ -1,0 +1,5 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Initialize new session composers with the same snapshotted defaults used on first send.

--- a/docs/superpowers/plans/2026-07-17-draft-composer-default-snapshot.md
+++ b/docs/superpowers/plans/2026-07-17-draft-composer-default-snapshot.md
@@ -1,0 +1,244 @@
+# Draft Composer Default Snapshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Initialize each new-session draft with a stable, explicit snapshot of every visible provider and model default before enabling its composer.
+
+**Architecture:** Add a pure resolver for daemon-equivalent draft defaults and an async initializer that fetches provider settings, resolves one complete `DraftCfg`, and stores it. Route both new-session entry paths and draft adapter changes through that initializer. Keep first send deterministic by sending and applying the stored snapshot only.
+
+**Tech Stack:** TypeScript, React, Zustand, Vitest, Testing Library, pnpm workspaces
+
+## Global Constraints
+
+- Keep daemon chat creation lazy until first send.
+- Snapshot defaults once per draft; later provider-setting changes cannot mutate it.
+- Switching the adapter in an empty draft snapshots the new adapter's defaults once.
+- Do not render an interactive composer from guessed defaults.
+- Preserve existing user changes in the dirty worktree and stage only files from this plan.
+- Add no comments unless they explain a non-obvious constraint.
+
+---
+
+### Task 1: Pure default snapshot resolver
+
+**Files:**
+- Create: `packages/ui/src/features/sessions/new-thread/resolve-draft-defaults.ts`
+- Create: `packages/ui/src/features/sessions/new-thread/__tests__/resolve-draft-defaults.test.ts`
+- Modify: `packages/ui/src/features/sessions/runtime/draft-config.ts`
+
+**Interfaces:**
+- Consumes: `AdapterInfo`, `ProviderConfig`, `DraftCfg`, `clampEffortToSupported`, and `TUNABLE_FEATURES` from shared types.
+- Produces: `resolveDraftDefaults(projectId: string, adapter: AdapterInfo, provider?: ProviderConfig): DraftCfg`.
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Cover these exact outcomes:
+
+```ts
+expect(resolveDraftDefaults('p1', adapter, {
+  defaultModel: 'opus',
+  defaultMode: 'yolo',
+  defaultPlanMode: 'true',
+  defaultEffort: 'high',
+  defaultFast: 'true',
+  defaultUltracode: 'false',
+  defaultAdaptiveThinking: 'true',
+})).toEqual({
+  projectId: 'p1', adapterId: 'claude', model: 'opus',
+  permissionMode: 'yolo', planMode: true, effort: 'high',
+  fast: true, ultracode: false, adaptiveThinking: true,
+});
+```
+
+Also test stale configured model fallback, catalog default fallback, first-model fallback, absent provider defaults, unsupported-feature clamping, effort clamping, and ultracode forcing `xhigh`.
+
+- [ ] **Step 2: Run the resolver test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/new-thread/__tests__/resolve-draft-defaults.test.ts
+```
+
+Expected: FAIL because `resolve-draft-defaults.ts` does not exist.
+
+- [ ] **Step 3: Implement the resolver**
+
+Implement one pure function. Resolve the model first, then use the shared effort clamp and feature metadata. Return explicit values for all fields. Throw `Error('Cannot initialize draft: adapter has no models')` when the catalog is empty.
+
+- [ ] **Step 4: Clarify the draft contract**
+
+Update `DraftCfg` documentation so model, permission, plan, effort, and features are explicit after initialization. Keep fields optional because partial patches and legacy/retry state still use the type.
+
+- [ ] **Step 5: Run the resolver test and verify GREEN**
+
+Run the command from Step 2. Expected: all resolver tests pass.
+
+### Task 2: Shared asynchronous draft initializer
+
+**Files:**
+- Create: `packages/ui/src/features/sessions/new-thread/initialize-draft.ts`
+- Create: `packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts`
+- Modify: `packages/ui/src/features/sessions/new-thread/use-new-thread-auto-config.ts`
+- Modify: `packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx`
+- Modify: `packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx`
+- Modify: `packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx`
+- Modify: `packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts`
+- Modify: `packages/ui/src/features/sessions/new-thread/ChatSurface.tsx`
+- Modify: `packages/ui/src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx`
+
+**Interfaces:**
+- Consumes: `resolveDefaultAdapterId`, `resolveDraftDefaults`, `getProviderSettings`, adapter catalog state, draft store, and ready store.
+- Produces: `initializeDraft(args: { localId: string; projectId: string; port: number; defaultAdapterId: string | null; adapters: AdapterInfo[]; adapterId?: string }): Promise<DraftCfg>` and per-local-id initialization state (`idle | initializing | ready | error`).
+
+- [ ] **Step 1: Write failing initializer tests**
+
+Verify that `initializeDraft`:
+
+```ts
+await initializeDraft({ localId: '__LOCALID_1', projectId: 'p1', port: 31415, defaultAdapterId: null, adapters });
+expect(getDraftConfig('__LOCALID_1')).toEqual(expectedCompleteSnapshot);
+expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+```
+
+Use a deferred provider-settings promise to prove status is `initializing` and readiness remains false until settings resolve. Prove a rejected request stores no draft, records `error`, and leaves readiness false. Prove changing the mocked provider settings after resolution does not alter the stored snapshot.
+
+- [ ] **Step 2: Run the initializer test and verify RED**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
+```
+
+Expected: FAIL because `initializeDraft` does not exist.
+
+- [ ] **Step 3: Implement `initializeDraft`**
+
+Mark the local id initializing, fetch provider settings once, resolve the selected adapter, build the complete snapshot, store it, then mark ready. Mark readiness only after `setDraftConfig`. On failure, preserve any prior complete snapshot, record the error state, and reject. A retry calls the same initializer again.
+
+- [ ] **Step 4: Route the project-filter hook through the initializer**
+
+Read the daemon port with `useDaemonPort`. In the effect, call `initializeDraft` and log a tagged warning on rejection. Add cancellation so an obsolete effect cannot initialize a discarded or switched-away draft.
+
+- [ ] **Step 5: Route the All-project picker through the initializer**
+
+After `switchToNewThread()` returns the minted id, await `initializeDraft` instead of calling `setDraftConfig` and `markReady` directly. Keep the picker path retryable by surfacing failure with the existing toast facility and leaving the local id unready.
+
+- [ ] **Step 6: Update both entry-path tests**
+
+Replace partial-draft assertions with complete-snapshot assertions. Add deferred-request assertions showing neither path marks ready early. Retain minted-id, default-adapter, return-target, discard, and no-overwrite coverage.
+
+- [ ] **Step 7: Gate `ChatSurface` on initialization state**
+
+For a new local thread, render neither `ChatThread` nor its composer while status is `initializing`. Render the existing centered surface frame with `Initializing session…`. For `error`, render `Couldn’t initialize session` and a `Retry` button with `data-testid="new-session-initialization-retry"`; retry invokes the same initializer inputs retained by the status store. Add tests proving the composer is absent in both states and Retry transitions back to initializing.
+
+- [ ] **Step 8: Run entry-path tests and verify GREEN**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run \
+  src/features/sessions/new-thread/__tests__/initialize-draft.test.ts \
+  src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx \
+  src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx \
+  src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
+```
+
+Expected: all tests pass.
+
+### Task 3: Make toolbar changes and first send consume the snapshot
+
+**Files:**
+- Modify: `packages/ui/src/features/chat/composer/config-toolbar/use-composer-tuning.ts`
+- Modify: `packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts`
+- Modify: `packages/ui/src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts`
+- Modify: `packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts`
+- Modify: `packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts`
+- Modify: `packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts`
+
+**Interfaces:**
+- Consumes: `initializeDraft`, the complete `DraftCfg`, and the existing composer setters.
+- Produces: explicit draft `Chat` projection and adapter-switch reinitialization.
+
+- [ ] **Step 1: Write failing toolbar snapshot tests**
+
+Assert that `synthesizeDraftChat` forwards every explicit snapshot field. In `useComposerTuning`, initialize a draft, change mocked provider settings, and verify chat/model/permission/plan/effort/features remain equal to the snapshot. Add an adapter-switch test that awaits a fresh initialization for the selected adapter rather than clearing only the model.
+
+- [ ] **Step 2: Write failing first-send parity test**
+
+Seed a complete draft, change the provider-settings mock, call `createForLocal`, and assert:
+
+```ts
+expect(createChat).toHaveBeenCalledWith(31415, expect.objectContaining({
+  model: 'snapshotted-model', permissionMode: 'acceptEdits',
+}));
+expect(setChatConfig).toHaveBeenCalledWith(31415, 'chat-1', { planMode: true });
+expect(setChatTuning).toHaveBeenCalledWith(31415, 'chat-1', {
+  effort: 'high', fast: true, ultracode: false, adaptiveThinking: true,
+});
+```
+
+- [ ] **Step 3: Run toolbar and coordinator tests and verify RED**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run \
+  src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts \
+  src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts \
+  src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+```
+
+Expected: new adapter-switch and full-snapshot assertions fail.
+
+- [ ] **Step 4: Make draft projection explicit**
+
+Project the stored fields directly. Provider-default fallbacks remain only for existing real chats that intentionally inherit; initialized drafts no longer depend on them.
+
+- [ ] **Step 5: Reinitialize on draft adapter switch**
+
+Change the draft adapter setter to invoke the shared initializer with the current project and selected adapter. Disable or ignore repeated adapter choices while initialization is in flight. On failure, retain the previous complete snapshot and report the tagged error.
+
+- [ ] **Step 6: Keep first send snapshot-only**
+
+Require the initialized fields at the coordinator boundary and pass them explicitly to chat creation and tuning patches. Preserve the current create-once, retry, and worktree behavior.
+
+- [ ] **Step 7: Run targeted tests and verify GREEN**
+
+Run the command from Step 3. Expected: all tests pass.
+
+### Task 4: Final verification and changeset
+
+**Files:**
+- Create: `.changeset/<generated-name>.md`
+
+**Interfaces:**
+- Consumes: completed Tasks 1–3.
+- Produces: release metadata and verification evidence.
+
+- [ ] **Step 1: Run the complete focused test set**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run \
+  src/features/sessions/new-thread/__tests__/resolve-draft-defaults.test.ts \
+  src/features/sessions/new-thread/__tests__/initialize-draft.test.ts \
+  src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx \
+  src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx \
+  src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx \
+  src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts \
+  src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts \
+  src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+```
+
+Expected: zero failed tests.
+
+- [ ] **Step 2: Typecheck the UI**
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui typecheck
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Add a patch changeset**
+
+Run `pnpm changeset`, select `@qlan-ro/mainframe-ui`, choose `patch`, and describe that new-session composers now snapshot the exact defaults used on first send.
+
+- [ ] **Step 4: Inspect scope**
+
+Run `git diff --check` and `git status --short`. Confirm no unrelated user files are staged or modified by this implementation.

--- a/docs/superpowers/specs/2026-07-17-draft-composer-default-snapshot-design.md
+++ b/docs/superpowers/specs/2026-07-17-draft-composer-default-snapshot-design.md
@@ -1,0 +1,88 @@
+# Draft Composer Default Snapshot Design
+
+## Problem
+
+A new-session draft can display fallback values that differ from the values the daemon resolves on first send. The draft composer currently loads provider settings asynchronously and represents several inherited fields as absent. Individual controls then choose local display fallbacks, while chat creation independently applies provider defaults. This caused an Interactive permission pill to become Unattended after sending and leaves similar risks for plan mode, model, effort, and model features.
+
+## Goal
+
+Before a draft composer becomes interactive, resolve and snapshot every visible session default. The composer and first-send creation path must consume the same snapshot. Later provider-setting changes must not alter an open draft.
+
+## Scope
+
+The snapshot covers:
+
+- adapter
+- model
+- permission mode
+- plan mode
+- effort
+- fast mode
+- ultracode
+- adaptive thinking
+
+Project and worktree selections remain explicit draft values. Existing live-session configuration behavior remains unchanged.
+
+## Design
+
+### Default resolution
+
+Add one pure draft-default resolver in the UI domain layer. It accepts the selected adapter, its model catalog, and its provider configuration. It returns explicit draft fields using daemon-equivalent precedence:
+
+1. Use the configured provider model when it exists in the current catalog.
+2. Otherwise use the catalog model marked as default.
+3. Otherwise use the first catalog model.
+4. Use the provider permission mode, or Interactive when absent.
+5. Use the provider plan-mode default, or off when absent.
+6. Resolve effort from provider default, then model default, then medium, clamped to supported values.
+7. Resolve each feature from its provider default and clamp unsupported features to off.
+8. When effective ultracode is on, resolve effort to `xhigh`, matching the daemon tuning resolver.
+
+The resolver returns concrete values rather than inheritance sentinels. This makes the draft a stable snapshot.
+
+### Initialization lifecycle
+
+New-thread initialization must have the adapter catalog and provider settings before it marks the local draft ready. It creates `DraftCfg` with the selected project and the resolver's complete snapshot, then marks the local thread ready.
+
+The project-filter entry path and the All-project picker path must call the same initializer. Neither path may construct a partial draft independently.
+
+While initialization runs, the draft composer remains unavailable. If initialization fails, the UI retains the draft target and presents a retryable error instead of rendering guessed configuration. The implementation should reuse the existing loading or error surfaces where possible and avoid new layout work.
+
+### Composer behavior
+
+The toolbar reads explicit values from `DraftCfg`. Opening provider settings or changing defaults after initialization does not modify the draft. Toolbar actions continue to patch only the selected draft field.
+
+Switching the adapter inside an empty draft is the one intentional reinitialization boundary. It snapshots the newly selected adapter's current defaults because defaults from the previous adapter are invalid. Explicit changes made after that switch remain stable.
+
+### First send
+
+The new-thread coordinator sends the draft's explicit model and permission mode to `createChat`. It applies explicit plan mode and tuning before spawning the first agent turn. The daemon receives no ambiguous missing value for a visible composer field.
+
+Chat creation may still validate and capability-clamp values, but it must not replace a displayed draft default with a different provider default.
+
+## Error handling
+
+- Missing provider configuration is valid and resolves to product and model defaults.
+- An unavailable configured model falls back to the live catalog default.
+- A missing model catalog prevents readiness because the composer cannot show an authoritative model-dependent snapshot.
+- Provider-settings request failures keep initialization retryable and log the failure through the existing UI error convention.
+- Failed chat creation retains the completed snapshot so retry sends the same configuration.
+
+## Testing
+
+Add tests at three boundaries:
+
+1. Pure resolver tests cover provider defaults, absent defaults, stale model ids, capability clamping, and ultracode effort coercion.
+2. New-thread initialization tests prove both entry paths store complete snapshots and wait before marking ready.
+3. Coordinator tests prove first send transmits and applies the stored snapshot without consulting changed provider settings.
+
+Add a stability test that initializes a draft, changes provider defaults, and confirms the draft and toolbar values remain unchanged. Retain the permission-mode regression test that distinguishes an absent value from an explicit Interactive value.
+
+## Acceptance criteria
+
+- Every interactive draft control displays the exact value first send will use.
+- No draft control shows a guessed fallback while provider defaults are loading.
+- Provider-setting changes do not mutate an open draft.
+- Switching adapters snapshots the new adapter's defaults once.
+- Both new-session entry paths share the same initialization logic.
+- Initialization and coordinator tests cover model, permission, plan, effort, and supported features.

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
@@ -52,6 +52,14 @@ describe('synthesizeDraftChat — maps base fields', () => {
 
     expect(chat.permissionMode).toBe('yolo');
   });
+
+  it('preserves an unset permissionMode so the toolbar can show the provider default', () => {
+    const draft: DraftCfg = { projectId: 'p1', adapterId: 'claude' };
+
+    const chat = synthesizeDraftChat('__LOCALID_x', draft);
+
+    expect(chat.permissionMode).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -140,6 +148,30 @@ describe('synthesizeDraftChat — tuning fields forwarded', () => {
     expect(chat.fast).toBe(false);
     expect(chat.ultracode).toBe(true);
     expect(chat.adaptiveThinking).toBeNull();
+  });
+
+  it('forwards the complete initialized snapshot without provider fallback', () => {
+    const chat = synthesizeDraftChat('__LOCALID_x', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'snapshotted-model',
+      permissionMode: 'acceptEdits',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
+
+    expect(chat).toMatchObject({
+      model: 'snapshotted-model',
+      permissionMode: 'acceptEdits',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
   });
 });
 

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts
@@ -49,11 +49,16 @@ vi.mock('@/lib/api/adapters', () => ({
 
 // Draft-config mock — patchDraftConfig spy + useDraftConfig stub.
 const patchDraftConfigSpy = vi.fn();
+const initializeDraftSpy = vi.fn();
 let draftConfigStub: unknown = undefined;
 
 vi.mock('@/features/sessions/runtime/draft-config', () => ({
   patchDraftConfig: (...args: unknown[]) => patchDraftConfigSpy(...args),
   useDraftConfig: (_localId: string | null) => draftConfigStub,
+}));
+
+vi.mock('@/features/sessions/new-thread/initialize-draft', () => ({
+  initializeDraft: (...args: unknown[]) => initializeDraftSpy(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -126,6 +131,7 @@ function makeFakeExtras(chat: Chat | null = makeChat()) {
 beforeEach(() => {
   vi.clearAllMocks();
   patchDraftConfigSpy.mockReset();
+  initializeDraftSpy.mockReset();
   draftConfigStub = undefined;
   vi.mocked(useAuiState).mockReturnValue(false);
   vi.mocked(useChatExtras).mockReturnValue(makeFakeExtras() as unknown as ReturnType<typeof useChatExtras>);
@@ -412,6 +418,11 @@ function makeDraft(overrides?: Partial<DraftCfg>): DraftCfg {
     adapterId: 'claude',
     permissionMode: 'default',
     model: 'claude-3-sonnet',
+    planMode: true,
+    effort: 'high',
+    fast: true,
+    ultracode: false,
+    adaptiveThinking: true,
     ...overrides,
   };
 }
@@ -434,6 +445,61 @@ describe('useComposerTuning — draft mode: chat is synthesized from the draft',
     const { result } = renderHook(() => useComposerTuning([]));
 
     expect(result.current.chat?.model).toBe('claude-3-opus');
+  });
+
+  it('keeps every initialized snapshot field after provider settings change', async () => {
+    vi.mocked(useChatExtras).mockReturnValue(makeDraftExtras() as unknown as ReturnType<typeof useChatExtras>);
+    draftConfigStub = makeDraft();
+    vi.mocked(getProviderSettings).mockResolvedValue({
+      claude: {
+        defaultModel: 'claude-3-haiku',
+        defaultMode: 'yolo',
+        defaultPlanMode: 'false',
+        defaultEffort: 'low',
+        defaultFast: 'false',
+        defaultUltracode: 'true',
+        defaultAdaptiveThinking: 'false',
+      },
+    });
+
+    const { result } = renderHook(() => useComposerTuning([ADAPTER_CLAUDE]));
+    await waitFor(() => expect(result.current.providerDefaults).toBeDefined());
+
+    expect(result.current.chat).toMatchObject({
+      adapterId: 'claude',
+      model: 'claude-3-sonnet',
+      permissionMode: 'default',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
+  });
+});
+
+describe('useComposerTuning — draft mode: adapter switch reinitializes the snapshot', () => {
+  it('awaits initialization for the selected adapter and ignores a repeated in-flight choice', async () => {
+    vi.mocked(useChatExtras).mockReturnValue(makeDraftExtras() as unknown as ReturnType<typeof useChatExtras>);
+    draftConfigStub = makeDraft();
+    const pending = new Promise<DraftCfg>(() => undefined);
+    initializeDraftSpy.mockReturnValue(pending);
+
+    const { result } = renderHook(() => useComposerTuning([ADAPTER_CLAUDE]));
+    act(() => {
+      result.current.setAdapter('gemini');
+      result.current.setAdapter('gemini');
+    });
+
+    expect(initializeDraftSpy).toHaveBeenCalledExactlyOnceWith({
+      localId: LOCAL_DRAFT_ID,
+      projectId: 'proj-draft',
+      port: DRAFT_PORT,
+      defaultAdapterId: null,
+      adapters: [ADAPTER_CLAUDE],
+      adapterId: 'gemini',
+    });
+    expect(patchDraftConfigSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/use-composer-tuning.test.ts
@@ -58,7 +58,7 @@ vi.mock('@/features/sessions/runtime/draft-config', () => ({
 }));
 
 vi.mock('@/features/sessions/new-thread/initialize-draft', () => ({
-  initializeDraft: (...args: unknown[]) => initializeDraftSpy(...args),
+  reinitializeDraftAdapter: (...args: unknown[]) => initializeDraftSpy(...args),
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
@@ -14,12 +14,12 @@ import type { DraftCfg } from '@/features/sessions/runtime/draft-config';
 const EXEC_MODES = ['default', 'acceptEdits', 'yolo'] as const;
 
 export function synthesizeDraftChat(id: string, d: DraftCfg): Chat {
-  // Draft may omit permissionMode (so the daemon applies the provider defaultMode
-  // on create); show 'default' as the pre-send display fallback only.
   const permissionMode: Chat['permissionMode'] =
     d.permissionMode !== undefined && (EXEC_MODES as readonly string[]).includes(d.permissionMode)
       ? (d.permissionMode as Chat['permissionMode'])
-      : 'default';
+      : d.permissionMode === 'plan'
+        ? 'default'
+        : undefined;
   return {
     id,
     adapterId: d.adapterId,

--- a/packages/ui/src/features/chat/composer/config-toolbar/use-composer-tuning.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/use-composer-tuning.ts
@@ -36,7 +36,7 @@ import type {
 import { getProviderSettings } from '@/lib/api/settings';
 import { setChatTuning, setChatConfig, type ChatConfigPatch } from '@/lib/api/chats';
 import { useDraftConfig, patchDraftConfig } from '@/features/sessions/runtime/draft-config';
-import { initializeDraft } from '@/features/sessions/new-thread/initialize-draft';
+import { reinitializeDraftAdapter } from '@/features/sessions/new-thread/initialize-draft';
 import { useChatExtras } from '../../runtime/use-chat-thread-runtime';
 import { synthesizeDraftChat } from './synthesize-draft-chat';
 
@@ -217,7 +217,7 @@ export function useComposerTuning(adapters: AdapterInfo[]): ComposerTuningHook {
       if (draftMode && chatId && draft && port != null) {
         if (adapterInitializations.current.has(id)) return;
         adapterInitializations.current.add(id);
-        void initializeDraft({
+        void reinitializeDraftAdapter({
           localId: chatId,
           projectId: draft.projectId,
           port,

--- a/packages/ui/src/features/chat/composer/config-toolbar/use-composer-tuning.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/use-composer-tuning.ts
@@ -21,7 +21,7 @@
  * is threaded from `useChatExtras()` — no extra `getDaemonPort()` call here.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuiState } from '@assistant-ui/react';
 import type {
   AdapterInfo,
@@ -36,6 +36,7 @@ import type {
 import { getProviderSettings } from '@/lib/api/settings';
 import { setChatTuning, setChatConfig, type ChatConfigPatch } from '@/lib/api/chats';
 import { useDraftConfig, patchDraftConfig } from '@/features/sessions/runtime/draft-config';
+import { initializeDraft } from '@/features/sessions/new-thread/initialize-draft';
 import { useChatExtras } from '../../runtime/use-chat-thread-runtime';
 import { synthesizeDraftChat } from './synthesize-draft-chat';
 
@@ -131,6 +132,7 @@ export function useComposerTuning(adapters: AdapterInfo[]): ComposerTuningHook {
   const isLocalDraft = chatId != null && chatId.startsWith('__LOCALID_') && realChat == null;
   const draft = useDraftConfig(isLocalDraft ? chatId : null);
   const draftMode = isLocalDraft && draft != null;
+  const adapterInitializations = useRef(new Set<string>());
   const chat: Chat | null = realChat ?? (chatId != null && draft != null ? synthesizeDraftChat(chatId, draft) : null);
 
   // Live run-state from the assistant-ui thread — stays accurate mid-run
@@ -212,14 +214,26 @@ export function useComposerTuning(adapters: AdapterInfo[]): ComposerTuningHook {
   );
   const setAdapter = useCallback(
     (id: string) => {
-      // Switching adapter clears the model so it falls back to the new adapter's default.
-      if (draftMode && chatId) {
-        patchDraftConfig(chatId, { adapterId: id, model: undefined });
+      if (draftMode && chatId && draft && port != null) {
+        if (adapterInitializations.current.has(id)) return;
+        adapterInitializations.current.add(id);
+        void initializeDraft({
+          localId: chatId,
+          projectId: draft.projectId,
+          port,
+          defaultAdapterId: null,
+          adapters,
+          adapterId: id,
+        })
+          .catch((err: unknown) =>
+            console.warn('[composer/useComposerTuning] setAdapter draft initialization failed', { err }),
+          )
+          .finally(() => adapterInitializations.current.delete(id));
         return;
       }
       patchConfig({ adapterId: id }, 'setAdapter');
     },
-    [draftMode, chatId, patchConfig],
+    [adapters, draft, draftMode, chatId, patchConfig, port],
   );
   const setPlanMode = useCallback(
     (on: boolean) => {

--- a/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
+++ b/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
@@ -118,7 +118,7 @@ export function ChatSurface({ port: _port }: { port: number }) {
             <button
               type="button"
               data-testid="new-session-initialization-retry"
-              className="rounded-md border px-3 py-1.5 text-sm"
+              className="rounded-md border px-3 py-1.5 text-body"
               onClick={() => void initialization.retry?.().catch(() => undefined)}
             >
               Retry

--- a/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
+++ b/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
@@ -84,6 +84,7 @@ export function ChatSurface({ port: _port }: { port: number }) {
   const initialization = useNewThreadReady((s) =>
     mainThreadId ? s.getInitialization(mainThreadId) : { status: 'idle' as const },
   );
+  const isReady = useNewThreadReady((s) => (mainThreadId ? s.readyIds.has(mainThreadId) : false));
 
   const isNewLocal =
     mainThreadId != null && mainThreadId.startsWith('__LOCALID_') && itemStatus === 'new' && messageCount === 0;
@@ -103,12 +104,16 @@ export function ChatSurface({ port: _port }: { port: number }) {
     );
   }
 
-  if (isNewLocal && (initialization.status === 'initializing' || initialization.status === 'error')) {
+  const isInitializing =
+    initialization.status === 'initializing' ||
+    (initialization.status === 'idle' && filterProjectId != null && draftCfg == null && !isReady);
+
+  if (isNewLocal && (isInitializing || initialization.status === 'error')) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         <ChatCardHeader />
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-y-auto p-6">
-          <p>{initialization.status === 'initializing' ? 'Initializing session…' : 'Couldn’t initialize session'}</p>
+          <p>{isInitializing ? 'Initializing session…' : 'Couldn’t initialize session'}</p>
           {initialization.status === 'error' && (
             <button
               type="button"

--- a/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
+++ b/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
@@ -35,6 +35,7 @@ import { useNewThreadAutoConfig } from './use-new-thread-auto-config';
 import { useProjects } from '../use-projects';
 import { useDraftConfigStore } from '../runtime/draft-config';
 import { useNewSessionPickerTarget } from '../sidebar/use-new-session-picker-target';
+import { useNewThreadReady } from '../runtime/new-thread-ready-store';
 
 /** How long to wait, once we look like the zero-session boot dead-end, before
  *  forcing the project picker open. Long enough for useSessionListRouter's
@@ -80,6 +81,9 @@ export function ChatSurface({ port: _port }: { port: number }) {
   const draftCfg = useDraftConfigStore((s) => (mainThreadId ? s.drafts.get(mainThreadId) : undefined));
   const { projects, loading } = useProjects();
   const filterProjectId = useSessionFilters((s) => s.filterProjectId);
+  const initialization = useNewThreadReady((s) =>
+    mainThreadId ? s.getInitialization(mainThreadId) : { status: 'idle' as const },
+  );
 
   const isNewLocal =
     mainThreadId != null && mainThreadId.startsWith('__LOCALID_') && itemStatus === 'new' && messageCount === 0;
@@ -94,6 +98,27 @@ export function ChatSurface({ port: _port }: { port: number }) {
         <ChatCardHeader />
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto p-6">
           <ChatEmptyState variant="firstrun" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isNewLocal && (initialization.status === 'initializing' || initialization.status === 'error')) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ChatCardHeader />
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-y-auto p-6">
+          <p>{initialization.status === 'initializing' ? 'Initializing session…' : 'Couldn’t initialize session'}</p>
+          {initialization.status === 'error' && (
+            <button
+              type="button"
+              data-testid="new-session-initialization-retry"
+              className="rounded-md border px-3 py-1.5 text-sm"
+              onClick={() => void initialization.retry?.().catch(() => undefined)}
+            >
+              Retry
+            </button>
+          )}
         </div>
       </div>
     );

--- a/packages/ui/src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx
@@ -45,7 +45,11 @@ vi.mock('../../runtime/draft-config', () => ({
   useDraftConfigStore: (sel: (s: unknown) => unknown) => sel({ drafts: __draftMap }),
 }));
 vi.mock('../../runtime/new-thread-ready-store', () => ({
-  useNewThreadReady: (sel: (s: unknown) => unknown) => sel({ getInitialization: () => __initialization }),
+  useNewThreadReady: (sel: (s: unknown) => unknown) =>
+    sel({
+      getInitialization: () => __initialization,
+      readyIds: __initialization.status === 'ready' ? new Set(['__LOCALID_1']) : new Set(),
+    }),
 }));
 vi.mock('@/store/session-filters', () => ({
   useSessionFilters: (sel: (s: { filterProjectId: string | null }) => unknown) =>
@@ -109,6 +113,16 @@ describe('ChatSurface', () => {
 
   it('hides ChatThread and its composer while initialization is pending', () => {
     __initialization = { status: 'initializing' };
+    render(<ChatSurface port={31415} />);
+
+    expect(screen.getByText('Initializing session…')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-thread')).toBeNull();
+  });
+
+  it('hides ChatThread during the initial idle render for a project-filtered draft', () => {
+    __draftMap = new Map();
+    __filterProjectId = 'proj-a';
+    __initialization = { status: 'idle' };
     render(<ChatSurface port={31415} />);
 
     expect(screen.getByText('Initializing session…')).toBeInTheDocument();

--- a/packages/ui/src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/ChatSurface.test.tsx
@@ -28,6 +28,9 @@ let __draftMap = new Map<string, { projectId: string; adapterId: string }>([
   ['__LOCALID_1', { projectId: 'proj-a', adapterId: 'claude' }],
 ]);
 let __filterProjectId: string | null = null;
+let __initialization: { status: 'idle' | 'initializing' | 'ready' | 'error'; retry?: () => Promise<unknown> } = {
+  status: 'ready',
+};
 
 vi.mock('@assistant-ui/react', () => ({
   useAuiState: (sel: (s: unknown) => unknown) =>
@@ -40,6 +43,9 @@ vi.mock('@assistant-ui/react', () => ({
 vi.mock('../../use-projects', () => ({ useProjects: () => ({ projects: __projects, loading: __loading }) }));
 vi.mock('../../runtime/draft-config', () => ({
   useDraftConfigStore: (sel: (s: unknown) => unknown) => sel({ drafts: __draftMap }),
+}));
+vi.mock('../../runtime/new-thread-ready-store', () => ({
+  useNewThreadReady: (sel: (s: unknown) => unknown) => sel({ getInitialization: () => __initialization }),
 }));
 vi.mock('@/store/session-filters', () => ({
   useSessionFilters: (sel: (s: { filterProjectId: string | null }) => unknown) =>
@@ -66,6 +72,7 @@ describe('ChatSurface', () => {
     __loading = false;
     __filterProjectId = null;
     __draftMap = new Map([['__LOCALID_1', { projectId: 'proj-a', adapterId: 'claude' }]]);
+    __initialization = { status: 'ready' };
     useNewSessionPickerTarget.setState({ open: false });
   });
 
@@ -98,6 +105,24 @@ describe('ChatSurface', () => {
     render(<ChatSurface port={31415} />);
     expect(screen.getByTestId('chat-thread')).toBeInTheDocument();
     expect(screen.queryByTestId('empty-welcome')).toBeNull();
+  });
+
+  it('hides ChatThread and its composer while initialization is pending', () => {
+    __initialization = { status: 'initializing' };
+    render(<ChatSurface port={31415} />);
+
+    expect(screen.getByText('Initializing session…')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-thread')).toBeNull();
+  });
+
+  it('hides ChatThread on error and retries the same initialization', async () => {
+    const retry = vi.fn(async () => undefined);
+    __initialization = { status: 'error', retry };
+    render(<ChatSurface port={31415} />);
+
+    expect(screen.queryByTestId('chat-thread')).toBeNull();
+    await act(async () => screen.getByTestId('new-session-initialization-retry').click());
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui/src/features/sessions/new-thread/__tests__/default-adapter.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/default-adapter.test.ts
@@ -1,0 +1,39 @@
+/**
+ * resolveDefaultAdapterId — pure resolution order:
+ *   1. an explicit configured default, whatever it is
+ *   2. else the first INSTALLED adapter (not merely the first in the list)
+ *   3. else the 'claude' fallback
+ */
+import { describe, it, expect } from 'vitest';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import { resolveDefaultAdapterId } from '../default-adapter';
+
+function adapter(id: string, installed: boolean): AdapterInfo {
+  return { id, name: id, description: '', installed, models: [], capabilities: { planMode: false } };
+}
+
+describe('resolveDefaultAdapterId', () => {
+  it('returns the explicit default when one is configured, even if adapters differ', () => {
+    const adapters = [adapter('claude', true), adapter('gemini', true)];
+    expect(resolveDefaultAdapterId('codex', adapters)).toBe('codex');
+  });
+
+  it('falls back to the first installed adapter when no default is configured', () => {
+    const adapters = [adapter('codex', false), adapter('gemini', true), adapter('claude', true)];
+    expect(resolveDefaultAdapterId(null, adapters)).toBe('gemini');
+  });
+
+  it('skips uninstalled adapters even if they appear first in the list', () => {
+    const adapters = [adapter('codex', false), adapter('gemini', false), adapter('claude', true)];
+    expect(resolveDefaultAdapterId(undefined, adapters)).toBe('claude');
+  });
+
+  it('falls back to "claude" when no default is configured and nothing is installed', () => {
+    const adapters = [adapter('codex', false), adapter('gemini', false)];
+    expect(resolveDefaultAdapterId(null, adapters)).toBe('claude');
+  });
+
+  it('falls back to "claude" when no default is configured and the adapter list is empty', () => {
+    expect(resolveDefaultAdapterId(null, [])).toBe('claude');
+  });
+});

--- a/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdapterInfo, ProviderConfig } from '@qlan-ro/mainframe-types';
+import { getDraftConfig, useDraftConfigStore, type DraftCfg } from '../../runtime/draft-config';
+import { useNewThreadReady } from '../../runtime/new-thread-ready-store';
+
+const getProviderSettings = vi.fn();
+vi.mock('@/lib/api/settings', () => ({ getProviderSettings: (...args: unknown[]) => getProviderSettings(...args) }));
+
+const { initializeDraft } = await import('../initialize-draft');
+
+const adapters: AdapterInfo[] = [
+  {
+    id: 'claude',
+    name: 'Claude',
+    description: 'Claude Code',
+    installed: true,
+    models: [{ id: 'sonnet', label: 'Sonnet', isDefault: true, supportedEfforts: ['low', 'medium'] }],
+    capabilities: { planMode: true },
+  },
+];
+
+const expectedCompleteSnapshot: DraftCfg = {
+  projectId: 'p1',
+  adapterId: 'claude',
+  model: 'sonnet',
+  permissionMode: 'acceptEdits',
+  planMode: true,
+  effort: 'low',
+  fast: false,
+  ultracode: false,
+  adaptiveThinking: false,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  getProviderSettings.mockReset();
+  useDraftConfigStore.setState({ drafts: new Map() });
+  useNewThreadReady.setState({ readyIds: new Set(), initializations: new Map() });
+});
+
+describe('initializeDraft', () => {
+  it('stores a complete snapshot before marking the local id ready', async () => {
+    getProviderSettings.mockResolvedValue({
+      claude: { defaultMode: 'acceptEdits', defaultPlanMode: 'true', defaultEffort: 'low' },
+    });
+
+    await initializeDraft({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    });
+
+    expect(getDraftConfig('__LOCALID_1')).toEqual(expectedCompleteSnapshot);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('ready');
+  });
+
+  it('remains initializing and unready until provider settings resolve', async () => {
+    const request = deferred<Record<string, { defaultMode: 'acceptEdits' }>>();
+    getProviderSettings.mockReturnValue(request.promise);
+
+    const result = initializeDraft({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    });
+
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('initializing');
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(false);
+    expect(getDraftConfig('__LOCALID_1')).toBeUndefined();
+
+    request.resolve({ claude: { defaultMode: 'acceptEdits' } });
+    await result;
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+  });
+
+  it('records an error without replacing a prior snapshot or marking ready', async () => {
+    const prior = { ...expectedCompleteSnapshot, projectId: 'prior' };
+    useDraftConfigStore.getState().setDraft('__LOCALID_1', prior);
+    getProviderSettings.mockRejectedValue(new Error('settings unavailable'));
+
+    await expect(
+      initializeDraft({
+        localId: '__LOCALID_1',
+        projectId: 'p1',
+        port: 31415,
+        defaultAdapterId: null,
+        adapters,
+      }),
+    ).rejects.toThrow('settings unavailable');
+
+    expect(getDraftConfig('__LOCALID_1')).toEqual(prior);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(false);
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('error');
+  });
+
+  it('transitions an errored retry back to initializing', async () => {
+    getProviderSettings.mockRejectedValueOnce(new Error('settings unavailable'));
+    const args = {
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    };
+    await expect(initializeDraft(args)).rejects.toThrow('settings unavailable');
+    const request = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValue(request.promise);
+
+    const retry = useNewThreadReady.getState().getInitialization('__LOCALID_1').retry;
+    const result = retry?.();
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('initializing');
+
+    request.resolve({});
+    await result;
+  });
+
+  it('does not resurrect a draft cleared while initialization is pending', async () => {
+    const request = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValue(request.promise);
+    const result = initializeDraft({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    });
+
+    useNewThreadReady.getState().clearReady('__LOCALID_1');
+    request.resolve({});
+    await result;
+
+    expect(getDraftConfig('__LOCALID_1')).toBeUndefined();
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('idle');
+  });
+
+  it('stores an immutable snapshot of the resolved provider settings', async () => {
+    const provider: ProviderConfig = { defaultMode: 'acceptEdits', defaultEffort: 'low' };
+    getProviderSettings.mockResolvedValue({ claude: provider });
+
+    await initializeDraft({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    });
+    provider.defaultEffort = 'medium';
+
+    expect(getDraftConfig('__LOCALID_1')).toMatchObject({ effort: 'low' });
+  });
+});

--- a/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
@@ -6,7 +6,7 @@ import { useNewThreadReady } from '../../runtime/new-thread-ready-store';
 const getProviderSettings = vi.fn();
 vi.mock('@/lib/api/settings', () => ({ getProviderSettings: (...args: unknown[]) => getProviderSettings(...args) }));
 
-const { initializeDraft } = await import('../initialize-draft');
+const { initializeDraft, reinitializeDraftAdapter } = await import('../initialize-draft');
 
 const adapters: AdapterInfo[] = [
   {
@@ -15,6 +15,14 @@ const adapters: AdapterInfo[] = [
     description: 'Claude Code',
     installed: true,
     models: [{ id: 'sonnet', label: 'Sonnet', isDefault: true, supportedEfforts: ['low', 'medium'] }],
+    capabilities: { planMode: true },
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    description: 'Codex CLI',
+    installed: true,
+    models: [{ id: 'gpt-5', label: 'GPT-5', isDefault: true, supportedEfforts: ['high'] }],
     capabilities: { planMode: true },
   },
 ];
@@ -190,5 +198,95 @@ describe('initializeDraft', () => {
     provider.defaultEffort = 'medium';
 
     expect(getDraftConfig('__LOCALID_1')).toMatchObject({ effort: 'low' });
+  });
+});
+
+describe('reinitializeDraftAdapter', () => {
+  it('keeps the complete snapshot ready while switching and after a rejection', async () => {
+    const prior = { ...expectedCompleteSnapshot };
+    useDraftConfigStore.getState().setDraft('__LOCALID_1', prior);
+    useNewThreadReady.getState().markReady('__LOCALID_1');
+    const request = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValue(request.promise);
+
+    const result = reinitializeDraftAdapter({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+      adapterId: 'codex',
+    });
+
+    expect(getDraftConfig('__LOCALID_1')).toEqual(prior);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('ready');
+
+    request.reject(new Error('settings unavailable'));
+    await expect(result).rejects.toThrow('settings unavailable');
+    expect(getDraftConfig('__LOCALID_1')).toEqual(prior);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+    expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('ready');
+  });
+
+  it('atomically replaces config and preserves draft-scoped worktree selections', async () => {
+    const prior: DraftCfg = {
+      ...expectedCompleteSnapshot,
+      worktreePath: '/repo/.worktrees/feature',
+      branchName: 'feature',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feature-next' },
+    };
+    useDraftConfigStore.getState().setDraft('__LOCALID_1', prior);
+    useNewThreadReady.getState().markReady('__LOCALID_1');
+    const request = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValue(request.promise);
+
+    const result = reinitializeDraftAdapter({
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+      adapterId: 'codex',
+    });
+    expect(getDraftConfig('__LOCALID_1')).toEqual(prior);
+
+    request.resolve({ codex: { defaultMode: 'yolo', defaultEffort: 'high' } });
+    await result;
+
+    expect(getDraftConfig('__LOCALID_1')).toEqual({
+      projectId: 'p1',
+      adapterId: 'codex',
+      model: 'gpt-5',
+      permissionMode: 'yolo',
+      planMode: false,
+      effort: 'high',
+      fast: false,
+      ultracode: false,
+      adaptiveThinking: false,
+      worktreePath: '/repo/.worktrees/feature',
+      branchName: 'feature',
+      pendingWorktree: { baseBranch: 'main', branchName: 'feature-next' },
+    });
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+  });
+
+  it('prevents a stale adapter response from winning over a newer switch', async () => {
+    useDraftConfigStore.getState().setDraft('__LOCALID_1', expectedCompleteSnapshot);
+    useNewThreadReady.getState().markReady('__LOCALID_1');
+    const oldRequest = deferred<Record<string, ProviderConfig>>();
+    const latestRequest = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(latestRequest.promise);
+    const base = { localId: '__LOCALID_1', projectId: 'p1', port: 31415, defaultAdapterId: null, adapters };
+
+    const oldResult = reinitializeDraftAdapter({ ...base, adapterId: 'codex' });
+    const latestResult = reinitializeDraftAdapter({ ...base, adapterId: 'claude' });
+    latestRequest.resolve({ claude: { defaultMode: 'acceptEdits', defaultEffort: 'medium' } });
+    await latestResult;
+    oldRequest.resolve({ codex: { defaultMode: 'yolo', defaultEffort: 'high' } });
+    await oldResult;
+
+    expect(getDraftConfig('__LOCALID_1')).toMatchObject({ adapterId: 'claude', effort: 'medium' });
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
   });
 });

--- a/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/initialize-draft.test.ts
@@ -147,6 +147,35 @@ describe('initializeDraft', () => {
     expect(useNewThreadReady.getState().getInitialization('__LOCALID_1').status).toBe('idle');
   });
 
+  it('ignores an old response after cancellation and replacement initialization', async () => {
+    const oldRequest = deferred<Record<string, ProviderConfig>>();
+    const replacementRequest = deferred<Record<string, ProviderConfig>>();
+    getProviderSettings.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(replacementRequest.promise);
+    const args = {
+      localId: '__LOCALID_1',
+      projectId: 'p1',
+      port: 31415,
+      defaultAdapterId: null,
+      adapters,
+    };
+
+    const oldResult = initializeDraft(args);
+    const oldAttempt = useNewThreadReady.getState().getInitialization(args.localId).attempt;
+    if (oldAttempt == null) throw new Error('Expected old initialization attempt');
+    useNewThreadReady.getState().cancelInitialization(args.localId, oldAttempt);
+    const replacementResult = initializeDraft(args);
+    oldRequest.resolve({ claude: { defaultMode: 'yolo' } });
+    await oldResult;
+
+    expect(getDraftConfig(args.localId)).toBeUndefined();
+    expect(useNewThreadReady.getState().isReady(args.localId)).toBe(false);
+
+    replacementRequest.resolve({ claude: { defaultMode: 'acceptEdits' } });
+    await replacementResult;
+    expect(getDraftConfig(args.localId)).toMatchObject({ permissionMode: 'acceptEdits' });
+    expect(useNewThreadReady.getState().isReady(args.localId)).toBe(true);
+  });
+
   it('stores an immutable snapshot of the resolved provider settings', async () => {
     const provider: ProviderConfig = { defaultMode: 'acceptEdits', defaultEffort: 'low' };
     getProviderSettings.mockResolvedValue({ claude: provider });

--- a/packages/ui/src/features/sessions/new-thread/__tests__/reset-new-thread-draft.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/reset-new-thread-draft.test.ts
@@ -9,16 +9,21 @@
  * `getDraftConfig(localId)` (auto-config) and `!isReady` (ChatSurface picker gate)
  * both short-circuit and the chat is created in the stale project.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getDraftConfig, setDraftConfig, useDraftConfigStore } from '../../runtime/draft-config';
 import { useNewThreadReady } from '../../runtime/new-thread-ready-store';
 import { markDraftDiscarded, isDraftDiscarded, useDiscardedDraftStore } from '../discarded-drafts';
+const abandonCreateForLocal = vi.fn();
+vi.mock('../../runtime/new-thread-coordinator', () => ({
+  abandonCreateForLocal: (...args: unknown[]) => abandonCreateForLocal(...args),
+}));
 import { resetNewThreadDraft } from '../reset-new-thread-draft';
 
 beforeEach(() => {
   useDraftConfigStore.setState({ drafts: new Map() });
   useNewThreadReady.setState({ readyIds: new Set() });
   useDiscardedDraftStore.setState({ ids: new Set() });
+  abandonCreateForLocal.mockReset();
 });
 
 describe('resetNewThreadDraft', () => {
@@ -30,6 +35,7 @@ describe('resetNewThreadDraft', () => {
 
     expect(getDraftConfig('__LOCALID_1')).toBeUndefined();
     expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(false);
+    expect(abandonCreateForLocal).toHaveBeenCalledExactlyOnceWith('__LOCALID_1');
   });
 
   it('leaves other local ids untouched', () => {

--- a/packages/ui/src/features/sessions/new-thread/__tests__/resolve-draft-defaults.test.ts
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/resolve-draft-defaults.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { AdapterInfo, AdapterModel } from '@qlan-ro/mainframe-types';
+import { resolveDraftDefaults } from '../resolve-draft-defaults';
+
+function makeAdapter(models: AdapterModel[]): AdapterInfo {
+  return {
+    id: 'claude',
+    name: 'Claude',
+    description: 'Claude Code',
+    installed: true,
+    models,
+    capabilities: { planMode: true },
+  };
+}
+
+const opus: AdapterModel = {
+  id: 'opus',
+  label: 'Opus',
+  supportedEfforts: ['low', 'high', 'xhigh'],
+  defaultEffort: 'low',
+  supportsFast: true,
+  supportsUltracode: true,
+  supportsAdaptiveThinking: true,
+};
+
+describe('resolveDraftDefaults', () => {
+  it('resolves every configured provider default', () => {
+    const adapter = makeAdapter([opus]);
+
+    expect(
+      resolveDraftDefaults('p1', adapter, {
+        defaultModel: 'opus',
+        defaultMode: 'yolo',
+        defaultPlanMode: 'true',
+        defaultEffort: 'high',
+        defaultFast: 'true',
+        defaultUltracode: 'false',
+        defaultAdaptiveThinking: 'true',
+      }),
+    ).toEqual({
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'opus',
+      permissionMode: 'yolo',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
+  });
+
+  it('falls back from a stale configured model to the catalog default', () => {
+    const adapter = makeAdapter([
+      { ...opus, isDefault: true },
+      { id: 'sonnet', label: 'Sonnet' },
+    ]);
+
+    expect(resolveDraftDefaults('p1', adapter, { defaultModel: 'stale' }).model).toBe('opus');
+  });
+
+  it('uses the catalog default when no model is configured', () => {
+    const adapter = makeAdapter([
+      { id: 'sonnet', label: 'Sonnet' },
+      { ...opus, isDefault: true },
+    ]);
+
+    expect(resolveDraftDefaults('p1', adapter).model).toBe('opus');
+  });
+
+  it('uses the first model when there is no configured or catalog default', () => {
+    const adapter = makeAdapter([{ id: 'sonnet', label: 'Sonnet' }, opus]);
+
+    expect(resolveDraftDefaults('p1', adapter).model).toBe('sonnet');
+  });
+
+  it('returns explicit defaults when provider settings are absent', () => {
+    const adapter = makeAdapter([opus]);
+
+    expect(resolveDraftDefaults('p1', adapter)).toEqual({
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'opus',
+      permissionMode: 'default',
+      planMode: false,
+      effort: 'low',
+      fast: false,
+      ultracode: false,
+      adaptiveThinking: false,
+    });
+  });
+
+  it('forces configured features off when the model does not support them', () => {
+    const adapter = makeAdapter([
+      {
+        id: 'sonnet',
+        label: 'Sonnet',
+        supportedEfforts: ['medium'],
+        supportsFast: false,
+        supportsUltracode: false,
+        supportsAdaptiveThinking: false,
+      },
+    ]);
+
+    expect(
+      resolveDraftDefaults('p1', adapter, {
+        defaultFast: 'true',
+        defaultUltracode: 'true',
+        defaultAdaptiveThinking: 'true',
+      }),
+    ).toMatchObject({ fast: false, ultracode: false, adaptiveThinking: false });
+  });
+
+  it('clamps configured effort to the selected model', () => {
+    const adapter = makeAdapter([opus]);
+
+    expect(resolveDraftDefaults('p1', adapter, { defaultEffort: 'max' }).effort).toBe('low');
+  });
+
+  it('forces effort to xhigh when supported ultracode is enabled', () => {
+    const adapter = makeAdapter([opus]);
+
+    expect(
+      resolveDraftDefaults('p1', adapter, {
+        defaultEffort: 'low',
+        defaultUltracode: 'true',
+      }),
+    ).toMatchObject({ effort: 'xhigh', ultracode: true });
+  });
+
+  it('throws when the adapter catalog is empty', () => {
+    expect(() => resolveDraftDefaults('p1', makeAdapter([]))).toThrow('Cannot initialize draft: adapter has no models');
+  });
+});

--- a/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
@@ -53,6 +53,18 @@ const setDraftConfigSpy = vi.fn();
 let getDraftConfigResult: unknown = undefined;
 let initializationGate: Promise<void> | null = null;
 
+const completeSnapshot = (projectId: string, adapterId: string) => ({
+  projectId,
+  adapterId,
+  model: 'default-model',
+  permissionMode: 'default',
+  planMode: false,
+  effort: 'medium',
+  fast: false,
+  ultracode: false,
+  adaptiveThinking: false,
+});
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -91,9 +103,10 @@ vi.mock('../initialize-draft', () => ({
   }) => {
     if (initializationGate) await initializationGate;
     const adapterId = args.defaultAdapterId ?? args.adapters.find((adapter) => adapter.installed)?.id ?? 'claude';
-    setDraftConfigSpy(args.localId, { projectId: args.projectId, adapterId });
+    const snapshot = completeSnapshot(args.projectId, adapterId);
+    setDraftConfigSpy(args.localId, snapshot);
     useNewThreadReady.getState().markReady(args.localId);
-    return { projectId: args.projectId, adapterId };
+    return snapshot;
   },
 }));
 
@@ -148,10 +161,7 @@ describe('useNewThreadAutoConfig — project filter active on new local thread',
       renderHook(() => useNewThreadAutoConfig());
     });
 
-    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', {
-      projectId: 'proj-42',
-      adapterId: 'claude',
-    });
+    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', completeSnapshot('proj-42', 'claude'));
   });
 
   it('marks the local id ready in the store', async () => {
@@ -317,10 +327,7 @@ describe('useNewThreadAutoConfig — adapterId resolution', () => {
 
     renderHook(() => useNewThreadAutoConfig());
 
-    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', {
-      projectId: 'proj-42',
-      adapterId: 'gemini',
-    });
+    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', completeSnapshot('proj-42', 'gemini'));
   });
 
   it('falls back to the first installed adapter when defaultAdapterId is unset', () => {
@@ -333,10 +340,7 @@ describe('useNewThreadAutoConfig — adapterId resolution', () => {
 
     renderHook(() => useNewThreadAutoConfig());
 
-    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', {
-      projectId: 'proj-42',
-      adapterId: 'gemini',
-    });
+    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', completeSnapshot('proj-42', 'gemini'));
   });
 
   it('falls back to "claude" when defaultAdapterId is unset and nothing is installed', () => {
@@ -346,9 +350,6 @@ describe('useNewThreadAutoConfig — adapterId resolution', () => {
 
     renderHook(() => useNewThreadAutoConfig());
 
-    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', {
-      projectId: 'proj-42',
-      adapterId: 'claude',
-    });
+    expect(setDraftConfigSpy).toHaveBeenCalledExactlyOnceWith('__LOCALID_x', completeSnapshot('proj-42', 'claude'));
   });
 });

--- a/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
@@ -51,6 +51,7 @@ let fakeAdapters: { id: string; installed: boolean }[] = [];
 
 const setDraftConfigSpy = vi.fn();
 let getDraftConfigResult: unknown = undefined;
+let initializationGate: Promise<void> | null = null;
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,9 +75,26 @@ vi.mock('@/store/adapters', () => ({
   useAdapters: () => fakeAdapters,
 }));
 
+vi.mock('../../runtime/daemon-port-context', () => ({ useDaemonPort: () => 31415 }));
+
 vi.mock('../../runtime/draft-config', () => ({
   setDraftConfig: (...args: unknown[]) => setDraftConfigSpy(...args),
   getDraftConfig: (_id: string) => getDraftConfigResult,
+}));
+
+vi.mock('../initialize-draft', () => ({
+  initializeDraft: async (args: {
+    localId: string;
+    projectId: string;
+    defaultAdapterId: string | null;
+    adapters: { id: string; installed: boolean }[];
+  }) => {
+    if (initializationGate) await initializationGate;
+    const adapterId = args.defaultAdapterId ?? args.adapters.find((adapter) => adapter.installed)?.id ?? 'claude';
+    setDraftConfigSpy(args.localId, { projectId: args.projectId, adapterId });
+    useNewThreadReady.getState().markReady(args.localId);
+    return { projectId: args.projectId, adapterId };
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -94,6 +112,7 @@ const { useNewThreadAutoConfig } = await import('../use-new-thread-auto-config')
 beforeEach(() => {
   setDraftConfigSpy.mockReset();
   getDraftConfigResult = undefined;
+  initializationGate = null;
   fakeFilterProjectId = null;
   fakeDefaultAdapterId = null;
   fakeAdapters = [];
@@ -143,6 +162,20 @@ describe('useNewThreadAutoConfig — project filter active on new local thread',
     });
 
     expect(useNewThreadReady.getState().readyIds.has('__LOCALID_x')).toBe(true);
+  });
+
+  it('does not mark the local id ready before asynchronous initialization resolves', async () => {
+    let release!: () => void;
+    initializationGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setLocalThreadWithProject('__LOCALID_x', 'proj-42');
+
+    renderHook(() => useNewThreadAutoConfig());
+    expect(useNewThreadReady.getState().isReady('__LOCALID_x')).toBe(false);
+
+    await act(async () => release());
+    expect(useNewThreadReady.getState().isReady('__LOCALID_x')).toBe(true);
   });
 });
 

--- a/packages/ui/src/features/sessions/new-thread/default-adapter.ts
+++ b/packages/ui/src/features/sessions/new-thread/default-adapter.ts
@@ -1,0 +1,18 @@
+/**
+ * resolveDefaultAdapterId — which adapter a brand-new draft starts on.
+ *
+ * Shared by both entry points into a new thread (useNewThreadAutoConfig for the
+ * pill-active path, SessionsNewButton's picker for the "All" view) so a session
+ * starts on the same adapter however it was created.
+ */
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+
+/** Last-resort adapter when no default is configured and nothing is installed yet. */
+const FALLBACK_ADAPTER_ID = 'claude';
+
+export function resolveDefaultAdapterId(
+  defaultAdapterId: string | null | undefined,
+  adapters: readonly AdapterInfo[],
+): string {
+  return defaultAdapterId ?? adapters.find((a) => a.installed)?.id ?? FALLBACK_ADAPTER_ID;
+}

--- a/packages/ui/src/features/sessions/new-thread/initialize-draft.ts
+++ b/packages/ui/src/features/sessions/new-thread/initialize-draft.ts
@@ -36,3 +36,33 @@ export async function initializeDraft(args: InitializeDraftArgs): Promise<DraftC
     throw error;
   }
 }
+
+export async function reinitializeDraftAdapter(args: InitializeDraftArgs & { adapterId: string }): Promise<DraftCfg> {
+  const existing = getDraftConfig(args.localId);
+  if (!existing || !useNewThreadReady.getState().isReady(args.localId)) {
+    throw new Error(`Cannot reinitialize draft: ${args.localId} has no ready snapshot`);
+  }
+  const attempt = useNewThreadReady.getState().beginReadyReplacement(args.localId);
+
+  try {
+    const providers = await getProviderSettings(args.port);
+    const adapter = args.adapters.find((candidate) => candidate.id === args.adapterId);
+    if (!adapter) throw new Error(`Cannot initialize draft: adapter ${args.adapterId} is unavailable`);
+    const resolved = resolveDraftDefaults(args.projectId, adapter, providers[args.adapterId]);
+    const initialization = useNewThreadReady.getState().getInitialization(args.localId);
+    const current = getDraftConfig(args.localId);
+    if (initialization.attempt !== attempt || !current) return current ?? resolved;
+    const snapshot: DraftCfg = {
+      ...resolved,
+      ...(current.worktreePath !== undefined ? { worktreePath: current.worktreePath } : {}),
+      ...(current.branchName !== undefined ? { branchName: current.branchName } : {}),
+      ...(current.pendingWorktree !== undefined ? { pendingWorktree: current.pendingWorktree } : {}),
+    };
+    setDraftConfig(args.localId, snapshot);
+    useNewThreadReady.getState().completeInitialization(args.localId, attempt);
+    return snapshot;
+  } catch (error) {
+    useNewThreadReady.getState().completeInitialization(args.localId, attempt);
+    throw error;
+  }
+}

--- a/packages/ui/src/features/sessions/new-thread/initialize-draft.ts
+++ b/packages/ui/src/features/sessions/new-thread/initialize-draft.ts
@@ -1,0 +1,38 @@
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import { getProviderSettings } from '@/lib/api/settings';
+import { getDraftConfig, setDraftConfig, type DraftCfg } from '../runtime/draft-config';
+import { useNewThreadReady } from '../runtime/new-thread-ready-store';
+import { resolveDefaultAdapterId } from './default-adapter';
+import { resolveDraftDefaults } from './resolve-draft-defaults';
+
+export interface InitializeDraftArgs {
+  localId: string;
+  projectId: string;
+  port: number;
+  defaultAdapterId: string | null;
+  adapters: AdapterInfo[];
+  adapterId?: string;
+}
+
+export async function initializeDraft(args: InitializeDraftArgs): Promise<DraftCfg> {
+  const retry = () => initializeDraft(args);
+  const store = useNewThreadReady.getState();
+  const attempt = store.beginInitialization(args.localId, retry);
+
+  try {
+    const providers = await getProviderSettings(args.port);
+    const adapterId = args.adapterId ?? resolveDefaultAdapterId(args.defaultAdapterId, args.adapters);
+    const adapter = args.adapters.find((candidate) => candidate.id === adapterId);
+    if (!adapter) throw new Error(`Cannot initialize draft: adapter ${adapterId} is unavailable`);
+    const snapshot = resolveDraftDefaults(args.projectId, adapter, providers[adapterId]);
+    const initialization = useNewThreadReady.getState().getInitialization(args.localId);
+    if (initialization.attempt !== attempt) return getDraftConfig(args.localId) ?? snapshot;
+    setDraftConfig(args.localId, snapshot);
+    useNewThreadReady.getState().completeInitialization(args.localId, attempt);
+    useNewThreadReady.getState().markReady(args.localId);
+    return snapshot;
+  } catch (error) {
+    useNewThreadReady.getState().failInitialization(args.localId, attempt, error);
+    throw error;
+  }
+}

--- a/packages/ui/src/features/sessions/new-thread/reset-new-thread-draft.ts
+++ b/packages/ui/src/features/sessions/new-thread/reset-new-thread-draft.ts
@@ -22,10 +22,12 @@
  */
 import { clearDraftConfig } from '../runtime/draft-config';
 import { useNewThreadReady } from '../runtime/new-thread-ready-store';
+import { abandonCreateForLocal } from '../runtime/new-thread-coordinator';
 import { clearDraftDiscarded } from './discarded-drafts';
 
 export function resetNewThreadDraft(newThreadId: string | null | undefined): void {
   if (!newThreadId) return;
+  abandonCreateForLocal(newThreadId);
   clearDraftConfig(newThreadId);
   useNewThreadReady.getState().clearReady(newThreadId);
   clearDraftDiscarded(newThreadId);

--- a/packages/ui/src/features/sessions/new-thread/resolve-draft-defaults.ts
+++ b/packages/ui/src/features/sessions/new-thread/resolve-draft-defaults.ts
@@ -1,0 +1,37 @@
+import type { AdapterInfo, FeatureKey, ProviderConfig } from '@qlan-ro/mainframe-types';
+import { TUNABLE_FEATURES, clampEffortToSupported } from '@qlan-ro/mainframe-types';
+import type { DraftCfg } from '../runtime/draft-config';
+
+export function resolveDraftDefaults(projectId: string, adapter: AdapterInfo, provider?: ProviderConfig): DraftCfg {
+  const model =
+    adapter.models.find((candidate) => candidate.id === provider?.defaultModel) ??
+    adapter.models.find((candidate) => candidate.isDefault) ??
+    adapter.models[0];
+  if (!model) throw new Error('Cannot initialize draft: adapter has no models');
+
+  const features: Record<FeatureKey, boolean> = {
+    fast: false,
+    ultracode: false,
+    adaptiveThinking: false,
+  };
+  for (const feature of TUNABLE_FEATURES) {
+    features[feature.key] = Boolean(model[feature.capability] && provider?.[feature.providerDefault] === 'true');
+  }
+
+  const requestedEffort = provider?.defaultEffort ?? model.defaultEffort ?? 'medium';
+  const effort = features.ultracode
+    ? 'xhigh'
+    : clampEffortToSupported(requestedEffort, model.supportedEfforts ?? [], model.defaultEffort);
+
+  return {
+    projectId,
+    adapterId: adapter.id,
+    model: model.id,
+    permissionMode: provider?.defaultMode ?? 'default',
+    planMode: provider?.defaultPlanMode === 'true',
+    effort,
+    fast: features.fast,
+    ultracode: features.ultracode,
+    adaptiveThinking: features.adaptiveThinking,
+  };
+}

--- a/packages/ui/src/features/sessions/new-thread/use-new-thread-auto-config.ts
+++ b/packages/ui/src/features/sessions/new-thread/use-new-thread-auto-config.ts
@@ -13,19 +13,20 @@ import { useAuiState } from '@assistant-ui/react';
 import { useSessionFilters } from '@/store/session-filters';
 import { useSettingsStore } from '@/store/settings';
 import { useAdapters } from '@/store/adapters';
-import { getDraftConfig, setDraftConfig } from '../runtime/draft-config';
+import { getDraftConfig } from '../runtime/draft-config';
 import { useNewThreadReady } from '../runtime/new-thread-ready-store';
 import { isDraftDiscarded } from './discarded-drafts';
-import { resolveDefaultAdapterId } from './default-adapter';
+import { initializeDraft } from './initialize-draft';
+import { useDaemonPort } from '../runtime/daemon-port-context';
 
 export function useNewThreadAutoConfig(): void {
   const localId = useAuiState((s) => s.threadListItem?.id ?? null);
   const itemStatus = useAuiState((s) => s.threadListItem?.status);
   const messageCount = useAuiState((s) => s.thread.messages.length);
   const filterProjectId = useSessionFilters((s) => s.filterProjectId);
-  const isReady = useNewThreadReady((s) => (localId ? s.readyIds.has(localId) : false));
   const defaultAdapterId = useSettingsStore((s) => s.general.defaultAdapterId);
   const adapters = useAdapters();
+  const port = useDaemonPort();
 
   useEffect(() => {
     if (localId == null || filterProjectId == null) return;
@@ -34,11 +35,13 @@ export function useNewThreadAutoConfig(): void {
     // ready flag were just cleared, and switchToThread(target) away from it
     // hasn't landed yet. Without this guard we'd instantly re-seed the exact
     // draft the user just closed (see discarded-drafts.ts).
-    if (!isNewLocal || isReady || getDraftConfig(localId) || isDraftDiscarded(localId)) return;
-    const adapterId = resolveDefaultAdapterId(defaultAdapterId, adapters);
-    // No permissionMode: chat creation omits it so the daemon applies the user's
-    // provider defaultMode (matching desktop). A deliberate pick sets it later.
-    setDraftConfig(localId, { projectId: filterProjectId, adapterId });
-    useNewThreadReady.getState().markReady(localId);
-  }, [localId, itemStatus, messageCount, filterProjectId, isReady, defaultAdapterId, adapters]);
+    const readyStore = useNewThreadReady.getState();
+    if (!isNewLocal || readyStore.isReady(localId) || getDraftConfig(localId) || isDraftDiscarded(localId)) return;
+    const promise = initializeDraft({ localId, projectId: filterProjectId, port, defaultAdapterId, adapters });
+    const attempt = useNewThreadReady.getState().getInitialization(localId).attempt;
+    void promise.catch((error: unknown) => console.warn('[new-thread-auto-config] initialization failed', error));
+    return () => {
+      if (attempt != null) useNewThreadReady.getState().cancelInitialization(localId, attempt);
+    };
+  }, [localId, itemStatus, messageCount, filterProjectId, port, defaultAdapterId, adapters]);
 }

--- a/packages/ui/src/features/sessions/new-thread/use-new-thread-auto-config.ts
+++ b/packages/ui/src/features/sessions/new-thread/use-new-thread-auto-config.ts
@@ -16,9 +16,7 @@ import { useAdapters } from '@/store/adapters';
 import { getDraftConfig, setDraftConfig } from '../runtime/draft-config';
 import { useNewThreadReady } from '../runtime/new-thread-ready-store';
 import { isDraftDiscarded } from './discarded-drafts';
-
-/** Last-resort adapter when no default is configured and nothing is installed yet. */
-const FALLBACK_ADAPTER_ID = 'claude';
+import { resolveDefaultAdapterId } from './default-adapter';
 
 export function useNewThreadAutoConfig(): void {
   const localId = useAuiState((s) => s.threadListItem?.id ?? null);
@@ -37,7 +35,7 @@ export function useNewThreadAutoConfig(): void {
     // hasn't landed yet. Without this guard we'd instantly re-seed the exact
     // draft the user just closed (see discarded-drafts.ts).
     if (!isNewLocal || isReady || getDraftConfig(localId) || isDraftDiscarded(localId)) return;
-    const adapterId = defaultAdapterId ?? adapters.find((a) => a.installed)?.id ?? FALLBACK_ADAPTER_ID;
+    const adapterId = resolveDefaultAdapterId(defaultAdapterId, adapters);
     // No permissionMode: chat creation omits it so the daemon applies the user's
     // provider defaultMode (matching desktop). A deliberate pick sets it later.
     setDraftConfig(localId, { projectId: filterProjectId, adapterId });

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, afterEach, vi, type MockedFunction } from 'vitest';
 import type { Chat } from '@qlan-ro/mainframe-types';
-import { setDraftConfig as setStoredDraftConfig, clearDraftConfig, type DraftCfg } from '../draft-config';
+import {
+  setDraftConfig as setStoredDraftConfig,
+  getDraftConfig,
+  clearDraftConfig,
+  type DraftCfg,
+} from '../draft-config';
+import { useNewThreadReady } from '../new-thread-ready-store';
 
 // ---------------------------------------------------------------------------
 // Mock createChat, setChatTuning, setChatConfig — no HTTP calls
@@ -10,14 +16,6 @@ vi.mock('../../../../lib/api/chats', () => ({
   createChat: vi.fn(),
   setChatTuning: vi.fn().mockResolvedValue(undefined),
   setChatConfig: vi.fn().mockResolvedValue(undefined),
-}));
-
-// Mock the ready-store so we can assert the first-send cleanup without a real store.
-const clearReadySpy = vi.fn();
-vi.mock('../new-thread-ready-store', () => ({
-  useNewThreadReady: {
-    getState: () => ({ clearReady: (...args: unknown[]) => clearReadySpy(...args) }),
-  },
 }));
 
 // Mock enableWorktree (pendingWorktree carry) and the toast raised on its failure.
@@ -50,6 +48,7 @@ function setDraftConfig(localId: string, cfg: DraftCfg): void {
     adaptiveThinking: false,
     ...cfg,
   });
+  useNewThreadReady.getState().markReady(localId);
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +59,7 @@ afterEach(() => {
   clearDraftConfig('__LOCALID_a');
   clearDraftConfig('__LOCALID_b');
   clearDraftConfig('__LOCALID_c');
+  useNewThreadReady.setState({ readyIds: new Set(), initializations: new Map() });
   vi.clearAllMocks();
 });
 
@@ -177,7 +177,7 @@ describe('new-thread-coordinator — clears the new-thread-ready flag on first s
 
     await createForLocal('__LOCALID_a', 31415);
 
-    expect(clearReadySpy).toHaveBeenCalledWith('__LOCALID_a');
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(false);
   });
 
   it('does NOT clear the ready flag when the create fails (so retry still shows the composer)', async () => {
@@ -190,7 +190,7 @@ describe('new-thread-coordinator — clears the new-thread-ready flag on first s
 
     await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow('create failed');
 
-    expect(clearReadySpy).not.toHaveBeenCalled();
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(true);
   });
 });
 
@@ -265,8 +265,8 @@ describe('new-thread-coordinator — incomplete drafts are rejected before creat
   });
 });
 
-describe('new-thread-coordinator — setChatTuning rejection does NOT reject createForLocal', () => {
-  it('still resolves to {remoteId} even when setChatTuning rejects', async () => {
+describe('new-thread-coordinator — required snapshot stages resume after failure', () => {
+  it('retains and reuses the created chat when tuning fails', async () => {
     setDraftConfig('__LOCALID_a', {
       projectId: 'p1',
       adapterId: 'claude',
@@ -276,10 +276,61 @@ describe('new-thread-coordinator — setChatTuning rejection does NOT reject cre
     mockCreateChat.mockResolvedValueOnce({ id: 'chat-44' } as Chat);
     mockSetChatTuning.mockRejectedValueOnce(new Error('tuning failed'));
 
-    // The tuning hiccup is swallowed; createForLocal still resolves.
+    await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow('tuning failed');
+
+    expect(getDraftConfig('__LOCALID_a')).toBeDefined();
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(true);
+    expect(mockSetChatConfig).toHaveBeenCalledTimes(1);
+
     const result = await createForLocal('__LOCALID_a', 31415);
 
     expect(result).toEqual({ remoteId: 'chat-44' });
+    expect(mockCreateChat).toHaveBeenCalledTimes(1);
+    expect(mockSetChatTuning).toHaveBeenCalledTimes(2);
+    expect(mockSetChatConfig).toHaveBeenCalledTimes(2);
+    expect(getDraftConfig('__LOCALID_a')).toBeUndefined();
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(false);
+  });
+
+  it('retains and reuses the created chat when plan config fails', async () => {
+    setDraftConfig('__LOCALID_a', { projectId: 'p1', adapterId: 'claude', planMode: true });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-45' } as Chat);
+    mockSetChatConfig.mockRejectedValueOnce(new Error('config failed'));
+
+    await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow('config failed');
+    expect(getDraftConfig('__LOCALID_a')).toBeDefined();
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(true);
+    expect(mockSetChatTuning).toHaveBeenCalledTimes(1);
+
+    await expect(createForLocal('__LOCALID_a', 31415)).resolves.toEqual({ remoteId: 'chat-45' });
+    expect(mockCreateChat).toHaveBeenCalledTimes(1);
+    expect(mockSetChatTuning).toHaveBeenCalledTimes(2);
+    expect(mockSetChatConfig).toHaveBeenCalledTimes(2);
+    expect(getDraftConfig('__LOCALID_a')).toBeUndefined();
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(false);
+  });
+
+  it('shares one staged workflow between concurrent callers', async () => {
+    setDraftConfig('__LOCALID_a', { projectId: 'p1', adapterId: 'claude' });
+    let resolveChat!: (chat: Chat) => void;
+    mockCreateChat.mockReturnValueOnce(
+      new Promise<Chat>((resolve) => {
+        resolveChat = resolve;
+      }),
+    );
+
+    const first = createForLocal('__LOCALID_a', 31415);
+    const second = createForLocal('__LOCALID_a', 31415);
+    expect(second).toBe(first);
+    resolveChat({ id: 'chat-concurrent' } as Chat);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { remoteId: 'chat-concurrent' },
+      { remoteId: 'chat-concurrent' },
+    ]);
+    expect(mockCreateChat).toHaveBeenCalledTimes(1);
+    expect(mockSetChatTuning).toHaveBeenCalledTimes(1);
+    expect(mockSetChatConfig).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi, type MockedFunction } from 'vitest';
 import type { Chat } from '@qlan-ro/mainframe-types';
-import { setDraftConfig, clearDraftConfig } from '../draft-config';
+import { setDraftConfig as setStoredDraftConfig, clearDraftConfig, type DraftCfg } from '../draft-config';
 
 // ---------------------------------------------------------------------------
 // Mock createChat, setChatTuning, setChatConfig — no HTTP calls
@@ -39,6 +39,19 @@ const mockSetChatTuning = setChatTuning as MockedFunction<typeof setChatTuning>;
 const mockSetChatConfig = setChatConfig as MockedFunction<typeof setChatConfig>;
 const mockEnableWorktree = enableWorktree as MockedFunction<typeof enableWorktree>;
 
+function setDraftConfig(localId: string, cfg: DraftCfg): void {
+  setStoredDraftConfig(localId, {
+    model: 'snapshot-model',
+    permissionMode: 'default',
+    planMode: false,
+    effort: null,
+    fast: false,
+    ultracode: false,
+    adaptiveThinking: false,
+    ...cfg,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Reset draft-config singleton state + mock call counts between cases
 // ---------------------------------------------------------------------------
@@ -69,6 +82,7 @@ describe('new-thread-coordinator — happy path calls createChat with required f
     expect(mockCreateChat).toHaveBeenCalledWith(31415, {
       projectId: 'p1',
       adapterId: 'claude',
+      model: 'snapshot-model',
       permissionMode: 'default',
     });
   });
@@ -185,6 +199,38 @@ describe('new-thread-coordinator — clears the new-thread-ready flag on first s
 // ---------------------------------------------------------------------------
 
 describe('new-thread-coordinator — draft with tuning calls setChatTuning and setChatConfig', () => {
+  it('creates and tunes the first chat from the complete stored snapshot', async () => {
+    setDraftConfig('__LOCALID_a', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'snapshotted-model',
+      permissionMode: 'acceptEdits',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-1' } as Chat);
+
+    await createForLocal('__LOCALID_a', 31415);
+
+    expect(mockCreateChat).toHaveBeenCalledWith(
+      31415,
+      expect.objectContaining({
+        model: 'snapshotted-model',
+        permissionMode: 'acceptEdits',
+      }),
+    );
+    expect(mockSetChatConfig).toHaveBeenCalledWith(31415, 'chat-1', { planMode: true });
+    expect(mockSetChatTuning).toHaveBeenCalledWith(31415, 'chat-1', {
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: true,
+    });
+  });
+
   it('calls setChatTuning with effort and setChatConfig with planMode', async () => {
     setDraftConfig('__LOCALID_a', {
       projectId: 'p1',
@@ -203,24 +249,19 @@ describe('new-thread-coordinator — draft with tuning calls setChatTuning and s
     expect(mockSetChatTuning).toHaveBeenCalledExactlyOnceWith(31415, 'chat-42', {
       effort: 'high',
       fast: true,
+      ultracode: false,
+      adaptiveThinking: false,
     });
     expect(mockSetChatConfig).toHaveBeenCalledExactlyOnceWith(31415, 'chat-42', { planMode: true });
   });
 });
 
-describe('new-thread-coordinator — draft with no tuning fields calls neither setChatTuning nor setChatConfig', () => {
-  it('does NOT call setChatTuning or setChatConfig when the draft has only base fields', async () => {
-    setDraftConfig('__LOCALID_a', {
-      projectId: 'p1',
-      adapterId: 'claude',
-      permissionMode: 'default',
-    });
-    mockCreateChat.mockResolvedValueOnce({ id: 'chat-43' } as Chat);
+describe('new-thread-coordinator — incomplete drafts are rejected before creation', () => {
+  it('does not create a chat from legacy state that lacks initialized fields', async () => {
+    setStoredDraftConfig('__LOCALID_a', { projectId: 'p1', adapterId: 'claude' });
 
-    await createForLocal('__LOCALID_a', 31415);
-
-    expect(mockSetChatTuning).not.toHaveBeenCalled();
-    expect(mockSetChatConfig).not.toHaveBeenCalled();
+    await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow(/incomplete draft config/);
+    expect(mockCreateChat).not.toHaveBeenCalled();
   });
 });
 
@@ -246,16 +287,21 @@ describe('new-thread-coordinator — setChatTuning rejection does NOT reject cre
 // permissionMode omission fix — the key behaviour this covers
 // ---------------------------------------------------------------------------
 
-describe('new-thread-coordinator — permissionMode omission fix', () => {
-  it('omits permissionMode from the createChat body when the draft has none', async () => {
-    setDraftConfig('__LOCALID_b', { projectId: 'p1', adapterId: 'claude' });
-    mockCreateChat.mockResolvedValueOnce({ id: 'chat-1' } as Chat);
+describe('new-thread-coordinator — explicit snapshot permissionMode', () => {
+  it('rejects a snapshot with no explicit permissionMode', async () => {
+    setStoredDraftConfig('__LOCALID_b', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'snapshot-model',
+      planMode: false,
+      effort: null,
+      fast: false,
+      ultracode: false,
+      adaptiveThinking: false,
+    });
 
-    await createForLocal('__LOCALID_b', 31415);
-
-    const body = mockCreateChat.mock.calls[0]![1];
-    expect('permissionMode' in body).toBe(false);
-    expect(body).toMatchObject({ projectId: 'p1', adapterId: 'claude' });
+    await expect(createForLocal('__LOCALID_b', 31415)).rejects.toThrow(/permissionMode/);
+    expect(mockCreateChat).not.toHaveBeenCalled();
   });
 
   it('includes permissionMode in the createChat body when the draft set one', async () => {

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-coordinator.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../../../lib/api/chats', () => ({
   createChat: vi.fn(),
   setChatTuning: vi.fn().mockResolvedValue(undefined),
   setChatConfig: vi.fn().mockResolvedValue(undefined),
+  archiveChat: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock enableWorktree (pendingWorktree carry) and the toast raised on its failure.
@@ -28,13 +29,15 @@ vi.mock('../../../../lib/toast', () => ({
 }));
 
 // Import AFTER the mock is registered so the module under test picks up the mock.
-import { createForLocal } from '../new-thread-coordinator';
-import { createChat, setChatTuning, setChatConfig } from '../../../../lib/api/chats';
+import { abandonCreateForLocal, createForLocal } from '../new-thread-coordinator';
+import { resetNewThreadDraft } from '../../new-thread/reset-new-thread-draft';
+import { createChat, setChatTuning, setChatConfig, archiveChat } from '../../../../lib/api/chats';
 import { enableWorktree } from '../../../../lib/api/git';
 
 const mockCreateChat = createChat as MockedFunction<typeof createChat>;
 const mockSetChatTuning = setChatTuning as MockedFunction<typeof setChatTuning>;
 const mockSetChatConfig = setChatConfig as MockedFunction<typeof setChatConfig>;
+const mockArchiveChat = archiveChat as MockedFunction<typeof archiveChat>;
 const mockEnableWorktree = enableWorktree as MockedFunction<typeof enableWorktree>;
 
 function setDraftConfig(localId: string, cfg: DraftCfg): void {
@@ -56,6 +59,9 @@ function setDraftConfig(localId: string, cfg: DraftCfg): void {
 // ---------------------------------------------------------------------------
 
 afterEach(() => {
+  abandonCreateForLocal('__LOCALID_a');
+  abandonCreateForLocal('__LOCALID_b');
+  abandonCreateForLocal('__LOCALID_c');
   clearDraftConfig('__LOCALID_a');
   clearDraftConfig('__LOCALID_b');
   clearDraftConfig('__LOCALID_c');
@@ -331,6 +337,87 @@ describe('new-thread-coordinator — required snapshot stages resume after failu
     expect(mockCreateChat).toHaveBeenCalledTimes(1);
     expect(mockSetChatTuning).toHaveBeenCalledTimes(1);
     expect(mockSetChatConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('freezes the original snapshot for retries against a retained chat', async () => {
+    setDraftConfig('__LOCALID_a', {
+      projectId: 'p1',
+      adapterId: 'claude',
+      model: 'original-model',
+      permissionMode: 'acceptEdits',
+      planMode: true,
+      effort: 'high',
+      fast: true,
+    });
+    mockCreateChat.mockResolvedValueOnce({ id: 'chat-frozen' } as Chat);
+    mockSetChatConfig.mockRejectedValueOnce(new Error('config failed'));
+    await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow('config failed');
+
+    setDraftConfig('__LOCALID_a', {
+      projectId: 'p2',
+      adapterId: 'codex',
+      model: 'edited-model',
+      permissionMode: 'yolo',
+      planMode: false,
+      effort: 'low',
+      fast: false,
+    });
+    await createForLocal('__LOCALID_a', 31415);
+
+    expect(mockCreateChat).toHaveBeenCalledTimes(1);
+    expect(mockSetChatTuning).toHaveBeenLastCalledWith(31415, 'chat-frozen', {
+      effort: 'high',
+      fast: true,
+      ultracode: false,
+      adaptiveThinking: false,
+    });
+    expect(mockSetChatConfig).toHaveBeenLastCalledWith(31415, 'chat-frozen', { planMode: true });
+  });
+});
+
+describe('new-thread-coordinator — abandoned workflows cannot leak into reused local ids', () => {
+  it('archives the retained chat and creates a fresh chat for the reused id', async () => {
+    setDraftConfig('__LOCALID_a', { projectId: 'old', adapterId: 'claude' });
+    mockCreateChat
+      .mockResolvedValueOnce({ id: 'chat-old' } as Chat)
+      .mockResolvedValueOnce({ id: 'chat-fresh' } as Chat);
+    mockSetChatConfig.mockRejectedValueOnce(new Error('config failed'));
+    await expect(createForLocal('__LOCALID_a', 31415)).rejects.toThrow('config failed');
+
+    resetNewThreadDraft('__LOCALID_a');
+    setDraftConfig('__LOCALID_a', { projectId: 'fresh', adapterId: 'codex', model: 'fresh-model' });
+    await expect(createForLocal('__LOCALID_a', 31415)).resolves.toEqual({ remoteId: 'chat-fresh' });
+
+    expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-old', true);
+    expect(mockCreateChat).toHaveBeenCalledTimes(2);
+    expect(mockCreateChat).toHaveBeenLastCalledWith(
+      31415,
+      expect.objectContaining({
+        projectId: 'fresh',
+        adapterId: 'codex',
+        model: 'fresh-model',
+      }),
+    );
+  });
+
+  it('does not let an abandoned in-flight workflow clear a newer draft', async () => {
+    setDraftConfig('__LOCALID_a', { projectId: 'old', adapterId: 'claude' });
+    let resolveOld!: (chat: Chat) => void;
+    mockCreateChat.mockReturnValueOnce(
+      new Promise<Chat>((resolve) => {
+        resolveOld = resolve;
+      }),
+    );
+    const oldResult = createForLocal('__LOCALID_a', 31415);
+
+    resetNewThreadDraft('__LOCALID_a');
+    setDraftConfig('__LOCALID_a', { projectId: 'fresh', adapterId: 'codex', model: 'fresh-model' });
+    resolveOld({ id: 'chat-old-inflight' } as Chat);
+    await expect(oldResult).rejects.toThrow(/abandoned/);
+
+    expect(getDraftConfig('__LOCALID_a')).toMatchObject({ projectId: 'fresh', adapterId: 'codex' });
+    expect(useNewThreadReady.getState().isReady('__LOCALID_a')).toBe(true);
+    expect(mockArchiveChat).toHaveBeenCalledWith(31415, 'chat-old-inflight', true);
   });
 });
 

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-create-once.test.tsx
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-create-once.test.tsx
@@ -62,6 +62,9 @@ vi.mock('../../../../lib/api/chats', () => ({
   getChat: vi.fn(async (_port: number, chatId: string): Promise<Chat> => ({ id: chatId }) as Chat),
   getChatMessages: vi.fn(async (): Promise<ChatHistoryPayload> => ({ messages: [], transcriptMissing: false })),
   listChats: vi.fn(async (): Promise<Chat[]> => []),
+  setChatTuning: vi.fn(async () => undefined),
+  setChatConfig: vi.fn(async () => undefined),
+  archiveChat: vi.fn(async () => undefined),
 }));
 
 vi.mock('../../../../lib/api/attachments', () => ({
@@ -154,7 +157,17 @@ async function newThreadFirstSend(): Promise<{ runtime: AssistantRuntime; localI
   // ThreadListRuntimeImpl exposes ids via getState(), not as own properties.
   const localId = runtime.threads.getState().mainThreadId;
 
-  setDraftConfig(localId, { projectId: 'p1', adapterId: 'claude', permissionMode: 'default' });
+  setDraftConfig(localId, {
+    projectId: 'p1',
+    adapterId: 'claude',
+    model: 'sonnet',
+    permissionMode: 'default',
+    planMode: false,
+    effort: null,
+    fast: false,
+    ultracode: false,
+    adaptiveThinking: false,
+  });
 
   await act(async () => {
     const sendP = runtime.threads.main.append('hello');

--- a/packages/ui/src/features/sessions/runtime/draft-config.ts
+++ b/packages/ui/src/features/sessions/runtime/draft-config.ts
@@ -17,12 +17,11 @@ import type { EffortLevel, PermissionMode } from '@qlan-ro/mainframe-types';
 export interface DraftCfg {
   projectId: string;
   adapterId: string;
-  model?: string;
   /**
-   * Optional. When unset, chat creation omits it so the daemon applies the
-   * user's provider `defaultMode` (e.g. yolo) — matching desktop. Only a
-   * deliberate per-chat pick sets it.
+   * Initialization resolves model, permission, plan, effort, and feature values
+   * explicitly. They remain optional for partial patches and legacy/retry state.
    */
+  model?: string;
   permissionMode?: PermissionMode;
   planMode?: boolean;
   effort?: EffortLevel | null;

--- a/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
@@ -27,15 +27,19 @@
  * cache entry AND the draft are left intact so the user can retry.
  */
 import type { Chat, SessionTuning } from '@qlan-ro/mainframe-types';
-import { createChat, setChatConfig, setChatTuning } from '../../../lib/api/chats';
+import { archiveChat, createChat, setChatConfig, setChatTuning } from '../../../lib/api/chats';
 import { enableWorktree } from '../../../lib/api/git';
 import { mfToast } from '../../../lib/toast';
 import { getDraftConfig, clearDraftConfig, type DraftCfg } from './draft-config';
 import { useNewThreadReady } from './new-thread-ready-store';
 
 interface CreateWorkflow {
+  cfg: InitializedDraft;
+  port: number;
   chatId?: string;
   worktreeApplied: boolean;
+  abandoned: boolean;
+  archiveRequested: boolean;
   promise?: Promise<{ remoteId: string }>;
 }
 
@@ -53,6 +57,22 @@ function requireInitializedDraft(localId: string, cfg: DraftCfg): InitializedDra
     throw new Error(`new-thread-coordinator: incomplete draft config for ${localId}: ${missing.join(', ')}`);
   }
   return cfg as InitializedDraft;
+}
+
+function archiveAbandonedWorkflow(workflow: CreateWorkflow): void {
+  if (!workflow.chatId || workflow.archiveRequested) return;
+  workflow.archiveRequested = true;
+  void archiveChat(workflow.port, workflow.chatId, true).catch((err: unknown) =>
+    console.warn('[new-thread-coordinator] abandon archive failed', { chatId: workflow.chatId, err }),
+  );
+}
+
+export function abandonCreateForLocal(localId: string): void {
+  const workflow = workflows.get(localId);
+  if (!workflow) return;
+  workflows.delete(localId);
+  workflow.abandoned = true;
+  archiveAbandonedWorkflow(workflow);
 }
 
 /**
@@ -105,20 +125,29 @@ async function applyPendingWorktree(port: number, chatId: string, cfg: DraftCfg)
 export function createForLocal(localId: string, port: number): Promise<{ remoteId: string }> {
   const existing = workflows.get(localId);
   if (existing?.promise) return existing.promise;
-
-  const stored = getDraftConfig(localId);
-  if (!stored) {
-    return Promise.reject(new Error(`new-thread-coordinator: no draft config for ${localId}`));
+  let workflow = existing;
+  if (!workflow) {
+    const stored = getDraftConfig(localId);
+    if (!stored) return Promise.reject(new Error(`new-thread-coordinator: no draft config for ${localId}`));
+    let cfg: InitializedDraft;
+    try {
+      cfg = requireInitializedDraft(localId, stored);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    workflow = {
+      cfg: {
+        ...cfg,
+        ...(cfg.pendingWorktree ? { pendingWorktree: { ...cfg.pendingWorktree } } : {}),
+      },
+      port,
+      worktreeApplied: false,
+      abandoned: false,
+      archiveRequested: false,
+    };
   }
-  let cfg: InitializedDraft;
-  try {
-    cfg = requireInitializedDraft(localId, stored);
-  } catch (error) {
-    return Promise.reject(error);
-  }
-
-  const workflow = existing ?? { worktreeApplied: false };
   workflows.set(localId, workflow);
+  const cfg = workflow.cfg;
   const promise = (async () => {
     try {
       if (!workflow.chatId) {
@@ -132,18 +161,32 @@ export function createForLocal(localId: string, port: number): Promise<{ remoteI
         });
         workflow.chatId = chat.id;
       }
+      if (workflow.abandoned) {
+        archiveAbandonedWorkflow(workflow);
+        throw new Error(`new-thread-coordinator: workflow abandoned for ${localId}`);
+      }
       if (!workflow.worktreeApplied) {
         await applyPendingWorktree(port, workflow.chatId, cfg);
         workflow.worktreeApplied = true;
       }
+      if (workflow.abandoned) {
+        archiveAbandonedWorkflow(workflow);
+        throw new Error(`new-thread-coordinator: workflow abandoned for ${localId}`);
+      }
       await applyDraftTuning(port, workflow.chatId, cfg);
+      if (workflow.abandoned || workflows.get(localId) !== workflow) {
+        archiveAbandonedWorkflow(workflow);
+        throw new Error(`new-thread-coordinator: workflow abandoned for ${localId}`);
+      }
       clearDraftConfig(localId);
       useNewThreadReady.getState().clearReady(localId);
       workflows.delete(localId);
       return { remoteId: workflow.chatId };
     } catch (error) {
-      workflow.promise = undefined;
-      if (!workflow.chatId) workflows.delete(localId);
+      if (workflows.get(localId) === workflow) {
+        workflow.promise = undefined;
+        if (!workflow.chatId) workflows.delete(localId);
+      }
       throw error;
     }
   })();

--- a/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
@@ -36,6 +36,20 @@ import { useNewThreadReady } from './new-thread-ready-store';
 /** In-flight (and just-settled) create promises, keyed by the local thread id. */
 const inFlight = new Map<string, Promise<{ remoteId: string }>>();
 
+type InitializedDraft = DraftCfg &
+  Required<
+    Pick<DraftCfg, 'model' | 'permissionMode' | 'planMode' | 'effort' | 'fast' | 'ultracode' | 'adaptiveThinking'>
+  >;
+
+function requireInitializedDraft(localId: string, cfg: DraftCfg): InitializedDraft {
+  const fields = ['model', 'permissionMode', 'planMode', 'effort', 'fast', 'ultracode', 'adaptiveThinking'] as const;
+  const missing = fields.filter((field) => cfg[field] === undefined);
+  if (missing.length > 0) {
+    throw new Error(`new-thread-coordinator: incomplete draft config for ${localId}: ${missing.join(', ')}`);
+  }
+  return cfg as InitializedDraft;
+}
+
 /**
  * Apply the draft fields createChat does NOT accept — planMode (PATCH /config)
  * and effort/features (PATCH /tuning) — to the freshly created chat, before the
@@ -87,18 +101,22 @@ export function createForLocal(localId: string, port: number): Promise<{ remoteI
   const existing = inFlight.get(localId);
   if (existing) return existing;
 
-  const cfg = getDraftConfig(localId);
-  if (!cfg) {
+  const stored = getDraftConfig(localId);
+  if (!stored) {
     return Promise.reject(new Error(`new-thread-coordinator: no draft config for ${localId}`));
+  }
+  let cfg: InitializedDraft;
+  try {
+    cfg = requireInitializedDraft(localId, stored);
+  } catch (error) {
+    return Promise.reject(error);
   }
 
   const promise = createChat(port, {
     projectId: cfg.projectId,
     adapterId: cfg.adapterId,
-    ...(cfg.model !== undefined ? { model: cfg.model } : {}),
-    // Omit when unset so the daemon's createChatWithDefaults applies the user's
-    // provider defaultMode (matching desktop) instead of forcing 'default'.
-    ...(cfg.permissionMode !== undefined ? { permissionMode: cfg.permissionMode } : {}),
+    model: cfg.model,
+    permissionMode: cfg.permissionMode,
     ...(cfg.worktreePath !== undefined ? { worktreePath: cfg.worktreePath } : {}),
     ...(cfg.branchName !== undefined ? { branchName: cfg.branchName } : {}),
   })

--- a/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-coordinator.ts
@@ -33,8 +33,13 @@ import { mfToast } from '../../../lib/toast';
 import { getDraftConfig, clearDraftConfig, type DraftCfg } from './draft-config';
 import { useNewThreadReady } from './new-thread-ready-store';
 
-/** In-flight (and just-settled) create promises, keyed by the local thread id. */
-const inFlight = new Map<string, Promise<{ remoteId: string }>>();
+interface CreateWorkflow {
+  chatId?: string;
+  worktreeApplied: boolean;
+  promise?: Promise<{ remoteId: string }>;
+}
+
+const workflows = new Map<string, CreateWorkflow>();
 
 type InitializedDraft = DraftCfg &
   Required<
@@ -53,21 +58,21 @@ function requireInitializedDraft(localId: string, cfg: DraftCfg): InitializedDra
 /**
  * Apply the draft fields createChat does NOT accept — planMode (PATCH /config)
  * and effort/features (PATCH /tuning) — to the freshly created chat, before the
- * first send spawns the CLI. Best-effort: a tuning hiccup is logged, never
- * thrown, so it can't orphan an already-created chat.
+ * first send spawns the CLI. Both requests must settle so a failure in one does
+ * not skip the other required snapshot field.
  */
-async function applyDraftTuning(port: number, chatId: string, cfg: DraftCfg): Promise<void> {
+async function applyDraftTuning(port: number, chatId: string, cfg: InitializedDraft): Promise<void> {
   const tuning: SessionTuning = {};
-  if (cfg.effort !== undefined) tuning.effort = cfg.effort;
+  tuning.effort = cfg.effort;
   if (cfg.fast != null) tuning.fast = cfg.fast;
   if (cfg.ultracode != null) tuning.ultracode = cfg.ultracode;
   if (cfg.adaptiveThinking != null) tuning.adaptiveThinking = cfg.adaptiveThinking;
-  try {
-    if (Object.keys(tuning).length > 0) await setChatTuning(port, chatId, tuning);
-    if (cfg.planMode != null) await setChatConfig(port, chatId, { planMode: cfg.planMode });
-  } catch (err) {
-    console.warn('[new-thread-coordinator] applyDraftTuning failed', { chatId, err });
-  }
+  const results = await Promise.allSettled([
+    setChatTuning(port, chatId, tuning),
+    setChatConfig(port, chatId, { planMode: cfg.planMode }),
+  ]);
+  const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (failure) throw failure.reason;
 }
 
 /**
@@ -98,8 +103,8 @@ async function applyPendingWorktree(port: number, chatId: string, cfg: DraftCfg)
  * Throws if no draft exists or the POST fails (cache + draft preserved for retry).
  */
 export function createForLocal(localId: string, port: number): Promise<{ remoteId: string }> {
-  const existing = inFlight.get(localId);
-  if (existing) return existing;
+  const existing = workflows.get(localId);
+  if (existing?.promise) return existing.promise;
 
   const stored = getDraftConfig(localId);
   if (!stored) {
@@ -112,37 +117,36 @@ export function createForLocal(localId: string, port: number): Promise<{ remoteI
     return Promise.reject(error);
   }
 
-  const promise = createChat(port, {
-    projectId: cfg.projectId,
-    adapterId: cfg.adapterId,
-    model: cfg.model,
-    permissionMode: cfg.permissionMode,
-    ...(cfg.worktreePath !== undefined ? { worktreePath: cfg.worktreePath } : {}),
-    ...(cfg.branchName !== undefined ? { branchName: cfg.branchName } : {}),
-  })
-    .then(async (chat: Chat) => {
-      // Carry the draft fields createChat can't take (a pending new worktree,
-      // planMode/effort/features) onto the new chat BEFORE the first send
-      // spawns the CLI.
-      await applyPendingWorktree(port, chat.id, cfg);
-      await applyDraftTuning(port, chat.id, cfg);
-      // Created — the draft is consumed and the cache entry can be evicted so a
-      // future recycled localId starts fresh. The reactive ready flag is cleared
-      // too (its job — switching the surface to the composer — is done; the thread
-      // now flips to a real chat). The resolved value still flows to every awaiter
-      // that shares this promise.
+  const workflow = existing ?? { worktreeApplied: false };
+  workflows.set(localId, workflow);
+  const promise = (async () => {
+    try {
+      if (!workflow.chatId) {
+        const chat: Chat = await createChat(port, {
+          projectId: cfg.projectId,
+          adapterId: cfg.adapterId,
+          model: cfg.model,
+          permissionMode: cfg.permissionMode,
+          ...(cfg.worktreePath !== undefined ? { worktreePath: cfg.worktreePath } : {}),
+          ...(cfg.branchName !== undefined ? { branchName: cfg.branchName } : {}),
+        });
+        workflow.chatId = chat.id;
+      }
+      if (!workflow.worktreeApplied) {
+        await applyPendingWorktree(port, workflow.chatId, cfg);
+        workflow.worktreeApplied = true;
+      }
+      await applyDraftTuning(port, workflow.chatId, cfg);
       clearDraftConfig(localId);
       useNewThreadReady.getState().clearReady(localId);
-      inFlight.delete(localId);
-      return { remoteId: chat.id };
-    })
-    .catch((err: unknown) => {
-      // Keep the draft intact AND drop the cached rejection so the next call
-      // (user retry) starts a fresh POST rather than re-throwing the stale one.
-      inFlight.delete(localId);
-      throw err;
-    });
-
-  inFlight.set(localId, promise);
+      workflows.delete(localId);
+      return { remoteId: workflow.chatId };
+    } catch (error) {
+      workflow.promise = undefined;
+      if (!workflow.chatId) workflows.delete(localId);
+      throw error;
+    }
+  })();
+  workflow.promise = promise;
   return promise;
 }

--- a/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
@@ -27,6 +27,7 @@ export interface DraftInitialization {
 }
 
 const IDLE_INITIALIZATION: DraftInitialization = { status: 'idle' };
+let nextInitializationAttempt = 0;
 
 interface NewThreadReadyState {
   /** Local thread ids whose draft config is complete (project+adapter chosen). */
@@ -48,7 +49,7 @@ export const useNewThreadReady = create<NewThreadReadyState>((set, get) => ({
   isReady: (localId) => get().readyIds.has(localId),
   getInitialization: (localId) => get().initializations.get(localId) ?? IDLE_INITIALIZATION,
   beginInitialization: (localId, retry) => {
-    const attempt = (get().initializations.get(localId)?.attempt ?? 0) + 1;
+    const attempt = ++nextInitializationAttempt;
     set((state) => {
       const initializations = new Map(state.initializations);
       initializations.set(localId, { status: 'initializing', retry, attempt });

--- a/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
@@ -15,18 +15,75 @@
  * (`useNewThreadReady.getState()`) from the non-React coordinator.
  */
 import { create } from 'zustand';
+import type { DraftCfg } from './draft-config';
+
+export type DraftInitializationStatus = 'idle' | 'initializing' | 'ready' | 'error';
+
+export interface DraftInitialization {
+  status: DraftInitializationStatus;
+  retry?: () => Promise<DraftCfg>;
+  error?: unknown;
+  attempt?: number;
+}
+
+const IDLE_INITIALIZATION: DraftInitialization = { status: 'idle' };
 
 interface NewThreadReadyState {
   /** Local thread ids whose draft config is complete (project+adapter chosen). */
   readonly readyIds: ReadonlySet<string>;
+  readonly initializations: ReadonlyMap<string, DraftInitialization>;
   isReady: (localId: string) => boolean;
+  getInitialization: (localId: string) => DraftInitialization;
+  beginInitialization: (localId: string, retry: () => Promise<DraftCfg>) => number;
+  completeInitialization: (localId: string, attempt: number) => boolean;
+  failInitialization: (localId: string, attempt: number, error: unknown) => void;
+  cancelInitialization: (localId: string, attempt: number) => void;
   markReady: (localId: string) => void;
   clearReady: (localId: string) => void;
 }
 
 export const useNewThreadReady = create<NewThreadReadyState>((set, get) => ({
   readyIds: new Set<string>(),
+  initializations: new Map<string, DraftInitialization>(),
   isReady: (localId) => get().readyIds.has(localId),
+  getInitialization: (localId) => get().initializations.get(localId) ?? IDLE_INITIALIZATION,
+  beginInitialization: (localId, retry) => {
+    const attempt = (get().initializations.get(localId)?.attempt ?? 0) + 1;
+    set((state) => {
+      const initializations = new Map(state.initializations);
+      initializations.set(localId, { status: 'initializing', retry, attempt });
+      const readyIds = new Set(state.readyIds);
+      readyIds.delete(localId);
+      return { initializations, readyIds };
+    });
+    return attempt;
+  },
+  completeInitialization: (localId, attempt) => {
+    if (get().initializations.get(localId)?.attempt !== attempt) return false;
+    set((state) => {
+      const initializations = new Map(state.initializations);
+      const current = initializations.get(localId);
+      initializations.set(localId, { status: 'ready', retry: current?.retry, attempt });
+      return { initializations };
+    });
+    return true;
+  },
+  failInitialization: (localId, attempt, error) =>
+    set((state) => {
+      const current = state.initializations.get(localId);
+      if (current?.attempt !== attempt) return state;
+      const initializations = new Map(state.initializations);
+      initializations.set(localId, { status: 'error', retry: current.retry, error, attempt });
+      return { initializations };
+    }),
+  cancelInitialization: (localId, attempt) =>
+    set((state) => {
+      const current = state.initializations.get(localId);
+      if (current?.status !== 'initializing' || current.attempt !== attempt) return state;
+      const initializations = new Map(state.initializations);
+      initializations.delete(localId);
+      return { initializations };
+    }),
   markReady: (localId) =>
     set((state) => {
       if (state.readyIds.has(localId)) return state; // stable ref — no churn
@@ -36,9 +93,11 @@ export const useNewThreadReady = create<NewThreadReadyState>((set, get) => ({
     }),
   clearReady: (localId) =>
     set((state) => {
-      if (!state.readyIds.has(localId)) return state; // stable ref — no churn
       const next = new Set(state.readyIds);
       next.delete(localId);
-      return { readyIds: next };
+      const initializations = new Map(state.initializations);
+      initializations.delete(localId);
+      if (next.size === state.readyIds.size && initializations.size === state.initializations.size) return state;
+      return { readyIds: next, initializations };
     }),
 }));

--- a/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
@@ -36,6 +36,7 @@ interface NewThreadReadyState {
   isReady: (localId: string) => boolean;
   getInitialization: (localId: string) => DraftInitialization;
   beginInitialization: (localId: string, retry: () => Promise<DraftCfg>) => number;
+  beginReadyReplacement: (localId: string) => number;
   completeInitialization: (localId: string, attempt: number) => boolean;
   failInitialization: (localId: string, attempt: number, error: unknown) => void;
   cancelInitialization: (localId: string, attempt: number) => void;
@@ -55,6 +56,17 @@ export const useNewThreadReady = create<NewThreadReadyState>((set, get) => ({
       initializations.set(localId, { status: 'initializing', retry, attempt });
       const readyIds = new Set(state.readyIds);
       readyIds.delete(localId);
+      return { initializations, readyIds };
+    });
+    return attempt;
+  },
+  beginReadyReplacement: (localId) => {
+    const attempt = ++nextInitializationAttempt;
+    set((state) => {
+      const initializations = new Map(state.initializations);
+      initializations.set(localId, { status: 'ready', attempt });
+      const readyIds = new Set(state.readyIds);
+      readyIds.add(localId);
       return { initializations, readyIds };
     });
     return attempt;

--- a/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
@@ -16,14 +16,14 @@ import { ThreadListPrimitive, useAssistantRuntime } from '@assistant-ui/react';
 import { PlusIcon } from 'lucide-react';
 import type { Project } from '@qlan-ro/mainframe-types';
 import { resetNewThreadDraft } from '../new-thread/reset-new-thread-draft';
-import { resolveDefaultAdapterId } from '../new-thread/default-adapter';
-import { setDraftConfig } from '../runtime/draft-config';
-import { useNewThreadReady } from '../runtime/new-thread-ready-store';
+import { initializeDraft } from '../new-thread/initialize-draft';
 import { useDraftReturnTarget } from '../new-thread/use-draft-return-target';
 import { useSettingsStore } from '@/store/settings';
 import { useAdapters } from '@/store/adapters';
 import { NewSessionPickerPopover } from './NewSessionPickerPopover';
 import { useNewSessionPickerTarget } from './use-new-session-picker-target';
+import { useDaemonPort } from '../runtime/daemon-port-context';
+import { mfToast } from '@/lib/toast';
 
 // px-[12px] (not px-2/4px): matches SIDEBAR_BASE_INSET_PX, so the wrapping
 // SIDEBAR_INDENT_STEP_PX margin in SessionSidebar.tsx lands this row's content
@@ -53,6 +53,7 @@ export function SessionsNewButton({
   const setPickerOpen = useNewSessionPickerTarget((s) => s.setOpen);
   const defaultAdapterId = useSettingsStore((s) => s.general.defaultAdapterId);
   const adapters = useAdapters();
+  const port = useDaemonPort();
 
   /** Snapshot the currently-active session so a discard can return to it. */
   const rememberReturn = () => {
@@ -89,8 +90,13 @@ export function SessionsNewButton({
       await runtime.threads.switchToNewThread();
       const nid = runtime.threads.getState().newThreadId;
       if (nid == null) return;
-      setDraftConfig(nid, { projectId, adapterId: resolveDefaultAdapterId(defaultAdapterId, adapters) });
-      useNewThreadReady.getState().markReady(nid);
+      try {
+        await initializeDraft({ localId: nid, projectId, port, defaultAdapterId, adapters });
+      } catch (error) {
+        mfToast.error('Couldn’t initialize session', {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
     })();
   };
 

--- a/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
+++ b/packages/ui/src/features/sessions/sidebar/SessionsNewButton.tsx
@@ -5,7 +5,9 @@
  *
  * Pill active  → starts the draft in that project directly (native New; the
  *                auto-config hook seeds the draft on activation).
- * "All" view   → opens the NewSessionPickerPopover to resolve the project first.
+ * "All" view   → opens the NewSessionPickerPopover to resolve the project first,
+ *                then seeds the draft itself (auto-config stays out of the "All"
+ *                view — it has no project to seed from).
  *
  * Re-click retargets the single reused draft (never stacks); the pre-draft
  * selection is remembered so a discard can restore it.
@@ -14,9 +16,12 @@ import { ThreadListPrimitive, useAssistantRuntime } from '@assistant-ui/react';
 import { PlusIcon } from 'lucide-react';
 import type { Project } from '@qlan-ro/mainframe-types';
 import { resetNewThreadDraft } from '../new-thread/reset-new-thread-draft';
+import { resolveDefaultAdapterId } from '../new-thread/default-adapter';
 import { setDraftConfig } from '../runtime/draft-config';
 import { useNewThreadReady } from '../runtime/new-thread-ready-store';
 import { useDraftReturnTarget } from '../new-thread/use-draft-return-target';
+import { useSettingsStore } from '@/store/settings';
+import { useAdapters } from '@/store/adapters';
 import { NewSessionPickerPopover } from './NewSessionPickerPopover';
 import { useNewSessionPickerTarget } from './use-new-session-picker-target';
 
@@ -42,6 +47,12 @@ export function SessionsNewButton({
   onAddProject,
 }: SessionsNewButtonProps) {
   const runtime = useAssistantRuntime();
+  // Lifted so the global ⌘N hotkey and the zero-session boot fallback can open
+  // this SAME anchored popover (see useNewSessionPickerTarget).
+  const pickerOpen = useNewSessionPickerTarget((s) => s.open);
+  const setPickerOpen = useNewSessionPickerTarget((s) => s.setOpen);
+  const defaultAdapterId = useSettingsStore((s) => s.general.defaultAdapterId);
+  const adapters = useAdapters();
 
   /** Snapshot the currently-active session so a discard can return to it. */
   const rememberReturn = () => {
@@ -66,19 +77,21 @@ export function SessionsNewButton({
     );
   }
 
-  // Lifted so the global ⌘N hotkey and the zero-session boot fallback can open
-  // this SAME anchored popover (see useNewSessionPickerTarget).
-  const pickerOpen = useNewSessionPickerTarget((s) => s.open);
-  const setPickerOpen = useNewSessionPickerTarget((s) => s.setOpen);
-
   const pick = (projectId: string) => {
-    const nid = runtime.threads.getState().newThreadId;
-    if (nid == null) return;
-    rememberReturn();
-    resetNewThreadDraft(nid);
-    setDraftConfig(nid, { projectId, adapterId: 'claude' });
-    useNewThreadReady.getState().markReady(nid);
-    void runtime.threads.switchToNewThread();
+    void (async () => {
+      rememberReturn();
+      // Clear the CURRENT slot before switching, so a reused draft never flashes
+      // its stale project on activation. No-op when no slot exists.
+      resetNewThreadDraft(runtime.threads.getState().newThreadId);
+      // switchToNewThread OWNS the slot: `newThreadId` is undefined until it
+      // mints one (and again after each first send commits a draft), so the id
+      // is only readable once the switch has resolved.
+      await runtime.threads.switchToNewThread();
+      const nid = runtime.threads.getState().newThreadId;
+      if (nid == null) return;
+      setDraftConfig(nid, { projectId, adapterId: resolveDefaultAdapterId(defaultAdapterId, adapters) });
+      useNewThreadReady.getState().markReady(nid);
+    })();
   };
 
   return (

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
@@ -22,6 +22,7 @@ import { useAdaptersStore } from '@/store/adapters';
 
 const runtimeState = { newThreadId: undefined as string | undefined, mainThreadId: null as string | null };
 let switchCounter = 0;
+let initializationGate: Promise<void> | null = null;
 const switchToNewThread = vi.fn(async () => {
   switchCounter += 1;
   runtimeState.newThreadId = `__LOCALID_${switchCounter}`;
@@ -41,6 +42,18 @@ vi.mock('@assistant-ui/react', async () => {
     }),
   };
 });
+
+vi.mock('../../runtime/daemon-port-context', () => ({ useDaemonPort: () => 31415 }));
+
+vi.mock('../../new-thread/initialize-draft', () => ({
+  initializeDraft: async (args: { localId: string; projectId: string; defaultAdapterId: string | null }) => {
+    if (initializationGate) await initializationGate;
+    const adapterId = args.defaultAdapterId ?? 'claude';
+    useDraftConfigStore.getState().setDraft(args.localId, { projectId: args.projectId, adapterId });
+    useNewThreadReady.getState().markReady(args.localId);
+    return { projectId: args.projectId, adapterId };
+  },
+}));
 
 import { useNewSessionPickerTarget } from '../use-new-session-picker-target';
 import { SessionsNewButton } from '../SessionsNewButton';
@@ -69,6 +82,7 @@ async function pickProjectP1() {
 beforeEach(() => {
   switchToNewThread.mockClear();
   switchCounter = 0;
+  initializationGate = null;
   runtimeState.newThreadId = undefined;
   runtimeState.mainThreadId = null;
   useNewSessionPickerTarget.setState({ open: false });
@@ -154,5 +168,23 @@ describe('SessionsNewButton — All view, picking a project remembers the pre-sw
     // the remembered return target must be the PRE-switch value.
     expect(runtimeState.mainThreadId).toBe('__LOCALID_1');
     expect(useDraftReturnTarget.getState().returnThreadId).toBe('chat-existing');
+  });
+});
+
+describe('SessionsNewButton — asynchronous initialization', () => {
+  it('does not mark the minted id ready before initialization resolves', async () => {
+    let release!: () => void;
+    initializationGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    renderAllView();
+
+    void pickProjectP1();
+    await act(async () => undefined);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(false);
+
+    release();
+    await act(async () => undefined);
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
   });
 });

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
@@ -1,18 +1,33 @@
 /**
- * SessionsNewButton — behavior tests for the "All view" project-picker's
- * lifted open state (use-new-session-picker-target).
+ * SessionsNewButton — behavior tests for the "All view" project picker.
  *
- * The picker must open both from its own "+" trigger click AND from an
- * external `useNewSessionPickerTarget.setOpen(true)` call (the seam the
- * global ⌘N hotkey and the zero-session boot fallback use) — so the SAME
- * anchored popover serves every entry point, never a second instance.
+ * The `useAssistantRuntime` mock below models the REAL assistant-ui contract
+ * (verified against node_modules/@assistant-ui/core RemoteThreadListThreadListRuntimeCore):
+ * `newThreadId` is `undefined` until `switchToNewThread()` mints a `__LOCALID_*`
+ * slot — it is NOT always present. A mock that hands back a ready-made
+ * `__LOCALID_1` regardless of whether switchToNewThread was called cannot catch
+ * the regression this file guards against: `pick()` used to read `newThreadId`
+ * BEFORE switching, saw `undefined` in the common case (boot auto-selects a real
+ * session, so no draft slot pre-exists), and silently no-opped — "New session"
+ * then picking a project did nothing.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { Project } from '@qlan-ro/mainframe-types';
+import { getDraftConfig, useDraftConfigStore } from '../../runtime/draft-config';
+import { useNewThreadReady } from '../../runtime/new-thread-ready-store';
+import { useDraftReturnTarget } from '../../new-thread/use-draft-return-target';
+import { useSettingsStore } from '@/store/settings';
+import { useAdaptersStore } from '@/store/adapters';
 
-const switchToNewThread = vi.fn();
-const mainThreadIdMock = { current: null as string | null };
+const runtimeState = { newThreadId: undefined as string | undefined, mainThreadId: null as string | null };
+let switchCounter = 0;
+const switchToNewThread = vi.fn(async () => {
+  switchCounter += 1;
+  runtimeState.newThreadId = `__LOCALID_${switchCounter}`;
+  // Mirrors the real runtime: switching activates the new local slot.
+  runtimeState.mainThreadId = runtimeState.newThreadId;
+});
 
 vi.mock('@assistant-ui/react', async () => {
   const actual = await vi.importActual<typeof import('@assistant-ui/react')>('@assistant-ui/react');
@@ -20,7 +35,7 @@ vi.mock('@assistant-ui/react', async () => {
     ...actual,
     useAssistantRuntime: () => ({
       threads: {
-        getState: () => ({ newThreadId: '__LOCALID_1', mainThreadId: mainThreadIdMock.current }),
+        getState: () => ({ newThreadId: runtimeState.newThreadId, mainThreadId: runtimeState.mainThreadId }),
         switchToNewThread,
       },
     }),
@@ -44,9 +59,24 @@ function renderAllView() {
   );
 }
 
+async function pickProjectP1() {
+  fireEvent.click(screen.getByTestId('sessions-new-button'));
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('sessions-new-picker-project-p1'));
+  });
+}
+
 beforeEach(() => {
-  switchToNewThread.mockReset();
+  switchToNewThread.mockClear();
+  switchCounter = 0;
+  runtimeState.newThreadId = undefined;
+  runtimeState.mainThreadId = null;
   useNewSessionPickerTarget.setState({ open: false });
+  useDraftConfigStore.setState({ drafts: new Map() });
+  useNewThreadReady.setState({ readyIds: new Set() });
+  useDraftReturnTarget.setState({ returnThreadId: null });
+  useSettingsStore.setState((s) => ({ general: { ...s.general, defaultAdapterId: null } }));
+  useAdaptersStore.setState({ byId: {} });
 });
 
 describe('SessionsNewButton — All view, clicking the "+" trigger', () => {
@@ -79,5 +109,50 @@ describe('SessionsNewButton — All view, picking a project closes the shared st
     fireEvent.click(screen.getByTestId('sessions-new-picker-project-p1'));
 
     expect(useNewSessionPickerTarget.getState().open).toBe(false);
+  });
+});
+
+describe('SessionsNewButton — All view, picking a project with NO pre-existing draft slot (bug repro)', () => {
+  it('mints a new-thread slot via switchToNewThread and seeds its draft config', async () => {
+    expect(runtimeState.newThreadId).toBeUndefined();
+    renderAllView();
+
+    await pickProjectP1();
+
+    expect(switchToNewThread).toHaveBeenCalledTimes(1);
+    expect(getDraftConfig('__LOCALID_1')).toEqual({ projectId: 'p1', adapterId: 'claude' });
+  });
+
+  it('marks the minted id ready so the composer can render', async () => {
+    renderAllView();
+
+    await pickProjectP1();
+
+    expect(useNewThreadReady.getState().isReady('__LOCALID_1')).toBe(true);
+  });
+});
+
+describe('SessionsNewButton — All view, picking a project uses the configured default adapter', () => {
+  it('seeds the draft with the user default adapter instead of always "claude"', async () => {
+    useSettingsStore.setState((s) => ({ general: { ...s.general, defaultAdapterId: 'codex' } }));
+    renderAllView();
+
+    await pickProjectP1();
+
+    expect(getDraftConfig('__LOCALID_1')).toEqual({ projectId: 'p1', adapterId: 'codex' });
+  });
+});
+
+describe('SessionsNewButton — All view, picking a project remembers the pre-switch session', () => {
+  it('snapshots the session active BEFORE switchToNewThread, not the new local slot', async () => {
+    runtimeState.mainThreadId = 'chat-existing';
+    renderAllView();
+
+    await pickProjectP1();
+
+    // switchToNewThread's mock reassigns mainThreadId to the new local slot;
+    // the remembered return target must be the PRE-switch value.
+    expect(runtimeState.mainThreadId).toBe('__LOCALID_1');
+    expect(useDraftReturnTarget.getState().returnThreadId).toBe('chat-existing');
   });
 });

--- a/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
+++ b/packages/ui/src/features/sessions/sidebar/__tests__/SessionsNewButton.test.tsx
@@ -23,6 +23,17 @@ import { useAdaptersStore } from '@/store/adapters';
 const runtimeState = { newThreadId: undefined as string | undefined, mainThreadId: null as string | null };
 let switchCounter = 0;
 let initializationGate: Promise<void> | null = null;
+const completeSnapshot = (projectId: string, adapterId: string) => ({
+  projectId,
+  adapterId,
+  model: 'default-model',
+  permissionMode: 'default' as const,
+  planMode: false,
+  effort: 'medium' as const,
+  fast: false,
+  ultracode: false,
+  adaptiveThinking: false,
+});
 const switchToNewThread = vi.fn(async () => {
   switchCounter += 1;
   runtimeState.newThreadId = `__LOCALID_${switchCounter}`;
@@ -49,9 +60,10 @@ vi.mock('../../new-thread/initialize-draft', () => ({
   initializeDraft: async (args: { localId: string; projectId: string; defaultAdapterId: string | null }) => {
     if (initializationGate) await initializationGate;
     const adapterId = args.defaultAdapterId ?? 'claude';
-    useDraftConfigStore.getState().setDraft(args.localId, { projectId: args.projectId, adapterId });
+    const snapshot = completeSnapshot(args.projectId, adapterId);
+    useDraftConfigStore.getState().setDraft(args.localId, snapshot);
     useNewThreadReady.getState().markReady(args.localId);
-    return { projectId: args.projectId, adapterId };
+    return snapshot;
   },
 }));
 
@@ -134,7 +146,7 @@ describe('SessionsNewButton — All view, picking a project with NO pre-existing
     await pickProjectP1();
 
     expect(switchToNewThread).toHaveBeenCalledTimes(1);
-    expect(getDraftConfig('__LOCALID_1')).toEqual({ projectId: 'p1', adapterId: 'claude' });
+    expect(getDraftConfig('__LOCALID_1')).toEqual(completeSnapshot('p1', 'claude'));
   });
 
   it('marks the minted id ready so the composer can render', async () => {
@@ -153,7 +165,7 @@ describe('SessionsNewButton — All view, picking a project uses the configured 
 
     await pickProjectP1();
 
-    expect(getDraftConfig('__LOCALID_1')).toEqual({ projectId: 'p1', adapterId: 'codex' });
+    expect(getDraftConfig('__LOCALID_1')).toEqual(completeSnapshot('p1', 'codex'));
   });
 });
 


### PR DESCRIPTION
## Summary

- initialize new-session drafts with a stable snapshot of provider and model defaults before rendering the composer
- share initialization across project-filter and All-project entry paths, with retry and stale-attempt protection
- keep adapter switching atomic and preserve worktree state
- make first send apply the displayed snapshot deterministically, including safe retry and discard handling

## Verification

- 12 focused test files, 163 tests passed
- `pnpm --filter @qlan-ro/mainframe-ui typecheck`
- final whole-branch review: approved with no findings