### PR TITLE
fix(ui): route background-task events to a sidebar reload

### DIFF
--- a/.changeset/sidebar-background-task-status.md
+++ b/.changeset/sidebar-background-task-status.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Sidebar now shows a session as Working while only background subagents are active.
+
+The sidebar's WS event router dropped `background_task.started|updated|ended` in its default case, so a session whose only live activity was a background subagent never triggered a reload — the badge stayed on Idle even though the daemon's `displayStatus` was already Working. The router now reloads the session list on all three background-task lifecycle events.

--- a/packages/ui/src/features/sessions/ws/__tests__/session-list-router.test.ts
+++ b/packages/ui/src/features/sessions/ws/__tests__/session-list-router.test.ts
@@ -9,6 +9,7 @@
  *  - permission.requested (notify: true)  → onMarkUnread called with chatId; onReload not called
  *  - permission.requested (notify: false) → onMarkUnread called with chatId
  *  - permission.resolved  → neither mock called
+ *  - background_task.started|updated|ended → onReload called; onMarkUnread not called
  *  - dispose() unsubscribes; subsequent dispatched events are ignored
  *  - Unrelated event type (display.message.added) → no-op
  *
@@ -17,7 +18,7 @@
  * mocks so assertions are trivial.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
+import type { BackgroundTask, Chat, DaemonEvent } from '@qlan-ro/mainframe-types';
 import type { DaemonWsClient } from '../../../../lib/daemon/ws-client';
 import { SessionListRouter } from '../session-list-router';
 
@@ -236,6 +237,37 @@ describe('session-list-router — permission.resolved calls neither mock', () =>
     dispatch({ type: 'permission.resolved', chatId: 'c5', requestId: 'r1' });
 
     expect(onReload).not.toHaveBeenCalled();
+    expect(onMarkUnread).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// background_task.started|updated|ended → reload (D1: sidebar working indicator)
+// ---------------------------------------------------------------------------
+
+const BACKGROUND_TASK: BackgroundTask = {
+  id: 'bg1',
+  kind: 'agent',
+  toolName: 'Bash',
+  toolUseId: 't1',
+  command: 'run tests',
+  description: 'Running tests',
+  outputPath: null,
+  startedAt: 0,
+  endedAt: null,
+  status: 'running',
+  lastOutputLine: null,
+  summary: null,
+  usage: null,
+};
+
+describe('session-list-router — background_task lifecycle triggers reload', () => {
+  it('calls onReload for started, updated, and ended without marking unread', () => {
+    dispatch({ type: 'background_task.started', chatId: 'c6', task: BACKGROUND_TASK });
+    dispatch({ type: 'background_task.updated', chatId: 'c6', task: BACKGROUND_TASK });
+    dispatch({ type: 'background_task.ended', chatId: 'c6', task: { ...BACKGROUND_TASK, status: 'completed' } });
+
+    expect(onReload).toHaveBeenCalledTimes(3);
     expect(onMarkUnread).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/features/sessions/ws/session-list-router.ts
+++ b/packages/ui/src/features/sessions/ws/session-list-router.ts
@@ -12,6 +12,10 @@
  *   displayStatus and clears the "waiting" badge (Spike 0.3 / S4). If 0.3 shows
  *   the daemon does NOT re-emit chat.updated, add `case 'permission.resolved':
  *   this.deps.onReload(); return;`.
+ * background_task.started / .updated / .ended → reload. A background-only
+ *   window (only a subagent running, no foreground turn) never emits
+ *   chat.updated, so without this the sidebar badge freezes at idle even
+ *   though the daemon's displayStatus is already "working" (D1).
  *
  * The class is dependency-injected (onReload / onChatUpdated / onMarkUnread) so
  * it is testable with no React or zustand. useSessionListRouter (a sibling hook)
@@ -73,6 +77,12 @@ export class SessionListRouter {
 
       case 'permission.requested':
         this.deps.onMarkUnread(event.chatId);
+        return;
+
+      case 'background_task.started':
+      case 'background_task.updated':
+      case 'background_task.ended':
+        this.deps.onReload();
         return;
 
       default:


### PR DESCRIPTION
## Summary

- A session whose only live activity is a background subagent showed "idle" in the sidebar. The daemon's `displayStatus` is correct on pull (`Working` if `working || !live_tasks.is_empty()`), but the lifecycle is pushed as `background_task.started|updated|ended` events, which the sidebar's WS router (`packages/ui/src/features/sessions/ws/session-list-router.ts`) fell through to its `default` no-op case. No `chat.updated` fires during a background-only window, so the badge froze at idle until some unrelated event triggered a reload.
- Fix: add `background_task.started|updated|ended` cases that call `this.deps.onReload()` (already debounced upstream by `use-session-list-router.ts`; a reload re-runs `GET /api/chats`, which re-carries the enriched `displayStatus`).
- UI-only change — the `DaemonEvent` union already carried these arms in `@qlan-ro/mainframe-types`, so no types/daemon changes were needed.

## Test plan

- [x] Added a failing test asserting `onReload` is called 3x (started/updated/ended) and `onMarkUnread` is not called; confirmed RED before the fix.
- [x] `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/ws/__tests__/session-list-router.test.ts` — 14/14 passing after the fix.
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean.
- [x] Changeset added (`@qlan-ro/mainframe-ui` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)