### PR TITLE
fix: live background work never shows in a session (#273)

### DIFF
--- a/.changeset/background-activity-live-set.md
+++ b/.changeset/background-activity-live-set.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix live background work never showing in a session. The daemon never asked its
+background-task tracker which tasks were running, so the pill above the composer
+stayed empty and the session row showed no in-progress state while agents, bash
+tasks, or workflows ran. This was reported against a workflow because a workflow
+runs longest, but it affected every kind of background work.

--- a/.changeset/background-activity-live-set.md
+++ b/.changeset/background-activity-live-set.md
@@ -7,3 +7,8 @@ background-task tracker which tasks were running, so the pill above the composer
 stayed empty and the session row showed no in-progress state while agents, bash
 tasks, or workflows ran. This was reported against a workflow because a workflow
 runs longest, but it affected every kind of background work.
+
+Also fix orphaned background tasks staying stuck "running" forever after the
+CLI process exits (a stopped session, or a CLI crash) — the daemon now stops
+every live task for that chat on exit, so the pill and in-progress state clear
+along with it.

--- a/docs/plans/2026-07-27-todo-273-background-activity-live-plan.md
+++ b/docs/plans/2026-07-27-todo-273-background-activity-live-plan.md
@@ -1,0 +1,330 @@
+# Plan — todo #273: live background activity never reaches the client
+
+**Todo:** #273 (project `rgoM5ZldH0UeeOonms6PK`) · **Route:** no-spec · **Branch:** `todo/273-background-activity-live`
+**Worktree:** `/Users/doruchiulan/Projects/qlan/mainframe/.worktrees/todo-273-background-activity-live`
+
+## Goal
+
+The Rust daemon's production `ChatManagerDeps` implementation, `DaemonChatDeps`, never overrides
+`tracker_list_live`, so the trait's empty default wins and every chat enrichment path sees "no
+background work". `Chat.backgroundActivity` is therefore always absent and `Chat.displayStatus` never
+widens to `working` on background-only activity — the above-composer pill never appears and the
+session row shows no in-progress state, for agents, bash tasks, and workflows alike. This change adds
+the missing override so enrichment reads the real tracker, deletes the trait's empty default so the
+next implementation cannot repeat the omission silently, and adds wiring-level tests that exercise the
+production deps through `build_chat_manager` rather than calling the private `enrich_chat` helper — the
+gap that let the regression ship. No UI change: the client already resyncs its live set from
+`chat.backgroundActivity` on every `chat.updated`.
+
+## Verified against the code
+
+Line numbers are from this branch at `5f7fdcaa`; they differ from the ones quoted in the todo body.
+
+| Fact | Location |
+| --- | --- |
+| `tracker_list_live` declared with an empty default | `packages/core-rs/crates/mainframe-chat/src/chat_manager.rs:256-260` |
+| `DaemonChatDeps` overrides `tracker_remove_chat` but not `tracker_list_live` | `packages/core-rs/crates/mainframe-server/src/chat_deps.rs:665-667` |
+| `DaemonChatDeps` already holds `background_tasks: Arc<BackgroundTaskTracker>` | `packages/core-rs/crates/mainframe-server/src/chat_deps.rs:121` |
+| `enrich_chat` derivation (correct as written) | `packages/core-rs/crates/mainframe-chat/src/chat_manager.rs:367-387` |
+| Broadcast enrichment path | `enrich_and_emit`, `chat_manager.rs:390-406` |
+| Read/refresh enrichment paths | `get_chat` `:1158`, `list_chats` `:1173`, `list_all_chats` `:1190`, `list_filtered` `:1407` |
+| Only two `impl ChatManagerDeps` in the workspace | `chat_deps.rs:196` (production), `chat_manager/tests.rs:53` (`StoreDeps`) |
+| `BackgroundTaskTracker::list_live` filters `status == Running` | `packages/core-rs/crates/mainframe-background-tasks/src/tracker.rs:224-229` |
+| Production assembly entry point (public, usable from an integration test) | `build_chat_manager`, `chat_deps.rs:803-833` |
+| `ChatManager::new` calls `idle_scanner.start()` → `tokio::spawn` | `chat_manager.rs:1077-1078`, `idle_scanner.rs:68` |
+| UI resyncs from `chat.backgroundActivity` on every broadcast | `packages/ui/src/features/chat/controller/chat-event-router.ts:42-44` |
+| UI resyncs on subscribe/select from the fetched chat | `packages/ui/src/features/chat/controller/chat-thread-controller.ts:212` |
+
+## Constraints
+
+- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` must pass (`.github/workflows/rust-port.yml:28,31`).
+- New files stay under 300 lines; new functions under 50. `chat_deps.rs` (1550 lines) and
+  `chat_manager.rs` (2338) are pre-existing over-limit files — this change adds 5 and removes 3 lines
+  respectively, and must not grow them further. That is why the new tests live in their own file.
+- Changeset required. Daemon-side fixes post-cutover bump `@qlan-ro/mainframe-app-tauri: patch`
+  (precedent: `.changeset/setup-advisor-engine.md`).
+- TDD: the test task lands first and must be observed failing before the fix task.
+
+## Decisions
+
+- **D1 — The wiring tests live in a new integration test file, not in `chat_deps.rs`'s `#[cfg(test)]`
+  module.** `chat_deps.rs` is already 5× the 300-line limit; the acceptance criteria forbid growing a
+  file past the limit as a result of this change, and an integration test that drives the real
+  `build_chat_manager` output is a truer wiring test than a unit module poking private fields.
+- **D2 — The pending-permission precedence case (acceptance criterion 5) stays at the `enrich_chat`
+  unit level**, where `chat_manager/tests.rs:1083` already asserts it. `ChatManager` exposes no public
+  way to enqueue a pending permission; one arrives only through a live session's `control_request` via
+  the `EventHandler`. Faking that would mean standing up a fake `AdapterSession` and driving a control
+  request purely to re-assert a branch that is not on the regression's seam. The regression is the
+  tracker read, and the tracker read is covered at the wiring level.
+- **D3 — Two sibling methods with the same silent-default defect are reported, not fixed.**
+  `is_transcript_present` (`chat_manager.rs:270-277`, default `None`) and `adapter_snapshot_models`
+  (`chat_manager.rs:281-286`, default empty) are also declared with defaults and also never overridden
+  by `DaemonChatDeps`, so in production the transcript-presence predicate always answers "cannot
+  determine" and the lifecycle's default-model normalization always sees an empty catalog. Making them
+  required would force implementing both, which is a different change with its own behavior surface.
+  Filed as findings for the orchestrator (see "Findings to file separately").
+
+## Tasks
+
+### Task 1 — Wiring-level regression tests (RED)
+
+**File (new):** `packages/core-rs/crates/mainframe-server/tests/chat_background_activity.rs`
+
+Build the production stack through `build_chat_manager` with a real `BackgroundTaskTracker` the test
+retains, then assert enrichment on both the broadcast path and the read/refresh paths. The test must
+not construct the live-task vec by hand and must not call `enrich_chat`.
+
+Harness (one `fn`, under 50 lines, plus a `struct Harness`):
+
+```rust
+struct Harness {
+    manager: Arc<ChatManager>,
+    tracker: Arc<BackgroundTaskTracker>,
+    broadcast: broadcast::Sender<DaemonEvent>,
+    project_id: String,
+    chat_id: String,
+    _data_dir: TempDir,
+}
+```
+
+- `Db::spawn(|| DatabaseManager::open(Path::new(":memory:")))`, mirroring
+  `tests/support/mod.rs:70`.
+- `tokio::sync::broadcast::channel::<DaemonEvent>(64)`; keep the sender in the harness and
+  `subscribe()` per test.
+- `tracker = Arc::new(BackgroundTaskTracker::new())`, passed to `build_chat_manager` and kept.
+- Remaining args: `Arc::new(AdapterRegistry::new())`,
+  `Arc::new(AttachmentStore::new(data_dir.path().join("attachments")))`, `Arc::new(PushService::new())`,
+  `GitFactory`, `Arc::new(NoopLaunchStopper)`, `Arc::new(NoopScopeTunnelStopper)` (both from
+  `mainframe_server::chat_seams`), a `QuotaManager` over a local no-op `QuotaSettingsStore` (copy the
+  12-line `NoopQuotaSettings` shape from `chat_deps.rs:1283-1293`), and
+  `ResolvedPath::from_value("/usr/bin:/bin")`.
+- Seed rows through the Db actor. `ProjectsRepository::create` takes `&str`, not `&Path`
+  (`packages/core-rs/crates/mainframe-db/src/projects.rs:67`), and the closure must be `'static`, so
+  move an owned `String` in: `let path = data_dir.path().to_string_lossy().into_owned();` then
+  `db.call_blocking(move |d| d.projects.create(&path, None))`, then
+  `db.call_blocking(move |d| d.chats.create(&project_id, "claude", None, None, None))` with an owned
+  `project_id` clone.
+- Tests are `#[tokio::test]` — `ChatManager::new` starts the idle scanner with `tokio::spawn` and
+  panics outside a runtime. `Db::call_blocking` is safe to call from the test task because the DB actor
+  owns its own OS thread.
+
+Task-seeding helper:
+
+```rust
+fn seed(h: &Harness, id: &str, kind: BackgroundWorkKind, description: &str) {
+    h.tracker.start(
+        &h.chat_id,
+        TaskSeed {
+            id: id.to_string(),
+            kind,
+            tool_name: BackgroundTaskToolName::Monitor,
+            tool_use_id: format!("tu-{id}"),
+            command: "cmd".to_string(),
+            description: description.to_string(),
+        },
+        format!("/tmp/mf-273-{id}.log"),
+    );
+}
+```
+
+Cases:
+
+1. `chat_updated_broadcast_carries_background_activity_for_every_kind`
+   Seed three running tasks — `BackgroundWorkKind::Agent` ("reviewer"), `Bash` ("dev server"),
+   `Workflow` ("deploy"). Subscribe, call `manager.rename_chat(&chat_id, "renamed")`, then read events
+   until the first `DaemonEvent::ChatUpdated`. Wrap that receive loop in
+   `tokio::time::timeout(Duration::from_secs(5), …)` and `.expect("chat.updated within 5s")` — a RED
+   run must fail on an assertion or a timeout, never hang the suite. Assert on its `chat`:
+   `background_activity` is `Some`; `total == 3`; `by_kind` equals
+   `{Agent: 1, Bash: 1, Workflow: 1}`; the three task ids are present (sort before comparing — the
+   tracker stores tasks in a `HashMap`, so order is not stable); `display_status == Some(Working)`;
+   `is_running == Some(false)`.
+2. `read_paths_enrich_background_activity`
+   Seed one running `Workflow` task. Assert the same `background_activity.total == 1`,
+   `display_status == Some(Working)` and `is_running == Some(false)` on all four read call sites:
+   `manager.get_chat(&chat_id)`, `manager.list_chats(&project_id)`,
+   `manager.list_all_chats()`, and `manager.list_filtered(Some(&project_id), None, false, false)`.
+   Use a local `fn assert_live(chat: &Chat, total: u32)` so the test body stays under 50 lines.
+3. `ended_tasks_drop_out_of_the_live_set`
+   Assert first with no tasks: `get_chat` yields `background_activity == None`,
+   `display_status == Some(Idle)`, `is_running == Some(false)`. Then seed one `Agent` task, assert it
+   appears, then `tracker.end(&chat_id, "a-1", TerminalUpdate { status: BackgroundTaskStatus::Completed,
+   output_path: …, summary: String::new(), usage: None })` and assert `get_chat` is back to
+   `background_activity == None` and `display_status == Some(Idle)`.
+
+Top of file: `#![allow(clippy::unwrap_used, clippy::expect_used)]`, matching `tests/support/mod.rs:5`.
+
+**Verify:**
+```
+cd packages/core-rs && cargo test -p mainframe-server --test chat_background_activity
+```
+All three cases must FAIL on assertions (not compile errors) before Task 2. Record the failure output
+in the implement-stage notes.
+
+---
+
+### Task 2 — Override `tracker_list_live` and make it required (GREEN)
+
+**File:** `packages/core-rs/crates/mainframe-server/src/chat_deps.rs`
+Add the import `use mainframe_types::background_task::BackgroundTask;` (the file currently imports only
+`mainframe_types::chat::…`), and add the override immediately after `tracker_remove_chat`
+(`:665-667`), mirroring it:
+
+```rust
+    fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask> {
+        self.background_tasks.list_live(chat_id)
+    }
+```
+
+**File:** `packages/core-rs/crates/mainframe-chat/src/chat_manager.rs`
+Replace the defaulted declaration at `:256-260` with a required one and re-point the doc comment:
+
+```rust
+    /// `tracker.listLive(chatId)` — live (running) background tasks, for enrichChat's
+    /// backgroundActivity + widened working state. Required, not defaulted: an
+    /// implementation that silently inherited an empty default blanked
+    /// backgroundActivity for every chat (#273).
+    fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask>;
+```
+
+**File:** `packages/core-rs/crates/mainframe-chat/src/chat_manager/tests.rs`
+`StoreDeps` no longer compiles without the method. Add `use mainframe_types::background_task::BackgroundTask;`
+to the file's imports (the `background_activity` submodule imports it locally; the outer module does
+not) and add the explicit empty implementation next to `tracker_remove_chat` (`:280`):
+
+```rust
+    /// Empty on purpose: mainframe-server's chat_background_activity test covers the wiring (#273).
+    fn tracker_list_live(&self, _chat_id: &str) -> Vec<BackgroundTask> {
+        Vec::new()
+    }
+```
+
+Keep the comment to that one sentence. The brief requires an explicit reason on any implementation
+that previously relied on the default; the repo's comment rule caps it at one line.
+
+**Verify:**
+```
+cd packages/core-rs
+cargo test -p mainframe-server --test chat_background_activity   # now green
+cargo test -p mainframe-chat background_activity                 # existing 5 enrich_chat cases still green
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+```
+
+---
+
+### Task 3 — Refresh the PORT STATUS notes
+
+`chat_manager.rs` carries a trailing `// notes:` block that documents the broken state; leaving it is
+a stale-comment leftover.
+
+**File:** `packages/core-rs/crates/mainframe-chat/src/chat_manager.rs` (trailing notes block,
+`:2333-2337`)
+The line `New defaulted ChatManagerDeps methods (chat_deps.rs must override): tracker_list_live,
+is_transcript_present, chats_clear_session/worktree, adapter_snapshot_models` must drop
+`tracker_list_live` from the defaulted list and state that it is now required, so the reminder no
+longer claims a default that does not exist. In the same block, extend
+`Ported: chat-manager-background-activity (5, via direct enrich_chat)` to record that the production
+wiring is covered by `mainframe-server`'s `chat_background_activity` integration test.
+
+Leave `chat_deps.rs`'s trailing notes block alone. Nothing in it misdescribes `tracker_list_live`, and
+that file is already 5× the line limit — adding a note there would be growth for its own sake.
+
+Do not touch the `reconcile_transcript`, `is_transcript_present`, or `adapter_snapshot_models` notes
+beyond removing `tracker_list_live` from the shared list — see D3.
+
+**Verify:** `cd packages/core-rs && cargo fmt --check`, then re-read the `chat_manager.rs` notes block;
+no sentence should still describe `tracker_list_live` as defaulted or unwired.
+
+---
+
+### Task 4 — Changeset
+
+**File (new):** `.changeset/background-activity-live-set.md`
+
+```
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix live background work never showing in a session. The daemon never asked its
+background-task tracker which tasks were running, so the pill above the composer
+stayed empty and the session row showed no in-progress state while agents, bash
+tasks, or workflows ran. This was reported against a workflow because a workflow
+runs longest, but it affected every kind of background work.
+```
+
+**Verify:** `git status` shows the file; `head -4 .changeset/background-activity-live-set.md` matches
+the frontmatter above.
+
+---
+
+### Task 5 — Confirm the UI needs no change (read-only)
+
+Read, do not edit:
+- `packages/ui/src/features/chat/controller/chat-event-router.ts:42-44` — resyncs
+  `background.snapshot` from `event.chat.backgroundActivity?.tasks ?? []` on every `chat.updated`.
+- `packages/ui/src/features/chat/controller/chat-thread-controller.ts:212` — same resync from the
+  fetched chat on subscribe/select.
+- `packages/ui/src/features/chat/composer/BackgroundActivityBar.tsx` — renders
+  `composer-background-activity` with a per-task `composer-background-activity-item-<id>`.
+
+**Verify:**
+```
+pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/controller/__tests__/chat-event-router-background-snapshot.test.ts
+```
+Green with no source edit confirms the client contract. If any of the three files turns out to need a
+change, stop and report it as a separate finding — it is explicitly out of scope.
+
+## QA stage (not part of the implement groups)
+
+Manual end-to-end check against a dev daemon built from this branch, with an isolated data dir and
+port (`MAINFRAME_DATA_DIR` + `DAEMON_PORT`; never launch against `:31415` / `~/.mainframe`):
+
+1. Start a session and have the agent launch a background agent or a long-running bash task.
+2. The pill above the composer (`composer-background-activity`) appears with the right kind icon and
+   count, and one `composer-background-activity-item-<id>` per live task.
+3. Send another message so more `chat.updated` broadcasts land. The pill stays visible — it is not
+   wiped by the snapshot resync. This is the specific symptom the empty live set caused.
+4. The session row in the sidebar reads in-progress while the background work runs and the main turn
+   is idle.
+5. Reload the app: the pill and the session row come back from the fetched chat list, not only from
+   live `background_task.*` events.
+6. When the background work ends, both clear.
+
+## Findings to file separately (do not fix here)
+
+1. `is_transcript_present` (`chat_manager.rs:270-277`) is defaulted to `None` and never overridden by
+   `DaemonChatDeps` — same silent-default class as this bug. In production the transcript-presence
+   predicate always answers "cannot determine".
+2. `adapter_snapshot_models` (`chat_manager.rs:281-286`) is defaulted to an empty vec and never
+   overridden by `DaemonChatDeps`, so the lifecycle's default-model normalization always sees an empty
+   catalog.
+3. The two defects already named in the todo brief: the `spool_root()` uid stub
+   (`packages/core-rs/crates/mainframe-background-tasks/src/spool_root.rs:11-14`) and the unverified
+   `task_updated` status-field read (`packages/core-rs/crates/mainframe-adapter-claude/src/events.rs:169-173`).
+
+## Task groups
+
+| Group | Kind | Tasks | Files | Parallel-safe |
+| --- | --- | --- | --- | --- |
+| `wiring-test` | test | 1 | `packages/core-rs/crates/mainframe-server/tests/chat_background_activity.rs` | No — must land and be seen failing before `deps-fix` |
+| `deps-fix` | core | 2, 3, 4, 5 | `chat_deps.rs`, `chat_manager.rs`, `chat_manager/tests.rs`, `.changeset/background-activity-live-set.md` | No — depends on `wiring-test` |
+
+The two groups share no files, but the TDD order is a hard dependency in both directions: `wiring-test`
+can only be verified RED while the default is still in place, and `deps-fix` can only be verified GREEN
+once the test exists. Run them in sequence.
+
+## Definition of done
+
+- [ ] `cargo test -p mainframe-server --test chat_background_activity` green (was red before Task 2).
+- [ ] `cargo test -p mainframe-chat` green, including the five existing `background_activity` cases.
+- [ ] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
+- [ ] `tracker_list_live` has no default on the trait; omitting it is a compile error.
+- [ ] Changeset present.
+- [ ] No file newly exceeds 300 lines; no new function exceeds 50.
+- [ ] `chat-event-router-background-snapshot.test.ts` green with no UI source change.
+- [ ] All six QA steps run and recorded: pill appears with the right kind and count; pill survives
+      later `chat.updated` broadcasts; the sidebar row reads in-progress on background-only work;
+      a reload restores both from the fetched chat list; both clear when the work ends.

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
@@ -255,10 +255,10 @@ pub trait ChatManagerDeps: Send + Sync {
     fn extract_mentions_from_text(&self, chat_id: &str, text: &str) -> bool;
     fn tracker_remove_chat(&self, chat_id: &str);
     /// `tracker.listLive(chatId)` — live (running) background tasks, for enrichChat's
-    /// backgroundActivity + widened working state. Default empty.
-    fn tracker_list_live(&self, _chat_id: &str) -> Vec<BackgroundTask> {
-        Vec::new()
-    }
+    /// backgroundActivity + widened working state. Required, not defaulted: an
+    /// implementation that silently inherited an empty default blanked
+    /// backgroundActivity for every chat (#273).
+    fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask>;
     /// `db.chats.clearSession(chatId)` — NULL session id/file, transcript_missing=0.
     /// Required (not a no-op default): `continue-here` relies on it persisting.
     fn chats_clear_session(&self, chat_id: &str);

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
@@ -2330,11 +2330,11 @@ mod tests;
 // notes: transcript_presence + degraded_recovery modules via a `RecoveryWrapper` that
 // notes: implements both deps traits over the shared internals (chat lock is a leaf,
 // notes: emit-after-drop); sendMessage auto-`continueHere` when transcriptMissing && not
-// notes: spawned. New defaulted ChatManagerDeps methods (chat_deps.rs must override):
-// notes: is_transcript_present, chats_clear_session/worktree, adapter_snapshot_models;
-// notes: tracker_list_live is required, not defaulted (#273 — a silent default caused
-// notes: backgroundActivity to stay empty in production); generate_title gained an
-// notes: adapter_id arg (adapter-aware).
+// notes: spawned. New defaulted ChatManagerDeps methods still silently unoverridden
+// notes: in chat_deps.rs (filed as #289 is_transcript_present, #290
+// notes: adapter_snapshot_models): tracker_list_live is required, not defaulted
+// notes: (#273 — a silent default caused backgroundActivity to stay empty in
+// notes: production); generate_title gained an adapter_id arg (adapter-aware).
 // notes: Ported: chat-manager-background-activity (5, via direct enrich_chat); the
 // notes: production wiring is covered by mainframe-server's chat_background_activity
 // notes: integration test (#273). Also chat-manager-degraded (3).

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
@@ -2331,8 +2331,11 @@ mod tests;
 // notes: implements both deps traits over the shared internals (chat lock is a leaf,
 // notes: emit-after-drop); sendMessage auto-`continueHere` when transcriptMissing && not
 // notes: spawned. New defaulted ChatManagerDeps methods (chat_deps.rs must override):
-// notes: tracker_list_live, is_transcript_present, chats_clear_session/worktree,
-// notes: adapter_snapshot_models; generate_title gained an adapter_id arg (adapter-aware).
-// notes: Ported: chat-manager-background-activity (5, via direct enrich_chat) +
-// notes: chat-manager-degraded (3).
+// notes: is_transcript_present, chats_clear_session/worktree, adapter_snapshot_models;
+// notes: tracker_list_live is required, not defaulted (#273 — a silent default caused
+// notes: backgroundActivity to stay empty in production); generate_title gained an
+// notes: adapter_id arg (adapter-aware).
+// notes: Ported: chat-manager-background-activity (5, via direct enrich_chat); the
+// notes: production wiring is covered by mainframe-server's chat_background_activity
+// notes: integration test (#273). Also chat-manager-degraded (3).
 // todos: 2

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager.rs
@@ -259,6 +259,11 @@ pub trait ChatManagerDeps: Send + Sync {
     /// implementation that silently inherited an empty default blanked
     /// backgroundActivity for every chat (#273).
     fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask>;
+    /// `tracker?.endAllRunning(chatId)` — stop every live background task on session
+    /// exit. Required, not defaulted: an implementation that silently inherited an
+    /// empty default left orphaned tasks Running forever, pinning `displayStatus:
+    /// working` and `backgroundActivity` with no recovery path (#273).
+    fn tracker_end_all_running(&self, chat_id: &str);
     /// `db.chats.clearSession(chatId)` — NULL session id/file, transcript_missing=0.
     /// Required (not a no-op default): `continue-here` relies on it persisting.
     fn chats_clear_session(&self, chat_id: &str);
@@ -480,6 +485,9 @@ impl EventHandlerDeps for EhDeps {
     }
     fn on_worktree_trigger(&self, chat_id: &str) {
         self.worktree_offers.on_trigger(chat_id);
+    }
+    fn tracker_end_all_running(&self, chat_id: &str) {
+        self.deps.tracker_end_all_running(chat_id);
     }
 }
 
@@ -2332,9 +2340,11 @@ mod tests;
 // notes: emit-after-drop); sendMessage auto-`continueHere` when transcriptMissing && not
 // notes: spawned. New defaulted ChatManagerDeps methods still silently unoverridden
 // notes: in chat_deps.rs (filed as #289 is_transcript_present, #290
-// notes: adapter_snapshot_models): tracker_list_live is required, not defaulted
-// notes: (#273 — a silent default caused backgroundActivity to stay empty in
-// notes: production); generate_title gained an adapter_id arg (adapter-aware).
+// notes: adapter_snapshot_models): tracker_list_live and tracker_end_all_running
+// notes: are required, not defaulted (#273 — a silent default caused
+// notes: backgroundActivity to stay empty, then let orphaned tasks stay Running
+// notes: forever, in production); generate_title gained an adapter_id arg
+// notes: (adapter-aware).
 // notes: Ported: chat-manager-background-activity (5, via direct enrich_chat); the
 // notes: production wiring is covered by mainframe-server's chat_background_activity
 // notes: integration test (#273). Also chat-manager-degraded (3).

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager/tests.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::test_support::test_chat;
 use mainframe_adapter_api::{ContextFiles, ImageInput, SessionSink, StopBackgroundTaskResult};
 use mainframe_types::adapter::{AdapterProcess, ControlResponse, SessionSpawnOptions};
+use mainframe_types::background_task::BackgroundTask;
 use mainframe_types::chat::{Chat, ChatStatus, ProcessState};
 use mainframe_types::context::SkillFileEntry;
 use mainframe_types::settings::ExecutionMode;
@@ -278,6 +279,10 @@ impl ChatManagerDeps for StoreDeps {
         false
     }
     fn tracker_remove_chat(&self, _chat_id: &str) {}
+    /// Empty on purpose: mainframe-server's chat_background_activity test covers the wiring (#273).
+    fn tracker_list_live(&self, _chat_id: &str) -> Vec<BackgroundTask> {
+        Vec::new()
+    }
     fn is_transcript_present<'a>(
         &'a self,
         _adapter_id: &'a str,

--- a/packages/core-rs/crates/mainframe-chat/src/chat_manager/tests.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/chat_manager/tests.rs
@@ -283,6 +283,8 @@ impl ChatManagerDeps for StoreDeps {
     fn tracker_list_live(&self, _chat_id: &str) -> Vec<BackgroundTask> {
         Vec::new()
     }
+    /// Empty on purpose: chat_deps.rs's tracker_end_all_running_delegates_... test covers the wiring (#273).
+    fn tracker_end_all_running(&self, _chat_id: &str) {}
     fn is_transcript_present<'a>(
         &'a self,
         _adapter_id: &'a str,

--- a/packages/core-rs/crates/mainframe-chat/src/event_handler.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/event_handler.rs
@@ -92,9 +92,10 @@ pub trait EventHandlerDeps: Send + Sync {
     fn send_push(&self, _msg: PushOut) {}
 
     /// `tracker?.endAllRunning(chatId)` — stop every live background task on session
-    /// end (the CLI owns them; none can report completion after it dies). Default
-    /// no-op mirrors the TS optional `tracker?`.
-    fn tracker_end_all_running(&self, _chat_id: &str) {}
+    /// end (the CLI owns them; none can report completion after it dies). Required,
+    /// not defaulted: a silently-inherited no-op left orphaned tasks Running forever
+    /// in production, the same defaulted-trait bug class as #273.
+    fn tracker_end_all_running(&self, chat_id: &str);
 
     /// `onProviderQuota(adapterId, quota)` — an account-wide provider-plan quota
     /// escalation pushed from a session event (Codex `account/rateLimits/updated`,
@@ -1282,6 +1283,8 @@ mod tests {
                 q.ingest(adapter_id, quota, IngestMode::Push);
             }
         }
+        /// Empty on purpose: BgDeps below covers on_exit's tracker_end_all_running wiring.
+        fn tracker_end_all_running(&self, _chat_id: &str) {}
     }
 
     fn umsg(id: &str, meta: Option<HashMap<String, serde_json::Value>>) -> ChatMessage {
@@ -1947,8 +1950,9 @@ mod tests {
 // notes: parent assistant usage (or None); codex sends this turn's raw input usage
 // notes: to mirror the TS `undefined→usage` fallback. onContextUsage persists
 // notes: lastContextTotal/MaxTokens +
-// notes: broadcasts chat.updated ungated. onExit calls tracker_end_all_running (new
-// notes: defaulted deps method) BEFORE clearing processState. onMessage drain-turn
+// notes: broadcasts chat.updated ungated. onExit calls tracker_end_all_running
+// notes: (required deps method, wired through DaemonChatDeps — #273) BEFORE
+// notes: clearing processState. onMessage drain-turn
 // notes: re-entry flips a non-working processState back to working + emits chat.updated
 // notes: (snapshot-under-lock, emit-after-drop per CONCURRENCY.tsv rule 3).
 // notes: Ported: session-path (3), move-on-process (3), turn-timing (2),

--- a/packages/core-rs/crates/mainframe-chat/src/event_handler/worktree_trigger_tests.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/event_handler/worktree_trigger_tests.rs
@@ -74,6 +74,8 @@ impl EventHandlerDeps for TriggerDeps {
             .unwrap_or_else(|e| e.into_inner())
             .push(chat_id.to_string());
     }
+    /// Empty on purpose: this suite exercises worktree triggers, not on_exit.
+    fn tracker_end_all_running(&self, _chat_id: &str) {}
 }
 
 fn cell() -> Arc<Mutex<ActiveChat>> {

--- a/packages/core-rs/crates/mainframe-server/src/chat_deps.rs
+++ b/packages/core-rs/crates/mainframe-server/src/chat_deps.rs
@@ -58,6 +58,7 @@ use mainframe_services::settings::provider_config::SettingsReader;
 use mainframe_types::adapter::{
     AdapterModel, DetectedPr, DetectedPrSource, ExternalSessionPage, ProviderQuota, SessionOptions,
 };
+use mainframe_types::background_task::BackgroundTask;
 use mainframe_types::chat::{
     Chat, ChatMessage, ChatMessageType, ChatStatus, MessageContent, MessageContentNode, Project,
     ResolvedTuning, TodoItem,
@@ -664,6 +665,10 @@ impl ChatManagerDeps for DaemonChatDeps {
 
     fn tracker_remove_chat(&self, chat_id: &str) {
         self.background_tasks.remove_chat(chat_id);
+    }
+
+    fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask> {
+        self.background_tasks.list_live(chat_id)
     }
 }
 

--- a/packages/core-rs/crates/mainframe-server/src/chat_deps.rs
+++ b/packages/core-rs/crates/mainframe-server/src/chat_deps.rs
@@ -670,6 +670,10 @@ impl ChatManagerDeps for DaemonChatDeps {
     fn tracker_list_live(&self, chat_id: &str) -> Vec<BackgroundTask> {
         self.background_tasks.list_live(chat_id)
     }
+
+    fn tracker_end_all_running(&self, chat_id: &str) {
+        self.background_tasks.end_all_running(chat_id);
+    }
 }
 
 /// The daemon-side `ExternalSessionDeps` (`getExternalSessionService()`'s
@@ -1106,9 +1110,10 @@ mod scan_loaded_history_tests {
     use std::sync::Mutex as StdMutex;
 
     use mainframe_adapter_api::{AdapterError, ContextFiles, ImageInput, SessionSink};
-    use mainframe_background_tasks::tracker::BackgroundTaskTracker;
+    use mainframe_background_tasks::tracker::{BackgroundTaskTracker, TaskSeed};
     use mainframe_db::DatabaseManager;
     use mainframe_types::adapter::{AdapterProcess, ControlResponse, SessionSpawnOptions};
+    use mainframe_types::background_task::{BackgroundTaskToolName, BackgroundWorkKind};
     use mainframe_types::context::MentionKind;
 
     use super::*;
@@ -1321,6 +1326,28 @@ mod scan_loaded_history_tests {
             quota: Arc::new(quota),
             claude_external_session_cache: new_external_session_cache(),
         }
+    }
+
+    #[test]
+    fn tracker_end_all_running_delegates_to_the_background_task_tracker() {
+        let deps = test_deps();
+        deps.background_tasks.start(
+            "c-live",
+            TaskSeed {
+                id: "a-1".to_string(),
+                kind: BackgroundWorkKind::Agent,
+                tool_name: BackgroundTaskToolName::Monitor,
+                tool_use_id: "tu-a-1".to_string(),
+                command: "cmd".to_string(),
+                description: "reviewer".to_string(),
+            },
+            "/tmp/mf-273-a-1.log".to_string(),
+        );
+        assert_eq!(deps.background_tasks.list_live("c-live").len(), 1);
+
+        deps.tracker_end_all_running("c-live");
+
+        assert!(deps.background_tasks.list_live("c-live").is_empty());
     }
 
     #[test]

--- a/packages/core-rs/crates/mainframe-server/tests/chat_background_activity.rs
+++ b/packages/core-rs/crates/mainframe-server/tests/chat_background_activity.rs
@@ -1,0 +1,210 @@
+//! Wiring-level regression coverage for #273: the daemon's production
+//! `ChatManagerDeps` (`DaemonChatDeps`, assembled by `build_chat_manager`) must
+//! feed `ChatManager` enrichment the tracker's real live-task set. Unlike
+//! `mainframe-chat`'s `background_activity` unit tests — which call the private
+//! `enrich_chat` directly with a hand-built task vec — these tests drive the
+//! production stack end to end: a real `BackgroundTaskTracker` seeded through
+//! its own `start`/`end` API, read back only through `ChatManager`'s public
+//! broadcast and read paths. A regression where `tracker_list_live` silently
+//! falls back to an empty default would fail every case here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mainframe_adapter_api::AdapterRegistry;
+use mainframe_background_tasks::tracker::{BackgroundTaskTracker, TaskSeed, TerminalUpdate};
+use mainframe_chat::chat_manager::ChatManager;
+use mainframe_db::DatabaseManager;
+use mainframe_server::chat_seams::{NoopLaunchStopper, NoopScopeTunnelStopper};
+use mainframe_server::{Db, GitFactory, build_chat_manager};
+use mainframe_services::attachment::AttachmentStore;
+use mainframe_services::push::PushService;
+use mainframe_services::quota::{QuotaManager, QuotaManagerDeps, QuotaSettingsStore};
+use mainframe_types::background_task::{
+    BackgroundTaskStatus, BackgroundTaskToolName, BackgroundWorkKind,
+};
+use mainframe_types::chat::{Chat, DisplayStatus};
+use mainframe_types::events::DaemonEvent;
+use tempfile::TempDir;
+use tokio::sync::broadcast;
+
+struct NoopQuotaSettings;
+
+impl QuotaSettingsStore for NoopQuotaSettings {
+    fn get(&self, _category: &str, _key: &str) -> Option<String> {
+        None
+    }
+    fn get_by_category(&self, _category: &str) -> HashMap<String, String> {
+        HashMap::new()
+    }
+    fn set(&self, _category: &str, _key: &str, _value: &str) {}
+}
+
+struct Harness {
+    manager: Arc<ChatManager>,
+    tracker: Arc<BackgroundTaskTracker>,
+    broadcast: broadcast::Sender<DaemonEvent>,
+    project_id: String,
+    chat_id: String,
+    _data_dir: TempDir,
+}
+
+fn harness() -> Harness {
+    let data_dir = tempfile::tempdir().unwrap();
+    let db = Db::spawn(|| DatabaseManager::open(Path::new(":memory:"))).unwrap();
+    let (broadcast, _keepalive) = broadcast::channel::<DaemonEvent>(64);
+    let tracker = Arc::new(BackgroundTaskTracker::new());
+    let quota = Arc::new(QuotaManager::new(QuotaManagerDeps {
+        settings: Box::new(NoopQuotaSettings),
+        emit_event: Box::new(|_| {}),
+        now: None,
+    }));
+
+    let path = data_dir.path().to_string_lossy().into_owned();
+    let project = db
+        .call_blocking(move |d| d.projects.create(&path, None))
+        .unwrap();
+    let project_id_for_chat = project.id.clone();
+    let chat = db
+        .call_blocking(move |d| {
+            d.chats
+                .create(&project_id_for_chat, "claude", None, None, None)
+        })
+        .unwrap();
+
+    let manager = build_chat_manager(
+        db,
+        Arc::new(AdapterRegistry::new()),
+        Arc::clone(&tracker),
+        Arc::new(AttachmentStore::new(data_dir.path().join("attachments"))),
+        Arc::new(PushService::new()),
+        GitFactory,
+        broadcast.clone(),
+        Arc::new(NoopLaunchStopper),
+        Arc::new(NoopScopeTunnelStopper),
+        quota,
+        mainframe_runtime::ResolvedPath::from_value("/usr/bin:/bin"),
+    );
+
+    Harness {
+        manager,
+        tracker,
+        broadcast,
+        project_id: project.id,
+        chat_id: chat.id,
+        _data_dir: data_dir,
+    }
+}
+
+fn seed(h: &Harness, id: &str, kind: BackgroundWorkKind, description: &str) {
+    h.tracker.start(
+        &h.chat_id,
+        TaskSeed {
+            id: id.to_string(),
+            kind,
+            tool_name: BackgroundTaskToolName::Monitor,
+            tool_use_id: format!("tu-{id}"),
+            command: "cmd".to_string(),
+            description: description.to_string(),
+        },
+        format!("/tmp/mf-273-{id}.log"),
+    );
+}
+
+fn assert_live(chat: &Chat, total: u32) {
+    let activity = chat
+        .background_activity
+        .as_ref()
+        .expect("background_activity must be populated for a live task");
+    assert_eq!(activity.total, total);
+    assert_eq!(chat.display_status, Some(DisplayStatus::Working));
+    assert_eq!(chat.is_running, Some(false));
+}
+
+#[tokio::test]
+async fn chat_updated_broadcast_carries_background_activity_for_every_kind() {
+    let h = harness();
+    seed(&h, "a-1", BackgroundWorkKind::Agent, "reviewer");
+    seed(&h, "b-1", BackgroundWorkKind::Bash, "dev server");
+    seed(&h, "w-1", BackgroundWorkKind::Workflow, "deploy");
+
+    let mut rx = h.broadcast.subscribe();
+    h.manager.rename_chat(&h.chat_id, "renamed");
+
+    let chat = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await.expect("broadcast channel closed") {
+                DaemonEvent::ChatUpdated { chat, .. } => return chat,
+                _ => continue,
+            }
+        }
+    })
+    .await
+    .expect("chat.updated within 5s");
+
+    let activity = chat
+        .background_activity
+        .as_ref()
+        .expect("background_activity must be Some with three live tasks");
+    assert_eq!(activity.total, 3);
+    assert_eq!(
+        activity.by_kind,
+        HashMap::from([
+            (BackgroundWorkKind::Agent, 1),
+            (BackgroundWorkKind::Bash, 1),
+            (BackgroundWorkKind::Workflow, 1),
+        ])
+    );
+    let mut ids: Vec<&str> = activity.tasks.iter().map(|t| t.id.as_str()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec!["a-1", "b-1", "w-1"]);
+    assert_eq!(chat.display_status, Some(DisplayStatus::Working));
+    assert_eq!(chat.is_running, Some(false));
+}
+
+#[tokio::test]
+async fn read_paths_enrich_background_activity() {
+    let h = harness();
+    seed(&h, "w-1", BackgroundWorkKind::Workflow, "deploy");
+
+    assert_live(&h.manager.get_chat(&h.chat_id).expect("chat must exist"), 1);
+    let listed = h.manager.list_chats(&h.project_id);
+    assert_live(listed.iter().find(|c| c.id == h.chat_id).unwrap(), 1);
+    let listed_all = h.manager.list_all_chats();
+    assert_live(listed_all.iter().find(|c| c.id == h.chat_id).unwrap(), 1);
+    let filtered = h
+        .manager
+        .list_filtered(Some(&h.project_id), None, false, false);
+    assert_live(filtered.iter().find(|c| c.id == h.chat_id).unwrap(), 1);
+}
+
+#[tokio::test]
+async fn ended_tasks_drop_out_of_the_live_set() {
+    let h = harness();
+
+    let before = h.manager.get_chat(&h.chat_id).expect("chat must exist");
+    assert_eq!(before.background_activity, None);
+    assert_eq!(before.display_status, Some(DisplayStatus::Idle));
+    assert_eq!(before.is_running, Some(false));
+
+    seed(&h, "a-1", BackgroundWorkKind::Agent, "reviewer");
+    assert_live(&h.manager.get_chat(&h.chat_id).expect("chat must exist"), 1);
+
+    h.tracker.end(
+        &h.chat_id,
+        "a-1",
+        TerminalUpdate {
+            status: BackgroundTaskStatus::Completed,
+            output_path: "/tmp/mf-273-a-1.log".to_string(),
+            summary: String::new(),
+            usage: None,
+        },
+    );
+
+    let after = h.manager.get_chat(&h.chat_id).expect("chat must exist");
+    assert_eq!(after.background_activity, None);
+    assert_eq!(after.display_status, Some(DisplayStatus::Idle));
+}


### PR DESCRIPTION
## Summary

Fixes live background work (agents, bash tasks, workflows) never showing in a session: the daemon never asked its background-task tracker which tasks were running, so the pill above the composer and the session row's in-progress state stayed empty. Also fixes orphaned background tasks staying stuck "running" forever after the CLI process exits — the daemon now stops every live task for that chat on exit.

Artifacts: `docs/plans/2026-07-27-todo-273-background-activity-live-plan.md`

Review verdict: APPROVED (3 rounds). QA: 3/3.

## Decisions

- **D1**: The wiring tests land in a new integration test file (`packages/core-rs/crates/mainframe-server/tests/chat_background_activity.rs`) rather than `chat_deps.rs`'s `#[cfg(test)]` module. `chat_deps.rs` is already 1550 lines (5x the repo's 300-line limit) and the acceptance criteria forbid growing a file past the limit; an integration test driving the real `build_chat_manager` output is also a truer wiring test than a unit module poking private fields.
- **D2**: The pending-permission precedence case (acceptance criterion 5) stays at the `enrich_chat` unit level, where `chat_manager/tests.rs:1083` already asserts it. `ChatManager` exposes no public way to enqueue a pending permission — one arrives only via a live session's `control_request` through the `EventHandler` — so a wiring-level version would mean standing up a fake `AdapterSession` purely to re-assert a branch that is not on the regression's seam.
- **D3**: Two sibling methods with the same silent-default defect are reported, not fixed. `is_transcript_present` (`chat_manager.rs:270-277`, default `None`) and `adapter_snapshot_models` (`chat_manager.rs:281-286`, default empty) are also defaulted and also never overridden by `DaemonChatDeps`, so in production the transcript-presence predicate always answers "cannot determine" and the lifecycle's default-model normalization always sees an empty catalog. Making them required would force implementing both — a different change with its own behavior surface. Filed as findings.
- **D4**: Line numbers in the todo body had drifted from the branch; the plan re-verifies every citation against `5f7fdcaa` and carries a table of the confirmed locations.
- **D5**: The changeset bumps `@qlan-ro/mainframe-app-tauri`: patch, following the post-cutover precedent for daemon-side fixes (`.changeset/setup-advisor-engine.md`), since the Rust daemon is not itself a pnpm package.
- **D6**: Reviewer round 1 asked to delete the comment on `StoreDeps::tracker_list_live` as redundant; the approved brief explicitly requires "an explicit empty implementation with a comment saying why". Resolved by compressing it to one physical line, honoring both the brief and the repo's comment rule. Reviewer confirmed APPROVED.
- **D7**: `docs/plans/` is gitignored; the plan was force-added, matching how every prior lane plan in the repo is tracked.
- **D8**: Both task groups are marked `parallel_safe=false` despite sharing no files. The TDD order is a hard dependency in both directions: the test group can only be verified RED while the trait default is still in place, and the core group can only be verified GREEN once the test exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>