### PR TITLE
fix(rust-daemon): tunnel dies on SIGPIPE ~100ms after connecting

### DIFF
--- a/.changeset/rust-launch-group-kill-separator.md
+++ b/.changeset/rust-launch-group-kill-separator.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix the Rust daemon's process-group kill silently doing nothing on Linux. `kill -TERM -<pid>` without `--` is parsed as a signal spec by Linux `kill`, which exits 0 without delivering — so stopped launch children (and sweep targets) were never signalled and ran until natural exit. Both group-kill shell-outs now pass `--` before the negative pid.

--- a/.changeset/rust-tunnel-sigpipe-drain.md
+++ b/.changeset/rust-tunnel-sigpipe-drain.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix the Rust daemon killing its own cloudflared tunnel moments after it connects. The tunnel manager stopped reading the child's stdout/stderr once the tunnel registered, closing the pipes; cloudflared died on SIGPIPE at its next log write (~100ms after "ready"). A drain task now keeps reading for the child's whole life, matching the Node daemon's persistent data handlers.

--- a/packages/core-rs/crates/mainframe-launch/src/launch_manager.rs
+++ b/packages/core-rs/crates/mainframe-launch/src/launch_manager.rs
@@ -727,8 +727,12 @@ async fn kill_process(pid: Option<u32>, flag: &'static str) {
     let Some(pid) = pid else {
         return;
     };
+    // `--` is required before the negative pid: without it, Linux `kill` parses
+    // `-<pid>` as a signal spec and exits 0 WITHOUT delivering, so the
+    // single-pid fallback below never runs and stopped children linger.
     let group_ok = Command::new("kill")
         .arg(flag)
+        .arg("--")
         .arg(format!("-{pid}"))
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -970,6 +974,27 @@ mod tests {
             manager.get_all_statuses().get("fail-fast").copied(),
             Some(LaunchProcessStatus::Failed)
         );
+    }
+
+    // Guards the `--` in the group-kill shell-out: Linux `kill` parses a bare
+    // `-<pid>` as a signal spec and exits 0 without delivering, which skipped
+    // the single-pid fallback and left every stopped child running to natural
+    // exit (each sleep-100 test above then took the full 100s on CI).
+    #[tokio::test]
+    async fn kill_process_terminates_a_group_leader_child() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "sleep 30"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        command.process_group(0);
+        let mut child = command.spawn().unwrap();
+
+        kill_process(child.id(), "-TERM").await;
+
+        let exited = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+        assert!(exited.is_ok(), "child survived the group SIGTERM");
     }
 
     #[tokio::test]

