### PR TITLE
fix(ui): stop the render loop that crashed archiving a session

### DIFF
--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix the crash on archiving a session ("Maximum update depth exceeded", React #185).
+
+`useAdapters()` rebuilt its array on every render, and `useNewThreadAutoConfig` uses that array as an effect dependency — so the effect tore down and re-ran on every render. Both its body and its cleanup write to the store `ChatSurface` subscribes to, so each write re-rendered and re-armed it. Archiving the active session lands on an unresolved draft, which is the one state where that effect runs, so the loop crashed the window into the error boundary.
+
+`useAdapters()` is now memoized on the catalog, and `ChatSurface`'s no-active-thread fallback selects a shared idle value instead of a fresh object literal.

--- a/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
+++ b/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
@@ -35,7 +35,7 @@ import { useNewThreadAutoConfig } from './use-new-thread-auto-config';
 import { useProjects } from '../use-projects';
 import { useDraftConfigStore } from '../runtime/draft-config';
 import { useNewSessionPickerTarget } from '../sidebar/use-new-session-picker-target';
-import { useNewThreadReady } from '../runtime/new-thread-ready-store';
+import { IDLE_INITIALIZATION, useNewThreadReady } from '../runtime/new-thread-ready-store';
 
 /** How long to wait, once we look like the zero-session boot dead-end, before
  *  forcing the project picker open. Long enough for useSessionListRouter's
@@ -82,7 +82,7 @@ export function ChatSurface({ port: _port }: { port: number }) {
   const { projects, loading } = useProjects();
   const filterProjectId = useSessionFilters((s) => s.filterProjectId);
   const initialization = useNewThreadReady((s) =>
-    mainThreadId ? s.getInitialization(mainThreadId) : { status: 'idle' as const },
+    mainThreadId ? s.getInitialization(mainThreadId) : IDLE_INITIALIZATION,
   );
   const isReady = useNewThreadReady((s) => (mainThreadId ? s.readyIds.has(mainThreadId) : false));
 

--- a/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.render-loop.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.render-loop.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * useNewThreadAutoConfig — render-loop regression (React error #185).
+ *
+ * Uses the REAL @/store/adapters store (seeded via seedAdapters), not a mock —
+ * unlike the sibling suite (use-new-thread-auto-config.test.tsx), this test is
+ * anchored to the shipping useAdapters() implementation so it stays honest
+ * about the actual bug: an unmemoized `Object.values(byId)` handed this
+ * hook's effect a fresh array (and therefore a "changed" dependency) on every
+ * render, even when the catalog never changed. Everything else the hook
+ * touches (aui state, session filters, settings, daemon port, draft-config,
+ * initializeDraft) stays mocked, matching the sibling suite's harness.
+ *
+ * Behavior covered:
+ *  1. A fresh __LOCALID_* draft with a project filter active and
+ *     initializeDraft in flight: two re-renders that change nothing about
+ *     localId/filterProjectId/the adapter catalog must not restart
+ *     initialization (initializeDraft is called exactly once).
+ *  2. The same scenario must not rewrite the useNewThreadReady store (state
+ *     identity unchanged across the re-renders).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { DraftCfg } from '../../runtime/draft-config';
+
+interface FakeAuiState {
+  threadListItem: { id: string | null; status: string | undefined } | null;
+  thread: { messages: { id: string }[] };
+}
+
+let fakeAuiState: FakeAuiState = {
+  threadListItem: { id: '__LOCALID_x', status: 'new' },
+  thread: { messages: [] },
+};
+let fakeFilterProjectId: string | null = 'proj-42';
+
+const initializeDraftSpy = vi.fn();
+let getDraftConfigResult: unknown = undefined;
+let initializationGate: Promise<void> | null = null;
+
+const completeSnapshot = (projectId: string, adapterId: string) => ({
+  projectId,
+  adapterId,
+  model: 'default-model',
+  permissionMode: 'default',
+  planMode: false,
+  effort: 'medium',
+  fast: false,
+  ultracode: false,
+  adaptiveThinking: false,
+});
+
+// ---------------------------------------------------------------------------
+// Mocks — everything EXCEPT @/store/adapters, which is the real store.
+// ---------------------------------------------------------------------------
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (s: FakeAuiState) => unknown) => selector(fakeAuiState),
+}));
+
+vi.mock('@/store/session-filters', () => ({
+  useSessionFilters: (selector: (s: { filterProjectId: string | null }) => unknown) =>
+    selector({ filterProjectId: fakeFilterProjectId }),
+}));
+
+vi.mock('@/store/settings', () => ({
+  useSettingsStore: (selector: (s: { general: { defaultAdapterId: string | null } }) => unknown) =>
+    selector({ general: { defaultAdapterId: null } }),
+}));
+
+vi.mock('../../runtime/daemon-port-context', () => ({ useDaemonPort: () => 31415 }));
+
+vi.mock('../../runtime/draft-config', () => ({
+  setDraftConfig: () => undefined,
+  getDraftConfig: (_id: string) => getDraftConfigResult,
+}));
+
+vi.mock('../initialize-draft', () => ({
+  initializeDraft: async (args: {
+    localId: string;
+    projectId: string;
+    defaultAdapterId: string | null;
+    adapters: { id: string; installed: boolean }[];
+  }) => {
+    initializeDraftSpy(args.localId);
+    const adapterId = args.defaultAdapterId ?? args.adapters.find((adapter) => adapter.installed)?.id ?? 'claude';
+    const snapshot = completeSnapshot(args.projectId, adapterId);
+    // Mirrors the real initializeDraft's synchronous begin-then-await shape so
+    // the effect cleanup (cancelInitialization) has a real in-flight attempt
+    // to cancel, same as production.
+    const attempt = useNewThreadReady
+      .getState()
+      .beginInitialization(args.localId, () => Promise.resolve(snapshot as unknown as DraftCfg));
+    if (initializationGate) await initializationGate;
+    const stillCurrent = useNewThreadReady.getState().getInitialization(args.localId).attempt === attempt;
+    if (!stillCurrent) return snapshot;
+    useNewThreadReady.getState().completeInitialization(args.localId, attempt);
+    useNewThreadReady.getState().markReady(args.localId);
+    return snapshot;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import AFTER mocks — @/store/adapters and the ready store are REAL.
+// ---------------------------------------------------------------------------
+
+import { seedAdapters, resetAdapters } from '@/store/adapters';
+import { useNewThreadReady } from '../../runtime/new-thread-ready-store';
+const { useNewThreadAutoConfig } = await import('../use-new-thread-auto-config');
+
+beforeEach(() => {
+  initializeDraftSpy.mockReset();
+  getDraftConfigResult = undefined;
+  initializationGate = null;
+  fakeFilterProjectId = 'proj-42';
+  fakeAuiState = { threadListItem: { id: '__LOCALID_x', status: 'new' }, thread: { messages: [] } };
+  resetAdapters();
+  seedAdapters([
+    {
+      id: 'claude',
+      name: 'claude',
+      description: '',
+      installed: true,
+      models: [],
+      modelsRevision: 1,
+      catalogSource: 'fallback',
+      capabilities: { planMode: true },
+    },
+  ]);
+  useNewThreadReady.setState({ readyIds: new Set(), initializations: new Map() });
+});
+
+describe('useNewThreadAutoConfig — render-loop regression (real useAdapters)', () => {
+  it('does not restart initialization on re-renders with no actual change', async () => {
+    let release!: () => void;
+    initializationGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const { rerender, unmount } = renderHook(() => useNewThreadAutoConfig());
+    rerender();
+    rerender();
+
+    expect(initializeDraftSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => release());
+    unmount();
+  });
+
+  it('does not rewrite the useNewThreadReady store on re-renders with no actual change', async () => {
+    let release!: () => void;
+    initializationGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const { rerender, unmount } = renderHook(() => useNewThreadAutoConfig());
+    const stateAfterMount = useNewThreadReady.getState();
+    rerender();
+    rerender();
+
+    expect(useNewThreadReady.getState()).toBe(stateAfterMount);
+
+    await act(async () => release());
+    unmount();
+  });
+});

--- a/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/use-new-thread-auto-config.test.tsx
@@ -27,6 +27,10 @@
  * 10. defaultAdapterId is unset but an installed adapter exists → uses the first
  *     installed adapter's id.
  * 11. defaultAdapterId is unset and nothing is installed → falls back to 'claude'.
+ *
+ * The render-loop regression (React error #185 — an unstable useAdapters()
+ * identity churning this hook's effect) is covered separately, against the
+ * REAL @/store/adapters store, in use-new-thread-auto-config.render-loop.test.tsx.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';

--- a/packages/ui/src/features/sessions/runtime/__tests__/new-thread-ready-store.test.ts
+++ b/packages/ui/src/features/sessions/runtime/__tests__/new-thread-ready-store.test.ts
@@ -11,9 +11,13 @@
  *  3. clearReady(id) makes isReady(id) false again.
  *  4. markReady is idempotent — the readyIds reference is stable on a re-mark
  *     (so React subscribers don't churn).
+ *  5. getInitialization on an unknown id returns the exported IDLE_INITIALIZATION
+ *     reference, and the SAME reference on repeated calls (React error #185
+ *     regression: ChatSurface's no-active-thread fallback used to be a fresh
+ *     `{ status: 'idle' }` literal, which is never referentially stable).
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useNewThreadReady } from '../new-thread-ready-store';
+import { useNewThreadReady, IDLE_INITIALIZATION } from '../new-thread-ready-store';
 
 beforeEach(() => {
   // Reset the shared store between tests.
@@ -46,6 +50,17 @@ describe('new-thread-ready-store', () => {
 
     useNewThreadReady.getState().markReady('__LOCALID_a');
     const second = useNewThreadReady.getState().readyIds;
+
+    expect(second).toBe(first);
+  });
+
+  it('getInitialization on an unknown id returns the shared IDLE_INITIALIZATION reference', () => {
+    expect(useNewThreadReady.getState().getInitialization('unknown-id')).toBe(IDLE_INITIALIZATION);
+  });
+
+  it('getInitialization on an unknown id returns the same reference across repeated calls', () => {
+    const first = useNewThreadReady.getState().getInitialization('unknown-id');
+    const second = useNewThreadReady.getState().getInitialization('unknown-id');
 
     expect(second).toBe(first);
   });

--- a/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
+++ b/packages/ui/src/features/sessions/runtime/new-thread-ready-store.ts
@@ -26,7 +26,9 @@ export interface DraftInitialization {
   attempt?: number;
 }
 
-const IDLE_INITIALIZATION: DraftInitialization = { status: 'idle' };
+/** Exported so subscribers select this shared identity as their no-thread
+ *  fallback — a fresh literal there re-renders forever. */
+export const IDLE_INITIALIZATION: DraftInitialization = { status: 'idle' };
 let nextInitializationAttempt = 0;
 
 interface NewThreadReadyState {

--- a/packages/ui/src/store/__tests__/adapters.test.ts
+++ b/packages/ui/src/store/__tests__/adapters.test.ts
@@ -1,4 +1,17 @@
+// @vitest-environment jsdom
+/**
+ * store/adapters.test.ts — the shared adapter catalog store.
+ *
+ * Includes a regression suite for `useAdapters()` referential stability
+ * (React error #185 root cause): `Object.values(byId)` allocates a NEW array
+ * on every call once the catalog is non-empty, so any consumer that puts the
+ * return value in a `useEffect`/`useMemo` dependency array sees a "changed"
+ * dependency on every render, even when nothing in the catalog actually
+ * changed. Verified with `renderHook` by asserting reference identity
+ * (`toBe`/`not.toBe`) across re-renders, not by recomputing the contents.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
 
 const handlers = new Set<(e: any) => void>();
 vi.mock('@/lib/daemon/ws-client', () => ({
@@ -12,6 +25,7 @@ vi.mock('@/lib/daemon/ws-client', () => ({
 
 import {
   useAdaptersStore,
+  useAdapters,
   seedAdapters,
   resetAdapters,
   resetRevisionBaseline,
@@ -71,5 +85,65 @@ describe('ui adapters store', () => {
     seedAdapters([info('claude', 1, [])]);
     resetAdapters();
     expect(Object.keys(useAdaptersStore.getState().byId)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAdapters() referential stability (React error #185 regression).
+//
+// A consumer that lists useAdapters()'s return value in a useEffect/useMemo
+// dependency array relies on it being the SAME array reference across
+// re-renders when the catalog hasn't changed. If it isn't, the dependency
+// looks "changed" on every render, and any effect using it as a dep tears
+// down and reruns unconditionally.
+// ---------------------------------------------------------------------------
+
+describe('useAdapters — referential stability', () => {
+  beforeEach(() => {
+    resetAdapters();
+  });
+
+  it('returns a referentially stable array across re-renders when the catalog is unchanged', () => {
+    seedAdapters([info('claude', 1, [])]);
+
+    const { result, rerender } = renderHook(() => useAdapters());
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+    expect(result.current.map((a) => a.id)).toEqual(['claude']);
+  });
+
+  it('returns a new array reference after seedAdapters adds an adapter', () => {
+    seedAdapters([info('claude', 1, [])]);
+
+    const { result, rerender } = renderHook(() => useAdapters());
+    const first = result.current;
+    seedAdapters([info('codex', 1, [])]);
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current.map((a) => a.id).sort()).toEqual(['claude', 'codex']);
+  });
+
+  it('returns a new array reference after applyAdapterModels updates the catalog', () => {
+    seedAdapters([info('claude', 1, [{ id: 'a', label: 'A' }])]);
+
+    const { result, rerender } = renderHook(() => useAdapters());
+    const first = result.current;
+    applyAdapterModels('claude', [{ id: 'b', label: 'B' }], 2);
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current.map((a) => a.id)).toEqual(['claude']);
+  });
+
+  it('returns the same EMPTY-catalog reference across re-renders when there are no adapters', () => {
+    const { result, rerender } = renderHook(() => useAdapters());
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+    expect(result.current).toEqual([]);
   });
 });

--- a/packages/ui/src/store/adapters.ts
+++ b/packages/ui/src/store/adapters.ts
@@ -3,6 +3,7 @@
  * fresh by `adapter.models.updated`, applied only-if-newer by `modelsRevision`. Reset on
  * daemon switch/reconnect (module-level store survives the AppShell remount).
  */
+import { useMemo } from 'react';
 import { create } from 'zustand';
 import type { AdapterInfo, AdapterModel } from '@qlan-ro/mainframe-types';
 import { daemonWs } from '@/lib/daemon/ws-client';
@@ -14,9 +15,11 @@ interface AdaptersState {
 export const useAdaptersStore = create<AdaptersState>(() => ({ byId: {} }));
 
 const EMPTY: readonly AdapterInfo[] = [];
+/** Memoized: callers pass this array as a `useEffect` dep, and a fresh
+ *  `Object.values()` each render re-armed those effects until React threw #185. */
 export function useAdapters(): AdapterInfo[] {
   const byId = useAdaptersStore((s) => s.byId);
-  return Object.keys(byId).length ? Object.values(byId) : (EMPTY as AdapterInfo[]);
+  return useMemo(() => (Object.keys(byId).length ? Object.values(byId) : (EMPTY as AdapterInfo[])), [byId]);
 }
 
 function isNewer(current: number | undefined, incoming: number | undefined): boolean {


### PR DESCRIPTION
## The crash

Archiving a session dropped the app into the error boundary with React error #185, "Maximum update depth exceeded". Reported against `Mainframe-tauri-canary-2.0.0-rc.11`.

Identified from `~/.mainframe/logs/app-tauri.2026-07-21.log` (`module: "mf-error-boundary"`). The minified frames were mapped by rebuilding `packages/ui` locally — esbuild's name mangling is deterministic, so the shipped bundle's identifiers line up: `y2n` is `ChatSurface`, and frame `@9183:16261` lands exactly on the `cancelInitialization(` call in `useNewThreadAutoConfig`'s effect **cleanup** (the 3-argument `Sd` is `commitHookEffectListUnmount`, not the mount).

## Root cause

`useAdapters()` returned a fresh `Object.values(byId)` on every render, and `useNewThreadAutoConfig` passes that array as an effect dependency. The effect therefore tore down and re-ran on every render. Both its body (`beginInitialization`) and its cleanup (`cancelInitialization`) write to the store `ChatSurface` subscribes to, so each write re-rendered and re-armed it:

> write → render → new array → teardown + rerun → write → …

Archive is the trigger because it lands on an unresolved `__LOCALID_*` draft (`status: 'new'`, zero messages) while a project filter is active — the one state where that effect's guards don't short-circuit and `initializeDraft` is still in flight. The sidebar "+" path pre-resolves `draftCfg`, so its guard bails and it never loops.

## The fix

| File | Change |
|---|---|
| `store/adapters.ts` | `useAdapters()` memoized on `byId` |
| `sessions/new-thread/ChatSurface.tsx` | no-active-thread fallback selects a shared idle value, not a fresh literal |
| `sessions/runtime/new-thread-ready-store.ts` | exports that shared `IDLE_INITIALIZATION` sentinel |

The `ChatSurface` selector is the same bug class one store over — a selector returning a fresh object literal loops `useSyncExternalStore`. A repo-wide grep confirmed these were the only two.

## Tests

New: `use-new-thread-auto-config.render-loop.test.tsx` runs against the **real** adapters store (seeded via `seedAdapters`) rather than a mock, so it stays anchored to the shipping `useAdapters()`. Confirmed genuinely red without the fix — `expected 1 call, got 3`, and the ready-store identity changed across re-renders.

| Suite | Result |
|---|---|
| `store/__tests__/adapters.test.ts` | 8 passed |
| `use-new-thread-auto-config.test.tsx` | 13 passed |
| `use-new-thread-auto-config.render-loop.test.tsx` | 2 passed |
| `runtime/__tests__/new-thread-ready-store.test.ts` | 6 passed |
| `ChatSurface.test.tsx` | 11 passed |
| `tsc --noEmit` | clean |

Not verified by archiving a session in a running build — the diagnosis rests on the stack trace and the failing-without-the-fix test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)