### PR TITLE
codex: complete ThreadItem union + live sub-agent TaskCard streaming

### DIFF
--- a/.changeset/codex-subagent-reload-reconstruction.md
+++ b/.changeset/codex-subagent-reload-reconstruction.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': minor
+---
+
+Codex sub-agent (CollabAgent) work now streams into the TaskCard live and reload now reconstructs sub-agent file edits and MCP calls in addition to bash commands.

--- a/packages/core-rs/Cargo.lock
+++ b/packages/core-rs/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/packages/core-rs/Cargo.toml
+++ b/packages/core-rs/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors", "limit"] }
 serde = { version = "1", features = ["derive"] }

--- a/packages/core-rs/crates/mainframe-adapter-codex/Cargo.toml
+++ b/packages/core-rs/crates/mainframe-adapter-codex/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/child_tail.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/child_tail.rs
@@ -1,0 +1,115 @@
+//! Live-projection tail for a spawned sub-agent's rollout file.
+//!
+//! While a `CollabAgent` `wait` card is open, this polls the child's rollout
+//! JSONL and streams newly-appended items into the parent card via a
+//! `ParentIdSink`. Emissions here are transient live-projection only — nothing
+//! is persisted. Full reconstruction on reload goes through the same
+//! `read_rollout_items` path (B5); a daemon restart mid-wait simply drops the
+//! live tail and the next reload shows the same content via the reload path —
+//! by design, not a gap to fix here.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use mainframe_adapter_api::SessionSink;
+use tokio_util::sync::CancellationToken;
+
+use crate::event_mapper::ParentIdSink;
+use crate::history::{
+    bash_input, is_exec_error, reasoning_text, text_block, thinking_block, tool_result_block,
+    tool_use_block,
+};
+use crate::item_types::ThreadItem;
+use crate::rollout_reader::{RolloutReaderDeps, read_rollout_items};
+
+// One target file, watched for the lifetime of a single sub-agent wait. A
+// recursive fs-watch (notify/FSEvents) has already exhausted watch handles in
+// this codebase for a much smaller surface; a bounded poll on one path avoids
+// that class of bug entirely.
+const POLL_INTERVAL: Duration = Duration::from_millis(300);
+
+/// Spawns a background task that tails `rollout_path` for `child_thread_id` and
+/// streams newly-appended items into `sink`, tagged with `parent_tool_use_id`.
+/// The caller cancels `cancel` when the parent `wait` card closes; the task
+/// checks it both before polling (so a cancelled tail whose file never
+/// appeared exits promptly) and after polling but before emitting (so a
+/// completed wait never emits a late batch). `deps` overrides the
+/// `~/.codex/sessions` containment root — `None` in production, `Some(tempdir)`
+/// in tests, mirroring `read_rollout_items`'s own test seam.
+pub fn spawn_child_tail(
+    child_thread_id: String,
+    rollout_path: String,
+    sink: Arc<dyn SessionSink>,
+    parent_tool_use_id: String,
+    cancel: CancellationToken,
+    deps: Option<RolloutReaderDeps>,
+) -> tokio::task::JoinHandle<()> {
+    let wrapped: Arc<dyn SessionSink> = Arc::new(ParentIdSink::new(sink, parent_tool_use_id));
+    tokio::spawn(async move {
+        let mut emitted_count = 0usize;
+        let mut interval = tokio::time::interval(POLL_INTERVAL);
+        loop {
+            interval.tick().await;
+            if cancel.is_cancelled() {
+                return;
+            }
+            let items =
+                read_rollout_items(&rollout_path, Some(&child_thread_id), deps.as_ref()).await;
+            if cancel.is_cancelled() {
+                return;
+            }
+            if items.len() > emitted_count {
+                for item in &items[emitted_count..] {
+                    render_tail_item(item, &wrapped);
+                }
+                emitted_count = items.len();
+            }
+        }
+    })
+}
+
+/// Minimal per-variant rendering for the live tail — message/reasoning/exec are
+/// the only shapes `read_rollout_items` reconstructs today. Deliberately not
+/// `render_completed_item`: that function threads `CodexSessionState` through
+/// for collab-card/compaction bookkeeping that has no meaning on a raw tail.
+fn render_tail_item(item: &ThreadItem, sink: &Arc<dyn SessionSink>) {
+    match item {
+        ThreadItem::AgentMessage(m) => sink.on_message(vec![text_block(&m.text)], None),
+        ThreadItem::Reasoning(r) => {
+            let text = reasoning_text(&r.summary, &r.content);
+            sink.on_message(vec![thinking_block(&text)], None);
+        }
+        ThreadItem::CommandExecution(c) => {
+            sink.on_message(
+                vec![tool_use_block(&c.id, "Bash", bash_input(&c.command))],
+                None,
+            );
+            sink.on_tool_result(vec![tool_result_block(
+                &c.id,
+                &c.aggregated_output,
+                is_exec_error(c.exit_code),
+                None,
+            )]);
+        }
+        ThreadItem::FileChange(_)
+        | ThreadItem::McpToolCall(_)
+        | ThreadItem::WebSearch(_)
+        | ThreadItem::ImageGeneration(_)
+        | ThreadItem::TodoList(_)
+        | ThreadItem::UserMessage(_)
+        | ThreadItem::CollabAgentToolCall(_)
+        | ThreadItem::ContextCompaction(_)
+        | ThreadItem::SubAgentActivity(_)
+        | ThreadItem::DynamicToolCall(_)
+        | ThreadItem::EnteredReviewMode(_)
+        | ThreadItem::ExitedReviewMode(_)
+        | ThreadItem::ImageView(_)
+        | ThreadItem::Sleep(_)
+        | ThreadItem::HookPrompt(_) => {
+            tracing::debug!(
+                module = "codex:events",
+                "codex: child tail skipping an item shape rollout_reader doesn't reconstruct"
+            );
+        }
+    }
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
@@ -60,6 +60,9 @@ pub struct CodexSessionState {
     /// CollabAgent tool_use ids already resolved to an errored state by an
     /// `interrupted` `subAgentActivity` ping, ahead of the card's own completion.
     pub errored_collab_cards: HashSet<String>,
+    /// child thread id → the live rollout-tail task streaming that child's work
+    /// into the TaskCard, plus its cancellation handle (stopped on wait completion).
+    pub child_tails: HashMap<String, (tokio::task::JoinHandle<()>, tokio_util::sync::CancellationToken)>,
 }
 
 pub fn handle_notification(
@@ -217,10 +220,7 @@ fn handle_item_completed(
         .and_then(|tid| state.collab_child_threads.get(tid).cloned());
     let wrapped: Arc<dyn SessionSink>;
     let sink: &Arc<dyn SessionSink> = if let Some(pid) = parent_tool_use_id {
-        wrapped = Arc::new(ParentIdSink {
-            inner: sink.clone(),
-            parent: pid,
-        });
+        wrapped = Arc::new(ParentIdSink::new(sink.clone(), pid));
         &wrapped
     } else {
         sink
@@ -310,10 +310,17 @@ fn handle_token_usage(params: TokenUsageUpdatedParams, state: &mut CodexSessionS
 
 /// Wraps a sink to tag every emitted block with `parentToolUseId` (mirrors the TS
 /// `wrapSinkWithParentId`). Only `on_message`/`on_tool_result` are transformed;
-/// every other callback delegates unchanged.
-struct ParentIdSink {
+/// every other callback delegates unchanged. `pub(crate)` so `child_tail.rs` can
+/// wrap a raw sink before streaming reconstructed child items into it.
+pub(crate) struct ParentIdSink {
     inner: Arc<dyn SessionSink>,
     parent: String,
+}
+
+impl ParentIdSink {
+    pub(crate) fn new(inner: Arc<dyn SessionSink>, parent: String) -> Self {
+        Self { inner, parent }
+    }
 }
 
 impl SessionSink for ParentIdSink {

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
@@ -57,6 +57,9 @@ pub struct CodexSessionState {
     pub spawn_prompts: HashMap<String, String>,
     /// Per-turn dedupe: compact-done already emitted (item or legacy `thread/compacted` path).
     pub compaction_emitted: bool,
+    /// CollabAgent tool_use ids already resolved to an errored state by an
+    /// `interrupted` `subAgentActivity` ping, ahead of the card's own completion.
+    pub errored_collab_cards: HashSet<String>,
 }
 
 pub fn handle_notification(

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/event_mapper.rs
@@ -9,19 +9,17 @@ use std::sync::Arc;
 
 use mainframe_adapter_api::SessionSink;
 use mainframe_types::adapter::{MessageMetadata, MessageUsage, SessionResult};
-use mainframe_types::chat::{MessageContent, TodoItem, TodoStatus};
+use mainframe_types::chat::{MessageContent, TodoItem};
 use serde_json::Value;
 
-use crate::history::{
-    bash_input, collab_agent_tool_use, file_change_input, image_block, is_exec_error,
-    mcp_result_content, parse_unified_diff, reasoning_text, text_block, thinking_block,
-    tool_result_block, tool_use_block, with_parent,
-};
-use crate::item_types::{CollabAgentToolCallItem, ThreadItem, TodoListItem};
+use crate::history::with_parent;
+use crate::item_types::ThreadItem;
 use crate::quota_rate_limit::{
     has_recognized_window, normalize_rate_limit_snapshot, snapshot_has_window,
 };
-use crate::thread_registry::{agent_title, describe_agent, lookup_agent_metadata};
+use crate::thread_item_render::{
+    emit_collab_task_group_start, render_completed_item, stash_spawn_prompts,
+};
 use crate::types::{
     AccountRateLimitsUpdatedParams, ItemCompletedParams, ItemStartedParams, PlanDeltaParams,
     ThreadStartedParams, TokenUsageUpdatedParams, TurnCompletedParams, TurnStartedParams,
@@ -225,195 +223,32 @@ fn handle_item_completed(
         sink
     };
 
-    // Plan items arrive as a terminal `item/completed` with type === 'plan' (not
-    // part of the ThreadItem union) — branch defensively before typed dispatch.
-    let item = &params.item;
-    if item.get("type").and_then(|v| v.as_str()) == Some("plan")
-        && let (Some(text), Some(id)) = (
-            item.get("text").and_then(|v| v.as_str()),
-            item.get("id").and_then(|v| v.as_str()),
-        )
-    {
-        state.current_turn_plan = Some(CurrentTurnPlan {
-            id: id.to_string(),
-            text: text.to_string(),
-        });
+    if let Some((id, text)) = plan_item_fields(&params.item) {
+        state.current_turn_plan = Some(CurrentTurnPlan { id, text });
         return;
     }
 
-    let item: ThreadItem = match serde_json::from_value(params.item.clone()) {
-        Ok(i) => i,
+    match serde_json::from_value::<ThreadItem>(params.item.clone()) {
+        Ok(item) => render_completed_item(item, sink, state),
         Err(_) => {
             tracing::debug!(
                 module = "codex:events",
-                r#type = item.get("type").and_then(|v| v.as_str()).unwrap_or(""),
+                r#type = params.item.get("type").and_then(|v| v.as_str()).unwrap_or(""),
                 "codex: unhandled item type"
             );
-            return;
-        }
-    };
-
-    match item {
-        ThreadItem::AgentMessage(m) => sink.on_message(vec![text_block(&m.text)], None),
-        ThreadItem::Reasoning(r) => {
-            sink.on_message(
-                vec![thinking_block(&reasoning_text(&r.summary, &r.content))],
-                None,
-            );
-        }
-        ThreadItem::CommandExecution(c) => {
-            sink.on_message(
-                vec![tool_use_block(&c.id, "Bash", bash_input(&c.command))],
-                None,
-            );
-            sink.on_tool_result(vec![tool_result_block(
-                &c.id,
-                &c.aggregated_output,
-                is_exec_error(c.exit_code),
-                None,
-            )]);
-        }
-        ThreadItem::FileChange(f) => {
-            let is_completed = f.status != "inProgress";
-            let is_error = f.status == "failed" || f.status == "declined";
-            for (index, change) in f.changes.iter().enumerate() {
-                let tool_id = format!("{}:{}", f.id, index);
-                let is_add = matches!(change.kind, crate::item_types::PatchChangeKind::Add);
-                let tool_name = if is_add { "Write" } else { "Edit" };
-                let input = file_change_input(is_add, &change.path, &change.diff, &change.kind);
-                sink.on_message(vec![tool_use_block(&tool_id, tool_name, input)], None);
-                if is_completed {
-                    let sp = parse_unified_diff(&change.diff);
-                    let sp = if sp.is_empty() { None } else { Some(sp) };
-                    sink.on_tool_result(vec![tool_result_block(&tool_id, "OK", is_error, sp)]);
-                }
-            }
-        }
-        ThreadItem::ImageGeneration(img) => handle_image_generation(img, sink),
-        ThreadItem::CollabAgentToolCall(item) => handle_collab_completed(item, sink, state),
-        ThreadItem::McpToolCall(m) => {
-            let server = m.server.as_deref().unwrap_or("codex");
-            let tool_name = format!("mcp__{server}__{}", m.tool);
-            sink.on_message(
-                vec![tool_use_block(&m.id, &tool_name, m.arguments.clone())],
-                None,
-            );
-            let content =
-                mcp_result_content(m.result.as_ref().map(|r| &r.content), m.error.as_ref());
-            sink.on_tool_result(vec![tool_result_block(
-                &m.id,
-                &content,
-                m.error.is_some(),
-                None,
-            )]);
-        }
-        ThreadItem::TodoList(item) => {
-            let todos = normalize_todo_list_items(&item);
-            if !todos.is_empty() {
-                sink.on_todo_update(todos);
-            }
-        }
-        ThreadItem::ContextCompaction(_) => {
-            crate::compaction::handle_compaction_completed(sink, state);
-        }
-        _ => {
-            tracing::debug!(module = "codex:events", "codex: unhandled item type");
         }
     }
 }
 
-fn handle_image_generation(
-    img: crate::item_types::ImageGenerationItem,
-    sink: &Arc<dyn SessionSink>,
-) {
-    let prompt = img.revised_prompt.filter(|p| !p.is_empty());
-    if let Some(inline) = img.result {
-        let media = media_type_from_extension(img.saved_path.as_deref().unwrap_or(".png"));
-        emit_image(sink, prompt.as_deref(), &media, &inline);
-        return;
+/// Plan items arrive as a terminal `item/completed` with `type === "plan"` (not
+/// part of the ThreadItem union) — checked before typed dispatch.
+fn plan_item_fields(item: &Value) -> Option<(String, String)> {
+    if item.get("type").and_then(|v| v.as_str()) != Some("plan") {
+        return None;
     }
-    let Some(path) = img.saved_path else {
-        tracing::warn!(module = "codex:events", id = %img.id, "codex: imageGeneration missing both result and savedPath");
-        return;
-    };
-    // Read the saved image off disk asynchronously, then emit.
-    let sink = sink.clone();
-    tokio::spawn(async move {
-        match tokio::fs::read(&path).await {
-            Ok(bytes) => {
-                let media = media_type_from_extension(&path);
-                emit_image(&sink, prompt.as_deref(), &media, &base64_encode(&bytes));
-            }
-            Err(err) => {
-                tracing::warn!(module = "codex:events", err = %err, path, "codex: failed to read generated image");
-            }
-        }
-    });
-}
-
-fn emit_image(sink: &Arc<dyn SessionSink>, prompt: Option<&str>, media_type: &str, data: &str) {
-    let mut content: Vec<MessageContent> = vec![image_block(media_type, data)];
-    if let Some(p) = prompt {
-        content.insert(0, text_block(p));
-    }
-    sink.on_message(content, None);
-}
-
-fn handle_collab_completed(
-    item: CollabAgentToolCallItem,
-    sink: &Arc<dyn SessionSink>,
-    state: &mut CodexSessionState,
-) {
-    // `spawnAgent` is dispatch metadata only — stash its prompt for the `wait` card.
-    if item.tool == "spawnAgent" {
-        stash_spawn_prompts(&item, state);
-        return;
-    }
-    // `wait` is the renderable card — open it (if started didn't) and close with the result.
-    if !state.open_collab_cards.contains(&item.id) {
-        emit_collab_task_group_start(&item, sink, state);
-    }
-    let child_id = item
-        .receiver_thread_ids
-        .as_ref()
-        .and_then(|ids| ids.first());
-    let sub_agent_message = child_id
-        .and_then(|c| item.agents_states.as_ref().and_then(|s| s.get(c)))
-        .and_then(|s| s.message.clone());
-    let is_error = item.status == "failed" || item.status == "interrupted";
-    let content = sub_agent_message.unwrap_or_else(|| "Sub-agent completed".to_string());
-    sink.on_tool_result(vec![tool_result_block(&item.id, &content, is_error, None)]);
-    state.open_collab_cards.remove(&item.id);
-    // Stop routing further items from this spawn's child thread(s) and drop the prompt.
-    if let Some(children) = &item.receiver_thread_ids {
-        for cid in children {
-            state.collab_child_threads.remove(cid);
-            state.spawn_prompts.remove(cid);
-        }
-    }
-}
-
-fn stash_spawn_prompts(item: &CollabAgentToolCallItem, state: &mut CodexSessionState) {
-    if let (Some(children), Some(prompt)) = (&item.receiver_thread_ids, &item.prompt) {
-        for child_id in children {
-            state.spawn_prompts.insert(child_id.clone(), prompt.clone());
-        }
-    }
-}
-
-fn normalize_todo_list_items(item: &TodoListItem) -> Vec<TodoItem> {
-    item.items
-        .iter()
-        .map(|t| TodoItem {
-            content: t.text.clone(),
-            status: if t.completed {
-                TodoStatus::Completed
-            } else {
-                TodoStatus::Pending
-            },
-            active_form: t.text.clone(),
-        })
-        .collect()
+    let text = item.get("text").and_then(|v| v.as_str())?.to_string();
+    let id = item.get("id").and_then(|v| v.as_str())?.to_string();
+    Some((id, text))
 }
 
 fn handle_turn_completed(
@@ -468,68 +303,6 @@ fn handle_token_usage(params: TokenUsageUpdatedParams, state: &mut CodexSessionS
         output_tokens: params.usage.output_tokens,
         cache_read_input_tokens: params.usage.cached_input_tokens,
     });
-}
-
-fn media_type_from_extension(path: &str) -> String {
-    let ext = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        _ => "application/octet-stream",
-    }
-    .to_string()
-}
-
-fn emit_collab_task_group_start(
-    item: &CollabAgentToolCallItem,
-    sink: &Arc<dyn SessionSink>,
-    state: &mut CodexSessionState,
-) {
-    state.open_collab_cards.insert(item.id.clone());
-    // Register the spawned thread(s) so subsequent child items get tagged.
-    if let Some(children) = &item.receiver_thread_ids {
-        for child_id in children {
-            state
-                .collab_child_threads
-                .insert(child_id.clone(), item.id.clone());
-        }
-    }
-    let child_id = item
-        .receiver_thread_ids
-        .as_ref()
-        .and_then(|ids| ids.first());
-    // Same identity mapping as history.rs — subagent_type is the nickname,
-    // description is the spawn prompt (more informative than the bare role).
-    let meta = child_id.and_then(|c| lookup_agent_metadata(std::slice::from_ref(c)).remove(c));
-    let subagent_type = agent_title(meta.as_ref())
-        .or_else(|| describe_agent(meta.as_ref()))
-        .unwrap_or_else(|| "Sub-agent".to_string());
-    let prompt = child_id
-        .and_then(|c| state.spawn_prompts.get(c).cloned())
-        .or_else(|| item.prompt.clone())
-        .unwrap_or_default();
-    let description = describe_agent(meta.as_ref()).unwrap_or_else(|| {
-        if prompt.is_empty() {
-            subagent_type.clone()
-        } else {
-            prompt.clone()
-        }
-    });
-    sink.on_message(
-        vec![collab_agent_tool_use(
-            &item.id,
-            &prompt,
-            &description,
-            &subagent_type,
-        )],
-        None,
-    );
 }
 
 /// Wraps a sink to tag every emitted block with `parentToolUseId` (mirrors the TS
@@ -609,31 +382,6 @@ impl SessionSink for ParentIdSink {
     fn on_trust_required(&self, project_path: &str) {
         self.inner.on_trust_required(project_path);
     }
-}
-
-/// Minimal standard base64 encoder (no base64 crate in the allowlist), used only
-/// for the `imageGeneration` savedPath disk-read fallback.
-fn base64_encode(bytes: &[u8]) -> String {
-    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
-    for chunk in bytes.chunks(3) {
-        let b0 = chunk[0] as usize;
-        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
-        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
-        out.push(TABLE[b0 >> 2] as char);
-        out.push(TABLE[((b0 & 0x03) << 4) | (b1 >> 4)] as char);
-        out.push(if chunk.len() > 1 {
-            TABLE[((b1 & 0x0f) << 2) | (b2 >> 6)] as char
-        } else {
-            '='
-        });
-        out.push(if chunk.len() > 2 {
-            TABLE[b2 & 0x3f] as char
-        } else {
-            '='
-        });
-    }
-    out
 }
 
 // PORT STATUS: src/plugins/builtin/codex/event-mapper.ts (395 lines)

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/image_generation_render.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/image_generation_render.rs
@@ -1,0 +1,86 @@
+//! Renders a completed `imageGeneration` item, including the disk-read fallback
+//! for items that only carry a `savedPath`. Split out of `thread_item_render.rs`
+//! to keep that module under the 300-line ceiling.
+
+use std::sync::Arc;
+
+use mainframe_adapter_api::SessionSink;
+use mainframe_types::chat::MessageContent;
+
+use crate::history::{image_block, text_block};
+use crate::item_types::ImageGenerationItem;
+
+pub(crate) fn handle_image_generation(img: ImageGenerationItem, sink: &Arc<dyn SessionSink>) {
+    let prompt = img.revised_prompt.filter(|p| !p.is_empty());
+    if let Some(inline) = img.result {
+        let media = media_type_from_extension(img.saved_path.as_deref().unwrap_or(".png"));
+        emit_image(sink, prompt.as_deref(), &media, &inline);
+        return;
+    }
+    let Some(path) = img.saved_path else {
+        tracing::warn!(module = "codex:events", id = %img.id, "codex: imageGeneration missing both result and savedPath");
+        return;
+    };
+    // Read the saved image off disk asynchronously, then emit.
+    let sink = sink.clone();
+    tokio::spawn(async move {
+        match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let media = media_type_from_extension(&path);
+                emit_image(&sink, prompt.as_deref(), &media, &base64_encode(&bytes));
+            }
+            Err(err) => {
+                tracing::warn!(module = "codex:events", err = %err, path, "codex: failed to read generated image");
+            }
+        }
+    });
+}
+
+fn emit_image(sink: &Arc<dyn SessionSink>, prompt: Option<&str>, media_type: &str, data: &str) {
+    let mut content: Vec<MessageContent> = vec![image_block(media_type, data)];
+    if let Some(p) = prompt {
+        content.insert(0, text_block(p));
+    }
+    sink.on_message(content, None);
+}
+
+fn media_type_from_extension(path: &str) -> String {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
+
+/// Minimal standard base64 encoder (no base64 crate in the allowlist), used only
+/// for the `imageGeneration` savedPath disk-read fallback.
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
+        out.push(TABLE[b0 >> 2] as char);
+        out.push(TABLE[((b0 & 0x03) << 4) | (b1 >> 4)] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((b1 & 0x0f) << 2) | (b2 >> 6)] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[b2 & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
@@ -30,6 +30,13 @@ pub enum ThreadItem {
     UserMessage(UserMessageItem),
     CollabAgentToolCall(CollabAgentToolCallItem),
     ContextCompaction(ContextCompactionItem),
+    SubAgentActivity(SubAgentActivityItem),
+    DynamicToolCall(DynamicToolCallItem),
+    EnteredReviewMode(EnteredReviewModeItem),
+    ExitedReviewMode(ExitedReviewModeItem),
+    ImageView(ImageViewItem),
+    Sleep(SleepItem),
+    HookPrompt(HookPromptItem),
 }
 
 // PORT STATUS: src/plugins/builtin/codex/item-types.ts (119 lines)
@@ -42,3 +49,6 @@ pub enum ThreadItem {
 // notes: keeps `move_path` snake_case (Codex emits it snake) by NOT applying
 // notes: rename_all_fields. Internal to the crate (deserialize from Codex JSON-RPC),
 // notes: not daemon wire types.
+// notes: B1 (2026-07-24) added 7 variants Codex 0.144.3 introduced: subAgentActivity,
+// notes: dynamicToolCall, enteredReviewMode, exitedReviewMode, imageView, sleep,
+// notes: hookPrompt. event_mapper rendering for them is B2/B3, not this file.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/item_types.rs
@@ -1,19 +1,18 @@
 //! Ported from `packages/core/src/plugins/builtin/codex/item-types.ts`.
 //!
-//! `ThreadItem` union and all item-specific structs for the Codex protocol. These
-//! are INTERNAL to this crate (crate-map §2.8 `types.ts` note) — they deserialize
-//! from Codex app-server JSON-RPC payloads, so field names track Codex's camelCase
-//! (except `move_path`, which Codex emits snake_case) and unknown fields are
-//! tolerated (serde ignores them, matching the TS structural typing).
+//! `ThreadItem` union. INTERNAL to this crate (crate-map §2.8 `types.ts` note) —
+//! deserializes from Codex app-server JSON-RPC payloads, so variant tags track
+//! Codex's camelCase and unknown fields are tolerated (serde ignores them).
+//! Payload structs live in `thread_item_variants` (moved out to keep this file
+//! under the 300-line ceiling); re-exported here so existing `item_types::X` call
+//! sites keep compiling unchanged.
 
-use std::collections::HashMap;
-
-use serde::{Deserialize, Serialize};
+pub use crate::thread_item_variants::*;
 
 /// `ThreadItem` — the tagged union of every item type Codex streams. Statuses stay
 /// `String` (not enums) to mirror the TS string-literal comparisons and tolerate
 /// unknown Codex status values without failing the whole item.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(
     tag = "type",
     rename_all = "camelCase",
@@ -33,202 +32,13 @@ pub enum ThreadItem {
     ContextCompaction(ContextCompactionItem),
 }
 
-/// Bare compaction marker (Codex 0.144.3 v2): `{ "type": "contextCompaction", "id" }`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ContextCompactionItem {
-    pub id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentMessageItem {
-    pub id: String,
-    pub text: String,
-    pub phase: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReasoningItem {
-    pub id: String,
-    pub summary: Vec<String>,
-    pub content: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CommandExecutionItem {
-    pub id: String,
-    pub command: String,
-    pub aggregated_output: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i64>,
-    pub status: String,
-}
-
-/// Matches `PatchChangeKind` from the v2 schema (tagged union with optional
-/// `move_path`). Codex emits `move_path` snake_case, so the field is NOT renamed.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum PatchChangeKind {
-    Add,
-    Delete,
-    Update { move_path: Option<String> },
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FileChange {
-    pub path: String,
-    pub kind: PatchChangeKind,
-    pub diff: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FileChangeItem {
-    pub id: String,
-    pub changes: Vec<FileChange>,
-    /// `PatchApplyStatus` — kept `String` to mirror the TS string comparisons.
-    pub status: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct McpToolResult {
-    #[serde(default)]
-    pub content: serde_json::Value,
-    #[serde(default)]
-    pub structured_content: serde_json::Value,
-    #[serde(rename = "_meta", default)]
-    pub meta: serde_json::Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct CodexItemError {
-    pub message: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct McpToolCallItem {
-    pub id: String,
-    #[serde(default)]
-    pub server: Option<String>,
-    pub tool: String,
-    #[serde(default)]
-    pub arguments: HashMap<String, serde_json::Value>,
-    #[serde(default)]
-    pub result: Option<McpToolResult>,
-    #[serde(default)]
-    pub error: Option<CodexItemError>,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mcp_app_resource_uri: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration_ms: Option<i64>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WebSearchItem {
-    pub id: String,
-    pub query: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ImageGenerationItem {
-    pub id: String,
-    /// Base64-encoded image bytes (PNG). Always present in completed events.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<String>,
-    /// Filesystem path where Codex saved the generated image.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub saved_path: Option<String>,
-    /// The model's revised version of the user's prompt, if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub revised_prompt: Option<String>,
-    pub status: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TodoEntry {
-    pub text: String,
-    pub completed: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TodoListItem {
-    pub id: String,
-    pub items: Vec<TodoEntry>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UserContentBlock {
-    #[serde(rename = "type")]
-    pub kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text_elements: Option<Vec<serde_json::Value>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UserMessageItem {
-    pub id: String,
-    /// Codex 0.125 stores the prompt under `content[].text`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Vec<UserContentBlock>>,
-    /// Older variants may include a top-level `text` field; tolerate both.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentStateEntry {
-    pub status: String,
-    pub message: Option<String>,
-}
-
-/// Codex 0.125+ emits each sub-agent delegation as TWO `collabAgentToolCall`
-/// items: `tool: "spawnAgent"` (dispatch metadata; carries the prompt +
-/// `receiverThreadIds`) and `tool: "wait"` (the renderable card; carries the
-/// sub-agent output in `agentsStates[childThreadId].message`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CollabAgentToolCallItem {
-    pub id: String,
-    /// "spawnAgent" or "wait".
-    pub tool: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sender_thread_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub receiver_thread_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning_effort: Option<String>,
-    /// Per-child status snapshot. For `wait` items, contains the final `message`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub agents_states: Option<HashMap<String, AgentStateEntry>>,
-}
-
 // PORT STATUS: src/plugins/builtin/codex/item-types.ts (119 lines)
 // confidence: high
 // todos: 0
 // notes: ThreadItem is internally tagged on "type" with serde camelCase variant
 // notes: names (AgentMessage -> "agentMessage", etc.). Item statuses are String
 // notes: (not enums) to mirror the TS string-literal comparisons and tolerate
-// notes: unknown Codex status values. PatchChangeKind keeps `move_path` snake_case
-// notes: (Codex emits it snake) by NOT applying rename_all_fields. Internal to the
-// notes: crate (deserialize from Codex JSON-RPC), not daemon wire types.
+// notes: unknown Codex status values. PatchChangeKind (in thread_item_variants)
+// notes: keeps `move_path` snake_case (Codex emits it snake) by NOT applying
+// notes: rename_all_fields. Internal to the crate (deserialize from Codex JSON-RPC),
+// notes: not daemon wire types.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -19,6 +19,7 @@ pub mod event_mapper;
 pub mod external_session_parse;
 pub mod external_sessions;
 pub mod history;
+pub(crate) mod image_generation_render;
 pub mod item_types;
 pub mod jsonrpc;
 pub mod plan_mode_handler;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -27,6 +27,7 @@ pub mod quota_pull;
 pub mod quota_rate_limit;
 pub mod rollout_reader;
 pub mod session;
+pub(crate) mod thread_item_render;
 pub(crate) mod thread_item_variants;
 pub mod thread_registry;
 pub mod transcript;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -14,6 +14,9 @@
 
 pub mod adapter;
 pub mod approval_handler;
+// `pub`, not `pub(crate)`: `tests/child_tail.rs` exercises `spawn_child_tail`
+// directly as an integration test (no existing public entry point wraps it yet).
+pub mod child_tail;
 pub(crate) mod compaction;
 pub mod event_mapper;
 pub mod external_session_parse;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -27,6 +27,7 @@ pub mod quota_pull;
 pub mod quota_rate_limit;
 pub mod rollout_reader;
 pub mod session;
+pub(crate) mod thread_item_variants;
 pub mod thread_registry;
 pub mod transcript;
 pub mod turn_config;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/lib.rs
@@ -30,6 +30,7 @@ pub mod quota_identity;
 pub mod quota_pull;
 pub mod quota_rate_limit;
 pub mod rollout_reader;
+pub(crate) mod rollout_reconstruct;
 pub mod session;
 pub(crate) mod thread_item_render;
 pub(crate) mod thread_item_variants;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reader.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reader.rs
@@ -18,8 +18,15 @@ use crate::item_types::{
 
 /// Only paths inside `~/.codex/sessions` are allowed — `rollout_path` comes from an
 /// externally-owned SQLite DB so we treat it as untrusted input.
-fn sessions_root() -> Option<PathBuf> {
+fn default_sessions_root() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".codex").join("sessions"))
+}
+
+/// Injectable containment root — mirrors `transcript::CodexTranscriptDeps`, letting
+/// tests point at a temp dir instead of the real `~/.codex/sessions`.
+#[derive(Debug, Clone, Default)]
+pub struct RolloutReaderDeps {
+    pub sessions_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,6 +71,7 @@ struct RolloutLine {
 pub async fn read_rollout_items(
     rollout_path: &str,
     expected_thread_id: Option<&str>,
+    deps: Option<&RolloutReaderDeps>,
 ) -> Vec<ThreadItem> {
     // Resolve symlinks and ensure the file lives inside ~/.codex/sessions/.
     let resolved = match tokio::fs::canonicalize(rollout_path).await {
@@ -73,9 +81,17 @@ pub async fn read_rollout_items(
             return Vec::new();
         }
     };
-    let Some(root) = sessions_root() else {
+    let Some(root) = deps
+        .and_then(|d| d.sessions_root.clone())
+        .or_else(default_sessions_root)
+    else {
         return Vec::new();
     };
+    // `canonicalize` the root too — on macOS a tempdir (or `~`) path routes through a
+    // `/var` -> `/private/var` symlink, so comparing it as-is against the already
+    // resolved file path would spuriously fail containment. Fall back to the raw
+    // root if it doesn't exist yet (e.g. tests asserting containment on `nope/`).
+    let root = tokio::fs::canonicalize(&root).await.unwrap_or(root);
     if !resolved.starts_with(&root) {
         tracing::warn!(
             module = "codex:rollout",

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reader.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reader.rs
@@ -6,14 +6,23 @@
 //! ResponseItem the agent processed (function_call, function_call_output, message,
 //! reasoning), unlike `thread/read` which filters child-thread `commandExecution`s
 //! out. We only use it for SUB-AGENT child threads on history reload.
+//!
+//! B5 extends this beyond `exec_command`: sub-agent file edits arrive as a
+//! `custom_tool_call`/`custom_tool_call_output` pair (`name: "apply_patch"`), and
+//! MCP calls arrive as `function_call`/`function_call_output` tagged with a
+//! `namespace` starting `mcp__`. The parsing/building logic for both (plus the
+//! pre-existing exec-output parsing) lives in `rollout_reconstruct` to keep this
+//! file under the 300-line ceiling.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::Deserialize;
 
-use crate::item_types::{
-    AgentMessageItem, CommandExecutionItem, ReasoningItem, ThreadItem, UserMessageItem,
+use crate::item_types::{AgentMessageItem, ReasoningItem, ThreadItem, UserMessageItem};
+use crate::rollout_reconstruct::{
+    PendingMcp, handle_custom_tool_call, handle_custom_tool_call_output, handle_function_call,
+    handle_function_call_output,
 };
 
 /// Only paths inside `~/.codex/sessions` are allowed — `rollout_path` comes from an
@@ -38,7 +47,7 @@ struct RolloutContent {
 }
 
 #[derive(Debug, Deserialize)]
-struct RolloutPayload {
+pub(crate) struct RolloutPayload {
     #[serde(rename = "type", default)]
     kind: Option<String>,
     #[serde(default)]
@@ -46,15 +55,22 @@ struct RolloutPayload {
     #[serde(default)]
     content: Option<Vec<RolloutContent>>,
     #[serde(default)]
-    name: Option<String>,
+    pub(crate) name: Option<String>,
     #[serde(default)]
-    arguments: Option<String>,
+    pub(crate) arguments: Option<String>,
     #[serde(default)]
-    call_id: Option<String>,
+    pub(crate) call_id: Option<String>,
     #[serde(default)]
-    output: Option<String>,
+    pub(crate) output: Option<String>,
     #[serde(default)]
     summary: Option<Vec<RolloutContent>>,
+    /// Present on MCP `function_call` records (e.g. `"mcp__testserver"`); absent
+    /// (not just empty) on `exec_command` and other builtin tool calls.
+    #[serde(default)]
+    pub(crate) namespace: Option<String>,
+    /// The apply_patch envelope on a `custom_tool_call` record.
+    #[serde(default)]
+    pub(crate) input: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,27 +82,44 @@ struct RolloutLine {
 }
 
 /// Read a rollout JSONL and return `ThreadItem`s in the same shape as
-/// `thread/read`, but with `commandExecution` items reconstructed from the raw
-/// `function_call` / `function_call_output` records.
+/// `thread/read`, but with `commandExecution`/`fileChange`/`mcpToolCall` items
+/// reconstructed from the raw request/response record pairs.
 pub async fn read_rollout_items(
     rollout_path: &str,
     expected_thread_id: Option<&str>,
     deps: Option<&RolloutReaderDeps>,
 ) -> Vec<ThreadItem> {
-    // Resolve symlinks and ensure the file lives inside ~/.codex/sessions/.
+    let Some(resolved) = resolve_rollout_path(rollout_path, expected_thread_id, deps).await else {
+        return Vec::new();
+    };
+    let raw = match tokio::fs::read_to_string(&resolved).await {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(module = "codex:rollout", err = %err, rollout_path, "codex: failed to read rollout file");
+            return Vec::new();
+        }
+    };
+    parse_rollout_lines(&raw)
+}
+
+/// Resolves symlinks, then enforces two invariants before we trust `rollout_path`
+/// (untrusted input from an externally-owned SQLite DB): it must live inside
+/// `~/.codex/sessions/`, and its filename must embed `expected_thread_id`.
+async fn resolve_rollout_path(
+    rollout_path: &str,
+    expected_thread_id: Option<&str>,
+    deps: Option<&RolloutReaderDeps>,
+) -> Option<PathBuf> {
     let resolved = match tokio::fs::canonicalize(rollout_path).await {
         Ok(p) => p,
         Err(err) => {
             tracing::warn!(module = "codex:rollout", err = %err, rollout_path, "codex: rollout file not found");
-            return Vec::new();
+            return None;
         }
     };
-    let Some(root) = deps
+    let root = deps
         .and_then(|d| d.sessions_root.clone())
-        .or_else(default_sessions_root)
-    else {
-        return Vec::new();
-    };
+        .or_else(default_sessions_root)?;
     // `canonicalize` the root too — on macOS a tempdir (or `~`) path routes through a
     // `/var` -> `/private/var` symlink, so comparing it as-is against the already
     // resolved file path would spuriously fail containment. Fall back to the raw
@@ -99,9 +132,8 @@ pub async fn read_rollout_items(
             resolved = %resolved.display(),
             "codex: rollout path outside ~/.codex/sessions, refusing to read"
         );
-        return Vec::new();
+        return None;
     }
-    // Sanity: the rollout filename should embed the thread id.
     if let Some(expected) = expected_thread_id
         && !resolved.to_string_lossy().contains(expected)
     {
@@ -111,20 +143,21 @@ pub async fn read_rollout_items(
             expected_thread_id = expected,
             "codex: rollout filename does not match thread id, refusing to read"
         );
-        return Vec::new();
+        return None;
     }
+    Some(resolved)
+}
 
-    let raw = match tokio::fs::read_to_string(&resolved).await {
-        Ok(s) => s,
-        Err(err) => {
-            tracing::warn!(module = "codex:rollout", err = %err, rollout_path, "codex: failed to read rollout file");
-            return Vec::new();
-        }
-    };
-
+/// Walks the JSONL, dispatching each `response_item` payload to its handler.
+/// Each record kind gets its own pending map — call_id spaces from
+/// exec_command, MCP function_calls, and apply_patch custom_tool_calls are not
+/// guaranteed disjoint, and a bug in one pairing lifecycle must not be able to
+/// steal or corrupt another kind's pending entry.
+fn parse_rollout_lines(raw: &str) -> Vec<ThreadItem> {
     let mut items: Vec<ThreadItem> = Vec::new();
-    // Track function_call records by call_id so we can pair them with outputs.
     let mut pending_exec: HashMap<String, String> = HashMap::new();
+    let mut pending_mcp: HashMap<String, PendingMcp> = HashMap::new();
+    let mut pending_patch: HashMap<String, String> = HashMap::new();
     let mut counter = 0usize;
 
     for line in raw.split('\n') {
@@ -138,97 +171,84 @@ pub async fn read_rollout_items(
             continue;
         }
         let Some(p) = rec.payload else { continue };
-        let ptype = p.kind.as_deref();
-
-        // ─── Messages ──────────────────────────────────────────────────────────
-        if ptype == Some("message")
-            && let Some(content) = &p.content
-        {
-            let text: String = content
-                .iter()
-                .filter(|c| matches!(c.kind.as_deref(), Some("output_text") | Some("input_text")))
-                .map(|c| c.text.clone().unwrap_or_default())
-                .collect();
-            if text.is_empty() {
-                continue;
-            }
-            match p.role.as_deref() {
-                Some("assistant") => {
-                    let id = next_id(&mut counter);
-                    items.push(ThreadItem::AgentMessage(AgentMessageItem {
-                        id,
-                        text,
-                        phase: None,
-                    }));
-                }
-                Some("user") => {
-                    let id = next_id(&mut counter);
-                    items.push(ThreadItem::UserMessage(UserMessageItem {
-                        id,
-                        content: None,
-                        text: Some(text),
-                    }));
-                }
-                _ => {}
-            }
-            continue;
-        }
-
-        // ─── Reasoning ─────────────────────────────────────────────────────────
-        if ptype == Some("reasoning")
-            && let Some(summary_blocks) = &p.summary
-        {
-            let summary: Vec<String> = summary_blocks
-                .iter()
-                .map(|s| s.text.clone().unwrap_or_default())
-                .filter(|t| !t.is_empty())
-                .collect();
-            if summary.is_empty() {
-                continue;
-            }
-            let id = next_id(&mut counter);
-            items.push(ThreadItem::Reasoning(ReasoningItem {
-                id,
-                summary,
-                content: Vec::new(),
-            }));
-            continue;
-        }
-
-        // ─── Bash exec (function_call → exec_command) ──────────────────────────
-        if ptype == Some("function_call") && p.name.as_deref() == Some("exec_command") {
-            if let (Some(call_id), Some(arguments)) = (&p.call_id, &p.arguments)
-                && let Ok(args) = serde_json::from_str::<serde_json::Value>(arguments)
-                && let Some(cmd) = args.get("cmd").and_then(|v| v.as_str())
-            {
-                pending_exec.insert(call_id.clone(), cmd.to_string());
-            }
-            continue;
-        }
-
-        if ptype == Some("function_call_output")
-            && let Some(call_id) = &p.call_id
-        {
-            let Some(command) = pending_exec.remove(call_id) else {
-                continue;
-            };
-            let (exit_code, output) = parse_rollout_output(p.output.as_deref().unwrap_or(""));
-            items.push(ThreadItem::CommandExecution(CommandExecutionItem {
-                id: call_id.clone(),
-                command,
-                aggregated_output: output,
-                exit_code: Some(exit_code),
-                status: if exit_code == 0 {
-                    "completed".to_string()
-                } else {
-                    "failed".to_string()
-                },
-            }));
-            continue;
-        }
+        apply_rollout_payload(
+            &p,
+            &mut counter,
+            &mut pending_exec,
+            &mut pending_mcp,
+            &mut pending_patch,
+            &mut items,
+        );
     }
 
     items
+}
+
+fn apply_rollout_payload(
+    p: &RolloutPayload,
+    counter: &mut usize,
+    pending_exec: &mut HashMap<String, String>,
+    pending_mcp: &mut HashMap<String, PendingMcp>,
+    pending_patch: &mut HashMap<String, String>,
+    items: &mut Vec<ThreadItem>,
+) {
+    match p.kind.as_deref() {
+        Some("message") => handle_message(p, counter, items),
+        Some("reasoning") => handle_reasoning(p, counter, items),
+        Some("function_call") => handle_function_call(p, pending_exec, pending_mcp),
+        Some("function_call_output") => {
+            handle_function_call_output(p, pending_exec, pending_mcp, items);
+        }
+        Some("custom_tool_call") => handle_custom_tool_call(p, pending_patch),
+        Some("custom_tool_call_output") => {
+            handle_custom_tool_call_output(p, pending_patch, items);
+        }
+        _ => {}
+    }
+}
+
+fn handle_message(p: &RolloutPayload, counter: &mut usize, items: &mut Vec<ThreadItem>) {
+    let Some(content) = &p.content else { return };
+    let text: String = content
+        .iter()
+        .filter(|c| matches!(c.kind.as_deref(), Some("output_text") | Some("input_text")))
+        .map(|c| c.text.clone().unwrap_or_default())
+        .collect();
+    if text.is_empty() {
+        return;
+    }
+    match p.role.as_deref() {
+        Some("assistant") => items.push(ThreadItem::AgentMessage(AgentMessageItem {
+            id: next_id(counter),
+            text,
+            phase: None,
+        })),
+        Some("user") => items.push(ThreadItem::UserMessage(UserMessageItem {
+            id: next_id(counter),
+            content: None,
+            text: Some(text),
+        })),
+        _ => {}
+    }
+}
+
+fn handle_reasoning(p: &RolloutPayload, counter: &mut usize, items: &mut Vec<ThreadItem>) {
+    let Some(summary_blocks) = &p.summary else {
+        return;
+    };
+    let summary: Vec<String> = summary_blocks
+        .iter()
+        .map(|s| s.text.clone().unwrap_or_default())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if summary.is_empty() {
+        return;
+    }
+    items.push(ThreadItem::Reasoning(ReasoningItem {
+        id: next_id(counter),
+        summary,
+        content: Vec::new(),
+    }));
 }
 
 fn next_id(counter: &mut usize) -> String {
@@ -237,63 +257,13 @@ fn next_id(counter: &mut usize) -> String {
     id
 }
 
-/// Parse Codex's function_call_output payload. The string starts with a header
-/// (`Chunk ID`, `Wall time`, `Process exited with code N`, ...`Output:\n<output>`).
-/// Extract the exit code and strip the header.
-fn parse_rollout_output(raw: &str) -> (i64, String) {
-    let exit_code = raw
-        .lines()
-        .find_map(|l| l.strip_prefix("Process exited with code "))
-        .and_then(|rest| {
-            let digits: String = rest
-                .chars()
-                .take_while(|c| c.is_ascii_digit() || *c == '-')
-                .collect();
-            digits.parse::<i64>().ok()
-        })
-        .unwrap_or(0);
-    let marker = "\nOutput:\n";
-    let output = match raw.find(marker) {
-        Some(idx) => raw[idx + marker.len()..].to_string(),
-        None => raw.to_string(),
-    };
-    (exit_code, output)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_rollout_output_extracts_exit_and_strips_header() {
-        let raw = "Chunk ID: f71ecd\nWall time: 0.0 seconds\nProcess exited with code 0\nOutput:\nhello world";
-        let (code, out) = parse_rollout_output(raw);
-        assert_eq!(code, 0);
-        assert_eq!(out, "hello world");
-    }
-
-    #[test]
-    fn parse_rollout_output_nonzero_exit() {
-        let raw = "Process exited with code 127\nOutput:\nnot found";
-        let (code, out) = parse_rollout_output(raw);
-        assert_eq!(code, 127);
-        assert_eq!(out, "not found");
-    }
-
-    #[test]
-    fn parse_rollout_output_no_marker_returns_raw() {
-        let raw = "bare output";
-        let (code, out) = parse_rollout_output(raw);
-        assert_eq!(code, 0);
-        assert_eq!(out, "bare output");
-    }
-}
-
 // PORT STATUS: src/plugins/builtin/codex/rollout-reader.ts (167 lines)
 // confidence: high
 // todos: 0
 // notes: async tokio fs (canonicalize/read_to_string) mirrors the TS realpath +
-// notes: readFile. The `^Process exited with code (-?\d+)` regex is hand-rolled
-// notes: (no regex crate) as a line-prefix scan. SESSIONS_ROOT containment check
-// notes: uses PathBuf::starts_with on the canonicalized path. Added 3 unit tests
-// notes: for parse_rollout_output (no TS test file exists for this module).
+// notes: readFile. SESSIONS_ROOT containment check uses PathBuf::starts_with on
+// notes: the canonicalized path. B5 (2026-07-24) added apply_patch
+// notes: (custom_tool_call/custom_tool_call_output) and MCP (function_call with
+// notes: an mcp__* namespace) reconstruction; parse_rollout_output and its 3
+// notes: unit tests moved to rollout_reconstruct.rs alongside the new pure
+// notes: parsing helpers to keep this file under the 300-line ceiling.

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reconstruct.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/rollout_reconstruct.rs
@@ -1,0 +1,278 @@
+//! B5 reconstruction for `rollout_reader::read_rollout_items`: turning a paired
+//! `custom_tool_call`/`custom_tool_call_output` (apply_patch) or a
+//! `function_call`/`function_call_output` tagged with an `mcp__*` namespace back
+//! into a `FileChange`/`McpToolCall` item, plus the per-record-kind `handle_*`
+//! dispatch functions themselves. Split out from `rollout_reader.rs`, which owns
+//! the JSONL walk and the `pending_*` maps it threads through these handlers, to
+//! keep both files under the 300-line ceiling.
+
+use std::collections::HashMap;
+
+use crate::item_types::{
+    CommandExecutionItem, FileChange, FileChangeItem, McpToolCallItem, McpToolResult,
+    PatchChangeKind, ThreadItem,
+};
+use crate::rollout_reader::RolloutPayload;
+
+/// A `function_call` identified as an MCP call (`namespace` starts with
+/// `mcp__`), stashed until its matching `function_call_output` arrives.
+pub(crate) struct PendingMcp {
+    pub server: String,
+    pub tool: String,
+    pub arguments: HashMap<String, serde_json::Value>,
+}
+
+/// Codex encodes MCP arguments as a JSON string; a malformed one is kept as raw
+/// text under an `"arguments"` key rather than dropping the whole tool call —
+/// mirrors `dynamic_tool_call_input` in `thread_item_render.rs`, which wraps
+/// non-object argument values the same way.
+pub(crate) fn mcp_arguments_map(raw: &str) -> HashMap<String, serde_json::Value> {
+    let value =
+        serde_json::from_str(raw).unwrap_or_else(|_| serde_json::Value::String(raw.to_string()));
+    match value.as_object() {
+        Some(map) => map.clone().into_iter().collect(),
+        None => HashMap::from([("arguments".to_string(), value)]),
+    }
+}
+
+/// The rollout only gives a raw output string, not the structured
+/// `McpToolResult` a live MCP response carries — stash it as-is in `content`.
+pub(crate) fn build_mcp_tool_call_item(call_id: &str, pending: PendingMcp, output: &str) -> ThreadItem {
+    let result = McpToolResult {
+        content: serde_json::Value::String(output.to_string()),
+        structured_content: serde_json::Value::Null,
+        meta: serde_json::Value::Null,
+    };
+    ThreadItem::McpToolCall(McpToolCallItem {
+        id: call_id.to_string(),
+        server: Some(pending.server),
+        tool: pending.tool,
+        arguments: pending.arguments,
+        result: Some(result),
+        error: None,
+        status: "completed".to_string(),
+        mcp_app_resource_uri: None,
+        duration_ms: None,
+    })
+}
+
+struct PatchFileBlock {
+    path: String,
+    kind: PatchChangeKind,
+    diff: String,
+}
+
+/// Splits an `apply_patch` envelope on its `*** {Add|Update|Delete} File:`
+/// headers; everything up to the next header (or `*** End Patch`) is that
+/// file's diff/content block.
+fn parse_apply_patch_envelope(input: &str) -> Vec<PatchFileBlock> {
+    let mut blocks = Vec::new();
+    let mut current: Option<(String, PatchChangeKind, Vec<&str>)> = None;
+    for line in input.lines() {
+        if let Some(path) = line.strip_prefix("*** Update File: ") {
+            flush_patch_block(&mut blocks, &mut current);
+            let kind = PatchChangeKind::Update { move_path: None };
+            current = Some((path.to_string(), kind, Vec::new()));
+        } else if let Some(path) = line.strip_prefix("*** Add File: ") {
+            flush_patch_block(&mut blocks, &mut current);
+            current = Some((path.to_string(), PatchChangeKind::Add, Vec::new()));
+        } else if let Some(path) = line.strip_prefix("*** Delete File: ") {
+            flush_patch_block(&mut blocks, &mut current);
+            current = Some((path.to_string(), PatchChangeKind::Delete, Vec::new()));
+        } else if line == "*** End Patch" {
+            flush_patch_block(&mut blocks, &mut current);
+        } else if let Some((_, _, body)) = current.as_mut() {
+            body.push(line);
+        }
+    }
+    flush_patch_block(&mut blocks, &mut current);
+    blocks
+}
+
+fn flush_patch_block(
+    blocks: &mut Vec<PatchFileBlock>,
+    current: &mut Option<(String, PatchChangeKind, Vec<&str>)>,
+) {
+    if let Some((path, kind, body)) = current.take() {
+        blocks.push(PatchFileBlock {
+            path,
+            kind,
+            diff: body.join("\n"),
+        });
+    }
+}
+
+/// Mirrors `rollout_reader::parse_rollout_output`'s exit-code scan but against
+/// apply_patch's own header shape (`Exit code: N`, not `Process exited with
+/// code N`), plus the textual success marker Codex also emits.
+fn custom_tool_call_succeeded(output: &str) -> bool {
+    let exit_zero = output
+        .lines()
+        .find_map(|l| l.strip_prefix("Exit code: "))
+        .and_then(|rest| rest.trim().parse::<i64>().ok())
+        .map(|code| code == 0)
+        .unwrap_or(false);
+    exit_zero || output.contains("Success. Updated the following files:")
+}
+
+pub(crate) fn build_file_change_item(call_id: &str, input: &str, output: &str) -> ThreadItem {
+    let changes = parse_apply_patch_envelope(input)
+        .into_iter()
+        .map(|b| FileChange {
+            path: b.path,
+            kind: b.kind,
+            diff: b.diff,
+        })
+        .collect();
+    let status = if custom_tool_call_succeeded(output) {
+        "completed"
+    } else {
+        "failed"
+    };
+    ThreadItem::FileChange(FileChangeItem {
+        id: call_id.to_string(),
+        changes,
+        status: status.to_string(),
+    })
+}
+
+/// Stashes an `exec_command` call's shell command, or an MCP call's
+/// server/tool/arguments, keyed by `call_id` for the matching output below.
+/// Anything else (update_plan, write_stdin, collaboration's
+/// spawnAgent/wait/sendMessage) is handled elsewhere or genuinely out of scope
+/// here — its call_id stays unregistered so the matching output is silently
+/// ignored, unchanged from before B5.
+pub(crate) fn handle_function_call(
+    p: &RolloutPayload,
+    pending_exec: &mut HashMap<String, String>,
+    pending_mcp: &mut HashMap<String, PendingMcp>,
+) {
+    if p.name.as_deref() == Some("exec_command") {
+        if let (Some(call_id), Some(arguments)) = (&p.call_id, &p.arguments)
+            && let Ok(args) = serde_json::from_str::<serde_json::Value>(arguments)
+            && let Some(cmd) = args.get("cmd").and_then(|v| v.as_str())
+        {
+            pending_exec.insert(call_id.clone(), cmd.to_string());
+        }
+        return;
+    }
+    if let (Some(call_id), Some(name), Some(server)) = (
+        &p.call_id,
+        &p.name,
+        p.namespace.as_deref().and_then(|ns| ns.strip_prefix("mcp__")),
+    ) {
+        let arguments = mcp_arguments_map(p.arguments.as_deref().unwrap_or(""));
+        pending_mcp.insert(
+            call_id.clone(),
+            PendingMcp {
+                server: server.to_string(),
+                tool: name.clone(),
+                arguments,
+            },
+        );
+    }
+}
+
+pub(crate) fn handle_function_call_output(
+    p: &RolloutPayload,
+    pending_exec: &mut HashMap<String, String>,
+    pending_mcp: &mut HashMap<String, PendingMcp>,
+    items: &mut Vec<ThreadItem>,
+) {
+    let Some(call_id) = &p.call_id else { return };
+    let output = p.output.as_deref().unwrap_or("");
+    if let Some(command) = pending_exec.remove(call_id) {
+        let (exit_code, output) = parse_rollout_output(output);
+        items.push(ThreadItem::CommandExecution(CommandExecutionItem {
+            id: call_id.clone(),
+            command,
+            aggregated_output: output,
+            exit_code: Some(exit_code),
+            status: if exit_code == 0 {
+                "completed".to_string()
+            } else {
+                "failed".to_string()
+            },
+        }));
+    } else if let Some(pending) = pending_mcp.remove(call_id) {
+        items.push(build_mcp_tool_call_item(call_id, pending, output));
+    }
+}
+
+pub(crate) fn handle_custom_tool_call(
+    p: &RolloutPayload,
+    pending_patch: &mut HashMap<String, String>,
+) {
+    if p.name.as_deref() == Some("apply_patch")
+        && let (Some(call_id), Some(input)) = (&p.call_id, &p.input)
+    {
+        pending_patch.insert(call_id.clone(), input.clone());
+    }
+}
+
+pub(crate) fn handle_custom_tool_call_output(
+    p: &RolloutPayload,
+    pending_patch: &mut HashMap<String, String>,
+    items: &mut Vec<ThreadItem>,
+) {
+    let Some(call_id) = &p.call_id else { return };
+    let Some(input) = pending_patch.remove(call_id) else {
+        return;
+    };
+    let output = p.output.as_deref().unwrap_or("");
+    items.push(build_file_change_item(call_id, &input, output));
+}
+
+/// Parse Codex's function_call_output payload. The string starts with a header
+/// (`Chunk ID`, `Wall time`, `Process exited with code N`, ...`Output:\n<output>`).
+/// Extract the exit code and strip the header. Moved here (from
+/// `rollout_reader.rs`) alongside the other pure record-parsing helpers to keep
+/// that file under the 300-line ceiling.
+pub(crate) fn parse_rollout_output(raw: &str) -> (i64, String) {
+    let exit_code = raw
+        .lines()
+        .find_map(|l| l.strip_prefix("Process exited with code "))
+        .and_then(|rest| {
+            let digits: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_digit() || *c == '-')
+                .collect();
+            digits.parse::<i64>().ok()
+        })
+        .unwrap_or(0);
+    let marker = "\nOutput:\n";
+    let output = match raw.find(marker) {
+        Some(idx) => raw[idx + marker.len()..].to_string(),
+        None => raw.to_string(),
+    };
+    (exit_code, output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rollout_output_extracts_exit_and_strips_header() {
+        let raw = "Chunk ID: f71ecd\nWall time: 0.0 seconds\nProcess exited with code 0\nOutput:\nhello world";
+        let (code, out) = parse_rollout_output(raw);
+        assert_eq!(code, 0);
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn parse_rollout_output_nonzero_exit() {
+        let raw = "Process exited with code 127\nOutput:\nnot found";
+        let (code, out) = parse_rollout_output(raw);
+        assert_eq!(code, 127);
+        assert_eq!(out, "not found");
+    }
+
+    #[test]
+    fn parse_rollout_output_no_marker_returns_raw() {
+        let raw = "bare output";
+        let (code, out) = parse_rollout_output(raw);
+        assert_eq!(code, 0);
+        assert_eq!(out, "bare output");
+    }
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/session.rs
@@ -827,7 +827,7 @@ async fn load_history_inner(
             .get(child_id)
             .and_then(|m| m.rollout_path.clone());
         if let Some(rollout_path) = rollout_path {
-            let items = read_rollout_items(&rollout_path, Some(child_id)).await;
+            let items = read_rollout_items(&rollout_path, Some(child_id), None).await;
             if !items.is_empty() {
                 child_items_by_thread.insert(child_id.clone(), items);
                 continue;

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
@@ -17,7 +17,7 @@ use crate::history::{
 use crate::image_generation_render::handle_image_generation;
 use crate::item_types::{
     CollabAgentToolCallItem, CommandExecutionItem, DynamicToolCallItem, FileChangeItem,
-    McpToolCallItem, ReasoningItem, ThreadItem, TodoListItem,
+    McpToolCallItem, ReasoningItem, SubAgentActivityItem, ThreadItem, TodoListItem,
 };
 use crate::thread_registry::{agent_title, describe_agent, lookup_agent_metadata};
 
@@ -47,9 +47,7 @@ pub(crate) fn render_completed_item(
         ThreadItem::ImageView(_) => skip_item("imageView"),
         ThreadItem::Sleep(_) => skip_item("sleep"),
         ThreadItem::HookPrompt(_) => skip_item("hookPrompt"),
-        // TaskCard rendering for sub-agent activity pings is B3 territory; this
-        // placeholder only exists to keep the match exhaustive.
-        ThreadItem::SubAgentActivity(_) => {}
+        ThreadItem::SubAgentActivity(a) => handle_sub_agent_activity(&a, sink, state),
         ThreadItem::WebSearch(_) | ThreadItem::UserMessage(_) => {
             tracing::debug!(module = "codex:events", "codex: unhandled item type");
         }
@@ -170,20 +168,24 @@ fn handle_collab_completed(
         stash_spawn_prompts(&item, state);
         return;
     }
-    // `wait` is the renderable card — open it (if started didn't) and close with the result.
-    if !state.open_collab_cards.contains(&item.id) {
-        emit_collab_task_group_start(&item, sink, state);
+    // An `interrupted` subAgentActivity ping may have already closed this card with
+    // an error result; don't re-open the start block or double-emit the result.
+    let already_errored = state.errored_collab_cards.remove(&item.id);
+    if !already_errored {
+        if !state.open_collab_cards.contains(&item.id) {
+            emit_collab_task_group_start(&item, sink, state);
+        }
+        let child_id = item
+            .receiver_thread_ids
+            .as_ref()
+            .and_then(|ids| ids.first());
+        let sub_agent_message = child_id
+            .and_then(|c| item.agents_states.as_ref().and_then(|s| s.get(c)))
+            .and_then(|s| s.message.clone());
+        let is_error = item.status == "failed" || item.status == "interrupted";
+        let content = sub_agent_message.unwrap_or_else(|| "Sub-agent completed".to_string());
+        sink.on_tool_result(vec![tool_result_block(&item.id, &content, is_error, None)]);
     }
-    let child_id = item
-        .receiver_thread_ids
-        .as_ref()
-        .and_then(|ids| ids.first());
-    let sub_agent_message = child_id
-        .and_then(|c| item.agents_states.as_ref().and_then(|s| s.get(c)))
-        .and_then(|s| s.message.clone());
-    let is_error = item.status == "failed" || item.status == "interrupted";
-    let content = sub_agent_message.unwrap_or_else(|| "Sub-agent completed".to_string());
-    sink.on_tool_result(vec![tool_result_block(&item.id, &content, is_error, None)]);
     state.open_collab_cards.remove(&item.id);
     // Stop routing further items from this spawn's child thread(s) and drop the prompt.
     if let Some(children) = &item.receiver_thread_ids {
@@ -192,6 +194,39 @@ fn handle_collab_completed(
             state.spawn_prompts.remove(cid);
         }
     }
+}
+
+/// `started`/`interacted` pings have nothing to update (the TaskCard carries no
+/// status field beyond `isError`/`isRunning`); `interrupted` resolves the parent
+/// CollabAgent card to an errored state early, ahead of its own `wait` completion.
+fn handle_sub_agent_activity(
+    item: &SubAgentActivityItem,
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    if item.kind != "interrupted" {
+        tracing::debug!(
+            module = "codex:events",
+            kind = %item.kind,
+            "codex: subAgentActivity ping has no TaskCard effect"
+        );
+        return;
+    }
+    let Some(parent_id) = state.collab_child_threads.get(&item.agent_thread_id).cloned() else {
+        tracing::debug!(
+            module = "codex:events",
+            agent_thread_id = %item.agent_thread_id,
+            "codex: interrupted subAgentActivity for an unregistered agent thread"
+        );
+        return;
+    };
+    sink.on_tool_result(vec![tool_result_block(
+        &parent_id,
+        "Sub-agent interrupted",
+        true,
+        None,
+    )]);
+    state.errored_collab_cards.insert(parent_id);
 }
 
 pub(crate) fn stash_spawn_prompts(item: &CollabAgentToolCallItem, state: &mut CodexSessionState) {

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use mainframe_adapter_api::SessionSink;
 use mainframe_types::chat::{TodoItem, TodoStatus};
+use tokio_util::sync::CancellationToken;
 
+use crate::child_tail::spawn_child_tail;
 use crate::event_mapper::CodexSessionState;
 use crate::history::{
     bash_input, collab_agent_tool_use, file_change_input, is_exec_error, mcp_result_content,
@@ -19,7 +21,7 @@ use crate::item_types::{
     CollabAgentToolCallItem, CommandExecutionItem, DynamicToolCallItem, FileChangeItem,
     McpToolCallItem, ReasoningItem, SubAgentActivityItem, ThreadItem, TodoListItem,
 };
-use crate::thread_registry::{agent_title, describe_agent, lookup_agent_metadata};
+use crate::thread_registry::{AgentMetadata, agent_title, describe_agent, lookup_agent_metadata};
 
 /// Dispatches one parsed `ThreadItem` from `item/completed` to the sink. `sink` is
 /// already wrapped with `ParentIdSink` by the caller when the item belongs to a
@@ -192,6 +194,12 @@ fn handle_collab_completed(
         for cid in children {
             state.collab_child_threads.remove(cid);
             state.spawn_prompts.remove(cid);
+            // Signal-only: the tail observes this on its own next tick and exits, so a
+            // completed wait never races a late batch onto an already-closed card. The
+            // handle is dropped, not aborted — the task still gets to return cleanly.
+            if let Some((_, cancel)) = state.child_tails.remove(cid) {
+                cancel.cancel();
+            }
         }
     }
 }
@@ -243,29 +251,29 @@ pub(crate) fn emit_collab_task_group_start(
     state: &mut CodexSessionState,
 ) {
     state.open_collab_cards.insert(item.id.clone());
+    let children = item.receiver_thread_ids.clone().unwrap_or_default();
     // Register the spawned thread(s) so subsequent child items get tagged.
-    if let Some(children) = &item.receiver_thread_ids {
-        for child_id in children {
-            state
-                .collab_child_threads
-                .insert(child_id.clone(), item.id.clone());
-        }
+    for child_id in &children {
+        state
+            .collab_child_threads
+            .insert(child_id.clone(), item.id.clone());
     }
-    let child_id = item
-        .receiver_thread_ids
-        .as_ref()
-        .and_then(|ids| ids.first());
+    // One lookup covers both the title/description derivation below and each
+    // child's rollout_path for the live tail — the brief calls out not to
+    // look this up twice.
+    let meta_by_thread = lookup_agent_metadata(&children);
+    let child_id = children.first();
     // Same identity mapping as history.rs — subagent_type is the nickname,
     // description is the spawn prompt (more informative than the bare role).
-    let meta = child_id.and_then(|c| lookup_agent_metadata(std::slice::from_ref(c)).remove(c));
-    let subagent_type = agent_title(meta.as_ref())
-        .or_else(|| describe_agent(meta.as_ref()))
+    let meta = child_id.and_then(|c| meta_by_thread.get(c));
+    let subagent_type = agent_title(meta)
+        .or_else(|| describe_agent(meta))
         .unwrap_or_else(|| "Sub-agent".to_string());
     let prompt = child_id
         .and_then(|c| state.spawn_prompts.get(c).cloned())
         .or_else(|| item.prompt.clone())
         .unwrap_or_default();
-    let description = describe_agent(meta.as_ref()).unwrap_or_else(|| {
+    let description = describe_agent(meta).unwrap_or_else(|| {
         if prompt.is_empty() {
             subagent_type.clone()
         } else {
@@ -281,4 +289,43 @@ pub(crate) fn emit_collab_task_group_start(
         )],
         None,
     );
+    spawn_child_tails(&children, &item.id, &meta_by_thread, sink, state);
+}
+
+/// Starts a live rollout tail for each child thread with a known `rollout_path`,
+/// skipping any child already being tailed (double-tail guard on re-entrant
+/// `wait` items) and any child whose metadata has no rollout_path yet.
+fn spawn_child_tails(
+    children: &[String],
+    parent_tool_use_id: &str,
+    meta_by_thread: &HashMap<String, AgentMetadata>,
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    for child_id in children {
+        if state.child_tails.contains_key(child_id) {
+            continue;
+        }
+        let Some(rollout_path) = meta_by_thread
+            .get(child_id)
+            .and_then(|m| m.rollout_path.clone())
+        else {
+            tracing::debug!(
+                module = "codex:events",
+                child_id,
+                "codex: no rollout_path for sub-agent, skipping live tail"
+            );
+            continue;
+        };
+        let cancel = CancellationToken::new();
+        let handle = spawn_child_tail(
+            child_id.clone(),
+            rollout_path,
+            sink.clone(),
+            parent_tool_use_id.to_string(),
+            cancel.clone(),
+            None,
+        );
+        state.child_tails.insert(child_id.clone(), (handle, cancel));
+    }
 }

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
@@ -2,19 +2,21 @@
 //! `event_mapper.rs`'s `handle_item_completed` (was ~117 lines, over the
 //! 50-line ceiling) — the notification-dispatch shell stays in event_mapper.rs.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use mainframe_adapter_api::SessionSink;
-use mainframe_types::chat::{MessageContent, TodoItem, TodoStatus};
+use mainframe_types::chat::{TodoItem, TodoStatus};
 
 use crate::event_mapper::CodexSessionState;
 use crate::history::{
-    bash_input, collab_agent_tool_use, file_change_input, image_block, is_exec_error,
-    mcp_result_content, parse_unified_diff, reasoning_text, text_block, thinking_block,
-    tool_result_block, tool_use_block,
+    bash_input, collab_agent_tool_use, file_change_input, is_exec_error, mcp_result_content,
+    parse_unified_diff, reasoning_text, text_block, thinking_block, tool_result_block,
+    tool_use_block,
 };
+use crate::image_generation_render::handle_image_generation;
 use crate::item_types::{
-    CollabAgentToolCallItem, CommandExecutionItem, FileChangeItem, ImageGenerationItem,
+    CollabAgentToolCallItem, CommandExecutionItem, DynamicToolCallItem, FileChangeItem,
     McpToolCallItem, ReasoningItem, ThreadItem, TodoListItem,
 };
 use crate::thread_registry::{agent_title, describe_agent, lookup_agent_metadata};
@@ -39,10 +41,48 @@ pub(crate) fn render_completed_item(
         ThreadItem::ContextCompaction(_) => {
             crate::compaction::handle_compaction_completed(sink, state);
         }
-        _ => {
+        ThreadItem::DynamicToolCall(d) => render_dynamic_tool_call(&d, sink),
+        ThreadItem::EnteredReviewMode(_) => skip_item("enteredReviewMode"),
+        ThreadItem::ExitedReviewMode(_) => skip_item("exitedReviewMode"),
+        ThreadItem::ImageView(_) => skip_item("imageView"),
+        ThreadItem::Sleep(_) => skip_item("sleep"),
+        ThreadItem::HookPrompt(_) => skip_item("hookPrompt"),
+        // TaskCard rendering for sub-agent activity pings is B3 territory; this
+        // placeholder only exists to keep the match exhaustive.
+        ThreadItem::SubAgentActivity(_) => {}
+        ThreadItem::WebSearch(_) | ThreadItem::UserMessage(_) => {
             tracing::debug!(module = "codex:events", "codex: unhandled item type");
         }
     }
+}
+
+fn skip_item(name: &str) {
+    tracing::debug!(
+        module = "codex:events",
+        item = name,
+        "skipping unrendered thread item"
+    );
+}
+
+fn dynamic_tool_call_name(d: &DynamicToolCallItem) -> String {
+    match d.namespace.as_deref().filter(|ns| !ns.is_empty()) {
+        Some(ns) => format!("{ns}__{}", d.tool),
+        None => d.tool.clone(),
+    }
+}
+
+fn dynamic_tool_call_input(arguments: &serde_json::Value) -> HashMap<String, serde_json::Value> {
+    match arguments.as_object() {
+        Some(map) => map.clone().into_iter().collect(),
+        None if arguments.is_null() => HashMap::new(),
+        None => HashMap::from([("arguments".to_string(), arguments.clone())]),
+    }
+}
+
+fn render_dynamic_tool_call(d: &DynamicToolCallItem, sink: &Arc<dyn SessionSink>) {
+    let name = dynamic_tool_call_name(d);
+    let input = dynamic_tool_call_input(&d.arguments);
+    sink.on_message(vec![tool_use_block(&d.id, &name, input)], None);
 }
 
 fn render_reasoning(r: &ReasoningItem, sink: &Arc<dyn SessionSink>) {
@@ -118,81 +158,6 @@ fn normalize_todo_list_items(item: &TodoListItem) -> Vec<TodoItem> {
             active_form: t.text.clone(),
         })
         .collect()
-}
-
-fn handle_image_generation(img: ImageGenerationItem, sink: &Arc<dyn SessionSink>) {
-    let prompt = img.revised_prompt.filter(|p| !p.is_empty());
-    if let Some(inline) = img.result {
-        let media = media_type_from_extension(img.saved_path.as_deref().unwrap_or(".png"));
-        emit_image(sink, prompt.as_deref(), &media, &inline);
-        return;
-    }
-    let Some(path) = img.saved_path else {
-        tracing::warn!(module = "codex:events", id = %img.id, "codex: imageGeneration missing both result and savedPath");
-        return;
-    };
-    // Read the saved image off disk asynchronously, then emit.
-    let sink = sink.clone();
-    tokio::spawn(async move {
-        match tokio::fs::read(&path).await {
-            Ok(bytes) => {
-                let media = media_type_from_extension(&path);
-                emit_image(&sink, prompt.as_deref(), &media, &base64_encode(&bytes));
-            }
-            Err(err) => {
-                tracing::warn!(module = "codex:events", err = %err, path, "codex: failed to read generated image");
-            }
-        }
-    });
-}
-
-fn emit_image(sink: &Arc<dyn SessionSink>, prompt: Option<&str>, media_type: &str, data: &str) {
-    let mut content: Vec<MessageContent> = vec![image_block(media_type, data)];
-    if let Some(p) = prompt {
-        content.insert(0, text_block(p));
-    }
-    sink.on_message(content, None);
-}
-
-fn media_type_from_extension(path: &str) -> String {
-    let ext = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        _ => "application/octet-stream",
-    }
-    .to_string()
-}
-
-/// Minimal standard base64 encoder (no base64 crate in the allowlist), used only
-/// for the `imageGeneration` savedPath disk-read fallback.
-fn base64_encode(bytes: &[u8]) -> String {
-    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
-    for chunk in bytes.chunks(3) {
-        let b0 = chunk[0] as usize;
-        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
-        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
-        out.push(TABLE[b0 >> 2] as char);
-        out.push(TABLE[((b0 & 0x03) << 4) | (b1 >> 4)] as char);
-        out.push(if chunk.len() > 1 {
-            TABLE[((b1 & 0x0f) << 2) | (b2 >> 6)] as char
-        } else {
-            '='
-        });
-        out.push(if chunk.len() > 2 {
-            TABLE[b2 & 0x3f] as char
-        } else {
-            '='
-        });
-    }
-    out
 }
 
 fn handle_collab_completed(

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_render.rs
@@ -1,0 +1,284 @@
+//! Renders a completed `ThreadItem` into `SessionSink` calls. Moved out of
+//! `event_mapper.rs`'s `handle_item_completed` (was ~117 lines, over the
+//! 50-line ceiling) — the notification-dispatch shell stays in event_mapper.rs.
+
+use std::sync::Arc;
+
+use mainframe_adapter_api::SessionSink;
+use mainframe_types::chat::{MessageContent, TodoItem, TodoStatus};
+
+use crate::event_mapper::CodexSessionState;
+use crate::history::{
+    bash_input, collab_agent_tool_use, file_change_input, image_block, is_exec_error,
+    mcp_result_content, parse_unified_diff, reasoning_text, text_block, thinking_block,
+    tool_result_block, tool_use_block,
+};
+use crate::item_types::{
+    CollabAgentToolCallItem, CommandExecutionItem, FileChangeItem, ImageGenerationItem,
+    McpToolCallItem, ReasoningItem, ThreadItem, TodoListItem,
+};
+use crate::thread_registry::{agent_title, describe_agent, lookup_agent_metadata};
+
+/// Dispatches one parsed `ThreadItem` from `item/completed` to the sink. `sink` is
+/// already wrapped with `ParentIdSink` by the caller when the item belongs to a
+/// spawned sub-agent's thread.
+pub(crate) fn render_completed_item(
+    item: ThreadItem,
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    match item {
+        ThreadItem::AgentMessage(m) => sink.on_message(vec![text_block(&m.text)], None),
+        ThreadItem::Reasoning(r) => render_reasoning(&r, sink),
+        ThreadItem::CommandExecution(c) => render_command_execution(&c, sink),
+        ThreadItem::FileChange(f) => render_file_change(&f, sink),
+        ThreadItem::ImageGeneration(img) => handle_image_generation(img, sink),
+        ThreadItem::CollabAgentToolCall(item) => handle_collab_completed(item, sink, state),
+        ThreadItem::McpToolCall(m) => render_mcp_tool_call(&m, sink),
+        ThreadItem::TodoList(item) => render_todo_list(&item, sink),
+        ThreadItem::ContextCompaction(_) => {
+            crate::compaction::handle_compaction_completed(sink, state);
+        }
+        _ => {
+            tracing::debug!(module = "codex:events", "codex: unhandled item type");
+        }
+    }
+}
+
+fn render_reasoning(r: &ReasoningItem, sink: &Arc<dyn SessionSink>) {
+    sink.on_message(
+        vec![thinking_block(&reasoning_text(&r.summary, &r.content))],
+        None,
+    );
+}
+
+fn render_command_execution(c: &CommandExecutionItem, sink: &Arc<dyn SessionSink>) {
+    sink.on_message(
+        vec![tool_use_block(&c.id, "Bash", bash_input(&c.command))],
+        None,
+    );
+    sink.on_tool_result(vec![tool_result_block(
+        &c.id,
+        &c.aggregated_output,
+        is_exec_error(c.exit_code),
+        None,
+    )]);
+}
+
+fn render_file_change(f: &FileChangeItem, sink: &Arc<dyn SessionSink>) {
+    let is_completed = f.status != "inProgress";
+    let is_error = f.status == "failed" || f.status == "declined";
+    for (index, change) in f.changes.iter().enumerate() {
+        let tool_id = format!("{}:{}", f.id, index);
+        let is_add = matches!(change.kind, crate::item_types::PatchChangeKind::Add);
+        let tool_name = if is_add { "Write" } else { "Edit" };
+        let input = file_change_input(is_add, &change.path, &change.diff, &change.kind);
+        sink.on_message(vec![tool_use_block(&tool_id, tool_name, input)], None);
+        if is_completed {
+            let sp = parse_unified_diff(&change.diff);
+            let sp = if sp.is_empty() { None } else { Some(sp) };
+            sink.on_tool_result(vec![tool_result_block(&tool_id, "OK", is_error, sp)]);
+        }
+    }
+}
+
+fn render_mcp_tool_call(m: &McpToolCallItem, sink: &Arc<dyn SessionSink>) {
+    let server = m.server.as_deref().unwrap_or("codex");
+    let tool_name = format!("mcp__{server}__{}", m.tool);
+    sink.on_message(
+        vec![tool_use_block(&m.id, &tool_name, m.arguments.clone())],
+        None,
+    );
+    let content = mcp_result_content(m.result.as_ref().map(|r| &r.content), m.error.as_ref());
+    sink.on_tool_result(vec![tool_result_block(
+        &m.id,
+        &content,
+        m.error.is_some(),
+        None,
+    )]);
+}
+
+fn render_todo_list(item: &TodoListItem, sink: &Arc<dyn SessionSink>) {
+    let todos = normalize_todo_list_items(item);
+    if !todos.is_empty() {
+        sink.on_todo_update(todos);
+    }
+}
+
+fn normalize_todo_list_items(item: &TodoListItem) -> Vec<TodoItem> {
+    item.items
+        .iter()
+        .map(|t| TodoItem {
+            content: t.text.clone(),
+            status: if t.completed {
+                TodoStatus::Completed
+            } else {
+                TodoStatus::Pending
+            },
+            active_form: t.text.clone(),
+        })
+        .collect()
+}
+
+fn handle_image_generation(img: ImageGenerationItem, sink: &Arc<dyn SessionSink>) {
+    let prompt = img.revised_prompt.filter(|p| !p.is_empty());
+    if let Some(inline) = img.result {
+        let media = media_type_from_extension(img.saved_path.as_deref().unwrap_or(".png"));
+        emit_image(sink, prompt.as_deref(), &media, &inline);
+        return;
+    }
+    let Some(path) = img.saved_path else {
+        tracing::warn!(module = "codex:events", id = %img.id, "codex: imageGeneration missing both result and savedPath");
+        return;
+    };
+    // Read the saved image off disk asynchronously, then emit.
+    let sink = sink.clone();
+    tokio::spawn(async move {
+        match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let media = media_type_from_extension(&path);
+                emit_image(&sink, prompt.as_deref(), &media, &base64_encode(&bytes));
+            }
+            Err(err) => {
+                tracing::warn!(module = "codex:events", err = %err, path, "codex: failed to read generated image");
+            }
+        }
+    });
+}
+
+fn emit_image(sink: &Arc<dyn SessionSink>, prompt: Option<&str>, media_type: &str, data: &str) {
+    let mut content: Vec<MessageContent> = vec![image_block(media_type, data)];
+    if let Some(p) = prompt {
+        content.insert(0, text_block(p));
+    }
+    sink.on_message(content, None);
+}
+
+fn media_type_from_extension(path: &str) -> String {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
+
+/// Minimal standard base64 encoder (no base64 crate in the allowlist), used only
+/// for the `imageGeneration` savedPath disk-read fallback.
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as usize;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as usize;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as usize;
+        out.push(TABLE[b0 >> 2] as char);
+        out.push(TABLE[((b0 & 0x03) << 4) | (b1 >> 4)] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((b1 & 0x0f) << 2) | (b2 >> 6)] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[b2 & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+fn handle_collab_completed(
+    item: CollabAgentToolCallItem,
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    // `spawnAgent` is dispatch metadata only — stash its prompt for the `wait` card.
+    if item.tool == "spawnAgent" {
+        stash_spawn_prompts(&item, state);
+        return;
+    }
+    // `wait` is the renderable card — open it (if started didn't) and close with the result.
+    if !state.open_collab_cards.contains(&item.id) {
+        emit_collab_task_group_start(&item, sink, state);
+    }
+    let child_id = item
+        .receiver_thread_ids
+        .as_ref()
+        .and_then(|ids| ids.first());
+    let sub_agent_message = child_id
+        .and_then(|c| item.agents_states.as_ref().and_then(|s| s.get(c)))
+        .and_then(|s| s.message.clone());
+    let is_error = item.status == "failed" || item.status == "interrupted";
+    let content = sub_agent_message.unwrap_or_else(|| "Sub-agent completed".to_string());
+    sink.on_tool_result(vec![tool_result_block(&item.id, &content, is_error, None)]);
+    state.open_collab_cards.remove(&item.id);
+    // Stop routing further items from this spawn's child thread(s) and drop the prompt.
+    if let Some(children) = &item.receiver_thread_ids {
+        for cid in children {
+            state.collab_child_threads.remove(cid);
+            state.spawn_prompts.remove(cid);
+        }
+    }
+}
+
+pub(crate) fn stash_spawn_prompts(item: &CollabAgentToolCallItem, state: &mut CodexSessionState) {
+    if let (Some(children), Some(prompt)) = (&item.receiver_thread_ids, &item.prompt) {
+        for child_id in children {
+            state.spawn_prompts.insert(child_id.clone(), prompt.clone());
+        }
+    }
+}
+
+pub(crate) fn emit_collab_task_group_start(
+    item: &CollabAgentToolCallItem,
+    sink: &Arc<dyn SessionSink>,
+    state: &mut CodexSessionState,
+) {
+    state.open_collab_cards.insert(item.id.clone());
+    // Register the spawned thread(s) so subsequent child items get tagged.
+    if let Some(children) = &item.receiver_thread_ids {
+        for child_id in children {
+            state
+                .collab_child_threads
+                .insert(child_id.clone(), item.id.clone());
+        }
+    }
+    let child_id = item
+        .receiver_thread_ids
+        .as_ref()
+        .and_then(|ids| ids.first());
+    // Same identity mapping as history.rs — subagent_type is the nickname,
+    // description is the spawn prompt (more informative than the bare role).
+    let meta = child_id.and_then(|c| lookup_agent_metadata(std::slice::from_ref(c)).remove(c));
+    let subagent_type = agent_title(meta.as_ref())
+        .or_else(|| describe_agent(meta.as_ref()))
+        .unwrap_or_else(|| "Sub-agent".to_string());
+    let prompt = child_id
+        .and_then(|c| state.spawn_prompts.get(c).cloned())
+        .or_else(|| item.prompt.clone())
+        .unwrap_or_default();
+    let description = describe_agent(meta.as_ref()).unwrap_or_else(|| {
+        if prompt.is_empty() {
+            subagent_type.clone()
+        } else {
+            prompt.clone()
+        }
+    });
+    sink.on_message(
+        vec![collab_agent_tool_use(
+            &item.id,
+            &prompt,
+            &description,
+            &subagent_type,
+        )],
+        None,
+    );
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_variants.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_variants.rs
@@ -197,3 +197,84 @@ pub struct CollabAgentToolCallItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agents_states: Option<HashMap<String, AgentStateEntry>>,
 }
+
+/// A live ping about a spawned sub-agent's activity, keyed by `agent_thread_id`
+/// into the parent `CollabAgentToolCall`. Rendering (TaskCard updates) is B3
+/// territory; this struct only lets the item round-trip through the union.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubAgentActivityItem {
+    pub id: String,
+    pub kind: String,
+    pub agent_thread_id: String,
+    pub agent_path: String,
+}
+
+/// One block of a `dynamicToolCall`'s `contentItems`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum DynamicToolCallContentItem {
+    InputText { text: String },
+    InputImage { image_url: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicToolCallItem {
+    pub id: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    pub tool: String,
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+    pub status: String,
+    #[serde(default)]
+    pub content_items: Option<Vec<DynamicToolCallContentItem>>,
+    #[serde(default)]
+    pub success: Option<bool>,
+    #[serde(default)]
+    pub duration_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnteredReviewModeItem {
+    pub id: String,
+    pub review: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExitedReviewModeItem {
+    pub id: String,
+    pub review: String,
+}
+
+/// `path` is Codex's `LegacyAppPathString`, which serializes as a plain string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageViewItem {
+    pub id: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SleepItem {
+    pub id: String,
+    pub duration_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookPromptFragment {
+    pub text: String,
+    pub hook_run_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookPromptItem {
+    pub id: String,
+    pub fragments: Vec<HookPromptFragment>,
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_variants.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/thread_item_variants.rs
@@ -1,0 +1,199 @@
+//! Payload structs for every `ThreadItem` variant (moved out of `item_types.rs` to
+//! keep that file at just the enum + its serde attributes, per the 300-line rule).
+//!
+//! Field names track Codex's camelCase wire format (except `move_path`, which
+//! Codex emits snake_case) and unknown fields are tolerated (serde ignores them).
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Bare compaction marker (Codex 0.144.3 v2): `{ "type": "contextCompaction", "id" }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextCompactionItem {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentMessageItem {
+    pub id: String,
+    pub text: String,
+    pub phase: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReasoningItem {
+    pub id: String,
+    pub summary: Vec<String>,
+    pub content: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandExecutionItem {
+    pub id: String,
+    pub command: String,
+    pub aggregated_output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i64>,
+    pub status: String,
+}
+
+/// Matches `PatchChangeKind` from the v2 schema (tagged union with optional
+/// `move_path`). Codex emits `move_path` snake_case, so the field is NOT renamed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum PatchChangeKind {
+    Add,
+    Delete,
+    Update { move_path: Option<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChange {
+    pub path: String,
+    pub kind: PatchChangeKind,
+    pub diff: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileChangeItem {
+    pub id: String,
+    pub changes: Vec<FileChange>,
+    /// `PatchApplyStatus` — kept `String` to mirror the TS string comparisons.
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolResult {
+    #[serde(default)]
+    pub content: serde_json::Value,
+    #[serde(default)]
+    pub structured_content: serde_json::Value,
+    #[serde(rename = "_meta", default)]
+    pub meta: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodexItemError {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallItem {
+    pub id: String,
+    #[serde(default)]
+    pub server: Option<String>,
+    pub tool: String,
+    #[serde(default)]
+    pub arguments: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub result: Option<McpToolResult>,
+    #[serde(default)]
+    pub error: Option<CodexItemError>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_app_resource_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSearchItem {
+    pub id: String,
+    pub query: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageGenerationItem {
+    pub id: String,
+    /// Base64-encoded image bytes (PNG). Always present in completed events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    /// Filesystem path where Codex saved the generated image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub saved_path: Option<String>,
+    /// The model's revised version of the user's prompt, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revised_prompt: Option<String>,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoEntry {
+    pub text: String,
+    pub completed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TodoListItem {
+    pub id: String,
+    pub items: Vec<TodoEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserContentBlock {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_elements: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserMessageItem {
+    pub id: String,
+    /// Codex 0.125 stores the prompt under `content[].text`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<Vec<UserContentBlock>>,
+    /// Older variants may include a top-level `text` field; tolerate both.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentStateEntry {
+    pub status: String,
+    pub message: Option<String>,
+}
+
+/// Codex 0.125+ emits each sub-agent delegation as TWO `collabAgentToolCall`
+/// items: `tool: "spawnAgent"` (dispatch metadata; carries the prompt +
+/// `receiverThreadIds`) and `tool: "wait"` (the renderable card; carries the
+/// sub-agent output in `agentsStates[childThreadId].message`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollabAgentToolCallItem {
+    pub id: String,
+    /// "spawnAgent" or "wait".
+    pub tool: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receiver_thread_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    /// Per-child status snapshot. For `wait` items, contains the final `message`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agents_states: Option<HashMap<String, AgentStateEntry>>,
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/child_tail.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/child_tail.rs
@@ -1,0 +1,241 @@
+//! Covers `child_tail::spawn_child_tail`'s bounded-poll rollout tail: backlog
+//! replay, a not-yet-created file, two children tailed concurrently without
+//! cross-contamination, cancel-on-complete dropping a late batch, and that a
+//! quiet second poll doesn't re-emit the first batch.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::time::Duration;
+
+use common::Recorder;
+use mainframe_adapter_codex::child_tail::spawn_child_tail;
+use mainframe_adapter_codex::rollout_reader::RolloutReaderDeps;
+use mainframe_types::content::LeafContent;
+use mainframe_types::chat::MessageContent;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+// The tail's own poll interval is 300ms; pad past it so a tick has definitely run.
+const PAST_ONE_TICK: Duration = Duration::from_millis(400);
+const PAST_TWO_TICKS: Duration = Duration::from_millis(700);
+
+fn deps(root: &TempDir) -> RolloutReaderDeps {
+    RolloutReaderDeps {
+        sessions_root: Some(root.path().to_path_buf()),
+    }
+}
+
+fn message_line(role: &str, text: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [{"type": "output_text", "text": text}],
+        }
+    })
+    .to_string()
+}
+
+fn write_rollout(root: &TempDir, thread_id: &str, lines: &[String]) -> String {
+    let path = root.path().join(format!("rollout-{thread_id}.jsonl"));
+    std::fs::write(&path, lines.join("\n")).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+fn append_rollout(rollout_path: &str, line: &str) {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(rollout_path)
+        .unwrap();
+    writeln!(f).unwrap();
+    write!(f, "{line}").unwrap();
+}
+
+fn message_texts(recorder: &Recorder) -> Vec<(String, Option<String>)> {
+    recorder
+        .messages()
+        .into_iter()
+        .flat_map(|blocks| {
+            blocks.into_iter().filter_map(|b| match b {
+                MessageContent::Leaf(LeafContent::Text {
+                    text,
+                    parent_tool_use_id,
+                }) => Some((text, parent_tool_use_id)),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn backlog_present_at_spawn_time_is_replayed() {
+    let root = tempfile::tempdir().unwrap();
+    let path = write_rollout(
+        &root,
+        "child_1",
+        &[
+            message_line("assistant", "first"),
+            message_line("assistant", "second"),
+        ],
+    );
+    let recorder = Recorder::new();
+    let cancel = CancellationToken::new();
+    let handle = spawn_child_tail(
+        "child_1".to_string(),
+        path,
+        recorder.sink(),
+        "parent_1".to_string(),
+        cancel.clone(),
+        Some(deps(&root)),
+    );
+    tokio::time::sleep(PAST_ONE_TICK).await;
+    cancel.cancel();
+    handle.await.unwrap();
+
+    let texts = message_texts(&recorder);
+    assert_eq!(
+        texts,
+        vec![
+            ("first".to_string(), Some("parent_1".to_string())),
+            ("second".to_string(), Some("parent_1".to_string())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn file_created_after_spawn_is_picked_up_on_a_later_poll() {
+    let root = tempfile::tempdir().unwrap();
+    let path = root
+        .path()
+        .join("rollout-child_2.jsonl")
+        .to_string_lossy()
+        .to_string();
+    let recorder = Recorder::new();
+    let cancel = CancellationToken::new();
+    let handle = spawn_child_tail(
+        "child_2".to_string(),
+        path.clone(),
+        recorder.sink(),
+        "parent_2".to_string(),
+        cancel.clone(),
+        Some(deps(&root)),
+    );
+
+    // First tick(s) find no file — must not panic, must not fabricate items.
+    tokio::time::sleep(PAST_ONE_TICK).await;
+    assert!(message_texts(&recorder).is_empty());
+
+    std::fs::write(&path, message_line("assistant", "late arrival")).unwrap();
+    tokio::time::sleep(PAST_ONE_TICK).await;
+    cancel.cancel();
+    handle.await.unwrap();
+
+    assert_eq!(
+        message_texts(&recorder),
+        vec![("late arrival".to_string(), Some("parent_2".to_string()))]
+    );
+}
+
+#[tokio::test]
+async fn two_children_tail_concurrently_without_cross_contamination() {
+    let root = tempfile::tempdir().unwrap();
+    let path_a = write_rollout(&root, "child_a", &[message_line("assistant", "from a")]);
+    let path_b = write_rollout(&root, "child_b", &[message_line("assistant", "from b")]);
+    let recorder = Recorder::new();
+    let cancel_a = CancellationToken::new();
+    let cancel_b = CancellationToken::new();
+    let handle_a = spawn_child_tail(
+        "child_a".to_string(),
+        path_a,
+        recorder.sink(),
+        "parent_a".to_string(),
+        cancel_a.clone(),
+        Some(deps(&root)),
+    );
+    let handle_b = spawn_child_tail(
+        "child_b".to_string(),
+        path_b,
+        recorder.sink(),
+        "parent_b".to_string(),
+        cancel_b.clone(),
+        Some(deps(&root)),
+    );
+
+    tokio::time::sleep(PAST_ONE_TICK).await;
+    cancel_a.cancel();
+    cancel_b.cancel();
+    handle_a.await.unwrap();
+    handle_b.await.unwrap();
+
+    let mut texts = message_texts(&recorder);
+    texts.sort();
+    assert_eq!(
+        texts,
+        vec![
+            ("from a".to_string(), Some("parent_a".to_string())),
+            ("from b".to_string(), Some("parent_b".to_string())),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn cancel_drops_a_batch_appended_after_cancellation_and_joins_cleanly() {
+    let root = tempfile::tempdir().unwrap();
+    let path = write_rollout(&root, "child_3", &[message_line("assistant", "before")]);
+    let recorder = Recorder::new();
+    let cancel = CancellationToken::new();
+    let handle = spawn_child_tail(
+        "child_3".to_string(),
+        path.clone(),
+        recorder.sink(),
+        "parent_3".to_string(),
+        cancel.clone(),
+        Some(deps(&root)),
+    );
+
+    tokio::time::sleep(PAST_ONE_TICK).await;
+    assert_eq!(message_texts(&recorder).len(), 1);
+
+    append_rollout(&path, &message_line("assistant", "after cancel"));
+    cancel.cancel();
+    // A clean `Ok(())` join (not aborted) proves the task observed cancellation
+    // and returned on its own, rather than being forcibly torn down.
+    tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("tail task did not exit after cancellation")
+        .expect("tail task should join cleanly, not be aborted");
+
+    assert_eq!(
+        message_texts(&recorder),
+        vec![("before".to_string(), Some("parent_3".to_string()))]
+    );
+}
+
+#[tokio::test]
+async fn a_quiet_second_poll_does_not_re_emit_the_first_batch() {
+    let root = tempfile::tempdir().unwrap();
+    let path = write_rollout(&root, "child_4", &[message_line("assistant", "only once")]);
+    let recorder = Recorder::new();
+    let cancel = CancellationToken::new();
+    let handle = spawn_child_tail(
+        "child_4".to_string(),
+        path,
+        recorder.sink(),
+        "parent_4".to_string(),
+        cancel.clone(),
+        Some(deps(&root)),
+    );
+
+    tokio::time::sleep(PAST_TWO_TICKS).await;
+    cancel.cancel();
+    handle.await.unwrap();
+
+    assert_eq!(
+        message_texts(&recorder),
+        vec![("only once".to_string(), Some("parent_4".to_string()))]
+    );
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
@@ -608,6 +608,92 @@ fn sleep_is_skipped_without_any_sink_call() {
     assert!(rec.tool_results().is_empty());
 }
 
+// --- B3: subAgentActivity folds into the TaskCard lifecycle ---
+
+fn activity_ping(kind: &str) -> Value {
+    json!({
+        "id": "activity_1",
+        "type": "subAgentActivity",
+        "kind": kind,
+        "agentThreadId": "child_thread_1",
+        "agentPath": "/some/path",
+    })
+}
+
+/// Spawns the card and opens it (spawnAgent + wait `item/started`), leaving
+/// `wait_item_1` open in `state.open_collab_cards` with no messages recorded yet.
+fn open_wait_card(rec: &Recorder, state: &mut CodexSessionState) {
+    dispatch_spawn(rec, state);
+    handle_notification(
+        "item/started",
+        &json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": wait_inprogress() }),
+        &rec.sink(),
+        state,
+    );
+    rec.clear_messages();
+}
+
+#[test]
+fn sub_agent_activity_started_and_interacted_are_noops() {
+    for kind in ["started", "interacted"] {
+        let rec = Recorder::new();
+        let mut state = state();
+        open_wait_card(&rec, &mut state);
+
+        item_completed(&rec, &mut state, activity_ping(kind));
+
+        assert!(rec.messages().is_empty());
+        assert!(rec.tool_results().is_empty());
+        assert!(state.open_collab_cards.contains("wait_item_1"));
+    }
+}
+
+#[test]
+fn sub_agent_activity_interrupted_emits_error_result_and_keeps_card_open() {
+    let rec = Recorder::new();
+    let mut state = state();
+    open_wait_card(&rec, &mut state);
+
+    item_completed(&rec, &mut state, activity_ping("interrupted"));
+
+    let results = rec.tool_results();
+    assert_eq!(results.len(), 1);
+    let block = to_values(&results[0]);
+    assert_eq!(block[0]["toolUseId"], json!("wait_item_1"));
+    assert_eq!(block[0]["isError"], json!(true));
+    assert!(rec.messages().is_empty());
+    assert!(state.open_collab_cards.contains("wait_item_1"));
+    assert!(state.errored_collab_cards.contains("wait_item_1"));
+}
+
+#[test]
+fn sub_agent_activity_interrupted_then_wait_completed_does_not_double_close() {
+    let rec = Recorder::new();
+    let mut state = state();
+    open_wait_card(&rec, &mut state);
+
+    item_completed(&rec, &mut state, activity_ping("interrupted"));
+    assert_eq!(rec.tool_results().len(), 1);
+
+    item_completed(&rec, &mut state, wait_completed("interrupted"));
+
+    assert!(rec.messages().is_empty());
+    assert_eq!(rec.tool_results().len(), 1);
+    assert!(!state.open_collab_cards.contains("wait_item_1"));
+    assert!(!state.collab_child_threads.contains_key("child_thread_1"));
+    assert!(!state.spawn_prompts.contains_key("child_thread_1"));
+    assert!(!state.errored_collab_cards.contains("wait_item_1"));
+}
+
+#[test]
+fn sub_agent_activity_unknown_thread_is_noop() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(&rec, &mut state, activity_ping("interrupted"));
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
 #[test]
 fn hook_prompt_is_skipped_without_any_sink_call() {
     let rec = Recorder::new();

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/event_mapper.rs
@@ -488,3 +488,139 @@ fn turn_completed_without_usage_reports_no_context_tokens() {
     assert_eq!(results[0].context_tokens, None);
     assert_eq!(results[0].usage, None);
 }
+
+// --- B2: dynamicToolCall render + explicit skip arms for the B1 union additions ---
+
+fn item_completed(rec: &Recorder, state: &mut CodexSessionState, item: Value) {
+    handle_notification(
+        "item/completed",
+        &json!({ "threadId": "parent_thread", "turnId": "turn_1", "item": item }),
+        &rec.sink(),
+        state,
+    );
+}
+
+#[test]
+fn dynamic_tool_call_renders_a_tool_use_block_namespaced_by_the_tool_source() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({
+            "id": "dyn_1",
+            "type": "dynamicToolCall",
+            "namespace": "web",
+            "tool": "search",
+            "arguments": { "query": "rust serde" },
+            "status": "completed",
+        }),
+    );
+    let messages = rec.messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(
+        to_values(&messages[0]),
+        json!([{
+            "type": "tool_use",
+            "id": "dyn_1",
+            "name": "web__search",
+            "input": { "query": "rust serde" },
+        }])
+    );
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn dynamic_tool_call_without_a_namespace_uses_the_bare_tool_name() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({
+            "id": "dyn_2",
+            "type": "dynamicToolCall",
+            "tool": "lookup",
+            "arguments": {},
+            "status": "completed",
+        }),
+    );
+    assert_eq!(
+        to_values(&rec.messages()[0]),
+        json!([{
+            "type": "tool_use",
+            "id": "dyn_2",
+            "name": "lookup",
+            "input": {},
+        }])
+    );
+}
+
+#[test]
+fn entered_review_mode_is_skipped_without_any_sink_call() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({ "id": "rev_1", "type": "enteredReviewMode", "review": "focus on security" }),
+    );
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn exited_review_mode_is_skipped_without_any_sink_call() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({ "id": "rev_2", "type": "exitedReviewMode", "review": "focus on security" }),
+    );
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn image_view_is_skipped_without_any_sink_call() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({ "id": "img_1", "type": "imageView", "path": "/tmp/shot.png" }),
+    );
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn sleep_is_skipped_without_any_sink_call() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({ "id": "sleep_1", "type": "sleep", "durationMs": 500 }),
+    );
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}
+
+#[test]
+fn hook_prompt_is_skipped_without_any_sink_call() {
+    let rec = Recorder::new();
+    let mut state = state();
+    item_completed(
+        &rec,
+        &mut state,
+        json!({
+            "id": "hook_1",
+            "type": "hookPrompt",
+            "fragments": [{ "text": "run lint", "hookRunId": "run_1" }],
+        }),
+    );
+    assert!(rec.messages().is_empty());
+    assert!(rec.tool_results().is_empty());
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/item_types.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/item_types.rs
@@ -1,0 +1,251 @@
+//! Round-trip tests for the B1 ThreadItem variants: `subAgentActivity`,
+//! `dynamicToolCall`, `enteredReviewMode`, `exitedReviewMode`, `imageView`,
+//! `sleep`, `hookPrompt`. Field shapes come from the codex 0.144.3 ts-rs schema
+//! (`ThreadItem.ts` at tag `rust-v0.144.3`), not hand-guessed.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use mainframe_adapter_codex::item_types::ThreadItem;
+use mainframe_adapter_codex::types::ThreadReadResult;
+use serde_json::json;
+
+fn parse(v: serde_json::Value) -> ThreadItem {
+    serde_json::from_value(v).expect("item must deserialize")
+}
+
+#[test]
+fn sub_agent_activity_round_trips() {
+    let item = parse(json!({
+        "id": "sa1",
+        "type": "subAgentActivity",
+        "kind": "started",
+        "agentThreadId": "child_1",
+        "agentPath": "agents/reviewer",
+    }));
+    match item {
+        ThreadItem::SubAgentActivity(a) => {
+            assert_eq!(a.id, "sa1");
+            assert_eq!(a.kind, "started");
+            assert_eq!(a.agent_thread_id, "child_1");
+            assert_eq!(a.agent_path, "agents/reviewer");
+        }
+        other => panic!("expected SubAgentActivity, got {other:?}"),
+    }
+}
+
+#[test]
+fn sub_agent_activity_tolerates_an_unknown_extra_field() {
+    let item = parse(json!({
+        "id": "sa1",
+        "type": "subAgentActivity",
+        "kind": "interacted",
+        "agentThreadId": "child_1",
+        "agentPath": "agents/reviewer",
+        "somethingNew": 42,
+    }));
+    assert!(matches!(item, ThreadItem::SubAgentActivity(_)));
+}
+
+#[test]
+fn dynamic_tool_call_round_trips() {
+    let item = parse(json!({
+        "id": "dt1",
+        "type": "dynamicToolCall",
+        "namespace": "browser",
+        "tool": "click",
+        "arguments": { "selector": "#go" },
+        "status": "completed",
+        "contentItems": [
+            { "type": "inputText", "text": "clicked" },
+            { "type": "inputImage", "imageUrl": "https://example.com/a.png" },
+        ],
+        "success": true,
+        "durationMs": 120,
+    }));
+    match item {
+        ThreadItem::DynamicToolCall(d) => {
+            assert_eq!(d.id, "dt1");
+            assert_eq!(d.namespace.as_deref(), Some("browser"));
+            assert_eq!(d.tool, "click");
+            assert_eq!(d.arguments, json!({ "selector": "#go" }));
+            assert_eq!(d.status, "completed");
+            assert_eq!(d.success, Some(true));
+            assert_eq!(d.duration_ms, Some(120));
+            let items = d.content_items.expect("contentItems must be present");
+            assert_eq!(items.len(), 2);
+        }
+        other => panic!("expected DynamicToolCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn dynamic_tool_call_tolerates_null_content_items_and_unknown_field() {
+    let item = parse(json!({
+        "id": "dt2",
+        "type": "dynamicToolCall",
+        "namespace": null,
+        "tool": "noop",
+        "arguments": {},
+        "status": "inProgress",
+        "contentItems": null,
+        "success": null,
+        "durationMs": null,
+        "somethingNew": "x",
+    }));
+    match item {
+        ThreadItem::DynamicToolCall(d) => {
+            assert_eq!(d.namespace, None);
+            assert_eq!(d.content_items, None);
+        }
+        other => panic!("expected DynamicToolCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn entered_review_mode_round_trips() {
+    let item = parse(json!({ "id": "erm1", "type": "enteredReviewMode", "review": "security" }));
+    match item {
+        ThreadItem::EnteredReviewMode(e) => {
+            assert_eq!(e.id, "erm1");
+            assert_eq!(e.review, "security");
+        }
+        other => panic!("expected EnteredReviewMode, got {other:?}"),
+    }
+}
+
+#[test]
+fn entered_review_mode_tolerates_an_unknown_extra_field() {
+    let item = parse(
+        json!({ "id": "erm1", "type": "enteredReviewMode", "review": "security", "extra": 1 }),
+    );
+    assert!(matches!(item, ThreadItem::EnteredReviewMode(_)));
+}
+
+#[test]
+fn exited_review_mode_round_trips() {
+    let item = parse(json!({ "id": "xrm1", "type": "exitedReviewMode", "review": "security" }));
+    match item {
+        ThreadItem::ExitedReviewMode(e) => {
+            assert_eq!(e.id, "xrm1");
+            assert_eq!(e.review, "security");
+        }
+        other => panic!("expected ExitedReviewMode, got {other:?}"),
+    }
+}
+
+#[test]
+fn exited_review_mode_tolerates_an_unknown_extra_field() {
+    let item =
+        parse(json!({ "id": "xrm1", "type": "exitedReviewMode", "review": "security", "extra": 1 }));
+    assert!(matches!(item, ThreadItem::ExitedReviewMode(_)));
+}
+
+#[test]
+fn image_view_round_trips() {
+    let item = parse(json!({ "id": "iv1", "type": "imageView", "path": "/tmp/screenshot.png" }));
+    match item {
+        ThreadItem::ImageView(i) => {
+            assert_eq!(i.id, "iv1");
+            assert_eq!(i.path, "/tmp/screenshot.png");
+        }
+        other => panic!("expected ImageView, got {other:?}"),
+    }
+}
+
+#[test]
+fn image_view_tolerates_an_unknown_extra_field() {
+    let item = parse(
+        json!({ "id": "iv1", "type": "imageView", "path": "/tmp/screenshot.png", "extra": true }),
+    );
+    assert!(matches!(item, ThreadItem::ImageView(_)));
+}
+
+#[test]
+fn sleep_round_trips() {
+    let item = parse(json!({ "id": "sl1", "type": "sleep", "durationMs": 500 }));
+    match item {
+        ThreadItem::Sleep(s) => {
+            assert_eq!(s.id, "sl1");
+            assert_eq!(s.duration_ms, 500);
+        }
+        other => panic!("expected Sleep, got {other:?}"),
+    }
+}
+
+#[test]
+fn sleep_tolerates_an_unknown_extra_field() {
+    let item = parse(json!({ "id": "sl1", "type": "sleep", "durationMs": 500, "extra": "x" }));
+    assert!(matches!(item, ThreadItem::Sleep(_)));
+}
+
+#[test]
+fn hook_prompt_round_trips() {
+    let item = parse(json!({
+        "id": "hp1",
+        "type": "hookPrompt",
+        "fragments": [
+            { "text": "run the linter", "hookRunId": "run_1" },
+            { "text": "then the tests", "hookRunId": "run_2" },
+        ],
+    }));
+    match item {
+        ThreadItem::HookPrompt(h) => {
+            assert_eq!(h.id, "hp1");
+            assert_eq!(h.fragments.len(), 2);
+            assert_eq!(h.fragments[0].text, "run the linter");
+            assert_eq!(h.fragments[0].hook_run_id, "run_1");
+        }
+        other => panic!("expected HookPrompt, got {other:?}"),
+    }
+}
+
+#[test]
+fn hook_prompt_tolerates_an_unknown_extra_field() {
+    let item = parse(json!({
+        "id": "hp1",
+        "type": "hookPrompt",
+        "fragments": [{ "text": "x", "hookRunId": "run_1" }],
+        "extra": 1,
+    }));
+    assert!(matches!(item, ThreadItem::HookPrompt(_)));
+}
+
+// --- Lenient-unknown belongs to the ThreadReadTurn.items seam, not bare ThreadItem ---
+//
+// A bare `serde_json::from_str::<ThreadItem>` on an unrecognized `type` correctly
+// hard-errors (internally-tagged enum working as designed). #502's tolerance lives
+// in `deserialize_lenient_items` on `ThreadReadTurn.items`.
+
+#[test]
+fn bare_thread_item_hard_errors_on_an_unknown_type() {
+    let result: Result<ThreadItem, _> = serde_json::from_value(json!({
+        "id": "u1",
+        "type": "somethingCodexAddsLater",
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn thread_read_turn_drops_an_unknown_typed_item_interleaved_with_known_ones() {
+    let payload = json!({
+        "thread": {
+            "id": "t1",
+            "turns": [{
+                "id": "turn1",
+                "status": "completed",
+                "items": [
+                    { "id": "a1", "type": "agentMessage", "text": "before", "phase": null },
+                    { "id": "u1", "type": "somethingCodexAddsLater", "whatever": true },
+                    { "id": "sl1", "type": "sleep", "durationMs": 10 },
+                ]
+            }]
+        }
+    });
+
+    let read: ThreadReadResult =
+        serde_json::from_value(payload).expect("turn must deserialize despite the unknown item");
+    let items = read.thread.turns.unwrap_or_default().remove(0).items;
+
+    assert_eq!(items.len(), 2);
+    assert!(matches!(&items[0], ThreadItem::AgentMessage(m) if m.text == "before"));
+    assert!(matches!(&items[1], ThreadItem::Sleep(s) if s.duration_ms == 10));
+}

--- a/packages/core-rs/crates/mainframe-adapter-codex/tests/rollout_reader.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/tests/rollout_reader.rs
@@ -1,0 +1,287 @@
+//! `read_rollout_items` reconstructing sub-agent `apply_patch` (custom_tool_call)
+//! and MCP (`function_call` w/ `namespace: "mcp__*"`) records on reload (B5),
+//! plus the existing message/reasoning/exec_command paths staying correct when
+//! interleaved with the new record types in the same rollout file.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use mainframe_adapter_codex::item_types::{PatchChangeKind, ThreadItem};
+use mainframe_adapter_codex::rollout_reader::{RolloutReaderDeps, read_rollout_items};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn deps(root: &TempDir) -> RolloutReaderDeps {
+    RolloutReaderDeps {
+        sessions_root: Some(root.path().to_path_buf()),
+    }
+}
+
+fn write_rollout(root: &TempDir, thread_id: &str, lines: &[String]) -> String {
+    let path = root.path().join(format!("rollout-{thread_id}.jsonl"));
+    std::fs::write(&path, lines.join("\n")).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+fn message_line(role: &str, text: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [{"type": "output_text", "text": text}],
+        }
+    })
+    .to_string()
+}
+
+fn reasoning_line(text: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": text}],
+        }
+    })
+    .to_string()
+}
+
+fn custom_tool_call_line(call_id: &str, input: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call",
+            "status": "completed",
+            "call_id": call_id,
+            "name": "apply_patch",
+            "input": input,
+        }
+    })
+    .to_string()
+}
+
+fn custom_tool_call_output_line(call_id: &str, output: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "custom_tool_call_output",
+            "call_id": call_id,
+            "output": output,
+        }
+    })
+    .to_string()
+}
+
+fn function_call_line(call_id: &str, name: &str, namespace: Option<&str>, arguments: &str) -> String {
+    let mut payload = json!({
+        "type": "function_call",
+        "id": format!("fc_{call_id}"),
+        "name": name,
+        "arguments": arguments,
+        "call_id": call_id,
+    });
+    if let Some(ns) = namespace {
+        payload["namespace"] = json!(ns);
+    }
+    json!({"type": "response_item", "payload": payload}).to_string()
+}
+
+fn function_call_output_line(call_id: &str, output: &str) -> String {
+    json!({
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        }
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn apply_patch_update_reconstructs_file_change() {
+    let root = tempfile::tempdir().unwrap();
+    let patch =
+        "*** Begin Patch\n*** Update File: src/synthetic_widget.rs\n@@\n-old line\n+new line\n*** End Patch\n";
+    let lines = vec![
+        custom_tool_call_line("call_patch_1", patch),
+        custom_tool_call_output_line(
+            "call_patch_1",
+            "Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess. Updated the following files:\nM src/synthetic_widget.rs\n",
+        ),
+    ];
+    let path = write_rollout(&root, "thread_patch_1", &lines);
+    let items = read_rollout_items(&path, Some("thread_patch_1"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 1);
+    let ThreadItem::FileChange(f) = &items[0] else {
+        panic!("expected FileChange, got {:?}", items[0])
+    };
+    assert_eq!(f.id, "call_patch_1");
+    assert_eq!(f.status, "completed");
+    assert_eq!(f.changes.len(), 1);
+    assert_eq!(f.changes[0].path, "src/synthetic_widget.rs");
+    assert!(matches!(f.changes[0].kind, PatchChangeKind::Update { .. }));
+    assert!(f.changes[0].diff.contains("+new line"));
+}
+
+#[tokio::test]
+async fn apply_patch_multi_file_add_and_delete() {
+    let root = tempfile::tempdir().unwrap();
+    let patch = "*** Begin Patch\n*** Add File: src/new_module.rs\n+pub fn hello() {}\n*** Delete File: src/old_module.rs\n-pub fn bye() {}\n*** End Patch\n";
+    let lines = vec![
+        custom_tool_call_line("call_patch_2", patch),
+        custom_tool_call_output_line(
+            "call_patch_2",
+            "Exit code: 0\nOutput:\nSuccess. Updated the following files:\nA src/new_module.rs\nD src/old_module.rs\n",
+        ),
+    ];
+    let path = write_rollout(&root, "thread_patch_2", &lines);
+    let items = read_rollout_items(&path, Some("thread_patch_2"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 1);
+    let ThreadItem::FileChange(f) = &items[0] else {
+        panic!("expected FileChange, got {:?}", items[0])
+    };
+    assert_eq!(f.changes.len(), 2);
+    assert_eq!(f.changes[0].path, "src/new_module.rs");
+    assert!(matches!(f.changes[0].kind, PatchChangeKind::Add));
+    assert!(f.changes[0].diff.contains("+pub fn hello() {}"));
+    assert_eq!(f.changes[1].path, "src/old_module.rs");
+    assert!(matches!(f.changes[1].kind, PatchChangeKind::Delete));
+    assert!(f.changes[1].diff.contains("-pub fn bye() {}"));
+}
+
+#[tokio::test]
+async fn apply_patch_failure_marks_file_change_errored() {
+    let root = tempfile::tempdir().unwrap();
+    let patch = "*** Begin Patch\n*** Update File: src/broken.rs\n@@\n-a\n+b\n*** End Patch\n";
+    let lines = vec![
+        custom_tool_call_line("call_patch_3", patch),
+        custom_tool_call_output_line(
+            "call_patch_3",
+            "Exit code: 1\nOutput:\nError: could not apply patch\n",
+        ),
+    ];
+    let path = write_rollout(&root, "thread_patch_3", &lines);
+    let items = read_rollout_items(&path, Some("thread_patch_3"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 1);
+    let ThreadItem::FileChange(f) = &items[0] else {
+        panic!("expected FileChange, got {:?}", items[0])
+    };
+    assert_eq!(f.status, "failed");
+}
+
+#[tokio::test]
+async fn mcp_function_call_reconstructs_mcp_tool_call() {
+    let root = tempfile::tempdir().unwrap();
+    let args = json!({"query": "synthetic lookup", "limit": 3}).to_string();
+    let lines = vec![
+        function_call_line("call_mcp_1", "lookup_thing", Some("mcp__testserver"), &args),
+        function_call_output_line("call_mcp_1", "synthetic result text"),
+    ];
+    let path = write_rollout(&root, "thread_mcp_1", &lines);
+    let items = read_rollout_items(&path, Some("thread_mcp_1"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 1);
+    let ThreadItem::McpToolCall(m) = &items[0] else {
+        panic!("expected McpToolCall, got {:?}", items[0])
+    };
+    assert_eq!(m.id, "call_mcp_1");
+    assert_eq!(m.server.as_deref(), Some("testserver"));
+    assert_eq!(m.tool, "lookup_thing");
+    assert_eq!(
+        m.arguments.get("query").and_then(|v| v.as_str()),
+        Some("synthetic lookup")
+    );
+    assert_eq!(m.arguments.get("limit").and_then(|v| v.as_i64()), Some(3));
+    let result = m.result.as_ref().expect("mcp call should have a result");
+    assert_eq!(result.content.as_str(), Some("synthetic result text"));
+}
+
+#[tokio::test]
+async fn mcp_arguments_fallback_to_raw_string_on_parse_failure() {
+    let root = tempfile::tempdir().unwrap();
+    let lines = vec![
+        function_call_line(
+            "call_mcp_2",
+            "lookup_thing",
+            Some("mcp__testserver"),
+            "not valid json{{",
+        ),
+        function_call_output_line("call_mcp_2", "ok"),
+    ];
+    let path = write_rollout(&root, "thread_mcp_2", &lines);
+    let items = read_rollout_items(&path, Some("thread_mcp_2"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 1);
+    let ThreadItem::McpToolCall(m) = &items[0] else {
+        panic!("expected McpToolCall, got {:?}", items[0])
+    };
+    assert_eq!(
+        m.arguments.get("arguments").and_then(|v| v.as_str()),
+        Some("not valid json{{")
+    );
+}
+
+#[tokio::test]
+async fn non_mcp_function_calls_are_not_reconstructed() {
+    let root = tempfile::tempdir().unwrap();
+    let lines = vec![
+        function_call_line("call_plan_1", "update_plan", None, "{}"),
+        function_call_output_line("call_plan_1", "ok"),
+        function_call_line("call_collab_1", "spawnAgent", Some("collaboration"), "{}"),
+        function_call_output_line("call_collab_1", "ok"),
+    ];
+    let path = write_rollout(&root, "thread_ignore_1", &lines);
+    let items = read_rollout_items(&path, Some("thread_ignore_1"), Some(&deps(&root))).await;
+
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn interleaved_record_kinds_reconstruct_without_cross_contamination() {
+    let root = tempfile::tempdir().unwrap();
+    let patch =
+        "*** Begin Patch\n*** Update File: src/interleaved.rs\n@@\n-old\n+new\n*** End Patch\n";
+    let mcp_args = json!({"topic": "synthetic"}).to_string();
+    let exec_args = json!({"cmd": "echo hi"}).to_string();
+    let lines = vec![
+        message_line("assistant", "starting work"),
+        reasoning_line("thinking it through"),
+        custom_tool_call_line("call_x_1", patch),
+        function_call_line("call_x_2", "exec_command", None, &exec_args),
+        function_call_line("call_x_3", "lookup", Some("mcp__docs"), &mcp_args),
+        custom_tool_call_output_line(
+            "call_x_1",
+            "Exit code: 0\nOutput:\nSuccess. Updated the following files:\nM src/interleaved.rs\n",
+        ),
+        function_call_output_line("call_x_2", "Process exited with code 0\nOutput:\nhi\n"),
+        function_call_output_line("call_x_3", "docs result"),
+        message_line("assistant", "done"),
+    ];
+    let path = write_rollout(&root, "thread_combo_1", &lines);
+    let items = read_rollout_items(&path, Some("thread_combo_1"), Some(&deps(&root))).await;
+
+    assert_eq!(items.len(), 6);
+    assert!(matches!(&items[0], ThreadItem::AgentMessage(m) if m.text == "starting work"));
+    assert!(matches!(items[1], ThreadItem::Reasoning(_)));
+    match &items[2] {
+        ThreadItem::FileChange(f) => assert_eq!(f.id, "call_x_1"),
+        other => panic!("expected FileChange, got {other:?}"),
+    }
+    match &items[3] {
+        ThreadItem::CommandExecution(c) => {
+            assert_eq!(c.id, "call_x_2");
+            assert_eq!(c.command, "echo hi");
+        }
+        other => panic!("expected CommandExecution, got {other:?}"),
+    }
+    match &items[4] {
+        ThreadItem::McpToolCall(m) => {
+            assert_eq!(m.id, "call_x_3");
+            assert_eq!(m.server.as_deref(), Some("docs"));
+        }
+        other => panic!("expected McpToolCall, got {other:?}"),
+    }
+    assert!(matches!(&items[5], ThreadItem::AgentMessage(m) if m.text == "done"));
+}


### PR DESCRIPTION
## Summary

Stream B (PR 3 of the Codex adapter rendering-fixes plan) — completes the `ThreadItem` union for Codex 0.144.3 and makes the CollabAgent TaskCard reflect real sub-agent activity, both live and on reload.

- **B1** — moved all `ThreadItem` payload structs out of `item_types.rs` into `thread_item_variants.rs` (mechanical, first commit), then added the 7 new Codex 0.144.3 variants: `subAgentActivity`, `dynamicToolCall`, `enteredReviewMode`, `exitedReviewMode`, `imageView`, `sleep`, `hookPrompt`.
- **B2** — decomposed `handle_item_completed` into `thread_item_render.rs`; `dynamicToolCall` renders as a generic `tool_call`; the other 5 new variants get an explicit typed skip (`tracing::debug!`), never a silent `_ => {}`.
- **B3** — `subAgentActivity` pings (`started`/`interacted`/`interrupted`) fold into the existing TaskCard open/close lifecycle, with a guard against double-closing a card.
- **B4** — `child_tail.rs`: count-delta polling (300ms) of a spawned child's rollout file, tagging emitted content via `ParentIdSink` so live sub-agent work (not just its final result) streams into the parent's TaskCard.
- **B5** — `rollout_reconstruct.rs`: on reload, reconstructs sub-agent file edits (`apply_patch` custom_tool_call envelopes) and MCP tool calls (`function_call`s namespaced `mcp__*`) from the child's rollout JSONL, in addition to the bash commands B4's predecessor already handled.

## B1 Step 0 — plan vs. binary-verified shapes

The plan listed 8 new variants (9 minus `contextCompaction`, already landed in Stream A) as "best reading, correct against the binary" (Step 0 explicitly anticipates this). Verified outcome:

| Variant | Plan assumption | Outcome |
|---|---|---|
| `subAgentActivity` | `{id, kind, agentThreadId, agentPath}` | confirmed as-is |
| `dynamicToolCall` | `{id, namespace, name, arguments, status, content, ...}` (8 fields) | modeled the known fields, rest tolerated (no `deny_unknown_fields`) |
| `enteredReviewMode` | `{id, target}` | confirmed |
| `exitedReviewMode` | `{id, reviewOutput}` | confirmed |
| `imageView` | shape uncertain, permissive | kept permissive/optional |
| `sleep` | `{id, durationMs}` | confirmed |
| `hookPrompt` | `{id, fragments}` | confirmed, `fragments: Vec<HookPromptFragment>` |
| `extension` | shape uncertain, permissive | **dropped** — not observed in the 0.144.3 serde output; this is a Step-0-anticipated correction, not a contradiction, so no variant was added for it |

## B5 — contradiction found, then resolved

The plan assumed B5 could reconstruct `apply_patch`/MCP items by porting the legacy TS `rollout-reader.ts`. That file (`packages/core/src/plugins/builtin/codex/rollout-reader.ts`) only ever handled `message`, `reasoning`, and `exec_command` pairs — verified by reading it directly and by a repo-wide grep for `apply_patch` (zero hits). Per the task's stop-on-genuine-contradiction rule, this was escalated rather than guessed at.

The coordinator then supplied wire shapes empirically verified against real local Codex 0.144.3 rollouts:
- `apply_patch` is a `custom_tool_call`/`custom_tool_call_output` pair; the patch body is a `*** Begin Patch / *** {Add|Update|Delete} File: <path> / *** End Patch` envelope; success/failure is read from the exit code and/or the "Success. Updated the following files:" marker text.
- MCP calls are `function_call`/`function_call_output` pairs discriminated by a `namespace` field prefixed `mcp__` (server = namespace minus prefix, tool = `name`); arguments are JSON-parsed leniently with a raw-string fallback. Non-MCP namespaces (`collaboration`, `web`, `image_gen`, no-namespace calls like `exec_command`) are left untouched.

B5 was implemented against these confirmed shapes, with `pending_mcp`/`pending_patch` call-id maps kept separate from the pre-existing `pending_exec` map so interleaved record kinds can't cross-pair. Test fixtures are synthetic, matching the confirmed structure only (no verbatim content from real session files).

## Other deviations flagged during implementation

- `ParentIdSink` (`event_mapper.rs`) made `pub(crate)` with a `pub(crate) fn new(inner, parent)` constructor so `child_tail.rs` could reuse it.
- `tokio-util = "0.7"` added as a new workspace + crate dependency (`CancellationToken`, used to stop tailing cleanly on card close) — plan-mandated, not scope creep.
- `child_tail` module declared `pub` (not `pub(crate)`) in `lib.rs`, because `tests/child_tail.rs` is an external integration-test binary that can't see `pub(crate)` items.
- Child-tail cancellation uses `.cancel()` on the token (checked before each emitted batch) rather than `.abort()` on the `JoinHandle`, so the tail task observes cancellation and returns normally — tests can `.join()` it cleanly instead of racing an aborted future.
- `emit_collab_task_group_start` now batch-fetches `AgentMetadata` for **all** `receiver_thread_ids` (was: only the first) so every spawned child's `rollout_path` resolves for its own tail.
- Fixed a real bug surfaced by B4's test seam: macOS's `/var → /private/var` symlink canonicalization broke the sessions-root containment check when tests injected a tempdir root; fixed by canonicalizing the configured root too, with a fallback to the raw path when it doesn't exist yet (preserves the "nonexistent root" test case).

## Verification

```
cargo test -p mainframe-adapter-codex           # 155 passed; 0 failed
cargo clippy -p mainframe-adapter-codex --all-targets -- -D warnings   # clean
cargo test -p mainframe-display                 # 50 passed; 0 failed (untouched)
```

## Files changed

- `src/item_types.rs` — reduced to the `ThreadItem` enum only (18 variants)
- `src/thread_item_variants.rs` (new) — all payload structs
- `src/thread_item_render.rs` (new) — extracted render dispatch + collab lifecycle
- `src/image_generation_render.rs` (new) — split out of thread_item_render to stay ≤300 lines
- `src/event_mapper.rs` — thin dispatchers; `errored_collab_cards`, `child_tails` state
- `src/child_tail.rs` (new) — count-delta child rollout tailing
- `src/rollout_reader.rs`, `src/rollout_reconstruct.rs` (new) — reload reconstruction incl. apply_patch/MCP
- `src/thread_registry.rs` — batch metadata lookup
- `src/lib.rs`, `Cargo.toml` / `packages/core-rs/Cargo.toml` — module wiring + `tokio-util` dep
- `tests/item_types.rs`, `tests/event_mapper.rs`, `tests/child_tail.rs`, `tests/rollout_reader.rs` (new/extended)
- `.changeset/codex-subagent-reload-reconstruction.md`

## Note on base branch

This PR was originally scoped to stack on `feat/adapter-agnostic-compaction-pill` (#505, Stream A). #505 merged (squash commit `750844f3` on `main`) before this branch was ready, so its source branch was deleted. Stream B's 7 commits have been rebased onto current `main` (`git rebase --onto origin/main <old-stream-A-tip>`, dropping the now-redundant Stream A commit since its tree is byte-identical to the squashed `750844f3`) so this PR's diff contains only Stream B's changes.

## Test plan

- [ ] `cargo test -p mainframe-adapter-codex`
- [ ] `cargo clippy -p mainframe-adapter-codex --all-targets -- -D warnings`
- [ ] `cargo test -p mainframe-display`