### PR TITLE
test(e2e): fix five flaky Tauri E2E specs

### DIFF
--- a/.changeset/eighty-radios-enter.md
+++ b/.changeset/eighty-radios-enter.md
@@ -1,0 +1,4 @@
+---
+---
+
+test(e2e): fix five flaky Tauri E2E specs (cross-platform editor shortcuts, self-contained footer test, deterministic working-status dot). Test/CI-only — no product code changes.

--- a/packages/core-rs/crates/mainframe-adapter-mock/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-mock/src/session.rs
@@ -13,6 +13,18 @@ use crate::history::recorded_session_id;
 
 const MAX_DELAY_MS: u64 = 120;
 
+/// Per-event replay delay ceiling. Defaults to `MAX_DELAY_MS` so the suite stays
+/// fast, but `E2E_MOCK_MAX_DELAY_MS` widens it for the rare test that must observe
+/// a transient state (e.g. the sidebar 'working' dot) whose window would otherwise
+/// collapse into the ~120ms burst and race a debounced client refetch.
+fn max_delay_ms() -> i64 {
+    std::env::var("E2E_MOCK_MAX_DELAY_MS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|v| *v >= 0)
+        .unwrap_or(MAX_DELAY_MS as i64)
+}
+
 pub(crate) struct SessionState {
     pub replay: ReplayState,
     pub last_delay: i64,
@@ -193,6 +205,7 @@ impl ReplaySession {
         let Some(sink) = self.sink() else {
             return;
         };
+        let delay_ceiling = max_delay_ms();
         tokio::spawn(async move {
             let started_at = tokio::time::Instant::now();
             for event in outputs {
@@ -200,7 +213,7 @@ impl ReplaySession {
                     event
                         .delay_ms
                         .saturating_sub(base)
-                        .clamp(0, MAX_DELAY_MS as i64) as u64,
+                        .clamp(0, delay_ceiling) as u64,
                 );
                 if let Some(remaining) = target.checked_sub(started_at.elapsed()) {
                     tokio::time::sleep(remaining).await;

--- a/packages/e2e/fixtures/app-tauri.ts
+++ b/packages/e2e/fixtures/app-tauri.ts
@@ -51,8 +51,12 @@ const TOUR_SUPPRESS = JSON.stringify({ state: { completed: true, step: 4 }, vers
 export async function launchTauriApp(opts?: {
   recordingKey?: string;
   suppressTour?: boolean;
+  mockMaxDelayMs?: number;
 }): Promise<TauriAppFixture> {
-  const daemonHandle = await startDaemon({ recordingKey: opts?.recordingKey });
+  const daemonHandle = await startDaemon({
+    recordingKey: opts?.recordingKey,
+    mockMaxDelayMs: opts?.mockMaxDelayMs,
+  });
   let context: BrowserContext | undefined;
   try {
     const browser = await getBrowser();

--- a/packages/e2e/fixtures/daemon.ts
+++ b/packages/e2e/fixtures/daemon.ts
@@ -151,7 +151,7 @@ export interface DaemonHandle {
   testDataDir: string;
 }
 
-export async function startDaemon(opts?: { recordingKey?: string }): Promise<DaemonHandle> {
+export async function startDaemon(opts?: { recordingKey?: string; mockMaxDelayMs?: number }): Promise<DaemonHandle> {
   await assertPortFree();
   const testDataDir = mkdtempSync(path.join(tmpdir(), 'mf-e2e-data-'));
 
@@ -160,6 +160,9 @@ export async function startDaemon(opts?: { recordingKey?: string }): Promise<Dae
     e2eEnv['E2E_MODE'] = E2E_MODE;
     e2eEnv['E2E_RECORDINGS_DIR'] = RECORDINGS_DIR;
     if (opts?.recordingKey) e2eEnv['E2E_RECORDING_KEY'] = opts.recordingKey;
+    // Widen the mock replay clamp for specs that must observe a transient state
+    // (e.g. the sidebar 'working' dot) whose window the default ~120ms burst collapses.
+    if (opts?.mockMaxDelayMs != null) e2eEnv['E2E_MOCK_MAX_DELAY_MS'] = String(opts.mockMaxDelayMs);
   }
   const daemonPath = resolveRustDaemon();
   const daemonLogFd = openSync(path.join(testDataDir, 'daemon.log'), 'w');

--- a/packages/e2e/tests-tauri/editor-diff.spec.ts
+++ b/packages/e2e/tests-tauri/editor-diff.spec.ts
@@ -259,7 +259,7 @@ test.describe('§editor-diff — Changes panel', () => {
     const bPane = editorDiff.locator('.cm-editor').nth(1);
     await bPane.click();
     await page.keyboard.type('// should never persist\n');
-    await page.keyboard.press('Meta+s');
+    await page.keyboard.press('ControlOrMeta+s');
 
     await expect(page.getByTestId('editor-save-status')).toHaveCount(0);
     await expect(page.getByTestId('editor-tab-save-error')).toHaveCount(0);

--- a/packages/e2e/tests-tauri/editor.spec.ts
+++ b/packages/e2e/tests-tauri/editor.spec.ts
@@ -143,7 +143,7 @@ test.describe('§editor', () => {
     await page.keyboard.type('// dirty-edit\n');
     await expect(page.getByTestId('editor-save-status')).toHaveText('● unsaved', { timeout: 5_000 });
 
-    await page.keyboard.press('Meta+s');
+    await page.keyboard.press('ControlOrMeta+s');
     await expect(page.getByTestId('editor-save-status')).toHaveText('● saved', { timeout: 10_000 });
 
     const saved = readFileSync(path.join(project.projectPath, 'utils.ts'), 'utf8');
@@ -161,7 +161,7 @@ test.describe('§editor', () => {
     try {
       await page.getByTestId('editor-code').click();
       await page.keyboard.type('// attempted edit\n');
-      await page.keyboard.press('Meta+s');
+      await page.keyboard.press('ControlOrMeta+s');
 
       const banner = page.getByTestId('editor-tab-save-error');
       await expect(banner).toBeVisible({ timeout: 10_000 });
@@ -246,7 +246,7 @@ test.describe('§editor', () => {
 
     await expect(page.locator('.cm-search')).toHaveCount(0);
     await page.getByTestId('editor-code').click();
-    await page.keyboard.press('Meta+f');
+    await page.keyboard.press('ControlOrMeta+f');
     await expect(page.locator('.cm-search')).toBeVisible({ timeout: 5_000 });
 
     const searchInput = page.locator('.cm-search input[name="search"]');
@@ -262,12 +262,16 @@ test.describe('§editor', () => {
 
   test('footer status shows Ln/Col that follows the cursor', async () => {
     const { page } = app;
-    // search.ts is still the active tab from the previous test.
-    await expect(tabByTitle(page, 'search.ts')).toHaveAttribute('aria-selected', 'true');
+    // Open search.ts explicitly rather than relying on the previous test leaving
+    // it active — Playwright restarts the worker after any failure, so an earlier
+    // failure would otherwise leave this tab closed. Clicking the tree row is
+    // idempotent: it activates the tab whether or not it is already open.
+    await page.getByTestId('file-tree-row-search.ts').click();
+    await expect(tabByTitle(page, 'search.ts')).toHaveAttribute('aria-selected', 'true', { timeout: 10_000 });
 
     const status = page.getByTestId('viewer-shell-status');
     await page.getByTestId('editor-code').click();
-    await page.keyboard.press('Meta+Home'); // cursorDocStart — deterministic anchor
+    await page.keyboard.press('ControlOrMeta+Home'); // cursorDocStart — deterministic anchor
     await expect(status).toHaveText('Ln 1, Col 1', { timeout: 5_000 });
 
     await page.keyboard.press('ArrowDown');
@@ -301,7 +305,7 @@ test.describe('§editor', () => {
     await expect(page.getByTestId('markdown-mode-edit')).toHaveAttribute('aria-pressed', 'true');
 
     await page.getByTestId('editor-code').click();
-    await page.keyboard.press('Meta+End'); // cursorDocEnd — deterministic anchor
+    await page.keyboard.press('ControlOrMeta+End'); // cursorDocEnd — deterministic anchor
     await page.keyboard.type('\n\nAppended paragraph.');
 
     await page.getByTestId('markdown-mode-preview').click();

--- a/packages/e2e/tests-tauri/sessions-rows.spec.ts
+++ b/packages/e2e/tests-tauri/sessions-rows.spec.ts
@@ -298,7 +298,12 @@ test.describe('§sessions-rows Working + waiting status dot during a gate-held r
   let chatId: string;
 
   test.beforeAll(async () => {
-    app = await launchTauriApp({ recordingKey: 'permissions-interactive' });
+    // Widen the mock replay clamp for this describe: the transient 'working' dot is
+    // broadcast at send (t≈0) but observed only via a debounced full-list refetch, and
+    // the default ~120ms burst collapses the whole turn (incl. the permission that flips
+    // the daemon to 'waiting') into a window the refetch races. An ~800ms ceiling delays
+    // the burst so the leading refetch reliably lands while the daemon is still working.
+    app = await launchTauriApp({ recordingKey: 'permissions-interactive', mockMaxDelayMs: 800 });
     project = await createTauriProject(app.page);
     chatId = await createTauriChat(app.page, project.projectId, 'default');
   });


### PR DESCRIPTION
## Summary

The release CI run surfaced five Tauri E2E failures (four editor, one session-row status). All five were **test defects, not product regressions** — the draft release was never published. This fixes all four root causes.

| Fix | Change |
|-----|--------|
| **Cross-platform editor shortcuts** | `Meta+*` → `ControlOrMeta+*` in `editor.spec.ts` (save, read-only save, `Cmd+F` search, cursor anchor). Linux CI maps CodeMirror's `Mod` to Ctrl, so the `Meta` keystrokes never reached the editor. |
| **Latent `Meta+S` false positive** | Same swap in `editor-diff.spec.ts`. |
| **Self-contained footer test** | The Ln/Col test relied on the preceding search test leaving `search.ts` open; a worker restart after any earlier failure left the tab closed. It now opens the file explicitly (idempotent tree-row click). |
| **Deterministic working-status dot** | The session-row `working` dot is broadcast at send (t≈0) but observed only via a debounced full-list refetch; the mock's ~120ms replay burst collapsed the whole turn (incl. the permission that flips the daemon to `waiting`) into a window the refetch raced. Added `E2E_MOCK_MAX_DELAY_MS` to the mock adapter, threaded through the e2e fixtures, and widened it to 800ms for just that describe. The intentional debounce is unchanged. |

## Testing

Run locally on macOS against the release Rust daemon:

- `sessions-rows.spec.ts` — 11 passed (incl. the working-spinner test that was failing in CI)
- `editor.spec.ts` + `editor-diff.spec.ts` — 17 passed (no regression from the `ControlOrMeta` swap, which still resolves to Cmd on macOS)
- `cargo check` + release build of `mainframe-daemon` — clean

macOS can't exercise the Linux `Mod→Ctrl` path directly — that fix is validated by CI itself — but the local runs confirm no regression and that the timing-sensitive working-dot fix now passes reliably.

Test/CI-only — no product code changes. Empty changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)