--- a/packages/core-rs/crates/mainframe-launch/src/process/sweep.rs
+++ b/packages/core-rs/crates/mainframe-launch/src/process/sweep.rs
@@ -182,8 +182,11 @@ fn signal_flag(signal: &str) -> String {
 /// one-run delay in an already-rare race.
 pub fn default_kill(pid: i64, signal: &str, group: bool) -> bool {
     let target = kill_target(pid, group);
+    // `--` is required: Linux `kill` parses a bare negative group target as a
+    // signal spec and exits 0 without delivering anything.
     match std::process::Command::new("kill")
         .arg(signal_flag(signal))
+        .arg("--")
         .arg(target.to_string())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/packages/core-rs/crates/mainframe-launch/src/tunnel_manager.rs
+++ b/packages/core-rs/crates/mainframe-launch/src/tunnel_manager.rs
@@ -370,6 +370,11 @@ impl TunnelManager {
             }
         }
 
+        // Keep reading the child's output for its whole life: dropping the pipe
+        // readers closes the pipes, and cloudflared (Go) dies on SIGPIPE at its
+        // next log write. The TS never hits this — its 'data' handlers persist.
+        spawn_output_drain(out_lines, err_lines);
+
         // Phase 2: connected. Register the tunnel, then wait for DNS while still
         // watching for an early exit (which rejects, per the TS `!done` branch).
         let url = pending_url.unwrap_or_default();
@@ -639,6 +644,21 @@ fn extract_hostname(url: &str) -> String {
         .or_else(|| url.strip_prefix("http://"))
         .unwrap_or(url);
     after.split(['/', ':']).next().unwrap_or(after).to_string()
+}
+
+/// Discard the child's remaining output until both streams hit EOF.
+fn spawn_output_drain(
+    mut out_lines: Option<Lines<BufReader<ChildStdout>>>,
+    mut err_lines: Option<Lines<BufReader<ChildStderr>>>,
+) {
+    tokio::spawn(async move {
+        while out_lines.is_some() || err_lines.is_some() {
+            tokio::select! {
+                _ = next_line_stdout(&mut out_lines) => {}
+                _ = next_line_stderr(&mut err_lines) => {}
+            }
+        }
+    });
 }
 
 async fn next_line_stdout(lines: &mut Option<Lines<BufReader<ChildStdout>>>) -> Option<String> {
@@ -963,6 +983,47 @@ mod tests {
         script.to_string_lossy().into_owned()
     }
 
+    /// `cloudflared` stand-in that keeps logging after registration, like the
+    /// real binary (which dies on SIGPIPE if the daemon stops reading its pipes).
+    fn write_chatty_cloudflared(dir: &std::path::Path) -> String {
+        let script = dir.join("chatty-cloudflared.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\necho 'https://abc-def.trycloudflare.com'\necho 'Registered tunnel connection'\nwhile true; do echo 'INF heartbeat'; sleep 0.05; done\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        script.to_string_lossy().into_owned()
+    }
+
+    #[tokio::test]
+    async fn tunnel_survives_continued_child_logging_after_start_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_chatty_cloudflared(dir.path());
+        let (broadcast, events) = recorder();
+        let config = TunnelConfig {
+            cloudflared_bin: bin,
+            dns_poll: Duration::from_millis(20),
+            dns_timeout: Duration::from_millis(100),
+            ..TunnelConfig::default()
+        };
+        let manager = TunnelManager::with_config(Some(broadcast), config);
+
+        let url = manager.start(3000, "daemon", None).await.unwrap();
+        assert_eq!(url, "https://abc-def.trycloudflare.com");
+
+        // Long enough for several post-ready log writes: with the pipes closed
+        // the child dies on SIGPIPE and the exit watcher removes the tunnel.
+        sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            manager.get_url("daemon").as_deref(),
+            Some("https://abc-def.trycloudflare.com")
+        );
+        assert_eq!(stopped_broadcasts(&events), 0);
+        manager.stop("daemon");
+    }
+
     #[tokio::test]
     async fn start_resolves_with_url_when_dns_outlasts_the_start_timeout() {
         let dir = tempfile::tempdir().unwrap();
@@ -1172,7 +1233,10 @@ mod tests {
 // uses tokio::net::lookup_host (system resolver) — the TS pins 1.1.1.1 via
 // node:dns Resolver; the specific-resolver behavior is lost (see blockers).
 // Tunnel/verify tests use real spawned processes / a canned local HTTP server,
-// not code mocks.
+// not code mocks. Post-connection, spawn_output_drain keeps reading stdout/stderr
+// for the child's life — dropping the readers closes the pipes and cloudflared
+// dies on SIGPIPE at its next log write (the TS 'data' handlers persist, so the
+// port needs the explicit drain).
 // #431/#442 child-reaping: TunnelManagerOptions{registry,cloudflaredPath} added;
 // recordSpawn/forgetSpawn fire-and-forget against an Arc<dyn ChildRegistryPort>
 // (absolute paths only, via tunnel_record_entry); a `pending` HashSet<pid> tracks


### PR DESCRIPTION
## Problem

Running the Rust daemon, the Cloudflare tunnel (`mainframe-tunnel.qlan.ro`) went down and the mobile app couldn't connect. Reproduced live: `POST /api/tunnel/start` succeeds, the log shows `tunnel ready (DNS verified)`, then `tunnel process exited code=None` **117ms later** — killed by a signal.

## Root cause

`TunnelManager::start` reads the child's stdout/stderr only during the Phase-1 registration scan. Once the tunnel registers, the `Lines` readers go out of scope when `start()` returns, which **closes the pipes**. cloudflared is a Go binary: its next log write after registration hits EPIPE and the Go runtime re-raises SIGPIPE, killing the process. Every tunnel — daemon and preview — collapses moments after reporting ready.

The Node daemon never hits this: its `child.stdout.on('data')` handlers persist for the child's life, so the pipes stay open.

Two pieces of corroborating evidence from the incident:
- A start attempt that *times out* survives the full 45s (the Phase-1 loop is still reading).
- The same cloudflared + token run manually with output redirected to a file is stable indefinitely.

## Fix

After the connection registers, hand both pipe readers to a `spawn_output_drain` task that reads until EOF — covering the DNS-wait window and the tunnel's whole life.

## Testing

- New regression test `tunnel_survives_continued_child_logging_after_start_resolves`: a chatty fake cloudflared keeps logging post-registration; without the fix it dies on SIGPIPE and the tunnel is removed (test failed before, passes after).
- `cargo test -p mainframe-launch`: 125 passed.
- clippy `-D warnings`, `cargo fmt --check`, `tools/verify-gate.sh` all clean.

## Incident notes (context, no code change)

The outage had a second layer: the daemon's boot sweep correctly reaped the Node daemon's orphaned cloudflared, but `config.json` had lost `tunnel`/`tunnelToken`/`tunnelUrl` (cleared Jul 17 via `tunnel/stop clearConfig`), so no auto-start happened. Tunnel credentials were re-minted from `cloudflared tunnel token` and re-persisted via `POST /api/tunnel/start`; config now has `tunnel: true` again, so the daemon auto-starts the tunnel at boot once this fix ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)