### PR TITLE
fix(agents): point the QA launch scripts at the Rust daemon

### DIFF
--- a/.agents/cleanup-test.sh
+++ b/.agents/cleanup-test.sh
@@ -1,40 +1,75 @@
 #!/usr/bin/env bash
 # Kill stale test-worktree dev processes. Protected: production daemon on 31415.
 # Run ONCE per fleet (orchestrator) or once before a single-branch launch.
+#
+# Targets are found by PORT, not by process name: name matching stopped matching
+# anything when the Node daemon was retired, so this script kept reporting
+# CLEANUP_OK while leaving every stale process running.
+#
+# The daemon range is swept wholesale — setup-ports.sh allocates from it and
+# nothing else on the machine uses it. Vite ports are NOT swept by range: 5174-
+# 6174 is crowded with unrelated software (ActivityWatch's aw-server sits on
+# 5600), so they're read back from the `.env` our own scripts generated in each
+# worktree, plus the tauri target's fixed default.
 set -uo pipefail
 
 PROTECTED_PORT=31415
+DAEMON_RANGE=31416-32416
+TAURI_VITE_PORT=5174
+CDP_PORT=9222
 
-pids=$(ps ax -o pid,command | grep 'mainframe-core run dev' | grep -v grep | awk '{print $1}')
-for pid in $pids; do
-  if ! lsof -iTCP:$PROTECTED_PORT -sTCP:LISTEN -a -p "$pid" 2>/dev/null | grep -q LISTEN; then
-    pkill -9 -P "$pid" 2>/dev/null
-    kill -9 "$pid" 2>/dev/null
+listeners() {
+  lsof -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u
+}
+
+protected_pids=$(listeners "$PROTECTED_PORT")
+
+is_protected() {
+  [ -n "$protected_pids" ] && echo "$protected_pids" | grep -qx "$1"
+}
+
+# Every checkout's generated .env — the browser target writes its isolated ports
+# there, so this finds runs in worktrees this script isn't sitting in.
+vite_ports() {
+  echo "$TAURI_VITE_PORT"
+  git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2"/.env"}' | while read -r env_file; do
+    [ -f "$env_file" ] && sed -n 's/^VITE_PORT=\([0-9]\{1,\}\)$/\1/p' "$env_file"
+  done
+}
+
+targets=$(
+  {
+    listeners "$DAEMON_RANGE"
+    listeners "$CDP_PORT"
+    for port in $(vite_ports | sort -u); do listeners "$port"; done
+  } | sort -u
+)
+
+for pid in $targets; do
+  if is_protected "$pid"; then
+    echo "SKIP $pid (production daemon on $PROTECTED_PORT)"
+    continue
   fi
-done
-
-pids=$(ps ax -o pid,command | grep 'mainframe-desktop run dev' | grep -v grep | awk '{print $1}')
-for pid in $pids; do
+  # A pnpm/vite listener is a child of a shell wrapper; -P is pid-scoped, so it
+  # can't reach anything but this process's own children.
   pkill -9 -P "$pid" 2>/dev/null
   kill -9 "$pid" 2>/dev/null
 done
 
-lsof -ti :9222 2>/dev/null | xargs kill -9 2>/dev/null
-
 sleep 2
 
-remaining=$(ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | awk '{print $1}')
-if [ -n "$remaining" ]; then
-  echo "$remaining" | xargs kill -9 2>/dev/null
-  sleep 2
-fi
+remaining=""
+for pid in $targets; do
+  is_protected "$pid" && continue
+  kill -0 "$pid" 2>/dev/null && remaining="$remaining $pid"
+done
 
-if ps ax -o pid,command | grep 'mainframe-\(core\|desktop\) run dev' | grep -v grep | grep -q .; then
-  echo "CLEANUP_FAILED: dev processes survived" >&2
+if [ -n "${remaining# }" ]; then
+  echo "CLEANUP_FAILED: survived SIGKILL:$remaining" >&2
   exit 1
 fi
 
-if lsof -iTCP:$PROTECTED_PORT -sTCP:LISTEN >/dev/null 2>&1; then
+if [ -n "$protected_pids" ]; then
   echo "CLEANUP_OK (production daemon on $PROTECTED_PORT untouched)"
 else
   echo "CLEANUP_OK (nothing on $PROTECTED_PORT — production app not running)"

--- a/.agents/launch-test-browser.sh
+++ b/.agents/launch-test-browser.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Launch the BROWSER target for test-worktree: daemon + shared renderer in a
-# plain browser — no Electron, no Rust. For renderer/daemon-only scenario
-# sets (no native shell surfaces). Blocks until ready; prints READY + facts.
-# Typical bring-up: 1-2 minutes. Engine: playwright-cli fresh browser at APP_URL.
+# plain browser — no Tauri shell. For renderer/daemon-only scenario sets (no
+# native shell surfaces). Blocks until ready; prints READY + facts. Bring-up is
+# 1-2 minutes on a warm worktree, several more if the daemon compiles cold.
+# Engine: playwright-cli fresh browser at APP_URL.
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 cd "$PROJECT_ROOT"
 
