### PR TITLE
fix(quota): headline the session window, not the tightest

### DIFF
--- a/.changeset/quota-session-headline.md
+++ b/.changeset/quota-session-headline.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Ambient quota row now headlines the trusted session window instead of whichever window has the highest used percent, so a fresh session no longer gets buried behind a tighter weekly window.

--- a/packages/ui/src/features/quota/__tests__/QuotaCard.test.tsx
+++ b/packages/ui/src/features/quota/__tests__/QuotaCard.test.tsx
@@ -59,15 +59,15 @@ describe('QuotaCard — always both providers', () => {
   });
 });
 
-describe('QuotaCard — collapsed row surfaces the tightest window', () => {
-  it('shows the highest-percent window (88), not the session (36)', () => {
+describe('QuotaCard — collapsed row headlines the session window', () => {
+  it('shows the session (36), not the highest-percent weekly-model window (88)', () => {
     applyProviderQuota('claude', claudeThreeWindows(88));
     render(<QuotaCard now={NOW} />);
     const row = screen.getByTestId('provider-quota-row-claude');
-    expect(within(row).getByText('88%')).toBeInTheDocument();
-    expect(within(row).queryByText('36%')).not.toBeInTheDocument();
+    expect(within(row).getByText('36%')).toBeInTheDocument();
+    expect(within(row).queryByText('88%')).not.toBeInTheDocument();
     expect(row).toHaveAttribute('data-state-kind', 'ok');
-    expect(row).toHaveAttribute('aria-label', expect.stringContaining('88% used'));
+    expect(row).toHaveAttribute('aria-label', expect.stringContaining('36% used'));
   });
 });
 

--- a/packages/ui/src/features/quota/__tests__/quota-format.test.ts
+++ b/packages/ui/src/features/quota/__tests__/quota-format.test.ts
@@ -28,24 +28,56 @@ describe('severityOf', () => {
   });
 });
 
-describe('deriveQuotaRow — tightest-window selection & designed states', () => {
+describe('deriveQuotaRow — session-first headline, tightest-window fallback, & designed states', () => {
   it('is unknown when there is no blob', () => {
     expect(deriveQuotaRow(undefined, NOW)).toEqual({ state: 'unknown' });
   });
 
-  it('surfaces the tightest (highest-percent) trusted window on the collapsed row', () => {
+  it('headlines the session window even when weekly/model windows run higher — session is what actually blocks the user', () => {
     const quota: ProviderQuota = {
       status: 'ok',
       observedAt: NOW - 40_000,
-      modelWindows: [{ kind: 'weekly-model', usedPercent: 88, resetsAt: NOW + 6 * DAY, label: 'Fable' }],
-      session: { kind: 'session', usedPercent: 36, resetsAt: NOW + 2 * HOUR },
-      weekly: { kind: 'weekly', usedPercent: 21, resetsAt: NOW + 6 * DAY },
+      session: { kind: 'session', usedPercent: 1, resetsAt: NOW + 2 * HOUR },
+      weekly: { kind: 'weekly', usedPercent: 53, resetsAt: NOW + 6 * DAY },
+      modelWindows: [{ kind: 'weekly-model', usedPercent: 59, resetsAt: NOW + 6 * DAY, label: 'Fable' }],
     };
-    const row = deriveQuotaRow(quota, NOW);
-    expect(row).toEqual({
+    expect(deriveQuotaRow(quota, NOW)).toEqual({
       state: 'ok',
-      usedPercent: 88,
-      severity: 'amber',
+      usedPercent: 1,
+      severity: 'normal',
+      resetsAt: NOW + 2 * HOUR,
+      stale: false,
+    });
+  });
+
+  it('falls back to the tightest trusted window when there is no session window (Codex weekly-only)', () => {
+    const quota: ProviderQuota = {
+      status: 'ok',
+      observedAt: NOW,
+      weekly: { kind: 'weekly', usedPercent: 53, resetsAt: NOW + 6 * DAY },
+      modelWindows: [{ kind: 'weekly-model', usedPercent: 21, resetsAt: NOW + 6 * DAY, label: 'o1' }],
+    };
+    expect(deriveQuotaRow(quota, NOW)).toEqual({
+      state: 'ok',
+      usedPercent: 53,
+      severity: 'normal',
+      resetsAt: NOW + 6 * DAY,
+      stale: false,
+    });
+  });
+
+  it('falls back to the tightest trusted window once the session window itself has expired', () => {
+    const quota: ProviderQuota = {
+      status: 'ok',
+      observedAt: NOW,
+      session: { kind: 'session', usedPercent: 1, resetsAt: NOW - HOUR },
+      weekly: { kind: 'weekly', usedPercent: 53, resetsAt: NOW + 6 * DAY },
+      modelWindows: [],
+    };
+    expect(deriveQuotaRow(quota, NOW)).toEqual({
+      state: 'ok',
+      usedPercent: 53,
+      severity: 'normal',
       resetsAt: NOW + 6 * DAY,
       stale: false,
     });

--- a/packages/ui/src/features/quota/quota-format.ts
+++ b/packages/ui/src/features/quota/quota-format.ts
@@ -4,7 +4,13 @@
  * components, so the render layer is pure wiring.
  */
 import type { ProviderQuota, QuotaWindow } from '@qlan-ro/mainframe-types';
-import { collectQuotaWindows, deriveProviderStatus, isProviderStale, selectTightestWindow } from './quota-lifecycle';
+import {
+  collectQuotaWindows,
+  deriveProviderStatus,
+  isProviderStale,
+  isWindowTrusted,
+  selectTightestWindow,
+} from './quota-lifecycle';
 
 /** Near-wall thresholds (tunable). At/above amber the ring warns; at/above red it alarms. */
 export const QUOTA_AMBER_THRESHOLD = 75;
@@ -29,7 +35,12 @@ export const QUOTA_PROVIDERS: readonly { id: string; label: string }[] = [
   { id: 'codex', label: 'Codex' },
 ];
 
-/** Collapsed-row view: the tightest window (or a designed unknown), plus staleness. */
+/**
+ * Collapsed-row view: the session window when it's trusted (that's the one that
+ * actually blocks the user next), falling back to the tightest trusted window when
+ * there's no live session (e.g. Codex, which only reports weekly) — or a designed
+ * unknown — plus staleness.
+ */
 export type QuotaRowVm =
   | { state: 'unknown' }
   | {
@@ -42,13 +53,16 @@ export type QuotaRowVm =
 
 export function deriveQuotaRow(quota: ProviderQuota | undefined, now: number): QuotaRowVm {
   if (!quota || deriveProviderStatus(quota, now) === 'unknown') return { state: 'unknown' };
-  const tightest = selectTightestWindow(quota, now);
-  if (!tightest) return { state: 'unknown' };
+  const headline =
+    quota.session && isWindowTrusted(quota.session, quota.observedAt, now)
+      ? quota.session
+      : selectTightestWindow(quota, now);
+  if (!headline) return { state: 'unknown' };
   return {
     state: 'ok',
-    usedPercent: tightest.usedPercent,
-    severity: severityOf(tightest.usedPercent),
-    resetsAt: tightest.resetsAt,
+    usedPercent: headline.usedPercent,
+    severity: severityOf(headline.usedPercent),
+    resetsAt: headline.resetsAt,
     stale: isProviderStale(quota, now),
   };
 }


### PR DESCRIPTION
## Problem

The ambient quota row headlined the *tightest* trusted window (highest used %). With Claude reporting session 1% / weekly 53% / Fable-weekly 59%, the row showed **59%** — the weekly Fable window — while the 5h session limit users actually work against was buried in the popover.

## Change

`deriveQuotaRow` now headlines the **session (5h) window** whenever it exists and is trusted, falling back to the previous tightest-window selection otherwise. The fallback keeps providers with no session data (Codex currently reports only a weekly window) showing their weekly % instead of degrading to unknown. The popover is unchanged and still lists every window, so weekly/model limits stay one hover away.

UI-only: `quota-lifecycle.ts` (the verbatim core mirror) is untouched, and the daemon never consumes the headline selection.

## Testing

- `quota-format.test.ts` — new session-first pins (the live 1/53/59 repro), weekly-only fallback (Codex shape), expired-session fallback, fail-closed unknown unchanged (16 pass)
- `QuotaCard.test.tsx` — collapsed-row assertion flipped to session-first (16 pass)
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)