### PR TITLE
fix(ui): swap the dark theme accent from periwinkle to macOS system blue

### DIFF
--- a/.changeset/dark-theme-accent-blue.md
+++ b/.changeset/dark-theme-accent-blue.md
@@ -2,4 +2,4 @@
 '@qlan-ro/mainframe-ui': patch
 ---
 
-Change the default dark theme's accent from periwinkle purple to macOS system blue (#0A84FF), matching the light theme. The dark selection tint, focus ring, and command-directive tint follow the new accent.
+Change the default dark theme's accent from periwinkle purple to macOS system blue (#0A84FF), matching the light theme. The dark selection tint, focus ring, command-directive tint, and code-editor selection highlight follow the new accent.

--- a/.changeset/dark-theme-accent-blue.md
+++ b/.changeset/dark-theme-accent-blue.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Change the default dark theme's accent from periwinkle purple to macOS system blue (#0A84FF), matching the light theme. The dark selection tint, focus ring, and command-directive tint follow the new accent.

--- a/packages/ui/src/styles/__tests__/contrast.test.ts
+++ b/packages/ui/src/styles/__tests__/contrast.test.ts
@@ -18,6 +18,10 @@ import { readFileSync } from 'node:fs';
 
 const WCAG_MIN = 4.49;
 
+/* #0a84ff on white is 3.65:1 — macOS system blue cannot reach AA-normal-text
+   with a white foreground; SC 1.4.11 (non-text/UI) and large-text bar is 3:1. */
+const UI_COMPONENT_MIN = 3.0;
+
 const css = readFileSync(new URL('../globals.css', import.meta.url), 'utf8');
 
 type Decls = Record<string, string>;
@@ -103,6 +107,13 @@ function parseColor(value: string): RGBA {
   throw new Error(`unsupported color value: "${value}"`);
 }
 
+/** Pull the rgba(...) call out of a shorthand value like a box-shadow. */
+function extractRgba(shorthand: string): string {
+  const m = shorthand.match(/rgba?\([^)]+\)/i);
+  if (!m) throw new Error(`no rgba()/rgb() found in "${shorthand}"`);
+  return m[0];
+}
+
 /** Composite a (possibly translucent) foreground color over an opaque backdrop. */
 function composite(fg: RGBA, bg: RGBA): RGBA {
   return {
@@ -176,5 +187,64 @@ describe('globals.css contrast guardrail', () => {
     // Guards the cascade model itself: these blocks do NOT redeclare --background.
     expect(resolve('ocean-light')['--background']).toBe('#ffffff');
     expect(resolve('velvet-light')['--background']).toBe('#ffffff');
+  });
+
+  it.each(ALL)('primary-foreground clears 3:1 as ink on --primary fill — %s', (theme) => {
+    const t = resolve(theme);
+    const fg = parseColor(req(t, '--primary-foreground'));
+    const bg = parseColor(req(t, '--primary'));
+    expect(contrast(fg, bg), `primary-foreground on primary (${theme})`).toBeGreaterThanOrEqual(UI_COMPONENT_MIN);
+  });
+
+  it('classic-dark accent stays legible as ink on its three backdrops', () => {
+    const t = resolve('classic-dark');
+    const ink = parseColor(req(t, '--primary'));
+    for (const [name, bg] of Object.entries(backdrops(t))) {
+      expect(contrast(ink, bg), `primary as ink on ${name} (classic-dark)`).toBeGreaterThanOrEqual(UI_COMPONENT_MIN);
+    }
+  });
+});
+
+describe('globals.css accent derivation', () => {
+  // Todo #277's literal acceptance criterion: classic-light and classic-dark
+  // share one accent. Pinning both halves also guards "light is unchanged".
+  const MACOS_SYSTEM_BLUE = '#0a84ff';
+
+  it('classic-light and classic-dark --primary are macOS system blue', () => {
+    expect(resolve('classic-light')['--primary']).toBe(MACOS_SYSTEM_BLUE);
+    expect(resolve('classic-dark')['--primary']).toBe(MACOS_SYSTEM_BLUE);
+  });
+
+  it.each(ALL)('--ring tracks --primary — %s', (theme) => {
+    const t = resolve(theme);
+    expect(t['--ring']).toBe(t['--primary']);
+  });
+
+  it.each(ALL)('--mf-selection carries --primary RGB (alpha differs per theme by design) — %s', (theme) => {
+    const t = resolve(theme);
+    const primary = parseColor(req(t, '--primary'));
+    const selection = parseColor(req(t, '--mf-selection'));
+    expect([selection.r, selection.g, selection.b]).toEqual([primary.r, primary.g, primary.b]);
+  });
+
+  it.each(ALL)('--mf-focus-ring carries --primary RGB (alpha differs per theme by design) — %s', (theme) => {
+    const t = resolve(theme);
+    const primary = parseColor(req(t, '--primary'));
+    const ring = parseColor(extractRgba(req(t, '--mf-focus-ring')));
+    expect([ring.r, ring.g, ring.b]).toEqual([primary.r, primary.g, primary.b]);
+  });
+
+  const DIRECTIVE_TINT_THEMES = ['classic-light', 'classic-dark', 'ocean-dark', 'velvet-dark'];
+  it.each(DIRECTIVE_TINT_THEMES)('--mf-directive-command-tint carries --primary RGB — %s', (theme) => {
+    const t = resolve(theme);
+    const primary = parseColor(req(t, '--primary'));
+    const tint = parseColor(req(t, '--mf-directive-command-tint'));
+    expect([tint.r, tint.g, tint.b]).toEqual([primary.r, primary.g, primary.b]);
+  });
+
+  it('ocean-light and velvet-light inherit --mf-directive-command-tint from :root (classic blue, not their own accent)', () => {
+    const classicTint = resolve('classic-light')['--mf-directive-command-tint'];
+    expect(resolve('ocean-light')['--mf-directive-command-tint']).toBe(classicTint);
+    expect(resolve('velvet-light')['--mf-directive-command-tint']).toBe(classicTint);
   });
 });