-# 1. Isolated ports + install + types build only (no shell builds).
-bash scripts/setup-ports.sh --minimal
+# 1. Isolated ports + install + types build.
+bash scripts/setup-ports.sh
 
 # 2. Load the isolated ports.
 set -a
@@ -21,11 +22,17 @@ export MAINFRAME_DATA_DIR="${MAINFRAME_DATA_DIR:-$HOME/.mainframe_dev}"
 DAEMON_LOG="/tmp/mf-daemon-${DAEMON_PORT}.log"
 UI_LOG="/tmp/mf-ui-${DAEMON_PORT}.log"
 
-# 3. Daemon (from source via tsx).
+# 3. Daemon — the Rust binary. Cargo never shares a target dir across worktrees
+# (five consumers hardcode packages/core-rs/target), so a fresh worktree pays a
+# cold compile of several minutes and several GB here; a warm one links in
+# seconds. `cargo sweep`/`cargo clean --profile dev` reclaim it afterwards.
+echo "Building mainframe-daemon (cold builds take several minutes)…"
+cargo build --manifest-path packages/core-rs/Cargo.toml -p mainframe-daemon
+
 DAEMON_PORT="$DAEMON_PORT" \
 MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \
 LOG_LEVEL=debug \
-  pnpm --filter @qlan-ro/mainframe-core run dev > "$DAEMON_LOG" 2>&1 &
+  packages/core-rs/target/debug/mainframe-daemon > "$DAEMON_LOG" 2>&1 &
 
 # 4. Shared renderer (Vite). Browser dev mode reads VITE_DAEMON_PORT (singular)
 # in fake-adapter.ts — the HTTP/WS pair is the electron/tauri shape and is NOT

--- a/.agents/launch-test-tauri.sh
+++ b/.agents/launch-test-tauri.sh
@@ -18,8 +18,11 @@ if [ "$DAEMON_PORT" = "31415" ]; then
   exit 2
 fi
 
-# Fresh-worktree provisioning (idempotent).
-[ -d node_modules ] || pnpm install
+# Fresh-worktree provisioning (idempotent). --frozen-lockfile is load-bearing:
+# a plain install re-resolves the workspace, and in a worktree the
+# `packages/mobile` submodule isn't populated, so pnpm strips it from the
+# lockfile. Frozen installs fine without it and never writes the file.
+pnpm install --frozen-lockfile
 cd packages/app-tauri
 
 # `pnpm tauri:dev` is the whole stack: it compiles+runs the Rust shell, starts

