### PR TITLE
fix(ui): dismiss the image lightbox by clicking the image or dimmed area

### DIFF
--- a/.changeset/lightbox-click-to-dismiss.md
+++ b/.changeset/lightbox-click-to-dismiss.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Dismiss the image lightbox by clicking the image or the dimmed area around it.
+
+The lightbox closed only on clicks that landed on the overlay — the empty bands above and below the image — because the image and the dimmed space beside it sit inside the dialog's content box. Clicking anywhere that is not a control now closes it; the prev/next buttons, the counter, Escape, and the close button behave as before.

--- a/packages/ui/src/features/chat/parts/ImageLightbox.tsx
+++ b/packages/ui/src/features/chat/parts/ImageLightbox.tsx
@@ -6,14 +6,15 @@
  * The parent owns the open index (`null` = closed); this renders the current
  * image plus prev/next controls, a counter, and ArrowLeft/ArrowRight keyboard
  * nav (wrapping at the ends). Restores the desktop multi-image gallery
- * affordance that the single-image `ZoomableImage` didn't cover. Built on our
- * shadcn `Dialog` so no new dependency.
+ * affordance that the single-image `ZoomableImage` didn't cover. The dialog
+ * shell, image, and click-to-dismiss behavior live in `LightboxSurface`.
  *
  * For a single image the nav chrome is omitted (it degrades to a plain zoom).
  */
 import { useEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Dialog } from '@/components/ui/dialog';
+import { LightboxSurface } from './LightboxSurface';
 
 export interface LightboxImage {
   src: string;
@@ -63,19 +64,13 @@ export function ImageLightbox({ images, index, onIndexChange }: ImageLightboxPro
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onIndexChange(null)}>
-      <DialogContent
-        data-testid="image-lightbox-dialog"
-        className="max-w-[92vw] border-none bg-transparent p-0 shadow-none"
+      <LightboxSurface
+        testId="image-lightbox-dialog"
+        imageTestId="image-lightbox-current"
+        src={current.src}
+        alt={current.alt}
+        onDismiss={() => onIndexChange(null)}
       >
-        <DialogTitle className="sr-only">Image preview</DialogTitle>
-
-        <img
-          data-testid="image-lightbox-current"
-          src={current.src}
-          alt={current.alt ?? ''}
-          className="mx-auto max-h-[88vh] max-w-full rounded-md object-contain"
-        />
-
         {hasNav && (
           <>
             <button
@@ -104,7 +99,7 @@ export function ImageLightbox({ images, index, onIndexChange }: ImageLightboxPro
             </div>
           </>
         )}
-      </DialogContent>
+      </LightboxSurface>
     </Dialog>
   );
 }

--- a/packages/ui/src/features/chat/parts/LightboxSurface.tsx
+++ b/packages/ui/src/features/chat/parts/LightboxSurface.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useRef, type ReactNode } from 'react';
+import { useRef, type MouseEvent, type ReactNode } from 'react';
 import { DialogContent, DialogTitle } from '@/components/ui/dialog';
 
 interface LightboxSurfaceProps {
-  /** testid for the dialog content box. */
   testId: string;
-  /** testid for the full-size image. */
   imageTestId: string;
   src: string;
   alt?: string;
@@ -20,7 +18,7 @@ export function LightboxSurface({ testId, imageTestId, src, alt = '', onDismiss,
 
   // Nav chrome and the close button live inside this box, so dismiss only for
   // clicks that land on the box itself or the image — never on a control.
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget || event.target === imageRef.current) onDismiss();
   };
 

--- a/packages/ui/src/features/chat/parts/LightboxSurface.tsx
+++ b/packages/ui/src/features/chat/parts/LightboxSurface.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRef, type ReactNode } from 'react';
+import { DialogContent, DialogTitle } from '@/components/ui/dialog';
+
+interface LightboxSurfaceProps {
+  /** testid for the dialog content box. */
+  testId: string;
+  /** testid for the full-size image. */
+  imageTestId: string;
+  src: string;
+  alt?: string;
+  onDismiss: () => void;
+  /** Nav chrome drawn over the image (absolutely positioned by the caller). */
+  children?: ReactNode;
+}
+
+export function LightboxSurface({ testId, imageTestId, src, alt = '', onDismiss, children }: LightboxSurfaceProps) {
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  // Nav chrome and the close button live inside this box, so dismiss only for
+  // clicks that land on the box itself or the image — never on a control.
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget || event.target === imageRef.current) onDismiss();
+  };
+
+  return (
+    <DialogContent
+      data-testid={testId}
+      onClick={handleClick}
+      className="max-w-[92vw] border-none bg-transparent p-0 shadow-none"
+    >
+      <DialogTitle className="sr-only">Image preview</DialogTitle>
+      <img
+        ref={imageRef}
+        data-testid={imageTestId}
+        src={src}
+        alt={alt}
+        className="mx-auto max-h-[88vh] max-w-full rounded-md object-contain"
+      />
+      {children}
+    </DialogContent>
+  );
+}

