### PR TITLE
fix(quota): pull Codex quota once at daemon boot

### DIFF
--- a/.changeset/codex-quota-boot-warmup.md
+++ b/.changeset/codex-quota-boot-warmup.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Codex quota now warms up with one automatic pull at daemon boot (both Node and Rust daemons), so the ambient indicator is populated on app start instead of waiting for a manual refresh. Codex still has no polling timer — beyond boot it stays manual refresh + session pushes.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/quota_pull.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/quota_pull.rs
@@ -47,8 +47,9 @@ pub async fn pull_codex_quota(deps: PullCodexQuotaDeps<'_>) -> Result<ProviderQu
 }
 
 /// Default connection: spawn one temp app-server, issue `account/rateLimits/read` and
-/// `account/read` back-to-back, then close it. Used by the manual-refresh puller only —
-/// never wired to a scheduler (Codex has no timer-based polling, unlike Claude).
+/// `account/read` back-to-back, then close it. Used by the puller on boot warm-up and
+/// manual refresh only — never wired to a scheduler (Codex has no timer-based polling,
+/// unlike Claude).
 pub async fn pull_codex_quota_via_temp_app_server(
     executable: &str,
     path: &str,

--- a/packages/core-rs/crates/mainframe-daemon/src/main.rs
+++ b/packages/core-rs/crates/mainframe-daemon/src/main.rs
@@ -442,6 +442,14 @@ async fn run_daemon() {
     });
     claude_quota_scheduler.start();
 
+    // Codex boot warm-up (index.ts parity): one pull so the first glance shouldn't
+    // need a manual refresh. One temp app-server spawn, no timer — beyond boot Codex
+    // stays manual refresh + session pushes.
+    let warmup_quota = Arc::clone(&quota_manager);
+    tokio::spawn(async move {
+        warmup_quota.refresh("codex").await;
+    });
+
     // Daemon tunnel (index.ts): auto-start when configured (opt-in), else adopt a
     // pre-configured URL. Failure is non-fatal — the daemon serves loopback anyway.
     if config.tunnel == Some(true) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,8 +94,8 @@ async function main(): Promise<void> {
     if (!resolved.valid) throw new Error('claude executable not resolved for quota pull');
     return pullClaudeQuota({ runUsage: () => spawnClaudeUsage(resolved.path) });
   });
-  // Codex has no scheduler (unlike Claude) — this puller only fires on manual refresh
-  // or piggybacks on an app-server already up; it must never spawn purely to poll.
+  // Codex has no scheduler (unlike Claude) — this puller fires once at boot and on manual
+  // refresh; it must never spawn on a timer purely to poll.
   // Its snapshot is sparse (a single window at a time), so pull results merge rather than replace.
   quota.registerPuller(
     'codex',
@@ -273,12 +273,19 @@ async function main(): Promise<void> {
   });
 
   // Claude's always-fresh cadence: one warm-up pull now (executable is backfilled),
-  // then a ~5-minute timer gated on a connected client. Codex stays passive push only.
+  // then a ~5-minute timer gated on a connected client.
   const claudeQuotaScheduler = new ClaudeQuotaScheduler({
     refresh: () => quota.refresh('claude'),
     hasClients: () => server.hasConnectedClients(),
   });
   claudeQuotaScheduler.start();
+
+  // Codex gets a single boot warm-up pull too — the daemon boots with the app, so the
+  // first glance shouldn't need a manual refresh. One temp app-server spawn, no timer;
+  // beyond boot Codex stays manual refresh + session pushes.
+  quota.refresh('codex').catch((err) => {
+    logger.warn({ err }, 'codex quota warm-up pull failed');
+  });
 
   if (config.tunnel === true) {
     try {


### PR DESCRIPTION
## Problem

On app start the ambient quota indicator shows nothing for Codex until you open the popover and hit Refresh. Claude warms up automatically (its scheduler does one boot pull, then a focus-gated 5-minute cadence), but Codex quota only ever arrived via manual refresh or session pushes — by design, since its pull spawns a temporary app-server and was never meant to poll.

## Change

Add a single Codex warm-up pull at daemon boot, in both daemons:

- **Node** (`packages/core/src/index.ts`): fire-and-forget `quota.refresh('codex')` next to the Claude scheduler start.
- **Rust** (`packages/core-rs/.../main.rs`): spawned `refresh("codex")` task at the same point, for `MAINFRAME_DAEMON_IMPL` parity.

The daemon boots with the app, so the first glance is populated. The "no timer polling" decision stands — this is one bounded app-server spawn per boot; beyond that Codex remains manual refresh + session pushes. Stale comments updated to match.

## Testing

- `pnpm --filter @qlan-ro/mainframe-core exec tsc --noEmit` clean
- `cargo check -p mainframe-daemon` clean
- Wiring-only change (composition roots); `QuotaManager.refresh` behavior is already covered by `manager.test.ts` / `manager.rs` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)