### PR TITLE
ci: install ripgrep in the release Rust gate

### DIFF
--- a/.changeset/shaggy-impalas-appear.md
+++ b/.changeset/shaggy-impalas-appear.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: install ripgrep in the release Rust gate so the suggestions-route TODO scan test passes on the macOS runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The suggestions-route tests shell out to ripgrep for the real
+      # TODO/FIXME scan, which silently returns no matches when rg is absent
+      # (mirrors the rust-port.yml check job).
+      - name: Install ripgrep
+        run: command -v rg >/dev/null 2>&1 || brew install ripgrep
+
       # Re-gate the Rust workspace at release time (rust-port.yml already gates
       # every PR touching packages/core-rs, but this is cheap insurance right
       # before we spend signing/notarization time on it — CUTOVER.md §6 step 2).


### PR DESCRIPTION
## Problem

The rc.11 release build failed at the **Rust workspace fmt/clippy/test gate** ([job](https://github.com/qlan-ro/mainframe/actions/runs/29829165377/job/88629456499)).

`cargo test --workspace` runs `routes_suggestions::returns_a_todo_suggestion_for_a_clean_repo_with_todo_comments`, which shells out to ripgrep for the real TODO/FIXME scan and returns no matches when `rg` is absent. GitHub's macOS runners ship without ripgrep, so the assertion fails.

This test reached main when #488 merged; `rust-port.yml` (the PR check job) already installs ripgrep, but the release workflow's gate did not.

## Fix

Add an `Install ripgrep` step before the release gate, mirroring `rust-port.yml`. Guarded (`command -v rg || brew install ripgrep`) so it's a no-op if the runner ever ships rg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)