--- a/packages/ui/src/features/chat/parts/ZoomableImage.tsx
+++ b/packages/ui/src/features/chat/parts/ZoomableImage.tsx
@@ -7,9 +7,12 @@
  * Single-image zoom only — the native `MessagePartPrimitive.Image` is a bare
  * `<img>` with no zoom, and the inventory decided single-image in-message zoom
  * can go native/shadcn (the multi-image gallery lightbox stays a separate
- * keep-ours). Built on our existing shadcn `Dialog` so no new dependency.
+ * keep-ours). The dialog shell, image, and click-to-dismiss behavior live in
+ * `LightboxSurface`.
  */
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { useState } from 'react';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
+import { LightboxSurface } from './LightboxSurface';
 
 interface ZoomableImageProps {
   src: string;
@@ -21,8 +24,10 @@ interface ZoomableImageProps {
 }
 
 export function ZoomableImage({ src, alt = '', className, onLoad }: ZoomableImageProps) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <button
           type="button"
@@ -33,13 +38,13 @@ export function ZoomableImage({ src, alt = '', className, onLoad }: ZoomableImag
           <img src={src} alt={alt} className={className} onLoad={onLoad} />
         </button>
       </DialogTrigger>
-      <DialogContent
-        data-testid="chat-image-zoom-dialog"
-        className="max-w-[92vw] border-none bg-transparent p-0 shadow-none"
-      >
-        <DialogTitle className="sr-only">Image preview</DialogTitle>
-        <img src={src} alt={alt} className="mx-auto max-h-[88vh] max-w-full rounded-md object-contain" />
-      </DialogContent>
+      <LightboxSurface
+        testId="chat-image-zoom-dialog"
+        imageTestId="chat-image-zoom-image"
+        src={src}
+        alt={alt}
+        onDismiss={() => setOpen(false)}
+      />
     </Dialog>
   );
 }

--- a/packages/ui/src/features/chat/parts/__tests__/ImageLightbox.test.tsx
+++ b/packages/ui/src/features/chat/parts/__tests__/ImageLightbox.test.tsx
@@ -74,4 +74,57 @@ describe('ImageLightbox', () => {
     expect(screen.queryByTestId('image-lightbox-prev')).toBeNull();
     expect(screen.queryByTestId('image-lightbox-counter')).toBeNull();
   });
+
+  it('clicking the image dismisses', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={1} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('image-lightbox-current'));
+    expect(onIndexChange).toHaveBeenCalledWith(null);
+  });
+
+  it('clicking the dimmed area beside the image dismisses', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={1} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('image-lightbox-dialog'));
+    expect(onIndexChange).toHaveBeenCalledWith(null);
+  });
+
+  it('clicking next navigates and does not dismiss', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={0} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('image-lightbox-next'));
+    expect(onIndexChange).toHaveBeenCalledWith(1);
+    expect(onIndexChange).not.toHaveBeenCalledWith(null);
+  });
+
+  it('clicking prev navigates and does not dismiss', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={0} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('image-lightbox-prev'));
+    expect(onIndexChange).toHaveBeenCalledWith(2);
+    expect(onIndexChange).not.toHaveBeenCalledWith(null);
+  });
+
+  it('clicking the counter does nothing', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={1} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('image-lightbox-counter'));
+    expect(onIndexChange).not.toHaveBeenCalled();
+  });
+
+  it('the close button still dismisses', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={1} onIndexChange={onIndexChange} />);
+    fireEvent.click(screen.getByTestId('dialog-close'));
+    expect(onIndexChange).toHaveBeenCalledWith(null);
+    expect(onIndexChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape still dismisses', () => {
+    const onIndexChange = vi.fn();
+    render(<ImageLightbox images={THREE} index={1} onIndexChange={onIndexChange} />);
+    fireEvent.keyDown(screen.getByTestId('image-lightbox-dialog'), { key: 'Escape' });
+    expect(onIndexChange).toHaveBeenCalledWith(null);
+    expect(onIndexChange).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/ui/src/features/chat/parts/__tests__/ZoomableImage.test.tsx
+++ b/packages/ui/src/features/chat/parts/__tests__/ZoomableImage.test.tsx
@@ -15,9 +15,11 @@
  *  2. Clicking the trigger opens the dialog; dialog content contains a full-
  *     size img with the same src.
  *  3. The alt prop is forwarded to the thumbnail img.
+ *  4. Clicking the full-size image or the dimmed area around it dismisses the
+ *     dialog; Escape still dismisses it too.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ZoomableImage } from '../ZoomableImage';
 
 // ---------------------------------------------------------------------------