--- a/.agents/test-worktree.md
+++ b/.agents/test-worktree.md
@@ -67,19 +67,20 @@ Limits for multi-branch runs (consumed by the skill's Fleet Mode):
   run genuinely in parallel.
 - **Max parallel runs: 4 total**, but at most one tauri run at a time (its
   full native build thrashes the machine; browser runs are cheap).
-- **Prefer the browser target.** Native builds are slow and heavy; the
-  browser target (vite + daemon, no cargo) is the default path for
-  renderer/daemon-only scenario sets — reserve tauri for genuinely native
-  surfaces.
+- **Prefer the browser target.** It builds only the daemon, where tauri also
+  compiles the whole native shell — so it stays the default path for
+  renderer/daemon-only scenario sets. Reserve tauri for genuinely native
+  surfaces. Neither target is free in a fresh worktree: cargo can't share a
+  target dir across worktrees, so the first run in one pays a cold compile.
 - Daemon/Vite ports and `MAINFRAME_DATA_DIR=~/.mainframe_dev` are isolated
   per run by `scripts/setup-ports.sh`, so parallel runs don't collide there —
   but they DO share `~/.mainframe_dev`; scenarios that assert on global DB
   state (project/chat counts) belong in sequential runs.
-- **Process kills in a fleet:** the Cleanup section below matches ANY
-  `mainframe-core/desktop run dev` process — including live test runs — so
-  it runs exactly once (orchestrator, before any env exists). Per-branch
-  teardown uses the Stop / Restart section, which is scoped to that
-  worktree's own `.env` ports and is parallel-safe.
+- **Process kills in a fleet:** the Cleanup section below kills ANY listener in
+  the test port ranges — including live test runs — so it runs exactly once
+  (orchestrator, before any env exists). Per-branch teardown uses the Stop /
+  Restart section, which is scoped to that worktree's own `.env` ports and is
+  parallel-safe.
 - Protected port `31415` applies to every run, always.
 
 ## Protected Ports

--- a/.changeset/agent-qa-scripts-rust-daemon.md
+++ b/.changeset/agent-qa-scripts-rust-daemon.md
@@ -1,0 +1,4 @@
+---
+---
+
+Agent QA tooling only — no package behavior changes.

--- a/scripts/setup-ports.sh
+++ b/scripts/setup-ports.sh
@@ -45,26 +45,17 @@ echo "Wrote $ENV_FILE"
 echo "  DAEMON_PORT=$DAEMON_PORT (renderer also reads via VITE_DAEMON_HTTP_PORT/WS_PORT)"
 echo "  VITE_PORT=$VITE_PORT"
 
-# Install dependencies and build types package
+# --frozen-lockfile is load-bearing, not hygiene: a plain install re-resolves the
+# whole workspace, and in a worktree the `packages/mobile` submodule isn't
+# populated, so pnpm silently strips every one of its entries from the lockfile.
+# Frozen installs fine without the submodule and never writes the file.
 echo ""
 echo "Installing dependencies…"
-(cd "$PROJECT_ROOT" && pnpm install)
+(cd "$PROJECT_ROOT" && pnpm install --frozen-lockfile)
 
 echo ""
 echo "Building @qlan-ro/mainframe-types…"
 (cd "$PROJECT_ROOT" && pnpm --filter @qlan-ro/mainframe-types build)
-
-# --minimal: browser-mode test runs need only ports + install + types
-# (daemon runs from source via tsx; Vite serves the renderer from source).
-if [ "${1:-}" = "--minimal" ]; then
-  echo ""
-  echo "Minimal setup complete (skipped core build)."
-  exit 0
-fi
-
-echo ""
-echo "Building @qlan-ro/mainframe-core…"
-(cd "$PROJECT_ROOT" && pnpm --filter @qlan-ro/mainframe-core build)
 
 echo ""
 echo "Worktree setup complete."


### PR DESCRIPTION
Found while QA-ing #191: the agent QA launch scripts still target the daemon that was retired in #510, and two of them damage the repo when they run.

## What was broken

**The browser target booted the Node daemon.** `launch-test-browser.sh` ran `pnpm --filter @qlan-ro/mainframe-core run dev`, so `/health` reported `2.0.0-rc.13` and every route under test answered `404` with an Express `Cannot GET` page. Any agent QA-ing a Rust-daemon feature had to notice the 404s and hand-launch the real daemon — the #191 run did exactly that.

**Both launchers ran a plain `pnpm install`, which strips the lockfile.** A full install re-resolves the workspace, and in a worktree the `packages/mobile` submodule isn't populated, so pnpm drops all 6971 of its lines from `pnpm-lock.yaml`. This isn't hypothetical — it happened mid-run during #191's QA and had to be reverted by hand. `pnpm install --frozen-lockfile` installs fine without the submodule and never writes the file.

**`cleanup-test.sh` had stopped cleaning anything.** It found targets by grepping the process list for `mainframe-core run dev`. That string went away with the Node daemon, so the script killed nothing and reported `CLEANUP_OK` — a silent no-op is worse than a failure, because the orchestrator trusts it before launching a fleet.

## The cleanup rewrite, and one thing it deliberately doesn't do

Cleanup now works from ports instead of process names. The daemon range (31416-32416) is swept wholesale — `setup-ports.sh` allocates from it and nothing else on the machine uses it.

Vite ports are **not** swept by range. The obvious version of this change sweeps 5174-6174, and I nearly shipped it: on this machine that range contains ActivityWatch's `aw-server` on 5600, so a fleet cleanup would have killed an unrelated user application. Instead the script reads `VITE_PORT` back out of the `.env` that our own scripts generated in each worktree (enumerated via `git worktree list`, so it finds runs in worktrees it isn't sitting in), plus the tauri target's fixed default.

The tradeoff: a stale vite launched outside our scripts won't be found. That's the right way to be wrong here — `setup-ports.sh` allocates a *free* port per run, so a stray vite never blocks anything, while killing a user's app does real harm.

## Also

Dropped `setup-ports.sh`'s `--minimal` branch. Its only job was building the retired core package, and its one caller always passed the flag.

## Verification

- `setup-ports.sh` run end-to-end in a fresh worktree with the submodule uninitialized: exit 0, `.env` generated with isolated ports, types built, and `git status pnpm-lock.yaml` empty afterwards — the lockfile is byte-identical.
- The daemon launch contract: the Rust binary honors `DAEMON_PORT` and `MAINFRAME_DATA_DIR`, and answers the script's exact readiness probe (`/api/projects` on the isolated port) with 200 — the route that returned 404 under the Node daemon. Production on `:31415` verified untouched throughout.
- `cargo build --manifest-path packages/core-rs/Cargo.toml -p mainframe-daemon` resolves to the right crate and produces `packages/core-rs/target/debug/mainframe-daemon`, the path the script executes.
- `cleanup-test.sh` target selection, dry-run with the kills stubbed: selects only our own vite listener; does not select `aw-server` on 5600. Re-run with the protected range deliberately widened to include 31415, it prints `SKIP 1353 (production daemon on 31415)` instead of killing it.

**Not verified:** the cold-compile path. Cargo can't share a target dir across worktrees, so exercising it means a multi-GB build in a throwaway checkout, and this machine recently ran out of disk. The build command itself was validated against a warm target as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
