### PR TITLE
fix(rust-daemon): codex transcript fails to load on unknown thread item types

### DIFF
--- a/.changeset/codex-history-unknown-item-types.md
+++ b/.changeset/codex-history-unknown-item-types.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Fix Codex sessions whose transcript failed to load in the Rust daemon. When a session's `thread/read` history contained an item type this port didn't know — `contextCompaction` (emitted after a context compaction) or `subAgentActivity` (multi-agent) — the whole payload failed to deserialize and the transcript rendered empty. Unrecognized items are now skipped on reload, matching the Node daemon, so the rest of the history still loads.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/types.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/types.rs
@@ -73,7 +73,41 @@ pub struct ThreadResumeResult {
 pub struct ThreadReadTurn {
     pub id: String,
     pub status: String,
+    #[serde(deserialize_with = "deserialize_lenient_items")]
     pub items: Vec<ThreadItem>,
+}
+
+/// Deserialize a turn's `items`, dropping any item whose `type` Codex added after
+/// this port (or whose shape changed) instead of failing the whole `thread/read`.
+///
+/// `ThreadItem` is an internally-tagged enum with no unknown-variant fallback, so a
+/// single unrecognized item (e.g. `contextCompaction` after a compaction, or
+/// `subAgentActivity` from multi-agent) would otherwise abort deserialization of the
+/// entire transcript and render it empty. This mirrors the TS reload path, where
+/// `convertThreadItems`'s `switch` silently skips items it doesn't handle.
+fn deserialize_lenient_items<'de, D>(deserializer: D) -> Result<Vec<ThreadItem>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Vec<Value> = Vec::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| {
+            let kind = v.get("type").and_then(|t| t.as_str()).unwrap_or("").to_string();
+            match serde_json::from_value::<ThreadItem>(v) {
+                Ok(item) => Some(item),
+                Err(err) => {
+                    tracing::debug!(
+                        module = "codex:history",
+                        r#type = kind,
+                        err = %err,
+                        "codex: skipping unrecognized thread item on history reload"
+                    );
+                    None
+                }
+            }
+        })
+        .collect())
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/history.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/history.rs
@@ -54,6 +54,51 @@ fn also_accepts_the_rollout_jsonl_shape_input_text() {
     );
 }
 
+// --- thread/read reload tolerates item types added after this port ---
+
+// Regression: Codex 0.144.3 emits `contextCompaction` (post-compaction) and
+// `subAgentActivity` (multi-agent) items that `ThreadItem` doesn't know. Because
+// `ThreadReadTurn.items` is a hard `Vec<ThreadItem>`, one unknown variant used to
+// abort deserialization of the whole `thread/read` payload, so history failed to
+// load and the transcript rendered empty (see codex:session "failed to load
+// history: unknown variant `contextCompaction`"). Unknown items must be skipped,
+// leaving the known ones intact.
+#[test]
+fn thread_read_skips_unknown_item_types_instead_of_failing_the_whole_turn() {
+    use mainframe_adapter_codex::types::ThreadReadResult;
+
+    let payload = json!({
+        "thread": {
+            "id": "t1",
+            "turns": [{
+                "id": "turn1",
+                "status": "completed",
+                "items": [
+                    { "id": "a1", "type": "agentMessage", "text": "before compaction", "phase": null },
+                    { "id": "c1", "type": "contextCompaction", "summary": "…", "anythingElse": 42 },
+                    { "id": "s1", "type": "subAgentActivity", "whatever": true },
+                    { "id": "a2", "type": "agentMessage", "text": "after compaction", "phase": null }
+                ]
+            }]
+        }
+    });
+
+    let read: ThreadReadResult =
+        serde_json::from_value(payload).expect("thread/read must deserialize despite unknown items");
+    let all: Vec<ThreadItem> = read
+        .thread
+        .turns
+        .unwrap_or_default()
+        .into_iter()
+        .flat_map(|t| t.items)
+        .collect();
+
+    // Both unknown items dropped; both agentMessages survive in order.
+    assert_eq!(all.len(), 2);
+    assert!(matches!(&all[0], ThreadItem::AgentMessage(m) if m.text == "before compaction"));
+    assert!(matches!(&all[1], ThreadItem::AgentMessage(m) if m.text == "after compaction"));
+}
+
 #[test]
 fn falls_back_to_the_legacy_top_level_item_text() {
     let out = convert(json!([{ "id": "m1", "type": "userMessage", "text": "legacy" }]));


### PR DESCRIPTION
## Problem

Latest build from main: some Codex sessions show an empty transcript in the desktop app (e.g. `019f8baa-afcf-7fd3-a00f-985f6371a44e`). The Rust daemon logged the cause on every reload attempt:

```
WARN mainframe_adapter_codex::session: codex: failed to load history
err=unknown variant `contextCompaction`, expected one of `agentMessage`, `reasoning`, ...
```

Codex 0.144.3 emits item types the port doesn't know: `contextCompaction` (appears once a session compacts) and `subAgentActivity` (multi-agent). `ThreadReadTurn.items` was a rigid `Vec<ThreadItem>` — an internally-tagged serde enum with no unknown-variant fallback — so a single unknown item aborted deserialization of the entire `thread/read` payload and history load returned an error.

Only the reload path was affected: the streaming path (`event_mapper`) already skips items it can't parse, and the Node daemon never had the bug (`convertThreadItems`' `switch` silently skips unknown types). That's why the session streamed fine live but came back empty after reopen.

## Fix

Lenient per-item deserialization for `ThreadReadTurn.items`: decode each item independently, drop the ones that don't parse (debug-logged with their `type`). Chosen over adding an `Unknown` enum variant because it also survives a *reshaped* known item type, not just new tags.

## Verification

- New regression test feeds a `thread/read` payload containing `contextCompaction` + `subAgentActivity` alongside two `agentMessage`s — confirmed **red without the fix** (fails with the exact production error), green with it; known items survive in order.
- Full `mainframe-adapter-codex` suite: 110 tests pass; clippy clean.

Follow-up (separate work): actually *render* these item types instead of skipping them, and restore compaction-start detection parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)