@@ -76,5 +78,42 @@ describe('ZoomableImage', () => {
     const trigger = screen.getByTestId('chat-image-zoom-trigger');
     const thumbnail = trigger.querySelector('img');
     expect(thumbnail).toHaveAttribute('alt', 'a cat');
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Dismissal
+  // -------------------------------------------------------------------------
+
+  it('clicking the full-size image closes the dialog', async () => {
+    render(<ZoomableImage src="https://example.com/photo.png" />);
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    await screen.findByTestId('chat-image-zoom-dialog');
+
+    const fullSizeImg = screen.getByTestId('chat-image-zoom-image');
+    expect(fullSizeImg).toHaveAttribute('src', 'https://example.com/photo.png');
+
+    fireEvent.click(fullSizeImg);
+    await waitFor(() => expect(screen.queryByTestId('chat-image-zoom-dialog')).toBeNull());
+  });
+
+  it('clicking the dimmed area beside the image closes the dialog', async () => {
+    render(<ZoomableImage src="https://example.com/photo.png" />);
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    const dialog = await screen.findByTestId('chat-image-zoom-dialog');
+
+    fireEvent.click(dialog);
+    await waitFor(() => expect(screen.queryByTestId('chat-image-zoom-dialog')).toBeNull());
+  });
+
+  it('Escape still closes the dialog', async () => {
+    render(<ZoomableImage src="https://example.com/photo.png" />);
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    const dialog = await screen.findByTestId('chat-image-zoom-dialog');
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('chat-image-zoom-dialog')).toBeNull());
   });
 });


### PR DESCRIPTION
Closes #276 (todos plugin).

## Summary

The lightbox only dismissed when you clicked the empty bands above or below the image. Radix's "interact outside Content" detection fires for pointer-downs on the overlay, and `DialogContent` wrapped the image tightly — so a click on the image itself counted as *inside* Content and did nothing. Users had to aim at the letterbox.

Both `ImageLightbox` (multi-image) and `ZoomableImage` (single) had the same shape, so the fix landed in a new shared `LightboxSurface` they both render. It owns the dialog content, the image, and one click handler:

```ts
if (event.target === event.currentTarget || event.target === imageRef.current) onDismiss();
```

Dismiss fires for the content box and the image; anything else — nav chrome, counter, close button, all absolutely positioned over the surface by the caller — is left alone. That is an identity check rather than `stopPropagation` on every control, so a control added later can't silently start dismissing.

Escape and the close "X" are unchanged.

## Route

`route:no-spec`. The brief was the spec; no product decisions were open.

## Review

`reviewer` and `quality-reviewer` both ran on the diff. Findings were nits only (naming and comment precision in `LightboxSurface`), fixed in `67be7427`. Nothing was skipped.

## QA

Autonomous run, 12 scenarios, all pass. jsdom `fireEvent` dispatches to whatever node you name regardless of visual overlap, so it cannot answer the question this fix actually turns on — whether nav chrome layered over the dismiss surface receives the real click. QA mounted both components in a throwaway Vite entry and drove them with real coordinate mouse events:

| Scenario | Result |
|---|---|
| Backdrop click dismisses (both components) | pass |
| Image click dismisses (both components) | pass |
| Next / Prev navigate, do not dismiss | pass |
| Counter click is a no-op | pass |
| Close button dismisses | pass |
| Escape dismisses (both components) | pass |
| Unit suite (22 tests) + UI typecheck | pass |

Not verified: the five call sites that open the lightbox (`InlineImageThumbs`, `AssistantMessage`, `TaskAttachments`, `SessionAttachmentsGrid`, `ImageViewer`) still pass props correctly — QA drove `LightboxSurface`'s two direct callers rather than seeding real image attachments. The diff is confined to those two callers and the shared surface.

**Correction to the brief:** it assumed clicking the image did not dismiss *and should*. That reads as if image-click were the only gap — in fact both the image and the side bands were dead, and both now work. The brief's "zoom/pan interactions must not be swallowed" is N/A: there is no pan/zoom gesture logic in this component (it is click-to-open-full-size only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)