--- a/packages/ui/src/styles/__tests__/contrast.test.ts
+++ b/packages/ui/src/styles/__tests__/contrast.test.ts
@@ -215,11 +215,6 @@ describe('globals.css accent derivation', () => {
     expect(resolve('classic-dark')['--primary']).toBe(MACOS_SYSTEM_BLUE);
   });
 
-  it.each(ALL)('--ring tracks --primary — %s', (theme) => {
-    const t = resolve(theme);
-    expect(t['--ring']).toBe(t['--primary']);
-  });
-
   it.each(ALL)('--mf-selection carries --primary RGB (alpha differs per theme by design) — %s', (theme) => {
     const t = resolve(theme);
     const primary = parseColor(req(t, '--primary'));
@@ -232,6 +227,15 @@ describe('globals.css accent derivation', () => {
     const primary = parseColor(req(t, '--primary'));
     const ring = parseColor(extractRgba(req(t, '--mf-focus-ring')));
     expect([ring.r, ring.g, ring.b]).toEqual([primary.r, primary.g, primary.b]);
+  });
+
+  it('classic-dark --mf-cm-selection/-focused carry --primary RGB (matches ocean/velvet dark pattern)', () => {
+    const t = resolve('classic-dark');
+    const primary = parseColor(req(t, '--primary'));
+    for (const token of ['--mf-cm-selection', '--mf-cm-selection-focused']) {
+      const c = parseColor(req(t, token));
+      expect([c.r, c.g, c.b], token).toEqual([primary.r, primary.g, primary.b]);
+    }
   });
 
   const DIRECTIVE_TINT_THEMES = ['classic-light', 'classic-dark', 'ocean-dark', 'velvet-dark'];

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -210,8 +210,8 @@
 }
 
 /* ────────────────────────────────────────────────────────────────────────
-   CLASSIC · DARK — playful Dracula-ish slate, periwinkle accent
-   (Redesigned 2026-06-12: was warm charcoal + shared blue.)
+   CLASSIC · DARK — playful Dracula-ish slate, macOS system-blue accent
+   (Slate redesigned 2026-06-12; accent unified with light's #0a84ff 2026-07-25.)
    ──────────────────────────────────────────────────────────────────────── */
 .dark {
   /* Without this WebKit paints native scrollbar chrome (the white track) light
@@ -224,7 +224,7 @@
   --card-foreground: #f2f2f8;
   --popover: #2c2e3d;
   --popover-foreground: #f2f2f8;
-  --primary: #8a70f5;              /* periwinkle accent, dark-classic */
+  --primary: #0a84ff;              /* macOS system blue, shared with light */
   --primary-foreground: #ffffff;
   --secondary: #313447;
   --secondary-foreground: #f2f2f8;
@@ -236,7 +236,7 @@
   --destructive-foreground: #1b1c25;
   --border: rgba(255,255,255,0.10);
   --input: rgba(255,255,255,0.10);
-  --ring: #8a70f5;
+  --ring: #0a84ff;
 
   --mf-window: #1b1c25;
   --mf-glass: rgba(34,36,47,0.85);
@@ -247,7 +247,7 @@
   --mf-text-3: #8b8ea4;
   --mf-text-4: #555870;
   --mf-chip: rgba(255,255,255,0.07);
-  --mf-selection: rgba(138,112,245,0.30);
+  --mf-selection: rgba(10,132,255,0.30);
   --mf-warning: #f5a960;
   --mf-success: #50d97c;
 
@@ -279,7 +279,7 @@
 
   --mf-shadow-pop: 0 18px 44px rgba(0,0,0,0.55), 0 0 0 0.5px rgba(255,255,255,0.10);
   --mf-shadow-modal: 0 28px 64px rgba(0,0,0,0.66), 0 0 0 0.5px rgba(255,255,255,0.10);
-  --mf-focus-ring: 0 0 0 3px rgba(138,112,245,0.50);
+  --mf-focus-ring: 0 0 0 3px rgba(10,132,255,0.50);
   --mf-scrim: rgba(0, 0, 0, 0.55); /* heavier scrim for all dark schemes (inherited by ocean/velvet dark) */
 
   /* ── App-only tokens — DARK ── */
@@ -291,7 +291,7 @@
   --mf-surface-run: #50d97c;
   --mf-directive-skill: #b48cff;
   --mf-directive-skill-tint: rgba(180, 140, 255, 0.14);
-  --mf-directive-command-tint: rgba(138, 112, 245, 0.14);
+  --mf-directive-command-tint: rgba(10, 132, 255, 0.14);
   --mf-tool-read: #8fb2ff;
   --mf-tool-read-tint: rgba(143, 178, 255, 0.14);
   --mf-tool-search: #c18ee8;

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -46,7 +46,7 @@
   --destructive-foreground: #ffffff;
   --border: rgba(0,0,0,0.08);       /* hairlines, dividers                         */
   --input: rgba(0,0,0,0.08);        /* field borders                               */
-  --ring: #0a84ff;                  /* focus ring color                            */
+  --ring: var(--primary);           /* focus ring — tracks each scheme's own primary via the cascade */
 
   --mf-window: #e9e7e2;
   --mf-glass: rgba(240,237,231,0.84);
@@ -236,7 +236,6 @@
   --destructive-foreground: #1b1c25;
   --border: rgba(255,255,255,0.10);
   --input: rgba(255,255,255,0.10);
-  --ring: #0a84ff;
 
   --mf-window: #1b1c25;
   --mf-glass: rgba(34,36,47,0.85);
@@ -348,8 +347,8 @@
   --mf-diff-del-text: #ff6272;
 
   --mf-cm-active-line: rgba(255,255,255,0.04);
-  --mf-cm-selection: rgba(59,130,246,0.3);
-  --mf-cm-selection-focused: rgba(59,130,246,0.4);
+  --mf-cm-selection: rgba(10,132,255,0.3);
+  --mf-cm-selection-focused: rgba(10,132,255,0.4);
   --mf-cm-match: rgba(251,191,36,0.2);
   --mf-cm-match-border: rgba(251,191,36,0.4);
   --mf-cm-match-selected: rgba(251,191,36,0.4);
@@ -374,7 +373,6 @@
   --destructive: #d23b4e;
   --border: rgba(10,40,45,0.10);
   --input: rgba(10,40,45,0.10);
-  --ring: #0e9888;
 
   --mf-window: #e2e8ea;
   --mf-glass: rgba(230,238,240,0.84);
@@ -468,7 +466,6 @@
   --destructive-foreground: #141923;
   --border: rgba(255,255,255,0.10);
   --input: rgba(255,255,255,0.10);
-  --ring: #2fc6b7;
 
   --mf-window: #141923;
   --mf-glass: rgba(26,33,44,0.85);
@@ -592,7 +589,6 @@
   --destructive: #d23b54;
   --border: rgba(60,20,55,0.10);
   --input: rgba(60,20,55,0.10);
-  --ring: #d6488f;
 
   --mf-window: #ebe4eb;
   --mf-glass: rgba(242,235,242,0.84);
@@ -684,7 +680,6 @@
   --destructive-foreground: #1e1726;
   --border: rgba(255,255,255,0.10);
   --input: rgba(255,255,255,0.10);
-  --ring: #f06bb3;
 
   --mf-window: #1e1726;
   --mf-glass: rgba(36,28,46,0.85);


### PR DESCRIPTION
Closes #277 (todos plugin).

## Summary

The default dark theme's accent was periwinkle `#8a70f5` while the default light theme was already macOS system blue `#0A84FF`. This makes classic-dark match: `--primary: #0a84ff`, and every token derived from the old purple follows it.

Because the accent is single-sourced through `@theme inline`, the token change alone propagates blue to buttons, active states, and focus rings — no per-component edits. Four derived tokens needed re-tinting by hand because they hardcoded the purple's RGB:

- `--mf-selection` → `rgba(10,132,255,0.30)`
- `--mf-focus-ring` → `rgba(10,132,255,0.50)`
- `--mf-directive-command-tint` → `rgba(10,132,255,0.14)`
- `--mf-cm-selection` / `-focused` → the CodeMirror selection highlight, which was stale Tailwind blue-500 rather than accent-derived

Ocean and velvet keep their own accents, and the light theme is untouched.

## Also in this diff: `--ring` stops being copy-pasted

`--ring` was declared five times — once per scheme, each duplicating that scheme's `--primary` literal. It is now `--ring: var(--primary)` in `:root`, so it tracks each scheme's own accent through the cascade and the four per-scheme copies are gone. That is why the diff touches ocean and velvet blocks despite their accents being unchanged: the deleted lines restated a value the cascade now supplies.

## Guardrails

`packages/ui/src/styles/__tests__/contrast.test.ts` gains tests that parse `globals.css` and assert the derivation holds, so a future accent change can't leave a tinted token behind:

- `--mf-selection`, `--mf-focus-ring`, `--mf-directive-command-tint`, and classic-dark's `--mf-cm-selection*` all carry `--primary`'s RGB (alpha still differs per theme by design)
- classic-light and classic-dark `--primary` are both `#0a84ff` — this pins the ACs literally and doubles as the "light is unchanged" guard
- `--primary-foreground` clears a contrast floor as ink on the `--primary` fill, for every theme

**The floor for those is 3:1, not 4.5:1, and that is a deliberate call worth reading.** `#0a84ff` against white is 3.65:1 — macOS system blue simply cannot reach WCAG AA for normal text with a white foreground. 3:1 is the SC 1.4.11 non-text/UI-component bar, which is the correct standard for a button fill or a focus ring. It would be the wrong standard for body copy on that blue, and the test does not claim otherwise. The light theme already shipped this exact blue, so this is inherited, not introduced.

## Route

`route:no-spec`. Both of the brief's open questions took the recommended answers: dark-classic only (ocean/velvet keep their accents), and yes, re-derive the selection tint.

## Review

`reviewer` and `quality-reviewer` both ran. The `--ring` duplication was their finding, fixed in `492668c9` along with the CodeMirror selection retint.

**Knowingly skipped:** `--mf-cm-sel-match` in classic-dark, and classic-light's `--mf-cm-*` blues, are still stale Tailwind blue-500. They are pre-existing and unrelated to the accent swap — retinting the whole CodeMirror palette is its own change, not a rider on this one.

## QA

7 scenarios, all pass — accent rendering in dark, selection tint, focus ring, light theme unchanged, ocean/velvet accents unchanged, no remaining `#8a70f5`/`138,112,245` in the dark theme, and the unit suite plus typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)