### PR TITLE
feat: adapter-agnostic compacting pill (Claude + Codex)

### DIFF
--- a/.changeset/compacting-pill.md
+++ b/.changeset/compacting-pill.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-ui': patch
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Show a live "Compacting…" pill in the transcript that resolves into "Context compacted", for Claude and Codex.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/compaction.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/compaction.rs
@@ -1,0 +1,33 @@
+//! Live compaction mapping for Codex 0.144.3+.
+//!
+//! Codex emits the canonical v2 item `{"type":"contextCompaction","id":…}`
+//! through the normal `item/started` → `item/completed` lifecycle (all three
+//! compaction paths at rust-v0.144.3: `core/src/compact{,_remote,_remote_v2}.rs`),
+//! deprecating the `thread/compacted` notification. Both end paths funnel
+//! through the per-turn `compaction_emitted` gate so an old server (notification
+//! only), a new server (item only), or any interleaving of the two emits the
+//! "Context compacted" pill exactly once. The gate resets on `turn/started`.
+
+use std::sync::Arc;
+
+use mainframe_adapter_api::SessionSink;
+
+use crate::event_mapper::CodexSessionState;
+
+/// `item/started(contextCompaction)` → the transient "Compacting…" pill.
+pub(crate) fn handle_compaction_started(sink: &Arc<dyn SessionSink>) {
+    sink.on_compact_start();
+}
+
+/// End-of-compaction, from either `item/completed(contextCompaction)` or the
+/// legacy `thread/compacted` notification — whichever arrives first wins.
+pub(crate) fn handle_compaction_completed(
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    if state.compaction_emitted {
+        return;
+    }
+    state.compaction_emitted = true;
+    sink.on_compact();
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
@@ -57,6 +57,8 @@ pub struct CodexSessionState {
     pub collab_child_threads: HashMap<String, String>,
     /// child thread id → spawn prompt (captured from `spawnAgent` items).
     pub spawn_prompts: HashMap<String, String>,
+    /// Per-turn dedupe: compact-done already emitted (item or legacy `thread/compacted` path).
+    pub compaction_emitted: bool,
 }
 
 pub fn handle_notification(
@@ -98,7 +100,7 @@ pub fn handle_notification(
                 handle_token_usage(p, state);
             }
         }
-        "thread/compacted" => sink.on_compact(),
+        "thread/compacted" => crate::compaction::handle_compaction_completed(sink, state),
         "item/started" => {
             if let Ok(p) = serde_json::from_value::<ItemStartedParams>(params.clone()) {
                 handle_item_started(p, sink, state);
@@ -166,6 +168,7 @@ fn handle_account_rate_limits_updated(
 fn handle_turn_started(params: TurnStartedParams, state: &mut CodexSessionState) {
     state.current_turn_plan = None;
     state.current_turn_id = Some(params.turn.id);
+    state.compaction_emitted = false;
 }
 
 fn handle_plan_delta(params: PlanDeltaParams, state: &mut CodexSessionState) {
@@ -182,18 +185,22 @@ fn handle_item_started(
     sink: &Arc<dyn SessionSink>,
     state: &mut CodexSessionState,
 ) {
-    let Ok(ThreadItem::CollabAgentToolCall(item)) =
-        serde_json::from_value::<ThreadItem>(params.item)
-    else {
-        return;
-    };
-    // `spawnAgent` is dispatch metadata only — stash its prompt for the later `wait` card.
-    if item.tool == "spawnAgent" {
-        stash_spawn_prompts(&item, state);
-        return;
+    match serde_json::from_value::<ThreadItem>(params.item) {
+        Ok(ThreadItem::ContextCompaction(_)) => {
+            crate::compaction::handle_compaction_started(sink);
+        }
+        Ok(ThreadItem::CollabAgentToolCall(item)) => {
+            // `spawnAgent` is dispatch metadata only — stash its prompt for the later `wait` card.
+            if item.tool == "spawnAgent" {
+                stash_spawn_prompts(&item, state);
+                return;
+            }
+            // Only `wait` items render a card.
+            emit_collab_task_group_start(&item, sink, state);
+        }
+        // Every other item type renders from its terminal `item/completed` event.
+        Ok(_) | Err(_) => {}
     }
-    // Only `wait` items render a card.
-    emit_collab_task_group_start(&item, sink, state);
 }
 
 fn handle_item_completed(
@@ -305,6 +312,9 @@ fn handle_item_completed(
             if !todos.is_empty() {
                 sink.on_todo_update(todos);
             }
+        }
+        ThreadItem::ContextCompaction(_) => {
+            crate::compaction::handle_compaction_completed(sink, state);
         }
         _ => {
             tracing::debug!(module = "codex:events", "codex: unhandled item type");

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/history.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/history.rs
@@ -7,7 +7,9 @@
 
 use std::collections::HashMap;
 
-use mainframe_types::chat::{ChatMessage, ChatMessageType, DiffHunk, MessageContent};
+use mainframe_types::chat::{
+    ChatMessage, ChatMessageType, DiffHunk, MessageContent, MessageContentNode,
+};
 use mainframe_types::content::LeafContent;
 use serde_json::{Value, json};
 
@@ -139,6 +141,17 @@ pub fn convert_thread_items(
                     child_items_by_thread,
                     agent_meta_by_thread,
                 );
+            }
+            ThreadItem::ContextCompaction(c) => {
+                // Same "Context compacted" pill Claude's compact_boundary produces.
+                messages.push(make_message(
+                    &c.id,
+                    chat_id,
+                    ChatMessageType::System,
+                    vec![MessageContent::Node(MessageContentNode::Compaction {
+                        parent_tool_use_id: None,
+                    })],
+                ));
             }
             // webSearch, todoList, imageGeneration — skip for now
             _ => {}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
@@ -30,6 +30,14 @@ pub enum ThreadItem {
     TodoList(TodoListItem),
     UserMessage(UserMessageItem),
     CollabAgentToolCall(CollabAgentToolCallItem),
+    ContextCompaction(ContextCompactionItem),
+}
+
+/// Bare compaction marker (Codex 0.144.3 v2): `{ "type": "contextCompaction", "id" }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextCompactionItem {
+    pub id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod adapter;
 pub mod approval_handler;
+pub(crate) mod compaction;
 pub mod event_mapper;
 pub mod external_session_parse;
 pub mod external_sessions;

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/common/mod.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/common/mod.rs
@@ -20,6 +20,7 @@ pub struct Recorded {
     pub todos: Vec<Vec<TodoItem>>,
     pub inits: Vec<String>,
     pub compacts: usize,
+    pub compact_starts: usize,
     pub provider_quotas: Vec<(String, ProviderQuota)>,
 }
 
@@ -51,6 +52,12 @@ impl Recorder {
     pub fn provider_quotas(&self) -> Vec<(String, ProviderQuota)> {
         self.0.lock().unwrap().provider_quotas.clone()
     }
+    pub fn compacts(&self) -> usize {
+        self.0.lock().unwrap().compacts
+    }
+    pub fn compact_starts(&self) -> usize {
+        self.0.lock().unwrap().compact_starts
+    }
 }
 
 struct RecordingSink(Arc<Mutex<Recorded>>);
@@ -76,7 +83,9 @@ impl SessionSink for RecordingSink {
     fn on_compact(&self) {
         self.0.lock().unwrap().compacts += 1;
     }
-    fn on_compact_start(&self) {}
+    fn on_compact_start(&self) {
+        self.0.lock().unwrap().compact_starts += 1;
+    }
     fn on_context_usage(&self, _usage: ContextUsage) {}
     fn on_plan_file(&self, _file_path: &str) {}
     fn on_skill_file(&self, _entry: SkillFileEntry) {}

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
@@ -331,6 +331,123 @@ fn clears_current_turn_plan_on_turn_completed() {
     assert_eq!(state.current_turn_plan, None);
 }
 
+// --- contextCompaction live mapping + thread/compacted dedupe ---
+//
+// Codex 0.144.3 emits the canonical v2 item `{"type":"contextCompaction","id":…}`
+// through item/started → item/completed on every compaction path (verified in
+// core/src/compact{,_remote,_remote_v2}.rs at rust-v0.144.3); the deprecated
+// thread/compacted notification is kept only as a legacy fallback and must never
+// double-emit the end pill.
+
+fn compaction_item() -> Value {
+    json!({ "id": "comp_1", "type": "contextCompaction" })
+}
+
+fn dispatch(rec: &Recorder, state: &mut CodexSessionState, method: &str, params: Value) {
+    handle_notification(method, &params, &rec.sink(), state);
+}
+
+#[test]
+fn context_compaction_item_started_then_completed_fires_start_and_end_exactly_once() {
+    let rec = Recorder::new();
+    let mut state = state();
+    dispatch(
+        &rec,
+        &mut state,
+        "item/started",
+        json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": compaction_item() }),
+    );
+    assert_eq!(rec.compact_starts(), 1);
+    assert_eq!(rec.compacts(), 0);
+
+    dispatch(
+        &rec,
+        &mut state,
+        "item/completed",
+        json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": compaction_item() }),
+    );
+    assert_eq!(rec.compact_starts(), 1);
+    assert_eq!(rec.compacts(), 1);
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn legacy_thread_compacted_after_item_completed_does_not_double_emit() {
+    let rec = Recorder::new();
+    let mut state = state();
+    dispatch(
+        &rec,
+        &mut state,
+        "item/completed",
+        json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": compaction_item() }),
+    );
+    dispatch(
+        &rec,
+        &mut state,
+        "thread/compacted",
+        json!({ "threadId": "parent_thread" }),
+    );
+    assert_eq!(rec.compacts(), 1);
+}
+
+#[test]
+fn item_completed_after_legacy_thread_compacted_does_not_double_emit() {
+    let rec = Recorder::new();
+    let mut state = state();
+    dispatch(
+        &rec,
+        &mut state,
+        "thread/compacted",
+        json!({ "threadId": "parent_thread" }),
+    );
+    dispatch(
+        &rec,
+        &mut state,
+        "item/completed",
+        json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": compaction_item() }),
+    );
+    assert_eq!(rec.compacts(), 1);
+}
+
+#[test]
+fn legacy_thread_compacted_alone_still_fires_exactly_one_compact() {
+    let rec = Recorder::new();
+    let mut state = state();
+    dispatch(
+        &rec,
+        &mut state,
+        "thread/compacted",
+        json!({ "threadId": "parent_thread" }),
+    );
+    assert_eq!(rec.compacts(), 1);
+}
+
+#[test]
+fn turn_started_resets_the_dedupe_so_a_later_compaction_emits_again() {
+    let rec = Recorder::new();
+    let mut state = state();
+    dispatch(
+        &rec,
+        &mut state,
+        "item/completed",
+        json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": compaction_item() }),
+    );
+    dispatch(
+        &rec,
+        &mut state,
+        "turn/started",
+        json!({ "threadId": "parent_thread", "turn": { "id": "turn_2" } }),
+    );
+    dispatch(
+        &rec,
+        &mut state,
+        "item/completed",
+        json!({ "threadId": "parent_thread", "turnId": "turn_2", "item": compaction_item() }),
+    );
+    assert_eq!(rec.compacts(), 2);
+}
+
 // Codex omits contextTokens in TS, so the sink falls back to the turn's usage
 // input tokens (event-handler.ts:366). Rust's Option<i64> can't carry the
 // undefined/null distinction, so the mapper resolves that fallback here by

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/history.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/history.rs
@@ -56,13 +56,13 @@ fn also_accepts_the_rollout_jsonl_shape_input_text() {
 
 // --- thread/read reload tolerates item types added after this port ---
 
-// Regression: Codex 0.144.3 emits `contextCompaction` (post-compaction) and
-// `subAgentActivity` (multi-agent) items that `ThreadItem` doesn't know. Because
-// `ThreadReadTurn.items` is a hard `Vec<ThreadItem>`, one unknown variant used to
-// abort deserialization of the whole `thread/read` payload, so history failed to
-// load and the transcript rendered empty (see codex:session "failed to load
-// history: unknown variant `contextCompaction`"). Unknown items must be skipped,
-// leaving the known ones intact.
+// Regression: Codex 0.144.3 emits items that `ThreadItem` doesn't know (e.g.
+// `subAgentActivity`). Because `ThreadReadTurn.items` is a hard
+// `Vec<ThreadItem>`, one unknown variant used to abort deserialization of the
+// whole `thread/read` payload, so history failed to load and the transcript
+// rendered empty (see codex:session "failed to load history: unknown variant
+// `contextCompaction`"). Unknown items must be skipped, leaving the known ones
+// intact. `contextCompaction` is a known variant now and survives the parse.
 #[test]
 fn thread_read_skips_unknown_item_types_instead_of_failing_the_whole_turn() {
     use mainframe_adapter_codex::types::ThreadReadResult;
@@ -83,8 +83,8 @@ fn thread_read_skips_unknown_item_types_instead_of_failing_the_whole_turn() {
         }
     });
 
-    let read: ThreadReadResult =
-        serde_json::from_value(payload).expect("thread/read must deserialize despite unknown items");
+    let read: ThreadReadResult = serde_json::from_value(payload)
+        .expect("thread/read must deserialize despite unknown items");
     let all: Vec<ThreadItem> = read
         .thread
         .turns
@@ -93,10 +93,24 @@ fn thread_read_skips_unknown_item_types_instead_of_failing_the_whole_turn() {
         .flat_map(|t| t.items)
         .collect();
 
-    // Both unknown items dropped; both agentMessages survive in order.
-    assert_eq!(all.len(), 2);
+    // The unknown subAgentActivity drops; the known items survive in order.
+    assert_eq!(all.len(), 3);
     assert!(matches!(&all[0], ThreadItem::AgentMessage(m) if m.text == "before compaction"));
-    assert!(matches!(&all[1], ThreadItem::AgentMessage(m) if m.text == "after compaction"));
+    assert!(matches!(&all[1], ThreadItem::ContextCompaction(c) if c.id == "c1"));
+    assert!(matches!(&all[2], ThreadItem::AgentMessage(m) if m.text == "after compaction"));
+}
+
+// --- convertThreadItems — contextCompaction → "Context compacted" pill ---
+
+#[test]
+fn context_compaction_item_becomes_a_system_compaction_message() {
+    let out = convert(json!([
+        { "id": "comp_1", "type": "contextCompaction" },
+    ]));
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].r#type, ChatMessageType::System);
+    assert_eq!(content_json(&out[0]), json!([{ "type": "compaction" }]));
+    assert_eq!(out[0].chat_id, "chat1");
 }
 
 #[test]

--- a/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-session-bar.test.ts
+++ b/packages/ui/src/features/chat/controller/__tests__/chat-thread-state-session-bar.test.ts
@@ -218,3 +218,31 @@ describe('reduceChatThreadState — compact.done', () => {
     expect(after.interactions).toBe(compacting.interactions);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Run ends mid-compaction — the pill must not strand
+// ---------------------------------------------------------------------------
+
+describe('reduceChatThreadState — run end clears compacting', () => {
+  it('clears compacting when run.stopped arrives without compact.done', () => {
+    const base = createChatThreadState(CHAT_ID);
+    const compacting = reduceChatThreadState(base, { type: 'compact.started' });
+    expect(compacting.compacting).toBe(true);
+
+    const after = reduceChatThreadState(compacting, { type: 'run.stopped' });
+
+    expect(after.compacting).toBe(false);
+    expect(after.runState).toEqual({ type: 'idle' });
+  });
+
+  it('clears compacting when run.failed arrives without compact.done', () => {
+    const base = createChatThreadState(CHAT_ID);
+    const compacting = reduceChatThreadState(base, { type: 'compact.started' });
+    expect(compacting.compacting).toBe(true);
+
+    const after = reduceChatThreadState(compacting, { type: 'run.failed', error: new Error('boom') });
+
+    expect(after.compacting).toBe(false);
+    expect(after.runState).toEqual({ type: 'error', error: new Error('boom') });
+  });
+});

--- a/packages/ui/src/features/chat/controller/chat-thread-state.ts
+++ b/packages/ui/src/features/chat/controller/chat-thread-state.ts
@@ -45,10 +45,7 @@ export interface ChatPermissionEntry {
 export type LoadState = { type: 'idle' } | { type: 'loading' } | { type: 'ready' } | { type: 'error'; error: unknown };
 
 export type RunState =
-  | { type: 'idle' }
-  | { type: 'running' }
-  | { type: 'cancelling' }
-  | { type: 'error'; error: unknown };
+  { type: 'idle' } | { type: 'running' } | { type: 'cancelling' } | { type: 'error'; error: unknown };
 
 export interface ChatThreadState {
   /**
@@ -82,7 +79,8 @@ export interface ChatThreadState {
    * chatConfig when null.
    */
   readonly contextUsage: { percentage: number; totalTokens: number; maxTokens: number } | null;
-  /** True between `chat.compacting` and `chat.compactDone` — session-bar status. */
+  /** True between `chat.compacting` and `chat.compactDone` (also cleared on
+   *  run end) — drives the transcript "Compacting…" pill. */
   readonly compacting: boolean;
   /**
    * Live background work (agents / bg bash / workflows) keyed by task id — fed
@@ -252,11 +250,13 @@ export function reduceChatThreadState(state: ChatThreadState, event: ChatStateEv
     case 'run.cancelling':
       return { ...state, runState: { type: 'cancelling' } };
 
+    // Run-end also clears `compacting`: a run that dies mid-compaction never
+    // sends compact.done, and the pill must not strand.
     case 'run.stopped':
-      return { ...state, runState: { type: 'idle' } };
+      return { ...state, runState: { type: 'idle' }, compacting: false };
 
     case 'run.failed':
-      return { ...state, runState: { type: 'error', error: event.error } };
+      return { ...state, runState: { type: 'error', error: event.error }, compacting: false };
 
     case 'chat.id.adopted':
       return state.chatId === event.chatId ? state : { ...state, chatId: event.chatId };

--- a/packages/ui/src/features/chat/messages/SystemMessage.tsx
+++ b/packages/ui/src/features/chat/messages/SystemMessage.tsx
@@ -32,6 +32,25 @@ export function CompactionPill() {
   );
 }
 
+/** Transient "Compacting…" pill — shown at the transcript tail while a
+ *  compaction runs, replaced by CompactionPill when it completes. */
+export function CompactingPill() {
+  return (
+    <div className="my-2 flex justify-center">
+      <div
+        data-testid="chat-compacting-pill"
+        className="inline-flex select-none items-center gap-1.5 rounded-full border border-border bg-mf-content2 px-3 py-1 font-mono text-caption text-muted-foreground"
+      >
+        <span
+          className="inline-block h-[7px] w-[7px] shrink-0 animate-spin rounded-full border-[1.5px] border-muted-foreground"
+          style={{ borderTopColor: 'transparent' }}
+        />
+        <span>Compacting…</span>
+      </div>
+    </div>
+  );
+}
+
 const CLI_ERROR_RE = /^Unknown (?:command|skill):/i;
 
 function SystemTextPill({ text }: { text: string }) {

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -15,6 +15,7 @@ import { BackgroundActivityBar } from '../composer/BackgroundActivityBar';
 import { SelectionToolbar } from '@/components/ui/assistant-ui/quote';
 import { ComposerEditProvider } from '../composer/edit/composer-edit-context';
 import { ChatGateMount } from '../gates/ChatGateMount';
+import { CompactingPill } from '../messages/SystemMessage';
 import { DegradedChatCard } from './DegradedChatCard';
 import { useChatExtras } from '../runtime/use-chat-thread-runtime';
 import { useRotatingPhrase } from './use-rotating-phrase';
@@ -64,6 +65,15 @@ function GeneratingIndicator() {
   );
 }
 
+/** Transient chrome, not a persisted message — lives outside
+ *  ThreadPrimitive.Messages; the "Context compacted" system message replaces
+ *  it once compact-done lands in the transcript. */
+function CompactingIndicator() {
+  const extras = useChatExtras();
+  if (!extras?.state.compacting) return null;
+  return <CompactingPill />;
+}
+
 export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
   useFindHotkey();
   const messageCount = useAuiState((s: { thread: { messages: readonly unknown[] } }) => s.thread.messages.length);
@@ -91,6 +101,7 @@ export function ChatThread({ emptyState }: { emptyState?: ReactNode } = {}) {
               {/* Inline "thinking/working" indicator — sits after the last message,
                   not pinned above the composer (#214). */}
               <GeneratingIndicator />
+              <CompactingIndicator />
               <ChatGateMount />
             </div>
 

--- a/packages/ui/src/features/chat/thread/__tests__/ChatThread-compacting.test.tsx
+++ b/packages/ui/src/features/chat/thread/__tests__/ChatThread-compacting.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * ChatThread — transient "Compacting…" pill.
+ *
+ * While `state.compacting` is true the transcript tail shows a spinner pill
+ * (chat-compacting-pill); when it flips false the pill unmounts (the persisted
+ * "Context compacted" system message takes over via the normal message list).
+ * Mocks mirror ChatThread.test.tsx: assistant-ui primitives + heavy children
+ * become identifiable stubs; `useChatExtras` is a mutable-state stub.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+// ── assistant-ui primitives → identifiable stub wrappers ─────────────────────
+vi.mock('@assistant-ui/react', () => {
+  return {
+    ThreadPrimitive: {
+      Root: ({ children }: { children?: ReactNode }) => <div data-testid="tp-root">{children}</div>,
+      Viewport: ({ children }: { children?: ReactNode }) => <div data-testid="tp-viewport">{children}</div>,
+      ViewportFooter: ({ children }: { children?: ReactNode }) => (
+        <div data-testid="tp-viewport-footer">{children}</div>
+      ),
+      ScrollToBottom: ({ children }: { children?: ReactNode }) => <>{children}</>,
+      Messages: () => <div data-testid="tp-messages" />,
+    },
+    useAuiState: (sel: (s: { thread: { isRunning: boolean; messages: unknown[] } }) => unknown) =>
+      sel({ thread: { isRunning: false, messages: [{}] } }),
+  };
+});
+
+// ── Heavy children → stubs ───────────────────────────────────────────────────
+vi.mock('../../messages/bounded-messages', () => ({ boundedMessageComponents: {} }));
+vi.mock('../../composer/Composer', () => ({ Composer: () => <div data-testid="composer-stub" /> }));
+vi.mock('../../composer/BackgroundActivityBar', () => ({ BackgroundActivityBar: () => null }));
+vi.mock('@/components/ui/assistant-ui/quote', () => ({ SelectionToolbar: () => null }));
+vi.mock('../../composer/edit/composer-edit-context', () => ({
+  ComposerEditProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../gates/ChatGateMount', () => ({ ChatGateMount: () => <div data-testid="gate-mount-stub" /> }));
+vi.mock('../DegradedChatCard', () => ({ DegradedChatCard: () => null }));
+vi.mock('../use-rotating-phrase', () => ({ useRotatingPhrase: () => 'Thinking…' }));
+vi.mock('@/features/skills/use-chat-skills', () => ({
+  SkillsProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../find/FindBar', () => ({ FindBar: () => null }));
+vi.mock('../../find/use-find-hotkey', () => ({ useFindHotkey: () => {} }));
+vi.mock('../../tools/register-cards', () => ({}));
+
+// Mutable extras state so a rerender can flip `compacting`.
+const extrasState = { compacting: true, loadState: { type: 'ready' } };
+vi.mock('../../runtime/use-chat-thread-runtime', () => ({
+  useChatExtras: () => ({ state: extrasState, retry: () => Promise.resolve() }),
+}));
+
+import { ChatThread } from '../ChatThread';
+
+describe('ChatThread — transient "Compacting…" pill', () => {
+  it('renders the pill with its label while compacting', () => {
+    extrasState.compacting = true;
+    render(<ChatThread />);
+    expect(screen.getByTestId('chat-compacting-pill')).toBeInTheDocument();
+    expect(screen.getByText('Compacting…')).toBeInTheDocument();
+  });
+
+  it('unmounts the pill when compacting flips false', () => {
+    extrasState.compacting = true;
+    const { rerender } = render(<ChatThread />);
+    expect(screen.getByTestId('chat-compacting-pill')).toBeInTheDocument();
+
+    extrasState.compacting = false;
+    rerender(<ChatThread />);
+    expect(screen.queryByTestId('chat-compacting-pill')).toBeNull();
+  });
+
+  it('renders the pill in the messages column, not the sticky footer', () => {
+    extrasState.compacting = true;
+    render(<ChatThread />);
+    const footer = screen.getByTestId('tp-viewport-footer');
+    expect(within(footer).queryByTestId('chat-compacting-pill')).toBeNull();
+    const messages = screen.getByTestId('tp-messages');
+    const pill = screen.getByTestId('chat-compacting-pill');
+    expect(messages.compareDocumentPosition(pill) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Stream A of the codex-adapter rendering-fixes plan: a transient "Compacting…" pill at the transcript tail that resolves into the existing "Context compacted" pill, for both Claude and Codex.

### The render-only regression

The daemon has emitted `chat.compacting` all along and the UI reducer set `state.compacting` — but the flag has had **zero consumers** since the 2026-07-02 density pass deleted ChatSessionBar. This PR adds the missing renderer (`CompactingPill`, testid `chat-compacting-pill`) mounted in `ChatThread` between the generating indicator and the gate mount, plus a stranded-pill fix: `run.stopped`/`run.failed` now clear `compacting`, so a run that dies mid-compaction (which never sends compact-done) cannot leave the pill up forever.

### Codex: item-driven start/end mapping

**A2 Step 0 evidence (verdict: full scope — Codex emits the start event).** Three independent lines, all at Codex 0.144.3 (tag `rust-v0.144.3`, sha `13307a9036baccd2c51b685d1457a4b89b5b2f3b`):

1. **Source**: all three compaction paths — `core/src/compact.rs` (:227, :370), `compact_remote.rs` (:204, :299), `compact_remote_v2.rs` (:215, :320) — call `emit_turn_item_started` then `emit_turn_item_completed` with `TurnItem::ContextCompaction`. `app-server/src/bespoke_event_handling.rs` forwards `ItemStarted` for **all** item types (`_ => true`, :939-969) and always forwards `ItemCompleted` (:980-995), while the deprecated `EventMsg::ContextCompacted` is **not** forwarded to v2 clients (:861-864).
2. **Binary**: the installed 0.144.3 binary's serde tables contain `contextCompaction` alongside the `item/started` / `item/completed` / `thread/compacted` method names.
3. **Rollout**: the session JSONL only carries atomic `compacted`/`context_compacted` persistence records — those are rollout fan-out, not the notification stream, so their shape doesn't contradict (1).

Wire shape: `{"type":"contextCompaction","id":String}`.

Mapping (new `compaction.rs` module — `event_mapper.rs` is over the 300-line ceiling):

- `item/started(contextCompaction)` → `on_compact_start()` → start pill
- `item/completed(contextCompaction)` → `on_compact()` → end pill
- Deduped per turn against the deprecated `thread/compacted` notification via a `compaction_emitted` gate (either path first → exactly one end pill; reset on `turn/started`), so old servers (notification only), new servers (item only), and any interleaving all behave.

### Codex: history parity

`ThreadItem::ContextCompaction` now converts to the same System message with a Compaction node that Claude's `compact_boundary` produces, so reloaded Codex transcripts show the "Context compacted" pill instead of silently dropping the item.

## Tests

- UI: new `ChatThread-compacting.test.tsx` (pill renders/unmounts/placement) + reducer run-end tests — 21/21 across the two touched files; typecheck clean
- Rust: 5 new event-mapper compaction tests (start+end exactly once, both dedupe orders, legacy-only, per-turn reset) + history conversion test with hardcoded expected content; full `mainframe-adapter-codex` crate green (116 tests); `clippy --all-targets -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)