### PR TITLE
fix(core-rs): wait out stop teardown when restarting a launch config

### DIFF
--- a/.changeset/launch-restart-race.md
+++ b/.changeset/launch-restart-race.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix a stop→restart race in the launch manager: restarting a config while its previous process was still being torn down (SIGTERM grace window) was silently ignored, leaving the preview stuck on the stopped CTA. `start` now waits for the dying process to exit and then spawns fresh; only genuinely starting/running processes still skip the duplicate start.

--- a/packages/core-rs/crates/mainframe-launch/src/launch_manager.rs
+++ b/packages/core-rs/crates/mainframe-launch/src/launch_manager.rs
@@ -354,9 +354,31 @@ impl LaunchManager {
         let inner = self.inner.clone();
         let name = config.name.clone();
 
-        if inner.processes.contains_key(&name) {
-            tracing::warn!(target: "launch", name = %name, "process already running, skipping start");
-            return Ok(());
+        if let Some((status, mut exit_rx)) = inner
+            .processes
+            .get(&name)
+            .map(|managed| (*lock(&managed.status), managed.exit_rx.clone()))
+        {
+            match status {
+                // A stop() in flight has already published `stopped` (the UI is
+                // showing the run CTA) but the child is still dying and its map
+                // entry survives until reaped — wait for the teardown instead of
+                // silently dropping the restart.
+                LaunchProcessStatus::Stopped | LaunchProcessStatus::Failed => {
+                    let teardown = inner.timings.stop_grace + Duration::from_secs(5);
+                    if tokio::time::timeout(teardown, wait_until_exited(&mut exit_rx))
+                        .await
+                        .is_err()
+                    {
+                        tracing::warn!(target: "launch", name = %name, "previous process did not exit after SIGKILL, skipping start");
+                        return Ok(());
+                    }
+                }
+                _ => {
+                    tracing::warn!(target: "launch", name = %name, "process already running, skipping start");
+                    return Ok(());
+                }
+            }
         }
 
         inner.state.reset(&name);
@@ -948,6 +970,58 @@ mod tests {
                 .iter()
                 .any(|(_, s)| *s == LaunchProcessStatus::Stopped)
         );
+    }
+
+    #[tokio::test]
+    async fn restart_during_stop_teardown_respawns_after_exit() {
+        let (broadcast, events) = recorder();
+        let manager = Arc::new(LaunchManager::with_timings(
+            "proj-1",
+            "/tmp",
+            broadcast,
+            None,
+            None,
+            None,
+            default_read_command(),
+            LaunchTimings {
+                stop_grace: Duration::from_millis(300),
+                ..LaunchTimings::default()
+            },
+        ));
+
+        // Loops so a group SIGTERM (which kills the `sleep` child, default
+        // disposition) doesn't end the `sh` script itself — it must survive to
+        // SIGKILL. The 50ms settle below lets the trap actually install before
+        // stop() fires; without it, SIGTERM can race the shell's startup and
+        // kill it via default disposition before the trap takes effect.
+        let config = cfg("server", "trap '' TERM; while :; do sleep 0.2; done", None);
+        manager.start(&config).await.unwrap();
+        assert_eq!(manager.get_status("server"), LaunchProcessStatus::Running);
+        sleep(Duration::from_millis(50)).await;
+
+        let stop_manager = manager.clone();
+        let stop_task = tokio::spawn(async move { stop_manager.stop("server").await });
+
+        sleep(Duration::from_millis(100)).await;
+        manager.start(&config).await.unwrap();
+
+        stop_task.await.unwrap();
+
+        assert_eq!(manager.get_status("server"), LaunchProcessStatus::Running);
+
+        let statuses = status_events(&events);
+        let stopped_idx = statuses
+            .iter()
+            .position(|(name, status)| name == "server" && *status == LaunchProcessStatus::Stopped)
+            .expect("expected a Stopped status event");
+        assert!(
+            statuses[stopped_idx + 1..]
+                .iter()
+                .any(|(name, status)| name == "server" && *status == LaunchProcessStatus::Starting),
+            "expected a Starting event after the Stopped event"
+        );
+
+        manager.stop("server").await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`preview.spec.ts:255` ("clicking the stopped-body CTA restarts the config back to running") flakes — confirmed pre-existing on `main`, not a cutover regression.

Root cause is a stop→restart race in `LaunchManager`:

1. `stop()` emits the `stopped` status **immediately** — the UI flips to the Run CTA.
2. The `processes` map entry is only removed after the child is actually reaped (`wait_for_exit_task`), which can be up to `stop_grace` (5s) later if the child ignores SIGTERM.
3. A `start()` landing in that window hit the already-running guard and returned `Ok(())` silently: HTTP `success:true`, no status event, no toast — and the UI stays on the stopped CTA forever.

Confirmed empirically against a scratch daemon: `stop` + `start` 30ms apart → both succeed, status stuck `stopped`, daemon log shows `"process already running, skipping start"` racing the SIGTERM. The retired TS daemon had the identical structure, which is why the flake predates the Rust cutover.

## Fix

`start()` now inspects the surviving entry's status instead of blindly skipping:

- **`Stopped`/`Failed`** — a teardown is in flight: wait for the process's exit signal (bounded by `stop_grace` + 5s, i.e. past the SIGKILL fallback), then spawn fresh.
- **`Starting`/`Running`** — keep the idempotent silent skip.

## Verification

- New characterization test `restart_during_stop_teardown_respawns_after_exit`: child ignores SIGTERM with a short `stop_grace` (300ms) so the race window is deterministic; red on the intended assertion before the fix, green after, 10/10 consecutive runs stable.
- `cargo test -p mainframe-launch`: 127/127; clippy and rustfmt clean.
- Previously flaky preview e2e describe block (`§preview — running lifecycle`, rebuilt release daemon): 3/3 runs, 8/8 tests each — the restart test now consistently completes in ~4s (waits out the teardown, then restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)