### PR TITLE
fix(core): show context usage for Codex sessions

### DIFF
--- a/.changeset/slimy-terms-march.md
+++ b/.changeset/slimy-terms-march.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Show context usage percentages for Codex sessions.

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -548,44 +548,6 @@ describe('handleNotification', () => {
     expect(sink.onMessage).not.toHaveBeenCalled();
   });
 
-  it('thread/tokenUsage/updated reports current Codex context usage', () => {
-    const sink = createSink();
-    const state = createState();
-
-    handleNotification(
-      'thread/tokenUsage/updated',
-      {
-        threadId: 't1',
-        turnId: 'turn_1',
-        tokenUsage: {
-          total: {
-            totalTokens: 250_000,
-            inputTokens: 240_000,
-            cachedInputTokens: 200_000,
-            outputTokens: 10_000,
-            reasoningOutputTokens: 4_000,
-          },
-          last: {
-            totalTokens: 100_000,
-            inputTokens: 95_000,
-            cachedInputTokens: 80_000,
-            outputTokens: 5_000,
-            reasoningOutputTokens: 2_000,
-          },
-          modelContextWindow: 200_000,
-        },
-      },
-      sink,
-      state,
-    );
-
-    expect(sink.onContextUsage).toHaveBeenCalledWith({
-      totalTokens: 98_000,
-      maxTokens: 200_000,
-      percentage: 49,
-    });
-  });
-
   it('turn/completed calls onResult with usage from prior tokenUsage event', () => {
     const sink = createSink();
     const state = createState();

--- a/packages/core/src/__tests__/codex-event-mapper.test.ts
+++ b/packages/core/src/__tests__/codex-event-mapper.test.ts
@@ -548,6 +548,44 @@ describe('handleNotification', () => {
     expect(sink.onMessage).not.toHaveBeenCalled();
   });
 
+  it('thread/tokenUsage/updated reports current Codex context usage', () => {
+    const sink = createSink();
+    const state = createState();
+
+    handleNotification(
+      'thread/tokenUsage/updated',
+      {
+        threadId: 't1',
+        turnId: 'turn_1',
+        tokenUsage: {
+          total: {
+            totalTokens: 250_000,
+            inputTokens: 240_000,
+            cachedInputTokens: 200_000,
+            outputTokens: 10_000,
+            reasoningOutputTokens: 4_000,
+          },
+          last: {
+            totalTokens: 100_000,
+            inputTokens: 95_000,
+            cachedInputTokens: 80_000,
+            outputTokens: 5_000,
+            reasoningOutputTokens: 2_000,
+          },
+          modelContextWindow: 200_000,
+        },
+      },
+      sink,
+      state,
+    );
+
+    expect(sink.onContextUsage).toHaveBeenCalledWith({
+      totalTokens: 98_000,
+      maxTokens: 200_000,
+      percentage: 49,
+    });
+  });
+
   it('turn/completed calls onResult with usage from prior tokenUsage event', () => {
     const sink = createSink();
     const state = createState();

--- a/packages/core/src/__tests__/codex-token-usage.test.ts
+++ b/packages/core/src/__tests__/codex-token-usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+import { handleNotification, type CodexSessionState } from '../plugins/builtin/codex/event-mapper.js';
+
+function createSink(): SessionSink {
+  return {
+    onInit: vi.fn(),
+    onMessage: vi.fn(),
+    onToolResult: vi.fn(),
+    onPermission: vi.fn(),
+    onResult: vi.fn(),
+    onExit: vi.fn(),
+    onError: vi.fn(),
+    onCompact: vi.fn(),
+    onCompactStart: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPlanFile: vi.fn(),
+    onSkillFile: vi.fn(),
+    onQueuedProcessed: vi.fn(),
+    onTodoUpdate: vi.fn(),
+    onPrDetected: vi.fn(),
+    onCliMessage: vi.fn(),
+    onSkillLoaded: vi.fn(),
+    onSubagentChild: vi.fn(),
+  };
+}
+
+describe('Codex token usage', () => {
+  it('reports context usage from the current tokenUsage notification', () => {
+    const sink = createSink();
+    const state: CodexSessionState = { threadId: null, currentTurnId: null, currentTurnPlan: null };
+
+    handleNotification(
+      'thread/tokenUsage/updated',
+      {
+        threadId: 't1',
+        turnId: 'turn_1',
+        tokenUsage: {
+          total: {
+            totalTokens: 250_000,
+            inputTokens: 240_000,
+            cachedInputTokens: 200_000,
+            outputTokens: 10_000,
+            reasoningOutputTokens: 4_000,
+          },
+          last: {
+            totalTokens: 100_000,
+            inputTokens: 95_000,
+            cachedInputTokens: 80_000,
+            outputTokens: 5_000,
+            reasoningOutputTokens: 2_000,
+          },
+          modelContextWindow: 200_000,
+        },
+      },
+      sink,
+      state,
+    );
+
+    expect(sink.onContextUsage).toHaveBeenCalledWith({
+      totalTokens: 98_000,
+      maxTokens: 200_000,
+      percentage: 49,
+    });
+  });
+});

--- a/packages/core/src/plugins/builtin/codex/event-mapper.ts
+++ b/packages/core/src/plugins/builtin/codex/event-mapper.ts
@@ -14,6 +14,7 @@ import type { PatchChangeKind, FileChangeItem, CollabAgentToolCallItem, TodoList
 import { parseUnifiedDiff } from '../../../messages/parse-unified-diff.js';
 import { lookupAgentMetadata, describeAgent, agentTitle } from './thread-registry.js';
 import { createChildLogger } from '../../../logger.js';
+import { handleTokenUsage } from './token-usage.js';
 
 const log = createChildLogger('codex:events');
 
@@ -323,14 +324,6 @@ function handleTurnCompleted(params: TurnCompletedParams, sink: SessionSink, sta
     result: turn.error?.message,
   });
   state.lastUsage = undefined;
-}
-
-function handleTokenUsage(params: TokenUsageUpdatedParams, _sink: SessionSink, state: CodexSessionState): void {
-  state.lastUsage = {
-    input_tokens: params.usage.input_tokens,
-    output_tokens: params.usage.output_tokens,
-    cache_read_input_tokens: params.usage.cached_input_tokens,
-  };
 }
 
 function mediaTypeFromExtension(path: string): string {

--- a/packages/core/src/plugins/builtin/codex/token-usage.ts
+++ b/packages/core/src/plugins/builtin/codex/token-usage.ts
@@ -1,0 +1,36 @@
+import type { SessionSink } from '@qlan-ro/mainframe-types';
+import type { TokenUsageUpdatedParams } from './types.js';
+
+interface TokenUsageState {
+  lastUsage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+export function handleTokenUsage(params: TokenUsageUpdatedParams, sink: SessionSink, state: TokenUsageState): void {
+  if ('tokenUsage' in params) {
+    const { last, modelContextWindow } = params.tokenUsage;
+    state.lastUsage = {
+      input_tokens: last.inputTokens,
+      output_tokens: last.outputTokens,
+      cache_read_input_tokens: last.cachedInputTokens,
+    };
+    if (modelContextWindow != null && modelContextWindow > 0) {
+      const contextTokens = Math.max(0, last.totalTokens - last.reasoningOutputTokens);
+      sink.onContextUsage({
+        totalTokens: contextTokens,
+        maxTokens: modelContextWindow,
+        percentage: Math.min(100, (contextTokens / modelContextWindow) * 100),
+      });
+    }
+    return;
+  }
+
+  state.lastUsage = {
+    input_tokens: params.usage.input_tokens,
+    output_tokens: params.usage.output_tokens,
+    cache_read_input_tokens: params.usage.cached_input_tokens,
+  };
+}

--- a/packages/core/src/plugins/builtin/codex/types.ts
+++ b/packages/core/src/plugins/builtin/codex/types.ts
@@ -192,10 +192,30 @@ export interface TurnCompletedParams {
   };
 }
 
-export interface TokenUsageUpdatedParams {
+export interface LegacyTokenUsageUpdatedParams {
   threadId: string;
   usage: Usage;
 }
+
+export interface TokenUsageBreakdown {
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+}
+
+export interface CurrentTokenUsageUpdatedParams {
+  threadId: string;
+  turnId: string;
+  tokenUsage: {
+    total: TokenUsageBreakdown;
+    last: TokenUsageBreakdown;
+    modelContextWindow: number | null;
+  };
+}
+
+export type TokenUsageUpdatedParams = LegacyTokenUsageUpdatedParams | CurrentTokenUsageUpdatedParams;
 
 // --- Config ---
 


### PR DESCRIPTION
## What changed

- Map the current Codex thread/tokenUsage/updated notification.
- Derive occupied context from the latest model request while excluding reasoning output.
- Preserve compatibility with the legacy usage payload.
- Add a focused regression test and a core patch changeset.

## Why

Codex app-server now sends token usage under tokenUsage with total, last, and modelContextWindow fields. Mainframe still read the legacy usage field, so the notification handler failed before it could update the context percentage indicator.

## Testing done

- pnpm --filter @qlan-ro/mainframe-core exec vitest run src/__tests__/codex-token-usage.test.ts src/__tests__/codex-event-mapper.test.ts src/__tests__/event-handler.test.ts — 49 tests passed
- pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit
- pnpm changeset status --since origin/main
- git diff --check origin/main...HEAD

## Checklist

- [ ] pnpm test passes — focused core tests run instead
- [ ] pnpm build passes — core TypeScript typecheck run instead
- [x] No secrets in staged files
- [x] File size limits respected for new files and functions