### PR TITLE
feat(ui): right-click an opened image to copy it (#282)

### DIFF
--- a/.changeset/copy-image-context-menu.md
+++ b/.changeset/copy-image-context-menu.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Right-clicking an opened image offers Copy Image, which puts the bitmap on the system clipboard.

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -204,13 +204,16 @@ transcript.** The brief scoped the menu to "images inside the transcript" and th
 design gate named the two chat paths. `LightboxSurface` is shared, so wrapping it
 also puts the menu on:
 
-| Call site | Route |
-|---|---|
-| `features/chat/messages/AssistantMessage.tsx` | `ZoomableImage` |
-| `features/chat/messages/InlineImageThumbs.tsx` | `ImageLightbox` |
-| `features/viewers/ImageViewer.tsx:151` | `ZoomableImage` |
-| `features/tasks/TaskAttachments.tsx:224` | `ImageLightbox` |
-| `features/context-panel/SessionAttachmentsGrid.tsx:85` | `ImageLightbox` |
+| Call site | Route | Verified by |
+|---|---|---|
+| `features/chat/messages/AssistantMessage.tsx` | `ZoomableImage` | Task 10 case 6 |
+| `features/chat/messages/InlineImageThumbs.tsx` | `ImageLightbox` | Task 10 case 7 |
+| `features/viewers/ImageViewer.tsx:151` | `ZoomableImage` | the same `ZoomableImage` Task 10 case 6 drives; `viewers/__tests__/ImageViewer.test.tsx` mocks it, so that suite is a regression guard, not menu coverage |
+| `features/tasks/TaskAttachments.tsx:224` | `ImageLightbox` | QA step 4 only — no unit suite exists |
+| `features/context-panel/SessionAttachmentsGrid.tsx:85` | `ImageLightbox` | `context-panel/__tests__/SessionAttachmentsGrid.test.tsx` (renders the real `ImageLightbox`) |
+
+Scope that a decision accepts has to be scope the verification reaches, so the last
+three rows are what Task 13's vitest invocation and QA step 4 now name explicitly.
 
 **Accepted, not worked around.** All five render the same `data:image/*` sources
 (`ImageViewer`'s own header documents its `src` as `data:image/...;base64,...`), so
@@ -239,6 +242,23 @@ to a boolean. It would exist solely to be asserted. `canCopyImage(src)` is there
 the data-URL regex test AND `imageClipboardSupported()`, and nothing else is
 exported. The source kinds do not go untested: they stay as rows of Task 1's truth
 table, which is where the gating rule belongs.
+
+The same call, applied once more: **`writeImageToClipboard` takes `src` alone.** The
+earlier `writeImageToClipboard(src, decoded)` carried the same image twice and used
+each half on a different branch — `decoded.bytes` only when the media type is
+`image/png`, `src` only on the canvas re-encode — while `copy-image.ts` called
+`decodeDataUrl(src)` unconditionally. Every JPEG, webp or gif copy therefore paid a
+full base64 → `Uint8Array` decode that the write discarded and re-derived from `src`
+through the canvas. The tell was the doc comment: a signature needed prose to say
+which of two representations of one image was the real one. So `write-image.ts` reads
+the media type off the `data:` prefix and calls `decodeDataUrl` only on the PNG
+branch, throwing when it returns `null`. That throw still precedes
+`navigator.clipboard.write`, so the "never touch the clipboard with a malformed
+source" property survives and the message still reaches the toast — `copy-image.ts`
+wraps the call in a `try` and maps a synchronous throw through the same failure path
+as a rejection. `DecodedDataUrl` leaves the cross-module contract: it is now
+`decodeDataUrl`'s return type, read once inside `write-image.ts`, and nothing else
+passes it around.
 
 **D12 — `CopyMenuItem` is extracted and all three copy menus migrate in this pass.**
 The item markup (`copied → Check` / `failed → AlertTriangle` / `idle → Copy`, plus
@@ -313,8 +333,8 @@ export function imageClipboardSupported(): boolean;
 export function canCopyImage(src: string): boolean;
 
 // packages/ui/src/lib/clipboard/write-image.ts
-/** `src` is the original `data:image/*` URL; `decoded` is its payload. */
-export function writeImageToClipboard(src: string, decoded: DecodedDataUrl): Promise<void>;
+/** Throws (synchronously, before any clipboard call) when `src` cannot be decoded. */
+export function writeImageToClipboard(src: string): Promise<void>;
 
 // packages/ui/src/lib/clipboard/copy-image.ts
 /** `message` is present only on failure, and only when a reason is worth showing. */
@@ -447,14 +467,16 @@ beforeEach(() => {
 afterEach(() => Reflect.deleteProperty(HTMLImageElement.prototype, 'decode'));
 ```
 
-Every call passes the data URL and its decoded payload:
-`writeImageToClipboard(PNG_DATA_URI, { mediaType: 'image/png', bytes })`.
+Every call passes the data URL and nothing else: `writeImageToClipboard(PNG_DATA_URI)`.
+The module decodes on the PNG branch itself (D11), so this suite uses the real
+`image-source` — do not mock it.
 
 Cases:
 - **PNG passthrough:** calls `write` once with a single `ClipboardItem`; the item's
-  `image/png` value resolves to a `Blob` of `type === 'image/png'` and
-  `size === bytes.length`; no canvas is touched (spy on `document.createElement` or
-  on the stubbed `getContext`).
+  `image/png` value resolves to a `Blob` of `type === 'image/png'` and a `size`
+  equal to the fixture's known decoded byte length (hardcode it; do not recompute it
+  with `atob`); no canvas is touched (spy on `document.createElement` or on the
+  stubbed `getContext`).
 - **Activation ordering:** `navigator.clipboard.write` has already been called
   **synchronously** when `writeImageToClipboard` returns — assert the spy's call
   count is 1 before awaiting the returned promise. This is the test that pins the
@@ -463,30 +485,42 @@ Cases:
 - **JPEG re-encode:** with the `decode`/`naturalWidth` stubs above,
   `HTMLCanvasElement.prototype.getContext` stubbed to a fake 2d context with a
   `drawImage` spy, and `HTMLCanvasElement.prototype.toBlob` stubbed to hand back a
-  PNG blob: `writeImageToClipboard(JPEG_DATA_URI, { mediaType: 'image/jpeg', bytes })`
-  still calls `write` synchronously, and the item's value resolves to the re-encoded
-  PNG blob. Also assert `seenSrc === JPEG_DATA_URI` — the `<img>` gets the original
-  data URL, which is what replaces the object-URL round trip.
+  PNG blob: `writeImageToClipboard(JPEG_DATA_URI)` still calls `write`
+  synchronously, and the item's value resolves to the re-encoded PNG blob. Also
+  assert `seenSrc === JPEG_DATA_URI` — the `<img>` gets the original data URL, which
+  is what replaces the object-URL round trip. **And assert no decode happened on
+  this path:** the non-PNG branch never touches `decodeDataUrl` (D11) — spy on
+  `atob` and assert it was not called.
 - **Re-encode failure:** a `decode` stub that rejects makes the promise
   `writeImageToClipboard` returned reject too (via the adopting `write` stub above).
   Same for a `null` 2d context and for a `toBlob` that yields `null`.
+- **Malformed base64 PNG source** (`data:image/png;base64,!!!`, which `decodeDataUrl`
+  cannot decode): `expect(() => writeImageToClipboard(BAD_PNG_DATA_URI)).toThrow()`
+  with a non-empty message, **and `navigator.clipboard.write` was never called.**
+  This is the "never touch the clipboard with a malformed source" property; it moved
+  here from Task 3 with the decode (D11). The throw is synchronous, so assert it with
+  `toThrow`, not `rejects`.
 
 ### Task 3 — Copy orchestration tests (RED)
 
 **File:** `packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts` — **new**
 (node environment).
 
-`vi.mock('../write-image')` so no DOM is needed; use the real `image-source`. Per
-D11 there are no host/source-kind cases here — that gate is Task 1's truth table.
-Cases:
-- **Happy path** → `writeImageToClipboard` receives the src unchanged as its first
-  argument and, as its second, the decoded record whose `mediaType` and `bytes` come
-  from the data URI; the result is `{ ok: true }` with no `message`.
+`vi.mock('../write-image')` is the **only** mock this file needs and no DOM is
+required: after D11, `copy-image.ts` imports nothing but `writeImageToClipboard` —
+the source gate is `canCopyImage`'s (Task 1's truth table) and the decode is
+`write-image`'s. Per D11 there are no host/source-kind cases here either. Cases:
+- **Happy path** → `writeImageToClipboard` receives the src unchanged as its **only**
+  argument (`toHaveBeenCalledWith(PNG_DATA_URI)`); the result is `{ ok: true }` with
+  no `message`.
 - **Synchronous write** → `writeImageToClipboard` has been called once before the
   returned promise is awaited (the D4 activation rule, pinned at this layer too).
-- **Malformed base64 data URI** (`decodeDataUrl` returns `null`) →
-  `{ ok: false }` with a non-empty `message`; `writeImageToClipboard` is never
-  called; one tagged `console.warn` (spy on it — the no-silent-catch rule).
+- **`writeImageToClipboard` throws synchronously** (`new Error('bad source')` — the
+  decode failure it raises before touching the clipboard) → `copyImageToClipboard`
+  resolves `{ ok: false, message: 'bad source' }` rather than propagating the throw,
+  and logs one tagged `console.warn` (spy on it — the no-silent-catch rule). This is
+  what pins the `try` around the call; without it a malformed source throws out of
+  the menu's `handleCopy`.
 - **`writeImageToClipboard` rejects with `new Error('boom')`** →
   `{ ok: false, message: 'boom' }` and one tagged `console.warn`.
 - **A non-`Error` rejection** (`Promise.reject('nope')`) still produces a non-empty
@@ -539,14 +573,28 @@ it is safe to call in a node test. `canCopyImage(src)` is one line:
 **File:** `packages/ui/src/lib/clipboard/write-image.ts` — **new.**
 
 ```ts
-export function writeImageToClipboard(src: string, decoded: DecodedDataUrl): Promise<void> {
-  const png =
-    decoded.mediaType === 'image/png'
-      ? Promise.resolve(new Blob([decoded.bytes], { type: 'image/png' }))
-      : reencodeToPng(src);
+export function writeImageToClipboard(src: string): Promise<void> {
+  const png = src.startsWith('data:image/png;base64,')
+    ? Promise.resolve(pngBlobFromDataUrl(src))
+    : reencodeToPng(src);
   return navigator.clipboard.write([new ClipboardItem({ 'image/png': png })]);
 }
+
+function pngBlobFromDataUrl(src: string): Blob {
+  const decoded = decodeDataUrl(src);
+  if (!decoded) throw new Error('That image could not be decoded.');
+  return new Blob([decoded.bytes], { type: 'image/png' });
+}
 ```
+
+**Only the PNG branch decodes** (D11), and `decodeDataUrl` is imported from
+`./image-source` — it stays there, node-tested by Task 1. The media type comes off
+the `data:` prefix, which `canCopyImage`'s regex
+(`/^data:image\/[a-zA-Z0-9.+-]+;base64,/`) already guarantees is present, so a PNG
+source is exactly `data:image/png;base64,…`; every other source goes to the canvas,
+which reads `src` and never needs the bytes. The `throw` is synchronous and precedes
+`navigator.clipboard.write`, so a malformed source never reaches the clipboard, and
+its message is what `copy-image.ts` puts in the toast.
 
 The `Uint8Array<ArrayBuffer>` annotation on `DecodedDataUrl.bytes` is what lets the
 `Blob` construction typecheck (Constraints). One comment, on the promise value:
@@ -579,17 +627,31 @@ into a second private helper in the same file.
 **File:** `packages/ui/src/lib/clipboard/copy-image.ts` — **new.**
 
 The exact ladder the Task 3 tests pin, and nothing more (D11 — no host or
-source-kind re-check): `decodeDataUrl(src)` → `writeImageToClipboard(src, decoded)`,
-with `.then(onOk, onErr)` rather than `await` (D4's activation rule; carry one
-comment saying so).
+source-kind re-check, and no decode: this module imports only
+`writeImageToClipboard`). One call, wrapped in a `try`, with `.then(onOk, onErr)`
+rather than `await` (D4's activation rule; carry one comment saying so):
 
-- `decodeDataUrl` returns `null` → `console.warn('[copy-image] could not decode the image source')`,
-  then `{ ok: false, message: 'That image could not be decoded.' }`.
-- write rejects → `console.warn('[copy-image] clipboard write failed', err)` — the
-  tagged-warn idiom `lib/editor/copy-reference.ts` already uses in this package —
-  then `{ ok: false, message }`, where `message` is `err.message` when it is a
-  non-empty `Error` message and `'The clipboard refused the image.'` otherwise.
+```ts
+export function copyImageToClipboard(src: string): Promise<CopyImageOutcome> {
+  try {
+    return writeImageToClipboard(src).then(() => ({ ok: true }), onErr);
+  } catch (err) {
+    return Promise.resolve(onErr(err));
+  }
+}
+```
+
+- `writeImageToClipboard` throws (the decode failure it raises before touching the
+  clipboard) or its promise rejects → both land in one private
+  `onErr(err: unknown): CopyImageOutcome`, which logs
+  `console.warn('[copy-image] copy failed', err)` — the tagged-warn idiom
+  `lib/editor/copy-reference.ts` already uses in this package — and returns
+  `{ ok: false, message }`, where `message` is `err.message` when it is a non-empty
+  `Error` message and `'The clipboard refused the image.'` otherwise.
 - success → `{ ok: true }`.
+
+The `catch` exists because the throw is synchronous: `.then(onOk, onErr)` cannot see
+it, and an uncaught throw would escape `handleCopy` in `ImageContextMenu`.
 
 No toast here: the component owns user-facing feedback so this module stays callable
 outside React.
@@ -929,7 +991,29 @@ stating that right-clicking an opened image offers Copy Image.
 
 **Verify:**
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck`
-- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/lib/ui src/features/chat/parts src/features/chat/messages/__tests__/MessagePathContextMenu.test.tsx`
+- ```
+  pnpm --filter @qlan-ro/mainframe-ui exec vitest run \
+    src/lib/clipboard src/lib/ui src/features/chat/parts \
+    src/features/chat/messages/__tests__/MessagePathContextMenu.test.tsx \
+    src/features/viewers/__tests__/ImageViewer.test.tsx \
+    src/features/context-panel/__tests__/SessionAttachmentsGrid.test.tsx
+  ```
+  **The last two files are the non-chat `LightboxSurface` callers D10 accepts**, and
+  they were missing from this run while D10 claimed the scope. Task 12 rewraps a
+  component all five call sites share, so the run has to reach past `features/chat`:
+  - `SessionAttachmentsGrid.test.tsx:39-46` renders the real `ImageLightbox` and
+    asserts `image-lightbox-dialog` after a thumb click, so it executes the rewrapped
+    `LightboxSurface` — this is the one suite outside chat that actually exercises
+    Task 12.
+  - `ImageViewer.test.tsx:30-44` **mocks `@/features/chat/parts/ZoomableImage`** with
+    a bare `<img>`, so it never reaches `LightboxSurface`. It runs here as the
+    regression guard on the viewer's own render path and on the day that mock is
+    dropped — not as coverage of the menu. Do not "fix" it by unmocking; that pulls
+    the Radix dialog into a viewer suite for no gain.
+  - **`TaskAttachments` has no unit suite at all** — the two files that name it mock
+    it away, so no vitest invocation can reach `TaskAttachments.tsx:224`. **QA smoke
+    step 4 is its only coverage**, which is where the file:line evidence lives. This
+    change writes no new suite for it.
 - `git status` shows no stray files; no file over 300 lines (`wc -l` on every touched
   file).
 - **Hygiene is checked against added lines only** — `git diff main...HEAD | grep '^+'`
@@ -1011,6 +1095,15 @@ Appendix A as the fix.
    `blocked_reason: "D7 webview clipboard gate needs an interactive macOS shell"`.
    An unverified PASS is the one outcome this gate exists to prevent.
 4. Right-click the *thumbnail* (not the opened image) → no menu (webview default).
+   Then open an image attachment from a **task** (Tasks panel → a task carrying an
+   image → the attachment opens in `ImageLightbox`) and right-click it → the menu
+   appears and Copy Image works. **This is the only coverage `TaskAttachments` gets.**
+   It has no unit suite: the two files that name it,
+   `features/tasks/__tests__/TaskEditModal.test.tsx:42-44` and
+   `features/tasks/__tests__/TasksSidebarSection.test.tsx:70-72`, both mock it away,
+   so no vitest run in Task 13 reaches `TaskAttachments.tsx:224`. If no task with an
+   image attachment is reachable, attach one first rather than skipping the step —
+   this is one of the three non-chat call sites D10 accepts.
 5. Right-click transcript text, a code block, and the composer → unchanged.
 6. Close the menu with Escape and with an outside click → the lightbox stays open;
    clicking the image itself still closes the lightbox. The outside *click* is the

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -5,28 +5,29 @@
 
 ## Goal
 
-An image the user opens in the chat transcript has no context menu, so there is no
-way to get the bitmap onto the system clipboard — text copies fine, binary image
-data does not. This change wraps the one `<img>` inside `LightboxSurface` — the
-choke point both zoom paths already route through (`ZoomableImage` for assistant
-images, `ImageLightbox` for the user-turn gallery, task and session attachment
-grids, and the file `ImageViewer`) — in a shadcn `ContextMenu` carrying a single
-**Copy Image** item. Clicking it writes the image to the system clipboard through
-the webview's own async Clipboard API (`navigator.clipboard.write` with a
-`ClipboardItem`), the same API the transcript already uses to copy text, so pasting
-into Preview or Slack yields the image, not a URL. No IPC, no Rust, no host port.
-The menu mounts only when the source is copyable (`data:image/*`) *and* the webview
-advertises image-clipboard support; otherwise `ImageContextMenu` renders its
+An image the user opens has no context menu, so there is no way to get the bitmap
+onto the system clipboard — text copies fine, binary image data does not. This
+change wraps the one `<img>` inside `LightboxSurface` — the choke point both zoom
+paths route through (`ZoomableImage`, `ImageLightbox`) — in a shadcn `ContextMenu`
+carrying a single **Copy Image** item. Clicking it writes the image to the system
+clipboard through the webview's own async Clipboard API (`navigator.clipboard.write`
+with a `ClipboardItem`), the same API the transcript already uses to copy text, so
+pasting into Preview or Slack yields the image, not a URL. No IPC, no Rust, no host
+port. The menu mounts only when the source is copyable (`data:image/*`) *and* the
+webview advertises image-clipboard support; otherwise `ImageContextMenu` renders its
 children bare and right-click falls through exactly as it does today. The item
-reports its own outcome inline (Copy → Copied / Copy failed) through the shared
-`useMenuCopyFeedback` hook, and a failure additionally raises an `mfToast` carrying
-the reason.
+reports its own outcome inline (Copy Image → Copied / Copy failed) through the
+shared `useMenuCopyFeedback` hook, and a failure additionally raises an `mfToast`
+carrying the reason. Because `LightboxSurface` is shared, the menu also reaches the
+file viewer and the task/session attachment grids — an accepted scope expansion,
+recorded as D10.
 
 ## Constraints
 
 - **`CLAUDE.md`:** max 300 lines/file, 50 lines/function; `data-testid` on every
   interactive element (`<surface>-<element>` kebab-case); tests required for new
-  core logic; no silent catches; changeset required before commit.
+  core logic; no silent catches; extract shared helpers at 3+ duplications;
+  changeset required before commit.
 - **`packages/ui/CLAUDE.md`:** shadcn primitives, never raw Radix; read the
   `mainframe-design-system` skill before writing markup or class names; pure logic
   lives outside React.
@@ -36,14 +37,23 @@ the reason.
   jsdom, `*.test.ts` in node. A `.test.ts` that touches DOM APIs must carry a
   `// @vitest-environment jsdom` pragma — `write-image.test.ts` needs it, the other
   two do not.
+- **TypeScript is 6.0.3** (root `package.json`, `packages/ui/package.json`). Its
+  `lib.dom.d.ts` declares `BlobPart → BufferSource → ArrayBufferView<ArrayBuffer>`,
+  so a bare `Uint8Array` (i.e. `Uint8Array<ArrayBufferLike>`) is **not** assignable
+  to a `Blob` constructor argument. Every byte-carrying signature in this plan is
+  therefore declared `Uint8Array<ArrayBuffer>`. Verified by compiling both forms
+  with the repo's own `tsc`: the annotated form is clean, the bare form is `TS2322`.
 - **Every file this plan touches is comfortably under the line limits.** Largest
   edited file: `LightboxSurface.tsx` (42 → ~48). Every new file lands well under
   300; every new function under 50.
 - **The worktree has no `node_modules`.** Run `pnpm install` from the worktree root
   before the first task.
-- **No Rust and no cold `cargo` build** on the primary path. Appendix A (the
-  fallback) is the only thing that would need one; do not pay for it before Task 13
-  says it is needed.
+- **The implement stage needs no Rust and never runs `cargo`.** The one step that
+  does — the D7 webview gate — is a **qa-stage** step, not an implement task
+  (D14). Its cost is stated there: a cold `packages/app-tauri/src-tauri` build in
+  this worktree, multi-GB per the Disk Hygiene section of `CLAUDE.md`, followed by
+  a sweep. Appendix A (the fallback) is the only thing that adds Rust *source*, and
+  it runs only if that gate fails.
 
 ## Decisions
 
@@ -62,14 +72,23 @@ work.
 "disabled item with a reason". A one-item menu whose only item is dead is worse
 than no menu; right-click falls through to the webview default.
 
-**D3 — Testids: `chat-image-context-menu` on the menu *content*, `chat-image-copy`
-on the item.** The design direction put the first one on the trigger, but the
-trigger is the `<img>`, which already carries `imageTestId`
-(`chat-image-zoom-image` / `image-lightbox-current`) that existing tests assert on;
-one element cannot hold two testids. Neither id is keyed by a message/attachment
-id because the lightbox renders exactly one image at a time — there is no list and
-no index to disambiguate, and threading an id through three call sites to satisfy
-the letter of the rule buys nothing.
+**D3 — Testids are surface-neutral: `image-context-menu` on the menu *content*,
+`image-copy` on the item.** Two departures from the design direction, both forced:
+
+1. *Not `chat-*`.* `LightboxSurface` is reached from four non-chat call sites
+   (D10), so a `chat-` prefix would put `chat-image-copy` on the file viewer, the
+   tasks panel, and the context panel — against the `<surface>-<element>` rule and
+   misleading for every future e2e selector. The neutral pair matches
+   `ImageLightbox`'s own `image-lightbox-*` ids. Renaming after merge would churn
+   spec files, so it is done now.
+2. *Not on the trigger.* The direction put the first id on the trigger, but the
+   trigger is the `<img>`, which already carries `imageTestId`
+   (`chat-image-zoom-image` / `image-lightbox-current`) that existing tests assert
+   on; one element cannot hold two testids.
+
+Neither id is keyed by a message/attachment id because the lightbox renders exactly
+one image at a time — there is no list and no index to disambiguate, and threading
+an id through three call sites to satisfy the letter of the rule buys nothing.
 
 **D4 — The webview writes the clipboard; nothing crosses the IPC boundary.**
 *(Replaces the earlier "renderer decodes to RGBA, Rust writes" decision.)* Three
@@ -91,8 +110,9 @@ origin is a secure context, which is the only precondition WebKit puts on
 `ClipboardItem`. WebKit has shipped `ClipboardItem` writes for `image/png` since
 Safari 13.4, and the shipped app is macOS-only today
 (`.github/workflows/release.yml`, `build-app-tauri` matrix). This decision is not
-taken on faith: **Task 13 is a hard gate** that verifies a real paste in the shell
-before the change can ship, and Appendix A specifies the fallback in full.
+taken on faith: **the QA-stage webview gate** (see *QA smoke*, step 3) verifies a
+real paste in the shell before the change can ship, and Appendix A specifies the
+fallback in full.
 
 **D5 — Supported sources are `data:image/*` only, normalized to PNG.** Every image
 the transcript renders today is a data URI: `convert-message.ts` builds
@@ -102,7 +122,7 @@ unsupported per the brief's "do not fetch on right-click" ruling; `file://` and
 asset-protocol sources are unsupported because nothing in the transcript produces
 them. WebKit accepts only `image/png` on write, so a `data:image/jpeg` (or webp,
 or gif) source is re-encoded to PNG through a canvas before the write — see
-Task 9.
+Task 5.
 
 **D6 — No `HostBridge.clipboard` port; capability is a runtime feature detection.**
 The brief asked for a host-adapter capability, which made sense when the write had
@@ -117,12 +137,13 @@ there; Firefox does not expose `ClipboardItem` writes by default, so it gets no
 menu. jsdom has neither, so every existing transcript test renders exactly as
 before.
 
-**D7 — Task 13 is a gate, not a QA step.** The webview path is the whole change; if
-WKWebView refuses the write, four of this plan's files are dead. So the plan is
-ordered so the *cheap* path is built and proven in the running shell (Task 13)
+**D7 — The webview write is gated by a real paste before the change ships.** The
+webview path is the whole change; if WKWebView refuses the write, four of this
+plan's files are dead. So the *cheap* path is built and proven in the running shell
 before any Rust exists, and Appendix A — the host port plus the Rust command — is
-executed only if that gate fails. The gate's outcome is recorded as a decision in
-the lane result either way.
+executed only if that gate fails. The gate lives in the qa stage (D14) and is
+specified as QA smoke step 3, with a machine-checkable pasteboard assertion. Its
+outcome is recorded as a decision in the lane result either way.
 
 **D8 — If Appendix A is taken, it keeps the raw-body invoke and fixes the CSP; it
 does not switch to plain typed args.** Recorded here because it is the reason the
@@ -149,12 +170,85 @@ transcript already has two copy context menus — `MessagePathContextMenu` and
 `LinkWithPreview` — and the hook exists precisely "so the message path menu doesn't
 paste the mechanism a second time". A third idiom (silent success, toast-only
 failure) would make three copy menus in one surface behave three ways, so the image
-menu adopts the hook: the item reads Copy → **Copied** / **Copy failed** and the
-menu self-closes after ~900 ms. The failure toast is kept on top of the inline
+menu adopts the hook: the item reads Copy Image → **Copied** / **Copy failed** and
+the menu self-closes after ~900 ms. The failure toast is kept on top of the inline
 state because it is the only place the *reason* fits. This also fixes the icon:
 the design direction wrote `<Copy size={13} className="text-muted-foreground" />`,
 but every ContextMenu copy item in the repo uses `className="mr-2 size-3.5"` with
-no colour override; the image menu matches its neighbours.
+no colour override; the image menu matches its neighbours. Reusing the hook forces
+two follow-on decisions, D12 and D13.
+
+**D10 — Scope: the menu reaches every `LightboxSurface` caller, not only the
+transcript.** The brief scoped the menu to "images inside the transcript" and the
+design gate named the two chat paths. `LightboxSurface` is shared, so wrapping it
+also puts the menu on:
+
+| Call site | Route |
+|---|---|
+| `features/chat/messages/AssistantMessage.tsx` | `ZoomableImage` |
+| `features/chat/messages/InlineImageThumbs.tsx` | `ImageLightbox` |
+| `features/viewers/ImageViewer.tsx:151` | `ZoomableImage` |
+| `features/tasks/TaskAttachments.tsx:224` | `ImageLightbox` |
+| `features/context-panel/SessionAttachmentsGrid.tsx:85` | `ImageLightbox` |
+
+**Accepted, not worked around.** All five render the same `data:image/*` sources
+(`ImageViewer`'s own header documents its `src` as `data:image/...;base64,...`), so
+the behavior is identical everywhere and the action is correct on each. Narrowing
+it back to chat would mean a prop threaded through three call sites to *disable* a
+working feature. The scope note the gate cared about is the *thumbnail* boundary —
+still honored: no thumbnail anywhere gets a menu. Consequence for D3: the testids
+must be surface-neutral.
+
+**D11 — One gate, one result shape.** `canCopyImage(src)` is the single
+authoritative gate; `copyImageToClipboard` does not re-check the host or the source
+kind. The earlier `CopyImageResult` union carried `reason: 'unsupported-host' |
+'unsupported-source' | 'write-failed'`, but `ImageContextMenu` is the only caller
+and it mounts the item only when `canCopyImage` is true, so the first two variants
+were unreachable in production and existed only to be asserted. The module now
+returns `{ ok: boolean; message?: string }` — the shape this codebase already uses
+for text (`writeToClipboard(text): Promise<boolean>` in
+`lib/editor/copy-reference.ts:117`, which logs a tagged warn and resolves false),
+widened only so the `DOMException` message can reach the toast description.
+`useMenuCopyFeedback.onCopySelect` consumes `result.ok` directly.
+
+**D12 — `CopyMenuItem` is extracted and all three copy menus migrate in this pass.**
+The item markup (`copied → Check` / `failed → AlertTriangle` / `idle → Copy`, plus
+the label ternary) already exists twice —
+`features/chat/messages/MessagePathContextMenu.tsx:39-58` (`CopyPathItem`) and
+`features/chat/parts/link-with-preview.tsx:90-95`. The image menu would be the
+third, which `CLAUDE.md` ("extract shared helpers at 3+ duplications") forbids. It
+moves to `lib/ui/CopyMenuItem.tsx`, beside `use-menu-copy-feedback.ts`, which
+already owns `CopyStatus`. `link-with-preview.tsx` migrates in the same pass rather
+than being left as a fourth copy: leaving it is exactly the leftover `CLAUDE.md`
+rules out, and its item is structurally identical (only the label differs).
+
+**D13 — `useMenuCopyFeedback` gains a generation token; the stray-Escape race is
+fixed in the hook, not worked around in `ImageContextMenu`.** The hook's
+`onCopySelect` re-arms `setTimeout(closeMenu, delayMs)` inside `run().then(...)`
+with no invalidation (`lib/ui/use-menu-copy-feedback.ts:56-61`), while
+`handleOpenChange(false)` clears only the timer that exists at that instant
+(lines 38-43); `closeMenu` dispatches a document-level Escape keydown (line 34).
+Radix's `DismissableLayer` gates Escape on `index === layers.size - 1`, so with the
+menu open the menu absorbs it — which is why the hook's two existing consumers
+never saw this. Inside a Dialog it bites: if the user dismisses the menu after
+clicking Copy Image but before the copy settles (the JPEG canvas re-encode, or a
+slow rejected write on an unfocused WKWebView document), the late settlement
+schedules an Escape that fires with the menu unmounted, the lightbox Dialog is then
+the highest layer, and **the image closes by itself ~900 ms later**. Fix: capture a
+generation counter at select time, bump it in `handleOpenChange(false)`, and drop
+settlements whose generation is stale. Fixing it in the hook costs three lines and
+protects the two existing consumers from the same bug the day either of them is
+nested in a dialog.
+
+**D14 — The webview gate belongs to the qa stage; the implement stage completes
+`unverified`.** The gate is a human-driven shell run: `pnpm tauri:dev`, right-click,
+Copy Image, paste. The lane contract's implement exit criteria are groups done +
+typecheck/tests + commits, with no slot for a manual gate, and the qa stage's
+"failures route back to the implementer once" is precisely the Appendix A escape
+hatch. So there is no implement task group for it — it is QA smoke step 3, with a
+machine-checkable pasteboard assertion and an explicit blocked path. This also keeps
+the implement stage free of `cargo`: the gate's cold `src-tauri` build is a
+multi-GB, qa-stage cost (Disk Hygiene), swept afterwards.
 
 ## Interfaces this change adds
 
@@ -162,26 +256,38 @@ no colour override; the image menu matches its neighbours.
 // packages/ui/src/lib/clipboard/image-source.ts
 export type ImageSourceKind = 'data-url' | 'remote' | 'unsupported';
 export function classifyImageSource(src: string): ImageSourceKind;
-export function decodeDataUrl(src: string): { mediaType: string; bytes: Uint8Array } | null;
+export function decodeDataUrl(src: string): { mediaType: string; bytes: Uint8Array<ArrayBuffer> } | null;
 export function imageClipboardSupported(): boolean;
 export function canCopyImage(src: string): boolean;
 
 // packages/ui/src/lib/clipboard/write-image.ts
-export function writeImageToClipboard(bytes: Uint8Array, mediaType: string): Promise<void>;
+export function writeImageToClipboard(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<void>;
 
 // packages/ui/src/lib/clipboard/copy-image.ts
-export type CopyImageResult =
-  | { ok: true }
-  | { ok: false; reason: 'unsupported-host' | 'unsupported-source' | 'write-failed'; message: string };
-export function copyImageToClipboard(src: string): Promise<CopyImageResult>;
+/** `message` is present only on failure, and only when a reason is worth showing. */
+export interface CopyImageOutcome { ok: boolean; message?: string }
+/** Assumes `canCopyImage(src)` — the single gate (D11). */
+export function copyImageToClipboard(src: string): Promise<CopyImageOutcome>;
+
+// packages/ui/src/lib/ui/CopyMenuItem.tsx
+export function CopyMenuItem(props: {
+  testId: string;
+  label: string;
+  status: CopyStatus;
+  onSelect: (event: Event) => void;
+}): React.ReactElement;
 ```
 
-`copyImageToClipboard` is **not** an `async` function. WebKit requires
-`navigator.clipboard.write` to run under the user activation of the click that
-triggered it, and an `await` before the call ends that activation. Everything up to
-the write is synchronous; the re-encode for non-PNG sources rides inside the
-`ClipboardItem` value as a promise, which is the form WebKit documents for exactly
-this case.
+`Uint8Array<ArrayBuffer>`, not `Uint8Array`, is load-bearing — see Constraints.
+`new Uint8Array(len)` already produces that type, so no defensive copy is needed
+anywhere.
+
+`copyImageToClipboard` and `writeImageToClipboard` are **not** `async` functions.
+WebKit requires `navigator.clipboard.write` to run under the user activation of the
+click that triggered it, and an `await` before the call ends that activation.
+Everything up to the write is synchronous; the re-encode for non-PNG sources rides
+inside the `ClipboardItem` value as a promise, which is the form WebKit documents
+for exactly this case.
 
 ---
 
@@ -210,15 +316,41 @@ Cover, with hardcoded expectations (no logic mirrored from the implementation):
   `ClipboardItem` present but no `navigator.clipboard.write`; `true` with both.
   Install and remove the globals with `vi.stubGlobal` / `vi.unstubAllGlobals`.
 - `canCopyImage` truth table over `{data-url, remote} × {supported, unsupported}` —
-  only `data-url` + supported is `true`.
+  only `data-url` + supported is `true`. This is the gate D11 makes authoritative,
+  so the table is the only place the gating rule is asserted.
 
 ### Task 2 — Clipboard write tests (RED)
 
 **File:** `packages/ui/src/lib/clipboard/__tests__/write-image.test.ts` — **new.**
 First line: `// @vitest-environment jsdom` (see Constraints).
 
-Stub `ClipboardItem` with a class that records its constructor argument, and
-`navigator.clipboard.write` with a spy. Cases:
+**Stub shape is prescribed, not left to the implementer.** `ClipboardItem` is a
+class that stores its constructor argument; `navigator.clipboard.write` **adopts**
+the item's `image/png` value rather than ignoring it:
+
+```ts
+class FakeClipboardItem {
+  constructor(readonly values: Record<string, Blob | Promise<Blob>>) {}
+}
+const write = vi.fn(async (items: FakeClipboardItem[]): Promise<void> => {
+  await items[0]!.values['image/png'];
+});
+```
+
+That mirrors WebKit, which rejects `write()` when a value promise rejects. A plain
+spy would orphan the rejection inside the fake item: the promise
+`writeImageToClipboard` returns would never adopt it, the "a rejecting decode()
+rejects the returned promise" case would fail, and the rejection would surface as an
+unhandled rejection. **Do not repair that by awaiting the blob before calling
+`write`** — that destroys the synchronous-write property the activation-ordering
+case below exists to protect. (The equivalent alternative, if the adopting stub
+proves awkward: assert rejection on the *stored* value and assert invocation
+separately. Pick one and say which in the file header.)
+
+The async body of `write` still records its call synchronously, so the activation
+assertion holds.
+
+Cases:
 - **PNG passthrough:** `writeImageToClipboard(bytes, 'image/png')` calls `write`
   once with a single `ClipboardItem`; the item's `image/png` value resolves to a
   `Blob` of `type === 'image/png'` and `size === bytes.length`; no canvas is
@@ -235,27 +367,29 @@ Stub `ClipboardItem` with a class that records its constructor argument, and
   `writeImageToClipboard(bytes, 'image/jpeg')` still calls `write` synchronously,
   and the item's value resolves to the re-encoded PNG blob. Assert
   `URL.createObjectURL` / `URL.revokeObjectURL` are balanced.
-- **Re-encode failure:** a rejecting `decode()` rejects the returned promise, and
-  the object URL is still revoked. Same for a `null` 2d context and for a `toBlob`
-  that yields `null`.
+- **Re-encode failure:** a rejecting `decode()` rejects the promise
+  `writeImageToClipboard` returned (via the adopting stub above), and the object URL
+  is still revoked. Same for a `null` 2d context and for a `toBlob` that yields
+  `null`.
 
 ### Task 3 — Copy orchestration tests (RED)
 
 **File:** `packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts` — **new**
 (node environment).
 
-`vi.mock('../write-image')` so no DOM is needed; use the real `image-source`.
+`vi.mock('../write-image')` so no DOM is needed; use the real `image-source`. Per
+D11 there are no host/source-kind cases here — that gate is Task 1's truth table.
 Cases:
-- No `ClipboardItem` global → `{ ok: false, reason: 'unsupported-host' }`, and
-  `writeImageToClipboard` is never called.
-- `https://…` source with support present → `{ ok: false, reason:
-  'unsupported-source' }`, nothing called.
-- Happy path → `writeImageToClipboard` receives exactly the decoded bytes and the
-  media type from the data URI; result is `{ ok: true }`.
-- `writeImageToClipboard` rejects → `{ ok: false, reason: 'write-failed' }` with a
-  non-empty `message` taken from the error, and one tagged `console.warn` (spy on
-  it — the no-silent-catch rule).
-- A non-`Error` rejection (`Promise.reject('nope')`) still produces a non-empty
+- **Happy path** → `writeImageToClipboard` receives exactly the decoded bytes and
+  the media type from the data URI; the result is `{ ok: true }` with no `message`.
+- **Synchronous write** → `writeImageToClipboard` has been called once before the
+  returned promise is awaited (the D4 activation rule, pinned at this layer too).
+- **Malformed base64 data URI** (`decodeDataUrl` returns `null`) →
+  `{ ok: false }` with a non-empty `message`; `writeImageToClipboard` is never
+  called; one tagged `console.warn` (spy on it — the no-silent-catch rule).
+- **`writeImageToClipboard` rejects with `new Error('boom')`** →
+  `{ ok: false, message: 'boom' }` and one tagged `console.warn`.
+- **A non-`Error` rejection** (`Promise.reject('nope')`) still produces a non-empty
   `message`.
 
 **Verify (whole group):** all three files fail on missing modules; no other suite
@@ -275,9 +409,11 @@ Pure, no DOM writes. `classifyImageSource` matches
 first `,`, verifies the prefix shape, `atob`s the payload inside a `try`
 (returning `null` on `InvalidCharacterError` — an `/* expected */`-commented catch,
 since a malformed URI is data, not a fault), and copies char codes into a
-`Uint8Array`. `imageClipboardSupported` is the two-term global check from D6 —
-guard both terms so it is safe to call in a node test. `canCopyImage` is the
-conjunction of the kind check and `imageClipboardSupported()`.
+`new Uint8Array(len)`, whose inferred type is already `Uint8Array<ArrayBuffer>` —
+declare the return that way and no copy is needed. `imageClipboardSupported` is the
+two-term global check from D6 — guard both terms so it is safe to call in a node
+test. `canCopyImage` is the conjunction of the kind check and
+`imageClipboardSupported()`.
 
 **Verify:** `vitest run src/lib/clipboard/__tests__/image-source.test.ts` green.
 
@@ -286,7 +422,7 @@ conjunction of the kind check and `imageClipboardSupported()`.
 **File:** `packages/ui/src/lib/clipboard/write-image.ts` — **new.**
 
 ```ts
-export function writeImageToClipboard(bytes: Uint8Array, mediaType: string): Promise<void> {
+export function writeImageToClipboard(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<void> {
   const png =
     mediaType === 'image/png'
       ? Promise.resolve(new Blob([bytes], { type: 'image/png' }))
@@ -295,9 +431,11 @@ export function writeImageToClipboard(bytes: Uint8Array, mediaType: string): Pro
 }
 ```
 
-One comment, on the promise value: WebKit accepts only `image/png` on write, and
-takes a promise so the re-encode can finish after the user gesture. Private
-`reencodeToPng(bytes, mediaType): Promise<Blob>`:
+The `Uint8Array<ArrayBuffer>` annotation is required for both `Blob` constructions
+to typecheck (Constraints). One comment, on the promise value: WebKit accepts only
+`image/png` on write, and takes a promise so the re-encode can finish after the user
+gesture. Private
+`reencodeToPng(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<Blob>`:
 1. `const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }))` — blob
    URLs are same-origin, so the canvas is never tainted.
 2. `const img = new Image(); img.src = url; await img.decode();` — `decode()` over
@@ -318,23 +456,119 @@ into a second private helper in the same file.
 
 **File:** `packages/ui/src/lib/clipboard/copy-image.ts` — **new.**
 
-The exact ladder the Task 3 tests pin: `imageClipboardSupported()` →
-`decodeDataUrl` → `writeImageToClipboard`, with `.then(onOk, onErr)` rather than
-`await` (D4's activation rule; carry one comment saying so). The error branch calls
-`console.warn('[copy-image] clipboard write failed', err)` — the tagged-warn idiom
-`lib/editor/copy-reference.ts` already uses in this package — before returning
-`{ ok: false, reason: 'write-failed', message }`, where `message` is the error's
-message or a fixed fallback for a non-`Error` throw. No toast here: the component
-owns user-facing feedback so this module stays callable outside React.
+The exact ladder the Task 3 tests pin, and nothing more (D11 — no host or
+source-kind re-check): `decodeDataUrl(src)` → `writeImageToClipboard`, with
+`.then(onOk, onErr)` rather than `await` (D4's activation rule; carry one comment
+saying so).
+
+- `decodeDataUrl` returns `null` → `console.warn('[copy-image] could not decode the image source')`,
+  then `{ ok: false, message: 'That image could not be decoded.' }`.
+- write rejects → `console.warn('[copy-image] clipboard write failed', err)` — the
+  tagged-warn idiom `lib/editor/copy-reference.ts` already uses in this package —
+  then `{ ok: false, message }`, where `message` is `err.message` when it is a
+  non-empty `Error` message and `'The clipboard refused the image.'` otherwise.
+- success → `{ ok: true }`.
+
+No toast here: the component owns user-facing feedback so this module stays callable
+outside React.
 
 **Verify:** `vitest run src/lib/clipboard` all green, and
 `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes.
 
 ---
 
-## Group 3 — `menu-tests` (test) · depends on: `clipboard-lib`
+## Group 3 — `copy-menu-shared-tests` (test) · depends on: nothing
 
-### Task 7 — `ImageContextMenu` behavior + both render paths (RED)
+### Task 7 — Stale-settlement tests for `useMenuCopyFeedback` (RED)
+
+**File:** `packages/ui/src/lib/ui/__tests__/use-menu-copy-feedback.test.tsx` —
+**modified** (the suite exists; append cases to the existing `describe`). Its
+`Harness` already exposes a deferred `run`, an `item-a` button, and a `close-menu`
+button that calls `handleOpenChange(false)`, and the file already runs on fake
+timers — reuse all of it, add no new harness.
+
+Red against Task 8's generation token. Three cases:
+1. **Close before a successful settle** — click `item-a` with a deferred run, click
+   `close-menu`, then settle `true` and `advanceTimersByTime(1000)`. Assert **no**
+   Escape keydown was dispatched on `document` and `item-a` still reads `Copy A`.
+   (Today the settlement re-arms the timer and one Escape fires — this is the bug
+   D13 describes.)
+2. **Close before a failed settle** — same, settling `false`. Same assertions; the
+   failure path re-arms the same timer.
+3. **A copy started *after* a close still reports** — click `close-menu` first, then
+   click `item-a` and settle `true`; `item-a` reads `Copied` and exactly one Escape
+   fires. This is the guard against a token that permanently poisons the hook.
+
+**Verify:** cases 1-2 fail (an Escape is dispatched), case 3 passes; every existing
+case in the file still passes.
+
+---
+
+## Group 4 — `copy-menu-shared` (ui) · depends on: `copy-menu-shared-tests`
+
+Read the `mainframe-design-system` skill before touching `CopyMenuItem`'s markup.
+
+### Task 8 — Generation token in `useMenuCopyFeedback`
+
+**File:** `packages/ui/src/lib/ui/use-menu-copy-feedback.ts`
+
+Add `const generationRef = useRef(0);`. `handleOpenChange(false)` increments it
+before clearing the timer and resetting `settled`. `onCopySelect` captures
+`const generation = generationRef.current` **outside** the `.then`, and the `.then`
+returns early when `generation !== generationRef.current`, alongside the existing
+`!mountedRef.current` guard. Extend the file's header comment by one sentence
+saying why (a settlement that lands after the menu closed must not dispatch an
+Escape — inside a Dialog the Dialog would eat it; D13). No API change: the three
+returned members keep their signatures.
+
+**Verify:** the whole `lib/ui/__tests__/use-menu-copy-feedback.test.tsx` suite is
+green, including Task 7's three new cases.
+
+### Task 9 — Extract `CopyMenuItem` and migrate both existing menus
+
+**Files:**
+- `packages/ui/src/lib/ui/CopyMenuItem.tsx` — **new.**
+- `packages/ui/src/features/chat/messages/MessagePathContextMenu.tsx` — modified.
+- `packages/ui/src/features/chat/parts/link-with-preview.tsx` — modified.
+
+`CopyMenuItem` is `MessagePathContextMenu`'s current `CopyPathItem` moved verbatim
+— same props, same icons, same class names, same label ternary — and re-exported
+from `lib/ui/`, beside the hook that owns `CopyStatus` (D12):
+
+```tsx
+export function CopyMenuItem({ testId, label, status, onSelect }: CopyMenuItemProps) {
+  return (
+    <ContextMenuItem data-testid={testId} onSelect={onSelect}>
+      {status === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
+      {status === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
+      {status === 'idle' && <Copy className="mr-2 size-3.5" />}
+      {status === 'copied' ? 'Copied' : status === 'failed' ? 'Copy failed' : label}
+    </ContextMenuItem>
+  );
+}
+```
+
+Then:
+- `MessagePathContextMenu` deletes its local `CopyPathItem` and imports
+  `CopyMenuItem`; both call sites keep their testids and labels
+  (`Copy Absolute Path` / `Copy Relative Path`) unchanged.
+- `link-with-preview.tsx` replaces its inlined copy item (lines 90-95) with `<CopyMenuItem testId="chat-link-copy" label="Copy link" status={menuStatus} onSelect={handleMenuCopy} />`.
+  Keep the label string exactly `Copy link` —
+  `features/chat/parts/__tests__/markdown-text.test.tsx:308-340` asserts it, along
+  with `Copied` and the delayed close. Its second item (`chat-link-open`) is not a
+  copy item and stays inline. Drop the now-unused `Check`/`Copy`/`AlertTriangle`
+  imports from both files.
+
+**Verify:**
+`vitest run src/features/chat/messages/__tests__/MessagePathContextMenu.test.tsx src/features/chat/parts/__tests__/markdown-text.test.tsx`
+green with no test edits — the migration is behavior-preserving, so a test change
+here means the extraction changed something it should not have.
+
+---
+
+## Group 5 — `menu-tests` (test) · depends on: `clipboard-lib`, `copy-menu-shared`
+
+### Task 10 — `ImageContextMenu` behavior + both render paths (RED)
 
 **File:** `packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx` — **new.**
 
@@ -351,30 +585,34 @@ real 1×1 PNG data URI constant for the copyable source.
 
 Cases:
 1. **Supported webview + data URI** — right-clicking the wrapped child opens
-   `chat-image-context-menu` containing `chat-image-copy` with the text
-   `Copy Image`.
-2. **Supported webview + `https://…` source** — no `chat-image-context-menu` after
+   `image-context-menu` containing `image-copy` with the text `Copy Image`.
+2. **Supported webview + `https://…` source** — no `image-context-menu` after
    `fireEvent.contextMenu`, and the child still renders.
 3. **No `ClipboardItem` + data URI** — same: no menu, child renders.
-4. **Copy succeeds** — clicking `chat-image-copy` calls `copyImageToClipboard` once
-   with the src; the item's text becomes `Copied`; `mfToast.error` is never called.
-5. **Copy fails** — `copyImageToClipboard` resolves
-   `{ ok: false, reason: 'write-failed', message: 'boom' }`; the item's text becomes
-   `Copy failed`, `mfToast.error` is called once, and its options carry
-   `description: 'boom'`.
+4. **Copy succeeds** — clicking `image-copy` calls `copyImageToClipboard` once with
+   the src; the item's text becomes `Copied`; `mfToast.error` is never called.
+5. **Copy fails** — `copyImageToClipboard` resolves `{ ok: false, message: 'boom' }`;
+   the item's text becomes `Copy failed`, `mfToast.error` is called once, and its
+   options carry `description: 'boom'`.
 6. **Assistant-image path** — render `<ZoomableImage src={PNG_DATA_URI} />`, click
    `chat-image-zoom-trigger`, await `chat-image-zoom-dialog`, then
-   `fireEvent.contextMenu` on `chat-image-zoom-image` → `chat-image-context-menu`
+   `fireEvent.contextMenu` on `chat-image-zoom-image` → `image-context-menu`
    appears. (Satisfies "the assistant/attachment render path gets the menu".)
 7. **User-gallery path** — render
    `<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />`,
-   `fireEvent.contextMenu` on `image-lightbox-current` → `chat-image-context-menu`
+   `fireEvent.contextMenu` on `image-lightbox-current` → `image-context-menu`
    appears. (Satisfies the second required render path.)
 8. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
    dialog open and the menu open, press `Escape` once: the menu closes and
    `chat-image-zoom-dialog` is still in the DOM. Then assert a plain click on
    `chat-image-zoom-image` (no menu open) still closes the dialog, so the existing
    dismissal contract survives the `asChild` wrap.
+9. **A copy that settles after the menu closed does not close the lightbox** (D13,
+   the integration counterpart to Task 7). Open the `ZoomableImage` dialog and the
+   menu, mock `copyImageToClipboard` to a **deferred** promise, click `image-copy`,
+   press `Escape` to dismiss the menu only, then settle the deferred copy and
+   `advanceTimersByTime(1000)`. Assert `chat-image-zoom-dialog` is **still** in the
+   DOM. Without Task 8's token this test fails by closing the image.
 
 **Verify:** the file fails on the missing `../ImageContextMenu` module; the three
 existing part tests (`ZoomableImage.test.tsx`, `ImageLightbox.test.tsx`,
@@ -383,11 +621,11 @@ they render exactly as before.
 
 ---
 
-## Group 4 — `image-context-menu` (ui) · depends on: `menu-tests`, `clipboard-lib`
+## Group 6 — `image-context-menu` (ui) · depends on: `menu-tests`, `clipboard-lib`, `copy-menu-shared`
 
 Read the `mainframe-design-system` skill before writing any markup here.
 
-### Task 8 — `ImageContextMenu.tsx`
+### Task 11 — `ImageContextMenu.tsx`
 
 **File:** `packages/ui/src/features/chat/parts/ImageContextMenu.tsx` — **new.**
 
@@ -398,28 +636,28 @@ interface ImageContextMenuProps { src: string; children: ReactNode }
 `useMenuCopyFeedback()` first (hooks before the early return), then
 `if (!canCopyImage(src)) return <>{children}</>;` — D2's "no menu at all". Otherwise
 the shadcn `ContextMenu onOpenChange={handleOpenChange}` /
-`ContextMenuTrigger asChild` / `ContextMenuContent className="w-44"` with one item,
-mirroring `MessagePathContextMenu`'s `CopyPathItem` markup (D9):
+`ContextMenuTrigger asChild` / `ContextMenuContent className="w-44"` holding one
+`CopyMenuItem` (D12):
 
 ```tsx
-<ContextMenuItem data-testid="chat-image-copy" onSelect={onCopySelect('chat-image-copy', handleCopy)}>
-  {status === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
-  {status === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
-  {status === 'idle' && <Copy className="mr-2 size-3.5" />}
-  {status === 'copied' ? 'Copied' : status === 'failed' ? 'Copy failed' : 'Copy Image'}
-</ContextMenuItem>
+<CopyMenuItem
+  testId="image-copy"
+  label="Copy Image"
+  status={statusFor('image-copy')}
+  onSelect={onCopySelect('image-copy', handleCopy)}
+/>
 ```
 
 `handleCopy` is the `() => Promise<boolean>` the hook expects: it awaits
 `copyImageToClipboard(src)`, fires
 `mfToast.error('Could not copy the image', { description: result.message })` when
 `!result.ok` (`mfToast`, never `sonner` directly), and returns `result.ok`.
-`data-testid="chat-image-context-menu"` goes on `ContextMenuContent` (D3). No
-separator and no reserved second group.
+`data-testid="image-context-menu"` goes on `ContextMenuContent` (D3). No separator
+and no reserved second group.
 
-**Verify:** cases 1–5 of Task 7 pass.
+**Verify:** cases 1-5 of Task 10 pass.
 
-### Task 9 — Wrap the lightbox image
+### Task 12 — Wrap the lightbox image
 
 **File:** `packages/ui/src/features/chat/parts/LightboxSurface.tsx`
 
@@ -430,11 +668,11 @@ untouched: Radix's `asChild` slot composes the ref, so
 still works. Add nothing to the props interface — the surface already receives
 `src`.
 
-**Verify:** cases 6–8 of Task 7 pass;
+**Verify:** cases 6-9 of Task 10 pass;
 `vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
 still green.
 
-### Task 10 — Changeset and full verification
+### Task 13 — Changeset and full verification
 
 **File:** `.changeset/<generated>.md` — **new.**
 
@@ -445,53 +683,64 @@ stating that right-clicking an opened image offers Copy Image.
 
 **Verify:**
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck`
-- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/features/chat/parts`
-- `git status` shows no stray files; no `@ts-ignore`, no `console.*` outside the one
-  tagged warn in `copy-image.ts`, no file over 300 lines (`wc -l` on every touched
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/lib/ui src/features/chat/parts src/features/chat/messages/__tests__/MessagePathContextMenu.test.tsx`
+- `git status` shows no stray files; no `@ts-ignore`, no `console.*` outside the
+  tagged warns in `copy-image.ts`, no file over 300 lines (`wc -l` on every touched
   file).
 
+The implement stage ends here and is reported `unverified` (D14): the real
+clipboard write has not yet been exercised in a webview.
+
 ---
 
-## Group 5 — `webview-clipboard-gate` (qa) · depends on: `image-context-menu`
+## QA smoke (the qa stage owns these; step 3 is the D7 gate)
 
-### Task 11 — Prove the write in the running shell
-
-This is the gate D7 describes, not a nice-to-have. Do it before considering the
-lane's implement stage complete, and record the outcome as a decision in the lane
-result.
+Steps 1-2 and 4-7 are ordinary smoke. **Step 3 is the gate**: if it fails, the
+change does not ship on this path and QA routes back to the implementer once, with
+Appendix A as the fix.
 
 1. `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR`
-   and `DAEMON_PORT` (per the memory note on production takeover). The Rust build
-   is cold in this worktree but the Rust *sources* are untouched, so nothing here
-   depends on Appendix A.
-2. Open a PNG image in the transcript, right-click, click **Copy Image**, and paste
-   into Preview (⌘N). The bitmap must appear with correct colours and dimensions.
-3. Repeat with a JPEG-sourced image if one is reachable (the re-encode path).
-
-**PASS** → the plan is complete; Appendix A is not executed and stays in this file
-as the recorded alternative.
-**FAIL** (`navigator.clipboard.write` rejects, or the paste yields nothing) →
-capture the exact rejection, record it as the D7 outcome, and execute Appendix A.
-Tasks 1–3 and 7–9 survive unchanged in that case; only `write-image.ts` and the
-capability term of `image-source.ts` are replaced.
-
----
-
-## QA smoke (for the qa stage, not this plan's tasks)
-
-1. `pnpm tauri:dev` with an isolated `MAINFRAME_DATA_DIR` and `DAEMON_PORT`.
-2. Send a screenshot to a session, open the resulting image in the transcript,
-   right-click it → menu appears at the pointer, not clipped by the lightbox box.
-3. Click **Copy Image** → the item reads **Copied** and the menu closes on its own;
-   paste into Preview → the bitmap appears, correct colours and dimensions, no alpha
-   inversion.
+   and `DAEMON_PORT` (per the memory note on production takeover). **Cost:** the
+   Rust build is cold in this worktree, and per the Disk Hygiene section of
+   `CLAUDE.md` every `.worktrees/*` checkout that runs `cargo` grows its own
+   multi-GB `target/`. The Rust *sources* are untouched, so this buys nothing but
+   the shell. After the gate, run `cargo sweep --installed && cargo sweep --time 14`
+   in `packages/app-tauri/src-tauri/target`, or `cargo clean --profile dev`, before
+   leaving the worktree.
+2. Send a screenshot to a session, open the resulting image, right-click it → menu
+   appears at the pointer, not clipped by the lightbox box.
+3. **Gate.** Click **Copy Image** → the item reads **Copied** and the menu closes on
+   its own. Then assert the *native pasteboard*, not a screenshot:
+   ```bash
+   osascript -e 'set f to (open for access POSIX file "/tmp/mf282.png" with write permission)' \
+             -e 'set eof f to 0' \
+             -e 'write (the clipboard as «class PNGf») to f' \
+             -e 'close access f'
+   sips -g pixelWidth -g pixelHeight /tmp/mf282.png
+   ```
+   **PASS** = the `osascript` succeeds (the pasteboard actually holds `PNGf`, so the
+   write landed as an image and not as text or a URL) **and** `sips` reports exactly
+   the source image's known pixel dimensions. Use a fixture whose dimensions you
+   recorded before the copy. Repeat with a JPEG-sourced image if one is reachable
+   (the re-encode path).
+   **FAIL** (`navigator.clipboard.write` rejects, the `osascript` errors with no
+   `PNGf` on the pasteboard, or the dimensions differ) → capture the exact rejection,
+   record it as the D7 outcome, and route back to the implementer to execute
+   Appendix A. Tasks 1-3 and 10-12 survive unchanged in that case; only
+   `write-image.ts` and the capability term of `image-source.ts` are replaced.
+   **BLOCKED** — if the shell cannot be driven (no interactive session, no macOS
+   host, `tauri:dev` will not start): do **not** report PASS. Hand off to a human
+   with these exact steps and the fixture, and mark the lane `blocked` with
+   `blocked_reason: "D7 webview clipboard gate needs an interactive macOS shell"`.
+   An unverified PASS is the one outcome this gate exists to prevent.
 4. Right-click the *thumbnail* (not the opened image) → no menu (webview default).
 5. Right-click transcript text, a code block, and the composer → unchanged.
 6. Close the menu with Escape and with an outside click → the lightbox stays open;
-   clicking the image itself still closes the lightbox.
+   clicking the image itself still closes the lightbox. Then click **Copy Image**
+   and immediately press Escape; wait two seconds → the lightbox is still open (D13).
 7. Browser mode (`vite` without Tauri, in Chromium) → the menu appears and the copy
    works (D6); no console error.
-8. **Only if Appendix A was executed:** run steps 2–3 against a packaged build
+8. **Only if Appendix A was executed:** run steps 2-3 against a packaged build
    (`scripts/build-release-local.sh --tauri`), not `tauri:dev`. The dev server
    serves no CSP header, so the IPC transport differs from the shipped app and a
    dev-only smoke cannot see the failure D8 describes. Also re-smoke the terminal,
@@ -501,24 +750,31 @@ capability term of `image-source.ts` are replaced.
 ## Risks
 
 - **`navigator.clipboard.write` in WKWebView is the load-bearing assumption.**
-  Mitigated by Task 11 (a hard gate before ship) and by Appendix A being specified
-  in full rather than discovered later. Evidence for it is in D4.
+  Mitigated by the QA gate (step 3, before ship) and by Appendix A being specified
+  in full rather than discovered later. Evidence for it is in D4. The cost of a
+  FAIL is one round-trip to the implementer, not a redesign.
 - **Non-PNG sources ride the canvas re-encode**, whose promise is resolved after the
   user gesture. WebKit documents promise values for exactly this reason, but if it
   refuses, PNG (every screenshot, the dominant case) still works and the JPEG case
   surfaces as an honest "Copy failed" toast rather than a corrupt clipboard entry.
 - **Radix menu inside a Radix dialog.** Both portal to `document.body` at `z-50`;
-  the menu mounts later so it stacks above. Covered by Task 7 case 8 and QA step 6.
+  the menu mounts later so it stacks above. Escape ordering is layer-based, which is
+  what makes D13's late-settlement bug possible; covered by Task 7, Task 10 cases
+  8-9, and QA step 6.
+- **`CopyMenuItem` touches two shipped menus.** The migration is behavior-preserving
+  and pinned by their existing suites, which must pass **unedited** (Task 9). Any
+  needed test edit is a signal the extraction drifted.
 - **jsdom cannot decode or write images**, so `write-image.ts` is only covered
-  against stubbed DOM APIs. The real write is proven by Task 11, not by unit tests.
+  against stubbed DOM APIs. The real write is proven by QA step 3, not by unit
+  tests.
 
 ---
 
 ## Appendix A — fallback: host port + Rust clipboard command
 
-**Execute only if Task 11 fails.** Everything here is additive to Tasks 1–3 and
-7–9; `write-image.ts` and the capability term of `image-source.ts` are replaced,
-`copy-image.ts` gains a `host` parameter, and `ImageContextMenu` calls
+**Execute only if the QA gate (smoke step 3) fails.** Everything here is additive to
+Tasks 1-3 and 10-12; `write-image.ts` and the capability term of `image-source.ts`
+are replaced, `copy-image.ts` gains a `host` parameter, and `ImageContextMenu` calls
 `canCopyImage(src, useHost())`. Budget one cold `cargo` build (multi-GB
 `src-tauri/target` in this worktree, per the Disk Hygiene section of `CLAUDE.md`).
 
@@ -532,9 +788,12 @@ clipboard: {
    *  rendering clipboard affordances — never probe by calling and catching. */
   readonly canWriteImage: boolean;
   /** rgba is width*height*4 bytes, row-major, non-premultiplied. */
-  writeImage(rgba: Uint8Array, width: number, height: number): Promise<void>;
+  writeImage(rgba: Uint8Array<ArrayBuffer>, width: number, height: number): Promise<void>;
 };
 ```
+
+`Uint8Array<ArrayBuffer>` for the same reason as the primary path (Constraints) —
+the renderer builds this array from `ImageData` and hands it straight to `fetch`.
 
 Placed after `shell` and before `notify`. No Zod schema in `host-contract.ts` —
 those schemas exist for the Electron `ipcMain` handlers, and the Electron adapter
@@ -565,7 +824,11 @@ image-copy PR), and QA step 8 becomes mandatory.
 **File:** `packages/ui/src/lib/tauri/bridge.ts`
 
 ```ts
-export async function clipboardWriteImage(rgba: Uint8Array, width: number, height: number): Promise<void> {
+export async function clipboardWriteImage(
+  rgba: Uint8Array<ArrayBuffer>,
+  width: number,
+  height: number,
+): Promise<void> {
   if (!IS_TAURI) throw new Error('clipboard.writeImage is not available outside the Tauri webview');
   await invoke<void>('clipboard_write_image', rgba, {
     headers: { 'x-image-width': String(width), 'x-image-height': String(height) },
@@ -588,7 +851,7 @@ as `{ headers: HeadersInit }`, so this is the supported raw-body form.
 
 - `packages/ui/src/lib/host/tauri-adapter.ts` — `clipboard = { canWriteImage: true, writeImage: (rgba, w, h) => bridge.clipboardWriteImage(rgba, w, h) };`
 - `packages/ui/src/lib/host/electron-adapter.ts` — `canWriteImage: false`; `writeImage` returns a rejected promise naming the host (mirror the file's existing not-supported style).
-- `packages/ui/src/lib/host/fake-adapter.ts` — `canWriteImage` reads `this.overrides.clipboard?.canWriteImage ?? false`; `writeImage` delegates to the override when set, otherwise `notSupported('clipboard.writeImage')`. Extend `FakeHostOverrides` with `clipboard?: { canWriteImage?: boolean; writeImage?: (rgba: Uint8Array, width: number, height: number) => Promise<void> }` — load-bearing, since without it no jsdom test can reach the menu.
+- `packages/ui/src/lib/host/fake-adapter.ts` — `canWriteImage` reads `this.overrides.clipboard?.canWriteImage ?? false`; `writeImage` delegates to the override when set, otherwise `notSupported('clipboard.writeImage')`. Extend `FakeHostOverrides` with `clipboard?: { canWriteImage?: boolean; writeImage?: (rgba: Uint8Array<ArrayBuffer>, width: number, height: number) => Promise<void> }` — load-bearing, since without it no jsdom test can reach the menu.
 
 Tests: `lib/host/__tests__/tauri-adapter.test.ts` gains one case (`clipboard.writeImage(rgba, 2, 1)` invokes `'clipboard_write_image'` with a `Uint8Array` of `byteLength === 8` and the two headers); `lib/host/__tests__/fake-adapter.test.ts` gains two (default rejects; override receives the arguments).
 
@@ -596,13 +859,14 @@ Tests: `lib/host/__tests__/tauri-adapter.test.ts` gains one case (`clipboard.wri
 
 **File:** `packages/ui/src/lib/clipboard/decode-image.ts` — replaces `write-image.ts`.
 
-`decodeToRgba(bytes, mediaType): Promise<{ rgba: Uint8Array; width: number; height: number }>`
+`decodeToRgba(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<{ rgba: Uint8Array<ArrayBuffer>; width: number; height: number }>`
 is A5's version of Task 5's `reencodeToPng`: same object-URL → `img.decode()` →
 canvas pipeline, ending at
 `{ rgba: new Uint8Array(imageData.data.buffer.slice(0)), width, height }` instead of
-`toBlob`. Its test file (`__tests__/decode-image.test.ts`, jsdom pragma) mirrors
-Task 2 with `getImageData` in place of `toBlob`. `copy-image.ts` gains a
-`decode-failed` reason between the source gate and the write.
+`toBlob` — `buffer.slice(0)` yields a real `ArrayBuffer`, so the annotation holds
+without a further copy. Its test file (`__tests__/decode-image.test.ts`, jsdom
+pragma) mirrors Task 2 with `getImageData` in place of `toBlob`. `copy-image.ts`
+gains a decode-failure message between the source gate and the write.
 
 ### A6 — Rust command
 

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -1,0 +1,501 @@
+# Todo #282 — Right-click an opened image to copy it
+
+**Route:** no-spec (this plan works directly from the approved Agent Brief + the 2026-07-28 Design direction)
+**Branch:** `todo/282-copy-image-context-menu` · **Worktree:** `.worktrees/todo-282-copy-image-context-menu`
+
+## Goal
+
+An image the user opens in the chat transcript has no context menu, so there is no
+way to get the bitmap onto the system clipboard — text copies fine, binary image
+data does not. This change wraps the one `<img>` inside `LightboxSurface` — the
+choke point both zoom paths already route through (`ZoomableImage` for assistant
+images, `ImageLightbox` for the user-turn gallery, task and session attachment
+grids, and the file `ImageViewer`) — in a shadcn `ContextMenu` carrying a single
+**Copy Image** item. Clicking it decodes the image to raw RGBA in the renderer and
+hands the bytes plus their dimensions to a new host-port method, which on Tauri
+calls the clipboard plugin so pasting into Preview or Slack yields the image, not a
+URL. The menu mounts only when the source is copyable (`data:image/*`) *and* the
+host advertises the capability; otherwise `ImageContextMenu` renders its children
+bare and right-click falls through exactly as it does today. A failed copy raises
+an `mfToast` error; a successful one is silent.
+
+## Constraints
+
+- **`CLAUDE.md`:** max 300 lines/file, 50 lines/function; `data-testid` on every
+  interactive element (`<surface>-<element>` kebab-case); tests required for new
+  core logic; single canonical type in `@qlan-ro/mainframe-types`; no silent
+  catches; validate input; changeset required before commit.
+- **`packages/ui/CLAUDE.md`:** shadcn primitives, never raw Radix; read the
+  `mainframe-design-system` skill before writing markup or class names; pure logic
+  lives outside React; `lib/tauri/` is the only Tauri-aware renderer module.
+- **Design gate (2026-07-28)** is authoritative where it and the brief disagree —
+  see D1/D2 below.
+- **Every file this plan touches is comfortably under the line limits.** Largest
+  edited file: `components/ui/context-menu.tsx` (untouched), then
+  `lib/host/fake-adapter.ts` (159 → ~172), `lib/tauri/bridge.ts` (245 → ~262),
+  `types/src/host/host-bridge.ts` (180 → ~195), `LightboxSurface.tsx` (42 → ~48).
+  Every new file lands well under 300; every new function under 50.
+- **The worktree has no `node_modules`.** Run `pnpm install` from the worktree root
+  before the first TypeScript task.
+- **Rust disk cost:** `cargo check` in this worktree is cold and builds the full
+  `app-tauri` dependency graph into a new `src-tauri/target` (multi-GB, per the
+  Disk Hygiene section of `CLAUDE.md`). Budget for it once, in Group
+  `tauri-clipboard-command`.
+
+## Decisions
+
+**D1 — Mount point is `LightboxSurface` only; `AttachmentPreviewDialog` is not
+wrapped.** The design gate scoped the menu to the *opened* image, and both zoom
+paths funnel through `LightboxSurface`. The third "opened image" surface,
+`AttachmentPreviewDialog` in `packages/ui/src/components/ui/assistant-ui/attachment.tsx`,
+is the **same dialog the composer uses for its own attachment previews**, which the
+brief explicitly rules out of scope. Wrapping it would leak the menu into the
+composer, so it stays out. Consequence: sandbox-capture attachments on a user turn
+(which render through `AttachmentPreviewDialog`, not `ImageLightbox`) get no menu.
+If that gap matters, splitting the message and composer preview dialogs is separate
+work.
+
+**D2 — Unsupported sources mount no menu** (design gate), superseding the brief's
+"disabled item with a reason". A one-item menu whose only item is dead is worse
+than no menu; right-click falls through to the webview default.
+
+**D3 — Testids: `chat-image-context-menu` on the menu *content*, `chat-image-copy`
+on the item.** The design direction put the first one on the trigger, but the
+trigger is the `<img>`, which already carries `imageTestId`
+(`chat-image-zoom-image` / `image-lightbox-current`) that existing tests assert on;
+one element cannot hold two testids. Neither id is keyed by a message/attachment
+id because the lightbox renders exactly one image at a time — there is no list and
+no index to disambiguate, and threading an id through three call sites to satisfy
+the letter of the rule buys nothing.
+
+**D4 — The renderer decodes; Rust only writes.** `copy-image.ts` turns the source
+into raw RGBA via the webview's own decoder (`<img>` + canvas `getImageData`) and
+passes the bytes as a raw invoke body with `x-image-width` / `x-image-height`
+headers. The Rust command validates the length, builds a `tauri::image::Image`, and
+calls `clipboard.write_image`. The alternative — shipping the encoded bytes and
+decoding in Rust — needs an image-decoding crate and a per-format support matrix
+for something the webview already decodes to display the image.
+
+**D5 — Supported sources are `data:image/*` only.** Every image the transcript
+renders today is a data URI: `convert-message.ts` builds
+`` `data:${c.mediaType};base64,${c.data}` ``, and `SessionAttachmentsGrid`,
+`TaskAttachments`, and `ImageViewer` all do the same. `http(s)` sources stay
+unsupported per the brief's "do not fetch on right-click" ruling; `file://` and
+asset-protocol sources are unsupported because nothing in the transcript produces
+them.
+
+**D6 — `ElectronAdapter` reports `canWriteImage: false`.** The Electron shell is
+legacy and its preload exposes no clipboard image API; adding one is not in scope.
+Its `writeImage` rejects, and the capability flag means the UI never calls it.
+
+## Interfaces this change adds
+
+```ts
+// packages/types/src/host/host-bridge.ts — added to HostBridge
+clipboard: {
+  /** True when the host can put a bitmap on the system clipboard. Read before
+   *  rendering clipboard affordances — never probe by calling and catching. */
+  readonly canWriteImage: boolean;
+  /** rgba is width*height*4 bytes, row-major, non-premultiplied. */
+  writeImage(rgba: Uint8Array, width: number, height: number): Promise<void>;
+};
+```
+
+```ts
+// packages/ui/src/lib/clipboard/image-source.ts
+export type ImageSourceKind = 'data-url' | 'remote' | 'unsupported';
+export function classifyImageSource(src: string): ImageSourceKind;
+export function decodeDataUrl(src: string): { mediaType: string; bytes: Uint8Array } | null;
+export function canCopyImage(src: string, host: Pick<HostBridge, 'clipboard'>): boolean;
+
+// packages/ui/src/lib/clipboard/decode-image.ts
+export function decodeToRgba(
+  bytes: Uint8Array, mediaType: string,
+): Promise<{ rgba: Uint8Array; width: number; height: number }>;
+
+// packages/ui/src/lib/clipboard/copy-image.ts
+export type CopyImageResult =
+  | { ok: true }
+  | { ok: false; reason: 'unsupported-host' | 'unsupported-source' | 'decode-failed' | 'write-failed'; message: string };
+export function copyImageToClipboard(
+  src: string, host: Pick<HostBridge, 'clipboard' | 'log'>,
+): Promise<CopyImageResult>;
+```
+
+---
+
+## Group 1 — `host-port-ts` (core) · depends on: nothing
+
+### Task 1 — Add `clipboard` to the host contract
+
+**File:** `packages/types/src/host/host-bridge.ts`
+
+Add the `clipboard` member to `HostBridge` exactly as written in *Interfaces*
+above, placed after `shell` and before `notify`. Doc-comment says why the flag is a
+readonly property and not a probe: browser mode must be able to hide the affordance
+*before* render.
+
+No Zod schema is added to `host-contract.ts` — those schemas exist for the Electron
+`ipcMain` handlers, and D6 means Electron never receives this payload.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-types build` succeeds. The UI
+typecheck fails at this point (three adapters do not implement the new member) —
+that is expected until Task 3.
+
+### Task 2 — Renderer→Tauri call
+
+**File:** `packages/ui/src/lib/tauri/bridge.ts`
+
+Add, following the file's existing `IS_TAURI` guard convention:
+
+```ts
+export async function clipboardWriteImage(rgba: Uint8Array, width: number, height: number): Promise<void> {
+  if (!IS_TAURI) throw new Error('clipboard.writeImage is not available outside the Tauri webview');
+  await invoke<void>('clipboard_write_image', rgba.slice().buffer, {
+    headers: { 'x-image-width': String(width), 'x-image-height': String(height) },
+  });
+}
+```
+
+`rgba.slice()` guarantees the ArrayBuffer holds exactly the pixel bytes: canvas
+`getImageData().data` may be a view into a larger buffer, and `invoke` sends the
+whole buffer. `@tauri-apps/api@2.11.1` types `InvokeArgs` as
+`Record<string, unknown> | number[] | ArrayBuffer | Uint8Array` and `InvokeOptions`
+as `{ headers: HeadersInit }`, so this is the supported raw-body form.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` reports no error in this
+file.
+
+### Task 3 — Implement `clipboard` in all three adapters
+
+**Files:**
+- `packages/ui/src/lib/host/tauri-adapter.ts` — `clipboard = { canWriteImage: true, writeImage: (rgba, w, h) => bridge.clipboardWriteImage(rgba, w, h) };`
+- `packages/ui/src/lib/host/electron-adapter.ts` — `canWriteImage: false`; `writeImage` returns a rejected promise with a message naming the host (mirror the existing not-supported style in that file).
+- `packages/ui/src/lib/host/fake-adapter.ts` — `canWriteImage` reads `this.overrides.clipboard?.canWriteImage ?? false`; `writeImage` delegates to `this.overrides.clipboard?.writeImage` when set, otherwise `notSupported('clipboard.writeImage')`.
+
+Also extend `FakeHostOverrides` in `fake-adapter.ts`:
+
+```ts
+clipboard?: {
+  canWriteImage?: boolean;
+  writeImage?: (rgba: Uint8Array, width: number, height: number) => Promise<void>;
+};
+```
+
+This override is load-bearing: without it no jsdom test can reach the menu at all,
+because the fake host's default is "no capability".
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes clean.
+
+---
+
+## Group 2 — `tauri-clipboard-command` (core) · depends on: nothing
+
+### Task 4 — Add the clipboard plugin and the write command
+
+**Files:**
+- `packages/app-tauri/src-tauri/Cargo.toml` — add `tauri-plugin-clipboard-manager = "2"` to `[dependencies]` (+ the resulting `Cargo.lock` churn).
+- `packages/app-tauri/src-tauri/src/commands/clipboard.rs` — **new.**
+- `packages/app-tauri/src-tauri/src/commands/mod.rs` — `pub mod clipboard;` + `pub use clipboard::clipboard_write_image;`.
+- `packages/app-tauri/src-tauri/src/lib.rs` — add `clipboard_write_image` to the `use commands::{…}` list and to `tauri::generate_handler![…]`; add `.plugin(tauri_plugin_clipboard_manager::init())` to the builder chain beside the other `.plugin(...)` calls.
+
+`clipboard.rs`:
+
+```rust
+use tauri::image::Image;
+use tauri::ipc::{InvokeBody, Request};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+/// Refuse absurd payloads before allocating: 64 MiB of RGBA is a ~4000×4000 image.
+const MAX_RGBA_BYTES: usize = 64 * 1024 * 1024;
+
+#[tauri::command]
+pub fn clipboard_write_image(app: tauri::AppHandle, request: Request<'_>) -> Result<(), String> { … }
+```
+
+Behavior, in order:
+1. `request.body()` must be `InvokeBody::Raw`; anything else is an error naming the
+   expected form.
+2. Parse `x-image-width` / `x-image-height` headers as `u32` via a small private
+   helper (`header_u32(&request, name) -> Result<u32, String>`); a missing or
+   unparsable header is an error.
+3. Reject `width == 0`, `height == 0`, `rgba.len() > MAX_RGBA_BYTES`, or
+   `rgba.len() != width * height * 4` (compute in `usize` with `checked_mul` so a
+   hostile header cannot overflow).
+4. `app.clipboard().write_image(&Image::new(rgba, width, height))`, mapping the
+   error to a `String` (Tauri commands returning `Result<_, String>` is the
+   established convention in `commands/fs.rs`).
+
+No capability entry is needed in `src-tauri/capabilities/main.json`: app-defined
+commands are not permission-gated (the existing `read_file` / `terminal_create`
+commands have no entry either), and the plugin's own JS commands are never invoked
+from the renderer.
+
+**Verify:** `cargo check` from `packages/app-tauri/src-tauri` passes (cold build —
+see Constraints). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`
+on the same directory are clean.
+
+---
+
+## Group 3 — `clipboard-core-tests` (test) · depends on: `host-port-ts`
+
+Two of these three files are **red-phase** — the modules they import do not exist
+yet, and Group `clipboard-lib` implements against them. The third is green-phase,
+verifying Group `host-port-ts`. State that expectation in each file's header
+comment so a reader is not confused by a mixed run.
+
+### Task 5 — Pure source-classification and gating tests (RED)
+
+**File:** `packages/ui/src/lib/clipboard/__tests__/image-source.test.ts` — **new.**
+
+Cover, with hardcoded expectations (no logic mirrored from the implementation):
+- `classifyImageSource` → `'data-url'` for `data:image/png;base64,…` and
+  `data:image/jpeg;base64,…`; `'remote'` for `http://…` and `https://…`;
+  `'unsupported'` for `file:///…`, `blob:…`, `asset://…`, `''`, and a
+  non-image data URI (`data:text/plain;base64,…`).
+- `decodeDataUrl` → `{ mediaType: 'image/png', bytes }` for a known 1×1 PNG data
+  URI, asserting the first eight bytes are the PNG signature
+  (`137 80 78 71 13 10 26 10`) and the byte length matches the base64 payload;
+  `null` for a non-base64 data URI (`data:image/svg+xml,<svg/>`), for a
+  non-image data URI, and for malformed base64.
+- `canCopyImage` truth table over `{data-url, remote} × {canWriteImage true,false}`
+  — only `data-url` + `true` is `true`.
+
+### Task 6 — Copy orchestration tests (RED)
+
+**File:** `packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts` — **new.**
+
+`vi.mock('../decode-image')` so no real canvas is needed. A hand-built host stub
+provides `clipboard` and a `log` spy. Cases:
+- Host without capability → `{ ok: false, reason: 'unsupported-host' }`, and
+  `decodeToRgba` and `writeImage` are never called.
+- `https://…` source → `{ ok: false, reason: 'unsupported-source' }`, nothing
+  called.
+- Happy path → `decodeToRgba` receives the decoded bytes and the media type from
+  the data URI; `writeImage` receives exactly those `rgba`, `width`, `height`;
+  result is `{ ok: true }`.
+- `decodeToRgba` rejects → `{ ok: false, reason: 'decode-failed' }` with a
+  non-empty `message`, and `host.log` was called at `warn` (the no-silent-catch
+  rule), and `writeImage` was never called.
+- `writeImage` rejects → `{ ok: false, reason: 'write-failed' }` with a non-empty
+  `message` and a `warn` log.
+
+### Task 7 — Decoder and adapter delegation tests
+
+**Files:**
+- `packages/ui/src/lib/clipboard/__tests__/decode-image.test.ts` — **new** (RED).
+  jsdom has no image decoding, so stub the DOM seam: replace
+  `HTMLImageElement.prototype.decode` with a resolver that sets `naturalWidth` /
+  `naturalHeight`, and stub `HTMLCanvasElement.prototype.getContext` to return a
+  fake 2d context whose `getImageData` yields a known `Uint8ClampedArray`. Assert:
+  the returned `rgba`/`width`/`height` match the fake; the object URL created for
+  the blob is revoked on both the success and the failure path (spy on
+  `URL.createObjectURL` / `URL.revokeObjectURL`); a rejecting `decode()` propagates
+  as a rejection; a `null` 2d context rejects with a message.
+- `packages/ui/src/lib/host/__tests__/tauri-adapter.test.ts` — **edit** (GREEN).
+  One case: `clipboard.canWriteImage === true`, and `clipboard.writeImage(rgba, 2, 1)`
+  invokes `'clipboard_write_image'` with an `ArrayBuffer` of `byteLength === 8` and
+  headers `{ 'x-image-width': '2', 'x-image-height': '1' }`.
+- `packages/ui/src/lib/host/__tests__/fake-adapter.test.ts` — **edit** (GREEN).
+  Two cases: default `canWriteImage === false` and `writeImage` rejects; with
+  `{ clipboard: { canWriteImage: true, writeImage: spy } }` overrides,
+  `canWriteImage === true` and the spy receives the arguments.
+
+**Verify (whole group):** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/host/__tests__/tauri-adapter.test.ts src/lib/host/__tests__/fake-adapter.test.ts`
+is green; the three `src/lib/clipboard/__tests__/*` files fail on missing modules.
+
+---
+
+## Group 4 — `clipboard-lib` (core) · depends on: `clipboard-core-tests`, `host-port-ts`
+
+### Task 8 — `image-source.ts`
+
+**File:** `packages/ui/src/lib/clipboard/image-source.ts` — **new.**
+
+Pure, no DOM. `classifyImageSource` matches `^data:image\/[a-zA-Z0-9.+-]+;base64,`
+for `'data-url'` and `^https?:` for `'remote'`; everything else is
+`'unsupported'`. `decodeDataUrl` splits on the first `,`, verifies the prefix
+shape, `atob`s the payload inside a `try` (returning `null` on `InvalidCharacterError`
+— a `/* expected */`-commented catch, since a malformed URI is data, not a fault),
+and copies char codes into a `Uint8Array`. `canCopyImage` is the two-line
+conjunction of the kind check and `host.clipboard.canWriteImage`.
+
+**Verify:** `vitest run src/lib/clipboard/__tests__/image-source.test.ts` green.
+
+### Task 9 — `decode-image.ts`
+
+**File:** `packages/ui/src/lib/clipboard/decode-image.ts` — **new.**
+
+`decodeToRgba(bytes, mediaType)`:
+1. `const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }))` —
+   blob URLs are same-origin, so the canvas is never tainted.
+2. `const img = new Image(); img.src = url; await img.decode();` — `decode()` over
+   `createImageBitmap`/`OffscreenCanvas` because it is supported by all three
+   webviews the shell ships on.
+3. Draw onto a `document.createElement('canvas')` sized to
+   `naturalWidth × naturalHeight`; throw when either is `0` or `getContext('2d')`
+   returns `null`.
+4. Return `{ rgba: new Uint8Array(imageData.data.buffer.slice(0)), width, height }`.
+5. `URL.revokeObjectURL(url)` in a `finally`.
+
+Keep it under 50 lines; if it crowds, extract the canvas step into a private
+helper in the same file.
+
+**Verify:** `vitest run src/lib/clipboard/__tests__/decode-image.test.ts` green.
+
+### Task 10 — `copy-image.ts`
+
+**File:** `packages/ui/src/lib/clipboard/copy-image.ts` — **new.**
+
+`copyImageToClipboard(src, host)` implements the ladder the Task 6 tests pin:
+capability gate → source gate → `decodeToRgba` (catch → `decode-failed`) →
+`host.clipboard.writeImage` (catch → `write-failed`). Every catch calls
+`host.log('warn', 'clipboard', …)` before returning; the returned `message` is the
+error's message, or a fixed fallback for a non-`Error` throw. No toast here — the
+component owns user-facing feedback so this module stays callable outside React.
+
+**Verify:** `vitest run src/lib/clipboard/__tests__/copy-image.test.ts` green, and
+`pnpm --filter @qlan-ro/mainframe-ui typecheck` passes.
+
+---
+
+## Group 5 — `menu-tests` (test) · depends on: `clipboard-lib`, `host-port-ts`
+
+### Task 11 — `ImageContextMenu` behavior + both render paths (RED)
+
+**File:** `packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx` — **new.**
+
+Red-phase against Group `image-context-menu`; it imports the real
+`lib/clipboard/image-source` (already built) and mocks
+`@/lib/clipboard/copy-image` and `@/lib/toast`. A helper installs a capable host
+via `setHostForTesting(new FakeHostBridge({ clipboard: { canWriteImage: true, writeImage: vi.fn() } }))`
+and `resetHostForTesting()` in `afterEach`. Radix context menus open on
+`fireEvent.contextMenu(element)` — the pattern proven in
+`features/sessions/sidebar/__tests__/SessionContextMenu.test.tsx`. Use a real 1×1
+PNG data URI constant for the copyable source.
+
+Cases:
+1. **Capable host + data URI** — right-clicking the wrapped child opens
+   `chat-image-context-menu` containing `chat-image-copy` with the text
+   `Copy Image`.
+2. **Capable host + `https://…` source** — no `chat-image-context-menu` after
+   `fireEvent.contextMenu`, and the child still renders.
+3. **Host without the capability + data URI** — same: no menu, child renders.
+4. **Copy succeeds** — clicking `chat-image-copy` calls `copyImageToClipboard`
+   once with the src, and `mfToast.error` is never called.
+5. **Copy fails** — `copyImageToClipboard` resolves
+   `{ ok: false, reason: 'write-failed', message: 'boom' }`; `mfToast.error` is
+   called once, and its options carry `description: 'boom'`.
+6. **Assistant-image path** — render `<ZoomableImage src={PNG_DATA_URI} />`, click
+   `chat-image-zoom-trigger`, await `chat-image-zoom-dialog`, then
+   `fireEvent.contextMenu` on `chat-image-zoom-image` → `chat-image-context-menu`
+   appears. (Satisfies "the attachment/assistant render path gets the menu".)
+7. **User-gallery path** — render `<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />`,
+   `fireEvent.contextMenu` on `image-lightbox-current` → `chat-image-context-menu`
+   appears. (Satisfies the second required render path.)
+8. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
+   dialog open and the menu open, press `Escape` once: the menu closes and
+   `chat-image-zoom-dialog` is still in the DOM. Then assert a plain click on
+   `chat-image-zoom-image` (no menu open) still closes the dialog, so the existing
+   dismissal contract survives the `asChild` wrap.
+
+**Verify:** the file fails on the missing `../ImageContextMenu` module; the three
+existing part tests (`ZoomableImage.test.tsx`, `ImageLightbox.test.tsx`,
+`markdown-text.test.tsx`) still pass untouched — the fake host's default
+`canWriteImage: false` means they render exactly as before.
+
+---
+
+## Group 6 — `image-context-menu` (ui) · depends on: `menu-tests`, `clipboard-lib`, `host-port-ts`
+
+Read the `mainframe-design-system` skill before writing any markup here.
+
+### Task 12 — `ImageContextMenu.tsx`
+
+**File:** `packages/ui/src/features/chat/parts/ImageContextMenu.tsx` — **new.**
+
+```tsx
+interface ImageContextMenuProps { src: string; children: ReactNode }
+```
+
+`useHost()` first (the only hook, so the early return below is safe), then
+`if (!canCopyImage(src, host)) return <>{children}</>;` — D2's "no menu at all".
+Otherwise the shadcn `ContextMenu` / `ContextMenuTrigger asChild` /
+`ContextMenuContent className="w-44"` / one `ContextMenuItem`, mirroring
+`EditorContextMenu`'s item markup exactly:
+
+```tsx
+<ContextMenuItem data-testid="chat-image-copy" onSelect={() => void handleCopy()}>
+  <Copy size={13} className="text-muted-foreground" />
+  Copy Image
+</ContextMenuItem>
+```
+
+`data-testid="chat-image-context-menu"` goes on `ContextMenuContent` (D3). No
+separator and no reserved second group. `handleCopy` awaits
+`copyImageToClipboard(src, host)` and, on `!ok`, fires
+`mfToast.error('Could not copy the image', { description: result.message })` —
+`mfToast`, never `sonner` directly. Success is silent.
+
+**Verify:** cases 1–5 of Task 11 pass.
+
+### Task 13 — Wrap the lightbox image
+
+**File:** `packages/ui/src/features/chat/parts/LightboxSurface.tsx`
+
+Wrap the existing `<img>` in `<ImageContextMenu src={src}>…</ImageContextMenu>`.
+Leave `imageRef`, `data-testid={imageTestId}`, the classes, and `handleClick`
+untouched: Radix's `asChild` slot composes the ref, so
+`event.target === imageRef.current` still identifies the image and click-to-dismiss
+still works. Add nothing to the props interface — the surface already receives
+`src`.
+
+**Verify:** cases 6–8 of Task 11 pass; `vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
+still green.
+
+### Task 14 — Changeset and full verification
+
+**File:** `.changeset/<generated>.md` — **new.**
+
+`pnpm changeset`, patch bump for `@qlan-ro/mainframe-ui`,
+`@qlan-ro/mainframe-types`, and `@qlan-ro/mainframe-app-tauri`. Summary: one line
+stating that right-clicking an opened image offers Copy Image.
+
+**Verify:**
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck`
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/lib/host src/features/chat/parts`
+- `git status` shows no stray files; no `@ts-ignore`, no `console.*` added, no file
+  over 300 lines (`wc -l` on every touched file).
+
+---
+
+## QA smoke (for the qa stage, not this plan's tasks)
+
+1. `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR`
+   and `DAEMON_PORT` (per the memory note on production takeover).
+2. Send a screenshot to a session, open the resulting image in the transcript,
+   right-click it → menu appears at the pointer, not clipped by the lightbox box.
+3. Click **Copy Image**, paste into Preview (⌘N) → the bitmap appears, correct
+   colors and dimensions, no alpha inversion.
+4. Right-click the *thumbnail* (not the opened image) → no menu (webview default).
+5. Right-click transcript text, a code block, and the composer → unchanged.
+6. Close the menu with Escape and with an outside click → the lightbox stays open;
+   clicking the image itself still closes the lightbox.
+7. Browser mode (`vite` without Tauri) → right-clicking the opened image shows the
+   webview's own menu, no app menu, no console error.
+
+## Risks
+
+- **The raw-body invoke (`tauri::ipc::Request` + headers) is unproven in this
+  repo.** `@tauri-apps/api@2.11.1` types it and the shell already uses the raw
+  *response* form (`InvokeResponseBody::Raw`) for the terminal, but the request
+  direction is new here. It is verified by `cargo check` plus QA step 3. If it
+  fails, the fallback is a base64 RGBA string argument plus a hand-rolled Rust
+  decoder mirroring `base64_encode` in `commands/fs.rs` — same shape, one extra
+  encode/decode hop.
+- **Radix menu inside a Radix dialog.** Both portal to `document.body` at `z-50`;
+  the menu mounts later so it stacks above. Covered by Task 11 case 8 and QA
+  step 6.
+- **jsdom cannot decode images**, so `decode-image.ts` is only covered against
+  stubbed DOM APIs. The real decode is proven by QA step 3, not by unit tests.
+- **Cold Rust build cost** in this worktree (see Constraints).

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -46,8 +46,11 @@ recorded as D10.
 - **Every file this plan touches is comfortably under the line limits.** Largest
   edited file: `LightboxSurface.tsx` (42 → ~48). Every new file lands well under
   300; every new function under 50.
-- **The worktree has no `node_modules`.** Run `pnpm install` from the worktree root
-  before the first task.
+- **The worktree has no `node_modules`.** `pnpm install` from the worktree root is a
+  **lane setup step, run once before wave 1** — it is not a precondition any group
+  satisfies for itself. Groups `clipboard-core-tests` and `copy-menu-shared-tests`
+  both start in wave 1 and both need the install; if each ran it, two installs would
+  hit the same workspace concurrently. No task below re-runs it.
 - **The implement stage needs no Rust and never runs `cargo`.** The one step that
   does — the D7 webview gate — is a **qa-stage** step, not an implement task
   (D14). Its cost is stated there: a cold `packages/app-tauri/src-tauri` build in
@@ -350,6 +353,26 @@ separately. Pick one and say which in the file header.)
 The async body of `write` still records its call synchronously, so the activation
 assertion holds.
 
+**jsdom has no object-URL API — stub it by assignment, not `vi.spyOn`.** Verified
+against this repo's jsdom (29.1.1): `URL.createObjectURL` and `URL.revokeObjectURL`
+are both `undefined`, unlike `toBlob`, which exists. `reencodeToPng` calls
+`createObjectURL` as its first statement, so without these stubs the JPEG re-encode
+case and all three re-encode-failure cases throw a `TypeError` before reaching the
+behavior they exist to pin — and the balance assertion below cannot be written as
+`vi.spyOn(URL, 'createObjectURL')`, which throws on a property that does not exist.
+Install by assignment and remove in teardown, since there is nothing to restore:
+
+```ts
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => 'blob:test');
+  URL.revokeObjectURL = vi.fn();
+});
+afterEach(() => {
+  Reflect.deleteProperty(URL, 'createObjectURL');
+  Reflect.deleteProperty(URL, 'revokeObjectURL');
+});
+```
+
 Cases:
 - **PNG passthrough:** `writeImageToClipboard(bytes, 'image/png')` calls `write`
   once with a single `ClipboardItem`; the item's `image/png` value resolves to a
@@ -365,8 +388,9 @@ Cases:
   stubbed to a fake 2d context with a `drawImage` spy, and
   `HTMLCanvasElement.prototype.toBlob` stubbed to hand back a PNG blob:
   `writeImageToClipboard(bytes, 'image/jpeg')` still calls `write` synchronously,
-  and the item's value resolves to the re-encoded PNG blob. Assert
-  `URL.createObjectURL` / `URL.revokeObjectURL` are balanced.
+  and the item's value resolves to the re-encoded PNG blob. Assert the two object-URL
+  mocks installed above are balanced (`createObjectURL` and `revokeObjectURL` each
+  called once, with the revoke receiving `'blob:test'`).
 - **Re-encode failure:** a rejecting `decode()` rejects the promise
   `writeImageToClipboard` returned (via the adopting stub above), and the object URL
   is still revoked. Same for a `null` 2d context and for a `toBlob` that yields
@@ -472,8 +496,17 @@ saying so).
 No toast here: the component owns user-facing feedback so this module stays callable
 outside React.
 
-**Verify:** `vitest run src/lib/clipboard` all green, and
-`pnpm --filter @qlan-ro/mainframe-ui typecheck` passes.
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard`
+all green — the clipboard suite alone, and nothing wider.
+
+**Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck` here.** That command is
+package-wide, and this group runs in the same worktree, concurrently, with group
+`copy-menu-shared`. With `noUnusedLocals: true` (`packages/ui/tsconfig.json:16`), any
+half-applied Task 9 state — `CopyPathItem` deleted before `lib/ui/CopyMenuItem.tsx`
+exists, or the now-unused `Check`/`Copy`/`AlertTriangle`/`CopyStatus`/`ContextMenuItem`
+imports not yet dropped from `MessagePathContextMenu.tsx` and `link-with-preview.tsx`
+— would fail this group on code it does not own and end the wave. Task 13 owns the
+package-wide typecheck, and by then both groups have landed.
 
 ---
 
@@ -589,8 +622,17 @@ Cases:
 2. **Supported webview + `https://…` source** — no `image-context-menu` after
    `fireEvent.contextMenu`, and the child still renders.
 3. **No `ClipboardItem` + data URI** — same: no menu, child renders.
-4. **Copy succeeds** — clicking `image-copy` calls `copyImageToClipboard` once with
-   the src; the item's text becomes `Copied`; `mfToast.error` is never called.
+4. **Copy succeeds, and the call is synchronous with the click** — this is the D4
+   user-activation rule at the component layer. Fire `fireEvent.click(image-copy)`,
+   then *immediately*, before any `await` or `waitFor`, assert `copyImageToClipboard`
+   has been called exactly once with the src. Task 11's `handleCopy` is an `async`
+   function; it satisfies D4 today only because the call precedes its first `await`,
+   and one inserted `await` — a permission check, a config read — would silently
+   break copy in WKWebView with every other assertion in this file still green.
+   `ImageContextMenu.tsx` is the file in this change most likely to be edited later,
+   so the rule is pinned at all three layers (Task 2, Task 3, and here). Only then
+   await the item's text becoming `Copied`, and assert `mfToast.error` was never
+   called.
 5. **Copy fails** — `copyImageToClipboard` resolves `{ ok: false, message: 'boom' }`;
    the item's text becomes `Copy failed`, `mfToast.error` is called once, and its
    options carry `description: 'boom'`.
@@ -684,9 +726,16 @@ stating that right-clicking an opened image offers Copy Image.
 **Verify:**
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck`
 - `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/lib/ui src/features/chat/parts src/features/chat/messages/__tests__/MessagePathContextMenu.test.tsx`
-- `git status` shows no stray files; no `@ts-ignore`, no `console.*` outside the
-  tagged warns in `copy-image.ts`, no file over 300 lines (`wc -l` on every touched
+- `git status` shows no stray files; no file over 300 lines (`wc -l` on every touched
   file).
+- **Hygiene is checked against added lines only** — `git diff main...HEAD | grep '^+'`
+  — not against whole files. No `@ts-ignore`, and no `console.*` beyond the tagged
+  warns this plan adds in `copy-image.ts`. One pre-existing tagged warn lives in a
+  file Task 9 modifies:
+  `packages/ui/src/features/chat/parts/link-with-preview.tsx:57`,
+  `console.warn('[link-with-preview] openExternal failed', href)`. It is the required
+  non-silent catch on the `openExternal` path, it is untouched by Task 9, and
+  removing it would be a regression. A whole-file grep would block on it.
 
 The implement stage ends here and is reported `unverified` (D14): the real
 clipboard write has not yet been exercised in a webview.
@@ -726,8 +775,32 @@ Appendix A as the fix.
    **FAIL** (`navigator.clipboard.write` rejects, the `osascript` errors with no
    `PNGf` on the pasteboard, or the dimensions differ) → capture the exact rejection,
    record it as the D7 outcome, and route back to the implementer to execute
-   Appendix A. Tasks 1-3 and 10-12 survive unchanged in that case; only
-   `write-image.ts` and the capability term of `image-source.ts` are replaced.
+   Appendix A. **Price that round-trip honestly before taking it**: the lane contract
+   allows exactly one qa→implement round-trip, and Appendix A is not a two-file swap.
+   Beyond the wholly new files it adds (the `HostBridge.clipboard` port, the Tauri
+   bridge call, the three adapters, the Rust command and its registration), it
+   rewrites work the primary path already produced:
+
+   | Rewritten | Why |
+   |---|---|
+   | `lib/clipboard/image-source.ts` | capability moves to `HostBridge.clipboard.canWriteImage`; `canCopyImage` becomes two-arg (A1/A4) |
+   | `lib/clipboard/write-image.ts` → `decode-image.ts` | deleted and replaced (A5) |
+   | `lib/clipboard/copy-image.ts` | gains a `host` parameter and a decode-failure message (A5) |
+   | `features/chat/parts/ImageContextMenu.tsx` | calls `canCopyImage(src, useHost())` (Task 11) |
+   | `src-tauri/tauri.conf.json` | the `connect-src` CSP token, app-wide blast radius (A2/D8) |
+   | `__tests__/image-source.test.ts` | the `imageClipboardSupported` cases go away and the `canCopyImage` truth table is re-derived two-arg |
+   | `__tests__/write-image.test.ts` → `decode-image.test.ts` | the whole file targets a module A5 deletes |
+   | `__tests__/copy-image.test.ts` | mocks `../decode-image`, not `../write-image`; host arg; decode-failure case |
+   | `__tests__/ImageContextMenu.test.tsx` | the `ClipboardItem` / `navigator.clipboard` global stubs no longer open the menu — the `FakeHostOverrides` extension in A4 does, which is why A4 calls it load-bearing |
+
+   Untouched by the fallback: Tasks 7-9 (the `useMenuCopyFeedback` generation token
+   and the `CopyMenuItem` extraction) and Task 12 (the `LightboxSurface` wrap).
+   Task 13 re-runs with the changeset widened to `@qlan-ro/mainframe-types` and
+   `@qlan-ro/mainframe-app-tauri`, and QA step 8 — the packaged-build smoke — becomes
+   mandatory rather than conditional. No fallback task graph is enumerated here on
+   purpose: the fallback is contingent, so the implementer sequences Appendix A's
+   sections (A2 first, then A1 → A3 → A4 → A5 → A6) when and only when this gate
+   fails.
    **BLOCKED** — if the shell cannot be driven (no interactive session, no macOS
    host, `tauri:dev` will not start): do **not** report PASS. Hand off to a human
    with these exact steps and the fixture, and mark the lane `blocked` with
@@ -772,11 +845,13 @@ Appendix A as the fix.
 
 ## Appendix A — fallback: host port + Rust clipboard command
 
-**Execute only if the QA gate (smoke step 3) fails.** Everything here is additive to
-Tasks 1-3 and 10-12; `write-image.ts` and the capability term of `image-source.ts`
-are replaced, `copy-image.ts` gains a `host` parameter, and `ImageContextMenu` calls
-`canCopyImage(src, useHost())`. Budget one cold `cargo` build (multi-GB
-`src-tauri/target` in this worktree, per the Disk Hygiene section of `CLAUDE.md`).
+**Execute only if the QA gate (smoke step 3) fails.** Much of this appendix is new
+code, but it also rewrites four source files and four test files the primary path
+already produced, changes the app's CSP, and makes the packaged-build QA step
+mandatory — the table under QA step 3's FAIL branch is the authoritative delta; read
+it before committing to this path. Budget one cold
+`cargo` build (multi-GB `src-tauri/target` in this worktree, per the Disk Hygiene
+section of `CLAUDE.md`).
 
 ### A1 — Host contract
 

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -46,11 +46,23 @@ recorded as D10.
 - **Every file this plan touches is comfortably under the line limits.** Largest
   edited file: `LightboxSurface.tsx` (42 → ~48). Every new file lands well under
   300; every new function under 50.
-- **The worktree has no `node_modules`.** `pnpm install` from the worktree root is a
-  **lane setup step, run once before wave 1** — it is not a precondition any group
-  satisfies for itself. Groups `clipboard-core-tests` and `copy-menu-shared-tests`
-  both start in wave 1 and both need the install; if each ran it, two installs would
-  hit the same workspace concurrently. No task below re-runs it.
+- **The worktree has no `node_modules`, and nothing outside the task graph installs
+  them.** The lane's only setup step creates the worktree and stamps the tracker, so
+  the install needs an owner *inside* the graph: **Task 1 runs `pnpm install` from
+  the worktree root as its first step**, and group `copy-menu-shared-tests` carries
+  `depends_on: ['clipboard-core-tests']` so it can never start before that install
+  finishes. One install, one owner, never two at once in the same workspace. No other
+  task re-runs it. Serializing those two groups costs nothing: from wave 2 on the
+  graph is a chain anyway.
+- **Only Task 13 runs the package-wide typecheck.**
+  `pnpm --filter @qlan-ro/mainframe-ui typecheck` compiles the whole package,
+  test files included, so it cannot pass in a group that has just committed tests
+  against modules that do not exist yet — `clipboard-core-tests` and `menu-tests`
+  both do, and `copy-menu-shared-tests` runs concurrently with a group whose files
+  are mid-edit. **This overrides the generic "typecheck + affected tests green"
+  expectation for every group except `image-context-menu`.** Each group below states
+  its own exit contract; a group meets that contract and returns, and Task 13 runs
+  the single package-wide typecheck once every other group has landed.
 - **The implement stage needs no Rust and never runs `cargo`.** The one step that
   does — the D7 webview gate — is a **qa-stage** step, not an implement task
   (D14). Its cost is stated there: a cold `packages/app-tauri/src-tauri` build in
@@ -253,6 +265,30 @@ machine-checkable pasteboard assertion and an explicit blocked path. This also k
 the implement stage free of `cargo`: the gate's cold `src-tauri` build is a
 multi-GB, qa-stage cost (Disk Hygiene), swept afterwards.
 
+**D15 — Markdown images get no menu; the design gate's "satisfied by construction"
+is wrong on the facts, and the gap is moot here.** The brief required "both the
+attachment-image and markdown-image render paths"; the gate waved markdown through
+on the grounds that both open through `LightboxSurface`. They do not.
+`features/chat/parts/markdown-text.tsx` maps no `img` component — its component map
+(lines 107-160) covers headings, `p`, `a`, lists, tables, `code` and the fenced-block
+slots — and `UserMessage`'s map overrides only `p` on top of it
+(`features/chat/messages/UserMessage.tsx:91`). A markdown image therefore renders as
+react-markdown's bare `<img>`, never reaching `ZoomableImage` or `LightboxSurface`,
+so it gets no menu and no test asserts one.
+
+Moot in practice, because a markdown image here can only be `http(s)`:
+`urlTransform` (`features/chat/parts/markdown-url-transform.ts:26`) admits a fixed
+app-protocol list and otherwise defers to react-markdown's `defaultUrlTransform`,
+which returns `''` for every protocol outside `https?|ircs?|mailto|xmpp` —
+`data:` included (`react-markdown@10.1.0/lib/index.js:421`). So a markdown
+`data:image/…` renders with an empty `src`, and a markdown `http(s)` image is exactly
+the source D5 leaves unsupported. Every image the menu could serve arrives as an
+attachment or an image part instead.
+
+Same shape as D1's `AttachmentPreviewDialog` gap, and recorded rather than buried:
+covering markdown would need an `img` entry in the markdown component map *and* the
+remote-fetch ruling the brief deferred. That is separate work.
+
 ## Interfaces this change adds
 
 ```ts
@@ -300,7 +336,26 @@ All three files are **red-phase**: the modules they import do not exist yet, and
 Group `clipboard-lib` implements against them. Say so in each file's header comment
 so a reader is not confused by a failing run.
 
-### Task 1 — Source classification and gating tests (RED)
+**Exit contract for this group** (it overrides the generic "typecheck + affected
+tests green"):
+
+- **Done** = the three test files below are written and committed, and the run
+  named under *Verify* fails for exactly the stated reason.
+- **Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck`.** It is
+  package-wide and would report `TS2307` on `../image-source`, `../write-image`
+  and `../copy-image` — modules this group is not allowed to create. Task 13 owns
+  the single package-wide typecheck (Constraints).
+- **Do not create `image-source.ts`, `write-image.ts` or `copy-image.ts`, not even
+  as empty stubs, to make the imports resolve.** Those three files belong to group
+  `clipboard-lib`; touching them here breaks the no-shared-files assumption that
+  `parallel_safe` rests on and hands `clipboard-lib` a file it did not write.
+
+### Task 1 — Install the workspace, then source classification and gating tests (RED)
+
+**First step, before anything else in this group:** run `pnpm install` from the
+worktree root. It is the only install in the whole graph (Constraints); every later
+group inherits `node_modules` from it, and `copy-menu-shared-tests` depends on this
+group so it cannot race the install.
 
 **File:** `packages/ui/src/lib/clipboard/__tests__/image-source.test.ts` — **new**
 (node environment; no DOM).
@@ -416,8 +471,12 @@ Cases:
 - **A non-`Error` rejection** (`Promise.reject('nope')`) still produces a non-empty
   `message`.
 
-**Verify (whole group):** all three files fail on missing modules; no other suite
-changes. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard`.
+**Verify (whole group):** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard`
+reports all three files as failed **suites**, each with a
+`Failed to resolve import "../image-source"` / `"../write-image"` / `"../copy-image"`
+error — the modules do not exist yet. That, and nothing else, is the expected red.
+No other suite in the package changes. If a file fails for any other reason, fix
+the test; if any file passes, it is asserting nothing.
 
 ---
 
@@ -510,7 +569,18 @@ package-wide typecheck, and by then both groups have landed.
 
 ---
 
-## Group 3 — `copy-menu-shared-tests` (test) · depends on: nothing
+## Group 3 — `copy-menu-shared-tests` (test) · depends on: `clipboard-core-tests`
+
+The dependency is the **install**, not the code: this group shares no file with
+`clipboard-core-tests` and reads none of its output, but Task 1 owns the one
+`pnpm install` and two concurrent installs in one workspace is the race the
+Constraints rule out. Nothing here needs `lib/clipboard`.
+
+**Exit contract for this group:** done = the cases below are written and committed,
+cases 1-2 fail for the stated reason, case 3 and every pre-existing case in the file
+pass. Skip the package-wide typecheck (Constraints): this group runs concurrently
+with `clipboard-lib`, whose files are mid-edit, so a package-wide compile here fails
+on code this group does not own. Task 13 owns it.
 
 ### Task 7 — Stale-settlement tests for `useMenuCopyFeedback` (RED)
 
@@ -532,8 +602,12 @@ Red against Task 8's generation token. Three cases:
    click `item-a` and settle `true`; `item-a` reads `Copied` and exactly one Escape
    fires. This is the guard against a token that permanently poisons the hook.
 
-**Verify:** cases 1-2 fail (an Escape is dispatched), case 3 passes; every existing
-case in the file still passes.
+**Verify:** `vitest run src/lib/ui/__tests__/use-menu-copy-feedback.test.tsx` — cases
+1 and 2 fail on the Escape assertion (`keydown` was dispatched on `document`, because
+today's hook re-arms `closeMenu` from the settlement), case 3 passes, and every
+case that was already in the file still passes. The suite compiles: the hook it
+imports already exists, so unlike Groups 1 and 5 there is no missing-module red here.
+Do not touch `use-menu-copy-feedback.ts` — the generation token is Task 8's.
 
 ---
 
@@ -601,6 +675,18 @@ here means the extraction changed something it should not have.
 
 ## Group 5 — `menu-tests` (test) · depends on: `clipboard-lib`, `copy-menu-shared`
 
+**Exit contract for this group:**
+
+- **Done** = the one test file below is written and committed and fails for exactly
+  the reason named under *Verify*.
+- **Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck`** — package-wide, and
+  it would report `TS2307` on `../ImageContextMenu`, which this group must not
+  create. Task 13 owns the single package-wide typecheck (Constraints).
+- **Do not create `ImageContextMenu.tsx`, not even as a stub, to make the import
+  resolve, and do not edit `LightboxSurface.tsx`.** Both belong to group
+  `image-context-menu`; writing them here breaks the no-shared-files assumption
+  `parallel_safe` rests on.
+
 ### Task 10 — `ImageContextMenu` behavior + both render paths (RED)
 
 **File:** `packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx` — **new.**
@@ -636,28 +722,56 @@ Cases:
 5. **Copy fails** — `copyImageToClipboard` resolves `{ ok: false, message: 'boom' }`;
    the item's text becomes `Copy failed`, `mfToast.error` is called once, and its
    options carry `description: 'boom'`.
-6. **Assistant-image path** — render `<ZoomableImage src={PNG_DATA_URI} />`, click
+6. **Assistant image-part path** — render `<ZoomableImage src={PNG_DATA_URI} />`, click
    `chat-image-zoom-trigger`, await `chat-image-zoom-dialog`, then
    `fireEvent.contextMenu` on `chat-image-zoom-image` → `image-context-menu`
-   appears. (Satisfies "the assistant/attachment render path gets the menu".)
+   appears. This covers the assistant turn's **image part** (`AssistantMessage`), not
+   a markdown image — markdown images never reach `LightboxSurface` and get no menu
+   (D15).
 7. **User-gallery path** — render
    `<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />`,
    `fireEvent.contextMenu` on `image-lightbox-current` → `image-context-menu`
-   appears. (Satisfies the second required render path.)
+   appears. This covers the **user turn's attachment gallery** (`InlineImageThumbs`).
+   Cases 6 and 7 are the two render paths this change covers, and they are the two
+   the design gate named; the brief's third, markdown, is out per D15.
 8. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
    dialog open and the menu open, press `Escape` once: the menu closes and
    `chat-image-zoom-dialog` is still in the DOM. Then assert a plain click on
    `chat-image-zoom-image` (no menu open) still closes the dialog, so the existing
    dismissal contract survives the `asChild` wrap.
-9. **A copy that settles after the menu closed does not close the lightbox** (D13,
-   the integration counterpart to Task 7). Open the `ZoomableImage` dialog and the
-   menu, mock `copyImageToClipboard` to a **deferred** promise, click `image-copy`,
-   press `Escape` to dismiss the menu only, then settle the deferred copy and
-   `advanceTimersByTime(1000)`. Assert `chat-image-zoom-dialog` is **still** in the
-   DOM. Without Task 8's token this test fails by closing the image.
+9. **Dismissing the menu with an outside pointer does not dismiss the lightbox** —
+   the interaction risk the design gate named, and the one QA step 6 would otherwise
+   own alone. Open the `ZoomableImage` dialog and the menu as in case 8, let the
+   pending timers run once (the suite uses
+   `vi.useFakeTimers({ shouldAdvanceTime: true })` like
+   `MessagePathContextMenu.test.tsx`; Radix registers its document `pointerdown`
+   listener inside a `setTimeout(0)`, so the listener is not armed on the tick the
+   menu opens), then `fireEvent.pointerDown(document.body)`. Assert the menu is gone
+   and `chat-image-zoom-dialog` is **still** in the DOM.
 
-**Verify:** the file fails on the missing `../ImageContextMenu` module; the three
-existing part tests (`ZoomableImage.test.tsx`, `ImageLightbox.test.tsx`,
+   **Fire `pointerDown` only — do not follow it with a `click`.** In a browser,
+   Radix's modal `DismissableLayer` sets `pointer-events: none` on `body` while the
+   menu is open, so the closing click never reaches the dialog. jsdom does no
+   hit-testing and ignores that style, so a synthetic `click` on the lightbox box
+   would reach `LightboxSurface.handleClick`
+   (`event.target === event.currentTarget`) and close the image for a reason that
+   cannot happen in the shell. The full click sequence stays with QA step 6, in a
+   real webview. If the pointerdown path still proves undrivable in jsdom (the
+   listener does not close the menu after two flush attempts), do not silently drop
+   this case: keep it as a `it.skip` naming the jsdom limitation, record the
+   downgrade as a decision in the lane result, and leave QA step 6 as the only
+   coverage.
+10. **A copy that settles after the menu closed does not close the lightbox** (D13,
+    the integration counterpart to Task 7). Open the `ZoomableImage` dialog and the
+    menu, mock `copyImageToClipboard` to a **deferred** promise, click `image-copy`,
+    press `Escape` to dismiss the menu only, then settle the deferred copy and
+    `advanceTimersByTime(1000)`. Assert `chat-image-zoom-dialog` is **still** in the
+    DOM. Without Task 8's token this test fails by closing the image.
+
+**Verify:** `vitest run src/features/chat/parts/__tests__/ImageContextMenu.test.tsx`
+fails as a **suite**, with `Failed to resolve import "../ImageContextMenu"` — that
+one error is the whole expected red; no case should fail for any other reason. The
+three existing part tests (`ZoomableImage.test.tsx`, `ImageLightbox.test.tsx`,
 `markdown-text.test.tsx`) still pass untouched — jsdom has no `ClipboardItem`, so
 they render exactly as before.
 
@@ -710,7 +824,7 @@ untouched: Radix's `asChild` slot composes the ref, so
 still works. Add nothing to the props interface — the surface already receives
 `src`.
 
-**Verify:** cases 6-9 of Task 10 pass;
+**Verify:** cases 6-10 of Task 10 pass;
 `vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
 still green.
 
@@ -809,8 +923,11 @@ Appendix A as the fix.
 4. Right-click the *thumbnail* (not the opened image) → no menu (webview default).
 5. Right-click transcript text, a code block, and the composer → unchanged.
 6. Close the menu with Escape and with an outside click → the lightbox stays open;
-   clicking the image itself still closes the lightbox. Then click **Copy Image**
-   and immediately press Escape; wait two seconds → the lightbox is still open (D13).
+   clicking the image itself still closes the lightbox. The outside *click* is the
+   half Task 10 case 9 cannot reach — jsdom ignores the `pointer-events: none` Radix
+   puts on `body` — so this step is its only coverage; run it deliberately. Then
+   click **Copy Image** and immediately press Escape; wait two seconds → the lightbox
+   is still open (D13).
 7. Browser mode (`vite` without Tauri, in Chromium) → the menu appears and the copy
    works (D6); no console error.
 8. **Only if Appendix A was executed:** run steps 2-3 against a packaged build
@@ -833,7 +950,9 @@ Appendix A as the fix.
 - **Radix menu inside a Radix dialog.** Both portal to `document.body` at `z-50`;
   the menu mounts later so it stacks above. Escape ordering is layer-based, which is
   what makes D13's late-settlement bug possible; covered by Task 7, Task 10 cases
-  8-9, and QA step 6.
+  8-10, and QA step 6. Case 9 covers outside-pointer dismissal only as far as jsdom
+  allows — a real closing *click* is gated by `pointer-events: none`, which jsdom
+  does not honor, so that half stays with QA step 6.
 - **`CopyMenuItem` touches two shipped menus.** The migration is behavior-preserving
   and pinned by their existing suites, which must pass **unedited** (Task 9). Any
   needed test edit is a signal the extraction drifted.

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -11,36 +11,39 @@ data does not. This change wraps the one `<img>` inside `LightboxSurface` — th
 choke point both zoom paths already route through (`ZoomableImage` for assistant
 images, `ImageLightbox` for the user-turn gallery, task and session attachment
 grids, and the file `ImageViewer`) — in a shadcn `ContextMenu` carrying a single
-**Copy Image** item. Clicking it decodes the image to raw RGBA in the renderer and
-hands the bytes plus their dimensions to a new host-port method, which on Tauri
-calls the clipboard plugin so pasting into Preview or Slack yields the image, not a
-URL. The menu mounts only when the source is copyable (`data:image/*`) *and* the
-host advertises the capability; otherwise `ImageContextMenu` renders its children
-bare and right-click falls through exactly as it does today. A failed copy raises
-an `mfToast` error; a successful one is silent.
+**Copy Image** item. Clicking it writes the image to the system clipboard through
+the webview's own async Clipboard API (`navigator.clipboard.write` with a
+`ClipboardItem`), the same API the transcript already uses to copy text, so pasting
+into Preview or Slack yields the image, not a URL. No IPC, no Rust, no host port.
+The menu mounts only when the source is copyable (`data:image/*`) *and* the webview
+advertises image-clipboard support; otherwise `ImageContextMenu` renders its
+children bare and right-click falls through exactly as it does today. The item
+reports its own outcome inline (Copy → Copied / Copy failed) through the shared
+`useMenuCopyFeedback` hook, and a failure additionally raises an `mfToast` carrying
+the reason.
 
 ## Constraints
 
 - **`CLAUDE.md`:** max 300 lines/file, 50 lines/function; `data-testid` on every
   interactive element (`<surface>-<element>` kebab-case); tests required for new
-  core logic; single canonical type in `@qlan-ro/mainframe-types`; no silent
-  catches; validate input; changeset required before commit.
+  core logic; no silent catches; changeset required before commit.
 - **`packages/ui/CLAUDE.md`:** shadcn primitives, never raw Radix; read the
   `mainframe-design-system` skill before writing markup or class names; pure logic
-  lives outside React; `lib/tauri/` is the only Tauri-aware renderer module.
+  lives outside React.
 - **Design gate (2026-07-28)** is authoritative where it and the brief disagree —
-  see D1/D2 below.
+  see D1/D2 below. Where this plan departs from the gate, D9 records why.
+- **Vitest project split** (`packages/ui/vitest.config.ts`): `*.test.tsx` runs in
+  jsdom, `*.test.ts` in node. A `.test.ts` that touches DOM APIs must carry a
+  `// @vitest-environment jsdom` pragma — `write-image.test.ts` needs it, the other
+  two do not.
 - **Every file this plan touches is comfortably under the line limits.** Largest
-  edited file: `components/ui/context-menu.tsx` (untouched), then
-  `lib/host/fake-adapter.ts` (159 → ~172), `lib/tauri/bridge.ts` (245 → ~262),
-  `types/src/host/host-bridge.ts` (180 → ~195), `LightboxSurface.tsx` (42 → ~48).
-  Every new file lands well under 300; every new function under 50.
+  edited file: `LightboxSurface.tsx` (42 → ~48). Every new file lands well under
+  300; every new function under 50.
 - **The worktree has no `node_modules`.** Run `pnpm install` from the worktree root
-  before the first TypeScript task.
-- **Rust disk cost:** `cargo check` in this worktree is cold and builds the full
-  `app-tauri` dependency graph into a new `src-tauri/target` (multi-GB, per the
-  Disk Hygiene section of `CLAUDE.md`). Budget for it once, in Group
-  `tauri-clipboard-command`.
+  before the first task.
+- **No Rust and no cold `cargo` build** on the primary path. Appendix A (the
+  fallback) is the only thing that would need one; do not pay for it before Task 13
+  says it is needed.
 
 ## Decisions
 
@@ -68,329 +71,303 @@ id because the lightbox renders exactly one image at a time — there is no list
 no index to disambiguate, and threading an id through three call sites to satisfy
 the letter of the rule buys nothing.
 
-**D4 — The renderer decodes; Rust only writes.** `copy-image.ts` turns the source
-into raw RGBA via the webview's own decoder (`<img>` + canvas `getImageData`) and
-passes the bytes as a raw invoke body with `x-image-width` / `x-image-height`
-headers. The Rust command validates the length, builds a `tauri::image::Image`, and
-calls `clipboard.write_image`. The alternative — shipping the encoded bytes and
-decoding in Rust — needs an image-decoding crate and a per-format support matrix
-for something the webview already decodes to display the image.
+**D4 — The webview writes the clipboard; nothing crosses the IPC boundary.**
+*(Replaces the earlier "renderer decodes to RGBA, Rust writes" decision.)* Three
+candidate paths were compared:
 
-**D5 — Supported sources are `data:image/*` only.** Every image the transcript
-renders today is a data URI: `convert-message.ts` builds
+| Path | Cost | Verdict |
+|---|---|---|
+| `navigator.clipboard.write([new ClipboardItem({'image/png': blob})])` in the renderer | one ~40-line module | **chosen** |
+| Renderer decodes to RGBA → raw-body `invoke` → `tauri-plugin-clipboard-manager` | new Rust command + plugin dep + host port + a CSP change with app-wide blast radius (D8) | fallback, Appendix A |
+| Ship the encoded bytes to Rust and decode there | an image-decoding crate and a per-format support matrix | rejected |
+
+Why the webview path is credible here rather than assumed: the renderer already
+calls `navigator.clipboard.writeText` successfully inside the Tauri WKWebView
+(`lib/editor/copy-reference.ts`, `features/chat/parts/CodeHeader.tsx`,
+`features/settings/panes/remote-access/CopyButton.tsx`), and `copy-reference.ts`
+documents an *observed* WKWebView failure mode ("refuses `writeText` whenever the
+document isn't focused") — the async Clipboard API is therefore present and the
+origin is a secure context, which is the only precondition WebKit puts on
+`ClipboardItem`. WebKit has shipped `ClipboardItem` writes for `image/png` since
+Safari 13.4, and the shipped app is macOS-only today
+(`.github/workflows/release.yml`, `build-app-tauri` matrix). This decision is not
+taken on faith: **Task 13 is a hard gate** that verifies a real paste in the shell
+before the change can ship, and Appendix A specifies the fallback in full.
+
+**D5 — Supported sources are `data:image/*` only, normalized to PNG.** Every image
+the transcript renders today is a data URI: `convert-message.ts` builds
 `` `data:${c.mediaType};base64,${c.data}` ``, and `SessionAttachmentsGrid`,
 `TaskAttachments`, and `ImageViewer` all do the same. `http(s)` sources stay
 unsupported per the brief's "do not fetch on right-click" ruling; `file://` and
 asset-protocol sources are unsupported because nothing in the transcript produces
-them.
+them. WebKit accepts only `image/png` on write, so a `data:image/jpeg` (or webp,
+or gif) source is re-encoded to PNG through a canvas before the write — see
+Task 9.
 
-**D6 — `ElectronAdapter` reports `canWriteImage: false`.** The Electron shell is
-legacy and its preload exposes no clipboard image API; adding one is not in scope.
-Its `writeImage` rejects, and the capability flag means the UI never calls it.
+**D6 — No `HostBridge.clipboard` port; capability is a runtime feature detection.**
+The brief asked for a host-adapter capability, which made sense when the write had
+to reach Rust. The write is now webview-native and identical on every host, so the
+port would be three adapter implementations that all forward to the same two lines.
+`imageClipboardSupported()` in `lib/clipboard/image-source.ts`
+(`typeof ClipboardItem !== 'undefined' && typeof navigator.clipboard?.write === 'function'`)
+satisfies the brief's actual requirement — *a flag the UI reads before render, not a
+throw at call time*. Consequence, in the user's favor: browser mode is no longer
+categorically disabled. Chromium supports the write, so the menu appears and works
+there; Firefox does not expose `ClipboardItem` writes by default, so it gets no
+menu. jsdom has neither, so every existing transcript test renders exactly as
+before.
+
+**D7 — Task 13 is a gate, not a QA step.** The webview path is the whole change; if
+WKWebView refuses the write, four of this plan's files are dead. So the plan is
+ordered so the *cheap* path is built and proven in the running shell (Task 13)
+before any Rust exists, and Appendix A — the host port plus the Rust command — is
+executed only if that gate fails. The gate's outcome is recorded as a decision in
+the lane result either way.
+
+**D8 — If Appendix A is taken, it keeps the raw-body invoke and fixes the CSP; it
+does not switch to plain typed args.** Recorded here because it is the reason the
+fallback looks the way it does. `packages/app-tauri/src-tauri/tauri.conf.json:31`
+sets `connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:* https: wss:`, with no
+`ipc:` token. Tauri's JS IPC sends every invoke as
+`fetch(convertFileSrc(cmd, 'ipc'))` (`tauri-2.11.5/scripts/ipc-protocol.js`), so in
+the packaged app that fetch is CSP-rejected, `customProtocolIpcFailed` latches, and
+every subsequent invoke falls back to `window.ipc.postMessage`, whose payload is
+JSON — reaching Rust as `InvokeBody::Json` (`tauri/src/ipc/protocol.rs`). Tauri does
+**not** inject the token for you: `manager::set_csp` only rewrites `script-src` and
+`style-src` nonces, and `tauri-utils`' own config docs show the developer writing
+`connect-src ipc: http://ipc.localhost` by hand. Because `build.devUrl` is served by
+Vite with no CSP header at all, this breaks *only* the packaged app. The obvious
+alternative — plain typed args — is worse, not safer:
+`scripts/process-ipc-message-fn.js` JSON-stringifies any object payload with
+`Uint8Array → Array.from` on **both** transports, so a 3024×1964 retina capture
+(23.7 MB of RGBA) becomes a ~75 MB JSON number array to stringify and parse on every
+copy. Appendix A therefore adds the CSP token, and its QA runs against a packaged
+build.
+
+**D9 — The menu reuses `useMenuCopyFeedback` and the in-repo item markup.** The
+transcript already has two copy context menus — `MessagePathContextMenu` and
+`LinkWithPreview` — and the hook exists precisely "so the message path menu doesn't
+paste the mechanism a second time". A third idiom (silent success, toast-only
+failure) would make three copy menus in one surface behave three ways, so the image
+menu adopts the hook: the item reads Copy → **Copied** / **Copy failed** and the
+menu self-closes after ~900 ms. The failure toast is kept on top of the inline
+state because it is the only place the *reason* fits. This also fixes the icon:
+the design direction wrote `<Copy size={13} className="text-muted-foreground" />`,
+but every ContextMenu copy item in the repo uses `className="mr-2 size-3.5"` with
+no colour override; the image menu matches its neighbours.
 
 ## Interfaces this change adds
-
-```ts
-// packages/types/src/host/host-bridge.ts — added to HostBridge
-clipboard: {
-  /** True when the host can put a bitmap on the system clipboard. Read before
-   *  rendering clipboard affordances — never probe by calling and catching. */
-  readonly canWriteImage: boolean;
-  /** rgba is width*height*4 bytes, row-major, non-premultiplied. */
-  writeImage(rgba: Uint8Array, width: number, height: number): Promise<void>;
-};
-```
 
 ```ts
 // packages/ui/src/lib/clipboard/image-source.ts
 export type ImageSourceKind = 'data-url' | 'remote' | 'unsupported';
 export function classifyImageSource(src: string): ImageSourceKind;
 export function decodeDataUrl(src: string): { mediaType: string; bytes: Uint8Array } | null;
-export function canCopyImage(src: string, host: Pick<HostBridge, 'clipboard'>): boolean;
+export function imageClipboardSupported(): boolean;
+export function canCopyImage(src: string): boolean;
 
-// packages/ui/src/lib/clipboard/decode-image.ts
-export function decodeToRgba(
-  bytes: Uint8Array, mediaType: string,
-): Promise<{ rgba: Uint8Array; width: number; height: number }>;
+// packages/ui/src/lib/clipboard/write-image.ts
+export function writeImageToClipboard(bytes: Uint8Array, mediaType: string): Promise<void>;
 
 // packages/ui/src/lib/clipboard/copy-image.ts
 export type CopyImageResult =
   | { ok: true }
-  | { ok: false; reason: 'unsupported-host' | 'unsupported-source' | 'decode-failed' | 'write-failed'; message: string };
-export function copyImageToClipboard(
-  src: string, host: Pick<HostBridge, 'clipboard' | 'log'>,
-): Promise<CopyImageResult>;
+  | { ok: false; reason: 'unsupported-host' | 'unsupported-source' | 'write-failed'; message: string };
+export function copyImageToClipboard(src: string): Promise<CopyImageResult>;
 ```
+
+`copyImageToClipboard` is **not** an `async` function. WebKit requires
+`navigator.clipboard.write` to run under the user activation of the click that
+triggered it, and an `await` before the call ends that activation. Everything up to
+the write is synchronous; the re-encode for non-PNG sources rides inside the
+`ClipboardItem` value as a promise, which is the form WebKit documents for exactly
+this case.
 
 ---
 
-## Group 1 — `host-port-ts` (core) · depends on: nothing
+## Group 1 — `clipboard-core-tests` (test) · depends on: nothing
 
-### Task 1 — Add `clipboard` to the host contract
+All three files are **red-phase**: the modules they import do not exist yet, and
+Group `clipboard-lib` implements against them. Say so in each file's header comment
+so a reader is not confused by a failing run.
 
-**File:** `packages/types/src/host/host-bridge.ts`
+### Task 1 — Source classification and gating tests (RED)
 
-Add the `clipboard` member to `HostBridge` exactly as written in *Interfaces*
-above, placed after `shell` and before `notify`. Doc-comment says why the flag is a
-readonly property and not a probe: browser mode must be able to hide the affordance
-*before* render.
-
-No Zod schema is added to `host-contract.ts` — those schemas exist for the Electron
-`ipcMain` handlers, and D6 means Electron never receives this payload.
-
-**Verify:** `pnpm --filter @qlan-ro/mainframe-types build` succeeds. The UI
-typecheck fails at this point (three adapters do not implement the new member) —
-that is expected until Task 3.
-
-### Task 2 — Renderer→Tauri call
-
-**File:** `packages/ui/src/lib/tauri/bridge.ts`
-
-Add, following the file's existing `IS_TAURI` guard convention:
-
-```ts
-export async function clipboardWriteImage(rgba: Uint8Array, width: number, height: number): Promise<void> {
-  if (!IS_TAURI) throw new Error('clipboard.writeImage is not available outside the Tauri webview');
-  await invoke<void>('clipboard_write_image', rgba.slice().buffer, {
-    headers: { 'x-image-width': String(width), 'x-image-height': String(height) },
-  });
-}
-```
-
-`rgba.slice()` guarantees the ArrayBuffer holds exactly the pixel bytes: canvas
-`getImageData().data` may be a view into a larger buffer, and `invoke` sends the
-whole buffer. `@tauri-apps/api@2.11.1` types `InvokeArgs` as
-`Record<string, unknown> | number[] | ArrayBuffer | Uint8Array` and `InvokeOptions`
-as `{ headers: HeadersInit }`, so this is the supported raw-body form.
-
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` reports no error in this
-file.
-
-### Task 3 — Implement `clipboard` in all three adapters
-
-**Files:**
-- `packages/ui/src/lib/host/tauri-adapter.ts` — `clipboard = { canWriteImage: true, writeImage: (rgba, w, h) => bridge.clipboardWriteImage(rgba, w, h) };`
-- `packages/ui/src/lib/host/electron-adapter.ts` — `canWriteImage: false`; `writeImage` returns a rejected promise with a message naming the host (mirror the existing not-supported style in that file).
-- `packages/ui/src/lib/host/fake-adapter.ts` — `canWriteImage` reads `this.overrides.clipboard?.canWriteImage ?? false`; `writeImage` delegates to `this.overrides.clipboard?.writeImage` when set, otherwise `notSupported('clipboard.writeImage')`.
-
-Also extend `FakeHostOverrides` in `fake-adapter.ts`:
-
-```ts
-clipboard?: {
-  canWriteImage?: boolean;
-  writeImage?: (rgba: Uint8Array, width: number, height: number) => Promise<void>;
-};
-```
-
-This override is load-bearing: without it no jsdom test can reach the menu at all,
-because the fake host's default is "no capability".
-
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes clean.
-
----
-
-## Group 2 — `tauri-clipboard-command` (core) · depends on: nothing
-
-### Task 4 — Add the clipboard plugin and the write command
-
-**Files:**
-- `packages/app-tauri/src-tauri/Cargo.toml` — add `tauri-plugin-clipboard-manager = "2"` to `[dependencies]` (+ the resulting `Cargo.lock` churn).
-- `packages/app-tauri/src-tauri/src/commands/clipboard.rs` — **new.**
-- `packages/app-tauri/src-tauri/src/commands/mod.rs` — `pub mod clipboard;` + `pub use clipboard::clipboard_write_image;`.
-- `packages/app-tauri/src-tauri/src/lib.rs` — add `clipboard_write_image` to the `use commands::{…}` list and to `tauri::generate_handler![…]`; add `.plugin(tauri_plugin_clipboard_manager::init())` to the builder chain beside the other `.plugin(...)` calls.
-
-`clipboard.rs`:
-
-```rust
-use tauri::image::Image;
-use tauri::ipc::{InvokeBody, Request};
-use tauri_plugin_clipboard_manager::ClipboardExt;
-
-/// Refuse absurd payloads before allocating: 64 MiB of RGBA is a ~4000×4000 image.
-const MAX_RGBA_BYTES: usize = 64 * 1024 * 1024;
-
-#[tauri::command]
-pub fn clipboard_write_image(app: tauri::AppHandle, request: Request<'_>) -> Result<(), String> { … }
-```
-
-Behavior, in order:
-1. `request.body()` must be `InvokeBody::Raw`; anything else is an error naming the
-   expected form.
-2. Parse `x-image-width` / `x-image-height` headers as `u32` via a small private
-   helper (`header_u32(&request, name) -> Result<u32, String>`); a missing or
-   unparsable header is an error.
-3. Reject `width == 0`, `height == 0`, `rgba.len() > MAX_RGBA_BYTES`, or
-   `rgba.len() != width * height * 4` (compute in `usize` with `checked_mul` so a
-   hostile header cannot overflow).
-4. `app.clipboard().write_image(&Image::new(rgba, width, height))`, mapping the
-   error to a `String` (Tauri commands returning `Result<_, String>` is the
-   established convention in `commands/fs.rs`).
-
-No capability entry is needed in `src-tauri/capabilities/main.json`: app-defined
-commands are not permission-gated (the existing `read_file` / `terminal_create`
-commands have no entry either), and the plugin's own JS commands are never invoked
-from the renderer.
-
-**Verify:** `cargo check` from `packages/app-tauri/src-tauri` passes (cold build —
-see Constraints). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`
-on the same directory are clean.
-
----
-
-## Group 3 — `clipboard-core-tests` (test) · depends on: `host-port-ts`
-
-Two of these three files are **red-phase** — the modules they import do not exist
-yet, and Group `clipboard-lib` implements against them. The third is green-phase,
-verifying Group `host-port-ts`. State that expectation in each file's header
-comment so a reader is not confused by a mixed run.
-
-### Task 5 — Pure source-classification and gating tests (RED)
-
-**File:** `packages/ui/src/lib/clipboard/__tests__/image-source.test.ts` — **new.**
+**File:** `packages/ui/src/lib/clipboard/__tests__/image-source.test.ts` — **new**
+(node environment; no DOM).
 
 Cover, with hardcoded expectations (no logic mirrored from the implementation):
 - `classifyImageSource` → `'data-url'` for `data:image/png;base64,…` and
   `data:image/jpeg;base64,…`; `'remote'` for `http://…` and `https://…`;
-  `'unsupported'` for `file:///…`, `blob:…`, `asset://…`, `''`, and a
-  non-image data URI (`data:text/plain;base64,…`).
+  `'unsupported'` for `file:///…`, `blob:…`, `asset://…`, `''`, and a non-image
+  data URI (`data:text/plain;base64,…`).
 - `decodeDataUrl` → `{ mediaType: 'image/png', bytes }` for a known 1×1 PNG data
   URI, asserting the first eight bytes are the PNG signature
   (`137 80 78 71 13 10 26 10`) and the byte length matches the base64 payload;
-  `null` for a non-base64 data URI (`data:image/svg+xml,<svg/>`), for a
-  non-image data URI, and for malformed base64.
-- `canCopyImage` truth table over `{data-url, remote} × {canWriteImage true,false}`
-  — only `data-url` + `true` is `true`.
+  `null` for a non-base64 data URI (`data:image/svg+xml,<svg/>`), for a non-image
+  data URI, and for malformed base64.
+- `imageClipboardSupported` → `false` with no `ClipboardItem` global; `false` with
+  `ClipboardItem` present but no `navigator.clipboard.write`; `true` with both.
+  Install and remove the globals with `vi.stubGlobal` / `vi.unstubAllGlobals`.
+- `canCopyImage` truth table over `{data-url, remote} × {supported, unsupported}` —
+  only `data-url` + supported is `true`.
 
-### Task 6 — Copy orchestration tests (RED)
+### Task 2 — Clipboard write tests (RED)
 
-**File:** `packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts` — **new.**
+**File:** `packages/ui/src/lib/clipboard/__tests__/write-image.test.ts` — **new.**
+First line: `// @vitest-environment jsdom` (see Constraints).
 
-`vi.mock('../decode-image')` so no real canvas is needed. A hand-built host stub
-provides `clipboard` and a `log` spy. Cases:
-- Host without capability → `{ ok: false, reason: 'unsupported-host' }`, and
-  `decodeToRgba` and `writeImage` are never called.
-- `https://…` source → `{ ok: false, reason: 'unsupported-source' }`, nothing
-  called.
-- Happy path → `decodeToRgba` receives the decoded bytes and the media type from
-  the data URI; `writeImage` receives exactly those `rgba`, `width`, `height`;
-  result is `{ ok: true }`.
-- `decodeToRgba` rejects → `{ ok: false, reason: 'decode-failed' }` with a
-  non-empty `message`, and `host.log` was called at `warn` (the no-silent-catch
-  rule), and `writeImage` was never called.
-- `writeImage` rejects → `{ ok: false, reason: 'write-failed' }` with a non-empty
-  `message` and a `warn` log.
+Stub `ClipboardItem` with a class that records its constructor argument, and
+`navigator.clipboard.write` with a spy. Cases:
+- **PNG passthrough:** `writeImageToClipboard(bytes, 'image/png')` calls `write`
+  once with a single `ClipboardItem`; the item's `image/png` value resolves to a
+  `Blob` of `type === 'image/png'` and `size === bytes.length`; no canvas is
+  touched (spy on `document.createElement` or on the stubbed `getContext`).
+- **Activation ordering:** `navigator.clipboard.write` has already been called
+  **synchronously** when `writeImageToClipboard` returns — assert the spy's call
+  count is 1 before awaiting the returned promise. This is the test that pins the
+  user-activation requirement from D4; without it a later refactor to `async`
+  silently breaks copy in WebKit.
+- **JPEG re-encode:** with `HTMLImageElement.prototype.decode` stubbed to resolve
+  (setting `naturalWidth`/`naturalHeight`), `HTMLCanvasElement.prototype.getContext`
+  stubbed to a fake 2d context with a `drawImage` spy, and
+  `HTMLCanvasElement.prototype.toBlob` stubbed to hand back a PNG blob:
+  `writeImageToClipboard(bytes, 'image/jpeg')` still calls `write` synchronously,
+  and the item's value resolves to the re-encoded PNG blob. Assert
+  `URL.createObjectURL` / `URL.revokeObjectURL` are balanced.
+- **Re-encode failure:** a rejecting `decode()` rejects the returned promise, and
+  the object URL is still revoked. Same for a `null` 2d context and for a `toBlob`
+  that yields `null`.
 
-### Task 7 — Decoder and adapter delegation tests
+### Task 3 — Copy orchestration tests (RED)
 
-**Files:**
-- `packages/ui/src/lib/clipboard/__tests__/decode-image.test.ts` — **new** (RED).
-  jsdom has no image decoding, so stub the DOM seam: replace
-  `HTMLImageElement.prototype.decode` with a resolver that sets `naturalWidth` /
-  `naturalHeight`, and stub `HTMLCanvasElement.prototype.getContext` to return a
-  fake 2d context whose `getImageData` yields a known `Uint8ClampedArray`. Assert:
-  the returned `rgba`/`width`/`height` match the fake; the object URL created for
-  the blob is revoked on both the success and the failure path (spy on
-  `URL.createObjectURL` / `URL.revokeObjectURL`); a rejecting `decode()` propagates
-  as a rejection; a `null` 2d context rejects with a message.
-- `packages/ui/src/lib/host/__tests__/tauri-adapter.test.ts` — **edit** (GREEN).
-  One case: `clipboard.canWriteImage === true`, and `clipboard.writeImage(rgba, 2, 1)`
-  invokes `'clipboard_write_image'` with an `ArrayBuffer` of `byteLength === 8` and
-  headers `{ 'x-image-width': '2', 'x-image-height': '1' }`.
-- `packages/ui/src/lib/host/__tests__/fake-adapter.test.ts` — **edit** (GREEN).
-  Two cases: default `canWriteImage === false` and `writeImage` rejects; with
-  `{ clipboard: { canWriteImage: true, writeImage: spy } }` overrides,
-  `canWriteImage === true` and the spy receives the arguments.
+**File:** `packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts` — **new**
+(node environment).
 
-**Verify (whole group):** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/host/__tests__/tauri-adapter.test.ts src/lib/host/__tests__/fake-adapter.test.ts`
-is green; the three `src/lib/clipboard/__tests__/*` files fail on missing modules.
+`vi.mock('../write-image')` so no DOM is needed; use the real `image-source`.
+Cases:
+- No `ClipboardItem` global → `{ ok: false, reason: 'unsupported-host' }`, and
+  `writeImageToClipboard` is never called.
+- `https://…` source with support present → `{ ok: false, reason:
+  'unsupported-source' }`, nothing called.
+- Happy path → `writeImageToClipboard` receives exactly the decoded bytes and the
+  media type from the data URI; result is `{ ok: true }`.
+- `writeImageToClipboard` rejects → `{ ok: false, reason: 'write-failed' }` with a
+  non-empty `message` taken from the error, and one tagged `console.warn` (spy on
+  it — the no-silent-catch rule).
+- A non-`Error` rejection (`Promise.reject('nope')`) still produces a non-empty
+  `message`.
+
+**Verify (whole group):** all three files fail on missing modules; no other suite
+changes. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard`.
 
 ---
 
-## Group 4 — `clipboard-lib` (core) · depends on: `clipboard-core-tests`, `host-port-ts`
+## Group 2 — `clipboard-lib` (core) · depends on: `clipboard-core-tests`
 
-### Task 8 — `image-source.ts`
+### Task 4 — `image-source.ts`
 
 **File:** `packages/ui/src/lib/clipboard/image-source.ts` — **new.**
 
-Pure, no DOM. `classifyImageSource` matches `^data:image\/[a-zA-Z0-9.+-]+;base64,`
-for `'data-url'` and `^https?:` for `'remote'`; everything else is
-`'unsupported'`. `decodeDataUrl` splits on the first `,`, verifies the prefix
-shape, `atob`s the payload inside a `try` (returning `null` on `InvalidCharacterError`
-— a `/* expected */`-commented catch, since a malformed URI is data, not a fault),
-and copies char codes into a `Uint8Array`. `canCopyImage` is the two-line
-conjunction of the kind check and `host.clipboard.canWriteImage`.
+Pure, no DOM writes. `classifyImageSource` matches
+`^data:image\/[a-zA-Z0-9.+-]+;base64,` for `'data-url'` and `^https?:` for
+`'remote'`; everything else is `'unsupported'`. `decodeDataUrl` splits on the
+first `,`, verifies the prefix shape, `atob`s the payload inside a `try`
+(returning `null` on `InvalidCharacterError` — an `/* expected */`-commented catch,
+since a malformed URI is data, not a fault), and copies char codes into a
+`Uint8Array`. `imageClipboardSupported` is the two-term global check from D6 —
+guard both terms so it is safe to call in a node test. `canCopyImage` is the
+conjunction of the kind check and `imageClipboardSupported()`.
 
 **Verify:** `vitest run src/lib/clipboard/__tests__/image-source.test.ts` green.
 
-### Task 9 — `decode-image.ts`
+### Task 5 — `write-image.ts`
 
-**File:** `packages/ui/src/lib/clipboard/decode-image.ts` — **new.**
+**File:** `packages/ui/src/lib/clipboard/write-image.ts` — **new.**
 
-`decodeToRgba(bytes, mediaType)`:
-1. `const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }))` —
-   blob URLs are same-origin, so the canvas is never tainted.
+```ts
+export function writeImageToClipboard(bytes: Uint8Array, mediaType: string): Promise<void> {
+  const png =
+    mediaType === 'image/png'
+      ? Promise.resolve(new Blob([bytes], { type: 'image/png' }))
+      : reencodeToPng(bytes, mediaType);
+  return navigator.clipboard.write([new ClipboardItem({ 'image/png': png })]);
+}
+```
+
+One comment, on the promise value: WebKit accepts only `image/png` on write, and
+takes a promise so the re-encode can finish after the user gesture. Private
+`reencodeToPng(bytes, mediaType): Promise<Blob>`:
+1. `const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }))` — blob
+   URLs are same-origin, so the canvas is never tainted.
 2. `const img = new Image(); img.src = url; await img.decode();` — `decode()` over
-   `createImageBitmap`/`OffscreenCanvas` because it is supported by all three
-   webviews the shell ships on.
+   `createImageBitmap`/`OffscreenCanvas` because every webview the shell ships on
+   supports it.
 3. Draw onto a `document.createElement('canvas')` sized to
    `naturalWidth × naturalHeight`; throw when either is `0` or `getContext('2d')`
    returns `null`.
-4. Return `{ rgba: new Uint8Array(imageData.data.buffer.slice(0)), width, height }`.
+4. `canvas.toBlob(resolve, 'image/png')`, rejecting when it yields `null`.
 5. `URL.revokeObjectURL(url)` in a `finally`.
 
-Keep it under 50 lines; if it crowds, extract the canvas step into a private
-helper in the same file.
+Keep each function under 50 lines; if `reencodeToPng` crowds, split the canvas step
+into a second private helper in the same file.
 
-**Verify:** `vitest run src/lib/clipboard/__tests__/decode-image.test.ts` green.
+**Verify:** `vitest run src/lib/clipboard/__tests__/write-image.test.ts` green.
 
-### Task 10 — `copy-image.ts`
+### Task 6 — `copy-image.ts`
 
 **File:** `packages/ui/src/lib/clipboard/copy-image.ts` — **new.**
 
-`copyImageToClipboard(src, host)` implements the ladder the Task 6 tests pin:
-capability gate → source gate → `decodeToRgba` (catch → `decode-failed`) →
-`host.clipboard.writeImage` (catch → `write-failed`). Every catch calls
-`host.log('warn', 'clipboard', …)` before returning; the returned `message` is the
-error's message, or a fixed fallback for a non-`Error` throw. No toast here — the
-component owns user-facing feedback so this module stays callable outside React.
+The exact ladder the Task 3 tests pin: `imageClipboardSupported()` →
+`decodeDataUrl` → `writeImageToClipboard`, with `.then(onOk, onErr)` rather than
+`await` (D4's activation rule; carry one comment saying so). The error branch calls
+`console.warn('[copy-image] clipboard write failed', err)` — the tagged-warn idiom
+`lib/editor/copy-reference.ts` already uses in this package — before returning
+`{ ok: false, reason: 'write-failed', message }`, where `message` is the error's
+message or a fixed fallback for a non-`Error` throw. No toast here: the component
+owns user-facing feedback so this module stays callable outside React.
 
-**Verify:** `vitest run src/lib/clipboard/__tests__/copy-image.test.ts` green, and
+**Verify:** `vitest run src/lib/clipboard` all green, and
 `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes.
 
 ---
 
-## Group 5 — `menu-tests` (test) · depends on: `clipboard-lib`, `host-port-ts`
+## Group 3 — `menu-tests` (test) · depends on: `clipboard-lib`
 
-### Task 11 — `ImageContextMenu` behavior + both render paths (RED)
+### Task 7 — `ImageContextMenu` behavior + both render paths (RED)
 
 **File:** `packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx` — **new.**
 
-Red-phase against Group `image-context-menu`; it imports the real
-`lib/clipboard/image-source` (already built) and mocks
-`@/lib/clipboard/copy-image` and `@/lib/toast`. A helper installs a capable host
-via `setHostForTesting(new FakeHostBridge({ clipboard: { canWriteImage: true, writeImage: vi.fn() } }))`
-and `resetHostForTesting()` in `afterEach`. Radix context menus open on
+Red-phase against Group `image-context-menu`. Imports the real
+`lib/clipboard/image-source` (already built) and mocks `@/lib/clipboard/copy-image`
+and `@/lib/toast`. A `beforeEach` installs `ClipboardItem` and
+`navigator.clipboard.write` stubs so `canCopyImage` returns true;
+`vi.unstubAllGlobals()` in `afterEach`. Radix context menus open on
 `fireEvent.contextMenu(element)` — the pattern proven in
-`features/sessions/sidebar/__tests__/SessionContextMenu.test.tsx`. Use a real 1×1
-PNG data URI constant for the copyable source.
+`features/sessions/sidebar/__tests__/SessionContextMenu.test.tsx`. Mirror
+`features/chat/messages/__tests__/MessagePathContextMenu.test.tsx` for how it
+handles the hook's delayed-close timer; do not invent a new timer strategy. Use a
+real 1×1 PNG data URI constant for the copyable source.
 
 Cases:
-1. **Capable host + data URI** — right-clicking the wrapped child opens
+1. **Supported webview + data URI** — right-clicking the wrapped child opens
    `chat-image-context-menu` containing `chat-image-copy` with the text
    `Copy Image`.
-2. **Capable host + `https://…` source** — no `chat-image-context-menu` after
+2. **Supported webview + `https://…` source** — no `chat-image-context-menu` after
    `fireEvent.contextMenu`, and the child still renders.
-3. **Host without the capability + data URI** — same: no menu, child renders.
-4. **Copy succeeds** — clicking `chat-image-copy` calls `copyImageToClipboard`
-   once with the src, and `mfToast.error` is never called.
+3. **No `ClipboardItem` + data URI** — same: no menu, child renders.
+4. **Copy succeeds** — clicking `chat-image-copy` calls `copyImageToClipboard` once
+   with the src; the item's text becomes `Copied`; `mfToast.error` is never called.
 5. **Copy fails** — `copyImageToClipboard` resolves
-   `{ ok: false, reason: 'write-failed', message: 'boom' }`; `mfToast.error` is
-   called once, and its options carry `description: 'boom'`.
+   `{ ok: false, reason: 'write-failed', message: 'boom' }`; the item's text becomes
+   `Copy failed`, `mfToast.error` is called once, and its options carry
+   `description: 'boom'`.
 6. **Assistant-image path** — render `<ZoomableImage src={PNG_DATA_URI} />`, click
    `chat-image-zoom-trigger`, await `chat-image-zoom-dialog`, then
    `fireEvent.contextMenu` on `chat-image-zoom-image` → `chat-image-context-menu`
-   appears. (Satisfies "the attachment/assistant render path gets the menu".)
-7. **User-gallery path** — render `<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />`,
+   appears. (Satisfies "the assistant/attachment render path gets the menu".)
+7. **User-gallery path** — render
+   `<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />`,
    `fireEvent.contextMenu` on `image-lightbox-current` → `chat-image-context-menu`
    appears. (Satisfies the second required render path.)
 8. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
@@ -401,16 +378,16 @@ Cases:
 
 **Verify:** the file fails on the missing `../ImageContextMenu` module; the three
 existing part tests (`ZoomableImage.test.tsx`, `ImageLightbox.test.tsx`,
-`markdown-text.test.tsx`) still pass untouched — the fake host's default
-`canWriteImage: false` means they render exactly as before.
+`markdown-text.test.tsx`) still pass untouched — jsdom has no `ClipboardItem`, so
+they render exactly as before.
 
 ---
 
-## Group 6 — `image-context-menu` (ui) · depends on: `menu-tests`, `clipboard-lib`, `host-port-ts`
+## Group 4 — `image-context-menu` (ui) · depends on: `menu-tests`, `clipboard-lib`
 
 Read the `mainframe-design-system` skill before writing any markup here.
 
-### Task 12 — `ImageContextMenu.tsx`
+### Task 8 — `ImageContextMenu.tsx`
 
 **File:** `packages/ui/src/features/chat/parts/ImageContextMenu.tsx` — **new.**
 
@@ -418,28 +395,31 @@ Read the `mainframe-design-system` skill before writing any markup here.
 interface ImageContextMenuProps { src: string; children: ReactNode }
 ```
 
-`useHost()` first (the only hook, so the early return below is safe), then
-`if (!canCopyImage(src, host)) return <>{children}</>;` — D2's "no menu at all".
-Otherwise the shadcn `ContextMenu` / `ContextMenuTrigger asChild` /
-`ContextMenuContent className="w-44"` / one `ContextMenuItem`, mirroring
-`EditorContextMenu`'s item markup exactly:
+`useMenuCopyFeedback()` first (hooks before the early return), then
+`if (!canCopyImage(src)) return <>{children}</>;` — D2's "no menu at all". Otherwise
+the shadcn `ContextMenu onOpenChange={handleOpenChange}` /
+`ContextMenuTrigger asChild` / `ContextMenuContent className="w-44"` with one item,
+mirroring `MessagePathContextMenu`'s `CopyPathItem` markup (D9):
 
 ```tsx
-<ContextMenuItem data-testid="chat-image-copy" onSelect={() => void handleCopy()}>
-  <Copy size={13} className="text-muted-foreground" />
-  Copy Image
+<ContextMenuItem data-testid="chat-image-copy" onSelect={onCopySelect('chat-image-copy', handleCopy)}>
+  {status === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
+  {status === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
+  {status === 'idle' && <Copy className="mr-2 size-3.5" />}
+  {status === 'copied' ? 'Copied' : status === 'failed' ? 'Copy failed' : 'Copy Image'}
 </ContextMenuItem>
 ```
 
+`handleCopy` is the `() => Promise<boolean>` the hook expects: it awaits
+`copyImageToClipboard(src)`, fires
+`mfToast.error('Could not copy the image', { description: result.message })` when
+`!result.ok` (`mfToast`, never `sonner` directly), and returns `result.ok`.
 `data-testid="chat-image-context-menu"` goes on `ContextMenuContent` (D3). No
-separator and no reserved second group. `handleCopy` awaits
-`copyImageToClipboard(src, host)` and, on `!ok`, fires
-`mfToast.error('Could not copy the image', { description: result.message })` —
-`mfToast`, never `sonner` directly. Success is silent.
+separator and no reserved second group.
 
-**Verify:** cases 1–5 of Task 11 pass.
+**Verify:** cases 1–5 of Task 7 pass.
 
-### Task 13 — Wrap the lightbox image
+### Task 9 — Wrap the lightbox image
 
 **File:** `packages/ui/src/features/chat/parts/LightboxSurface.tsx`
 
@@ -450,52 +430,232 @@ untouched: Radix's `asChild` slot composes the ref, so
 still works. Add nothing to the props interface — the surface already receives
 `src`.
 
-**Verify:** cases 6–8 of Task 11 pass; `vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
+**Verify:** cases 6–8 of Task 7 pass;
+`vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
 still green.
 
-### Task 14 — Changeset and full verification
+### Task 10 — Changeset and full verification
 
 **File:** `.changeset/<generated>.md` — **new.**
 
-`pnpm changeset`, patch bump for `@qlan-ro/mainframe-ui`,
-`@qlan-ro/mainframe-types`, and `@qlan-ro/mainframe-app-tauri`. Summary: one line
+`pnpm changeset`, patch bump for `@qlan-ro/mainframe-ui` only (no types or Rust
+change on this path; if Appendix A is executed, extend the changeset to
+`@qlan-ro/mainframe-types` and `@qlan-ro/mainframe-app-tauri`). Summary: one line
 stating that right-clicking an opened image offers Copy Image.
 
 **Verify:**
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck`
-- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/lib/host src/features/chat/parts`
-- `git status` shows no stray files; no `@ts-ignore`, no `console.*` added, no file
-  over 300 lines (`wc -l` on every touched file).
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard src/features/chat/parts`
+- `git status` shows no stray files; no `@ts-ignore`, no `console.*` outside the one
+  tagged warn in `copy-image.ts`, no file over 300 lines (`wc -l` on every touched
+  file).
+
+---
+
+## Group 5 — `webview-clipboard-gate` (qa) · depends on: `image-context-menu`
+
+### Task 11 — Prove the write in the running shell
+
+This is the gate D7 describes, not a nice-to-have. Do it before considering the
+lane's implement stage complete, and record the outcome as a decision in the lane
+result.
+
+1. `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR`
+   and `DAEMON_PORT` (per the memory note on production takeover). The Rust build
+   is cold in this worktree but the Rust *sources* are untouched, so nothing here
+   depends on Appendix A.
+2. Open a PNG image in the transcript, right-click, click **Copy Image**, and paste
+   into Preview (⌘N). The bitmap must appear with correct colours and dimensions.
+3. Repeat with a JPEG-sourced image if one is reachable (the re-encode path).
+
+**PASS** → the plan is complete; Appendix A is not executed and stays in this file
+as the recorded alternative.
+**FAIL** (`navigator.clipboard.write` rejects, or the paste yields nothing) →
+capture the exact rejection, record it as the D7 outcome, and execute Appendix A.
+Tasks 1–3 and 7–9 survive unchanged in that case; only `write-image.ts` and the
+capability term of `image-source.ts` are replaced.
 
 ---
 
 ## QA smoke (for the qa stage, not this plan's tasks)
 
-1. `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR`
-   and `DAEMON_PORT` (per the memory note on production takeover).
+1. `pnpm tauri:dev` with an isolated `MAINFRAME_DATA_DIR` and `DAEMON_PORT`.
 2. Send a screenshot to a session, open the resulting image in the transcript,
    right-click it → menu appears at the pointer, not clipped by the lightbox box.
-3. Click **Copy Image**, paste into Preview (⌘N) → the bitmap appears, correct
-   colors and dimensions, no alpha inversion.
+3. Click **Copy Image** → the item reads **Copied** and the menu closes on its own;
+   paste into Preview → the bitmap appears, correct colours and dimensions, no alpha
+   inversion.
 4. Right-click the *thumbnail* (not the opened image) → no menu (webview default).
 5. Right-click transcript text, a code block, and the composer → unchanged.
 6. Close the menu with Escape and with an outside click → the lightbox stays open;
    clicking the image itself still closes the lightbox.
-7. Browser mode (`vite` without Tauri) → right-clicking the opened image shows the
-   webview's own menu, no app menu, no console error.
+7. Browser mode (`vite` without Tauri, in Chromium) → the menu appears and the copy
+   works (D6); no console error.
+8. **Only if Appendix A was executed:** run steps 2–3 against a packaged build
+   (`scripts/build-release-local.sh --tauri`), not `tauri:dev`. The dev server
+   serves no CSP header, so the IPC transport differs from the shipped app and a
+   dev-only smoke cannot see the failure D8 describes. Also re-smoke the terminal,
+   file open, and daemon start/stop on that build, since the CSP change moves every
+   invoke onto the custom-protocol transport.
 
 ## Risks
 
-- **The raw-body invoke (`tauri::ipc::Request` + headers) is unproven in this
-  repo.** `@tauri-apps/api@2.11.1` types it and the shell already uses the raw
-  *response* form (`InvokeResponseBody::Raw`) for the terminal, but the request
-  direction is new here. It is verified by `cargo check` plus QA step 3. If it
-  fails, the fallback is a base64 RGBA string argument plus a hand-rolled Rust
-  decoder mirroring `base64_encode` in `commands/fs.rs` — same shape, one extra
-  encode/decode hop.
+- **`navigator.clipboard.write` in WKWebView is the load-bearing assumption.**
+  Mitigated by Task 11 (a hard gate before ship) and by Appendix A being specified
+  in full rather than discovered later. Evidence for it is in D4.
+- **Non-PNG sources ride the canvas re-encode**, whose promise is resolved after the
+  user gesture. WebKit documents promise values for exactly this reason, but if it
+  refuses, PNG (every screenshot, the dominant case) still works and the JPEG case
+  surfaces as an honest "Copy failed" toast rather than a corrupt clipboard entry.
 - **Radix menu inside a Radix dialog.** Both portal to `document.body` at `z-50`;
-  the menu mounts later so it stacks above. Covered by Task 11 case 8 and QA
-  step 6.
-- **jsdom cannot decode images**, so `decode-image.ts` is only covered against
-  stubbed DOM APIs. The real decode is proven by QA step 3, not by unit tests.
-- **Cold Rust build cost** in this worktree (see Constraints).
+  the menu mounts later so it stacks above. Covered by Task 7 case 8 and QA step 6.
+- **jsdom cannot decode or write images**, so `write-image.ts` is only covered
+  against stubbed DOM APIs. The real write is proven by Task 11, not by unit tests.
+
+---
+
+## Appendix A — fallback: host port + Rust clipboard command
+
+**Execute only if Task 11 fails.** Everything here is additive to Tasks 1–3 and
+7–9; `write-image.ts` and the capability term of `image-source.ts` are replaced,
+`copy-image.ts` gains a `host` parameter, and `ImageContextMenu` calls
+`canCopyImage(src, useHost())`. Budget one cold `cargo` build (multi-GB
+`src-tauri/target` in this worktree, per the Disk Hygiene section of `CLAUDE.md`).
+
+### A1 — Host contract
+
+**File:** `packages/types/src/host/host-bridge.ts`
+
+```ts
+clipboard: {
+  /** True when the host can put a bitmap on the system clipboard. Read before
+   *  rendering clipboard affordances — never probe by calling and catching. */
+  readonly canWriteImage: boolean;
+  /** rgba is width*height*4 bytes, row-major, non-premultiplied. */
+  writeImage(rgba: Uint8Array, width: number, height: number): Promise<void>;
+};
+```
+
+Placed after `shell` and before `notify`. No Zod schema in `host-contract.ts` —
+those schemas exist for the Electron `ipcMain` handlers, and the Electron adapter
+reports `canWriteImage: false` (its preload exposes no clipboard image API and
+adding one is out of scope), so it never receives this payload.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-types build` succeeds; the UI
+typecheck fails until A3.
+
+### A2 — CSP token (do this before anything else in the appendix)
+
+**File:** `packages/app-tauri/src-tauri/tauri.conf.json`
+
+Add `ipc: http://ipc.localhost` to the `connect-src` directive:
+
+```
+connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* https: wss:
+```
+
+Rationale and the rejected alternative are D8. Two consequences to state in the PR
+body: the packaged app's IPC moves from `window.ipc.postMessage` to the
+custom-protocol transport for **every** command (the transport dev already uses, so
+this reduces dev/prod divergence — but it is an app-wide change riding in an
+image-copy PR), and QA step 8 becomes mandatory.
+
+### A3 — Renderer→Tauri call
+
+**File:** `packages/ui/src/lib/tauri/bridge.ts`
+
+```ts
+export async function clipboardWriteImage(rgba: Uint8Array, width: number, height: number): Promise<void> {
+  if (!IS_TAURI) throw new Error('clipboard.writeImage is not available outside the Tauri webview');
+  await invoke<void>('clipboard_write_image', rgba, {
+    headers: { 'x-image-width': String(width), 'x-image-height': String(height) },
+  });
+}
+```
+
+Pass the `Uint8Array` **directly**; do not copy it. `process-ipc-message-fn.js`
+passes any `ArrayBuffer.isView` argument straight through to `fetch`, which reads
+only `byteOffset..byteOffset+byteLength`, and the RGBA array produced by the decode
+step is already exactly sized at offset 0. A defensive `.slice()` would cost a
+second full-size copy in the webview (≈59 MB for a 5K capture) and buy nothing. No
+comment is needed here beyond the `IS_TAURI` guard.
+
+`@tauri-apps/api@2.11.1` types `InvokeArgs` as
+`Record<string, unknown> | number[] | ArrayBuffer | Uint8Array` and `InvokeOptions`
+as `{ headers: HeadersInit }`, so this is the supported raw-body form.
+
+### A4 — Adapters
+
+- `packages/ui/src/lib/host/tauri-adapter.ts` — `clipboard = { canWriteImage: true, writeImage: (rgba, w, h) => bridge.clipboardWriteImage(rgba, w, h) };`
+- `packages/ui/src/lib/host/electron-adapter.ts` — `canWriteImage: false`; `writeImage` returns a rejected promise naming the host (mirror the file's existing not-supported style).
+- `packages/ui/src/lib/host/fake-adapter.ts` — `canWriteImage` reads `this.overrides.clipboard?.canWriteImage ?? false`; `writeImage` delegates to the override when set, otherwise `notSupported('clipboard.writeImage')`. Extend `FakeHostOverrides` with `clipboard?: { canWriteImage?: boolean; writeImage?: (rgba: Uint8Array, width: number, height: number) => Promise<void> }` — load-bearing, since without it no jsdom test can reach the menu.
+
+Tests: `lib/host/__tests__/tauri-adapter.test.ts` gains one case (`clipboard.writeImage(rgba, 2, 1)` invokes `'clipboard_write_image'` with a `Uint8Array` of `byteLength === 8` and the two headers); `lib/host/__tests__/fake-adapter.test.ts` gains two (default rejects; override receives the arguments).
+
+### A5 — RGBA decode in the renderer
+
+**File:** `packages/ui/src/lib/clipboard/decode-image.ts` — replaces `write-image.ts`.
+
+`decodeToRgba(bytes, mediaType): Promise<{ rgba: Uint8Array; width: number; height: number }>`
+is A5's version of Task 5's `reencodeToPng`: same object-URL → `img.decode()` →
+canvas pipeline, ending at
+`{ rgba: new Uint8Array(imageData.data.buffer.slice(0)), width, height }` instead of
+`toBlob`. Its test file (`__tests__/decode-image.test.ts`, jsdom pragma) mirrors
+Task 2 with `getImageData` in place of `toBlob`. `copy-image.ts` gains a
+`decode-failed` reason between the source gate and the write.
+
+### A6 — Rust command
+
+**Files:**
+- `packages/app-tauri/src-tauri/Cargo.toml` — `tauri-plugin-clipboard-manager = "2"` (+ `Cargo.lock` churn).
+- `packages/app-tauri/src-tauri/src/commands/clipboard.rs` — **new.**
+- `packages/app-tauri/src-tauri/src/commands/mod.rs` — `pub mod clipboard;` + `pub use clipboard::clipboard_write_image;`.
+- `packages/app-tauri/src-tauri/src/lib.rs` — add the command to the `use commands::{…}` list and `tauri::generate_handler![…]`; add `.plugin(tauri_plugin_clipboard_manager::init())` beside the other `.plugin(...)` calls.
+
+Split the module so the validation is testable without an `AppHandle` — every other
+module in this crate carries a `#[cfg(test)]` block (`presence.rs`, `shell_env.rs`,
+`sidecar.rs`, `log_sink.rs`, `terminal/mod.rs`, `menu.rs`, `updater/channel.rs`,
+`preview/bridge_plugin.rs`, `lib.rs`, `commands/daemons.rs`), and this is the code
+path whose failure mode the brief calls out as "worse than a disabled menu item".
+
+```rust
+/// Widest side any capture we accept can have; also the ceiling of the canvas the
+/// renderer decoded through.
+const MAX_IMAGE_DIMENSION: u32 = 16_384;
+/// 256 MiB of RGBA ≈ 67 Mpx. Sized from real retina captures, not a round number:
+/// a full-screen Pro Display XDR grab (6016×3384) is 81 MB and a scaled-4K/8K grab
+/// (7680×4320) is 133 MB — both must pass. Anything past this is refused with the
+/// "Could not copy the image" toast, which is the accepted user-visible cost of
+/// bounding a single allocation to a quarter gigabyte.
+const MAX_RGBA_BYTES: usize = 256 * 1024 * 1024;
+
+fn header_u32(headers: &HeaderMap, name: &str) -> Result<u32, String>;
+fn validate_rgba(len: usize, width: u32, height: u32) -> Result<(), String>;
+
+#[tauri::command]
+pub fn clipboard_write_image(app: tauri::AppHandle, request: Request<'_>) -> Result<(), String>;
+```
+
+The command: `request.body()` must be `InvokeBody::Raw` (anything else errors
+naming the expected form — with A2 in place this cannot happen, and the error says
+so); read `x-image-width` / `x-image-height` through `header_u32`; call
+`validate_rgba`; then
+`app.clipboard().write_image(&Image::new(rgba, width, height))`, mapping the error
+to a `String` (the `Result<_, String>` convention `commands/fs.rs` established).
+`validate_rgba` rejects `width == 0`, `height == 0`, either side over
+`MAX_IMAGE_DIMENSION`, `len > MAX_RGBA_BYTES`, and `len != width*height*4` computed
+in `usize` with `checked_mul` so a hostile header cannot overflow.
+
+`#[cfg(test)] mod tests` covers: `header_u32` with a missing header, a non-numeric
+header, a value past `u32::MAX`, and the happy path; `validate_rgba` with the happy
+path, `width == 0`, `height == 0`, a side over `MAX_IMAGE_DIMENSION`, a
+length mismatch, a length over `MAX_RGBA_BYTES`, and `(u32::MAX, u32::MAX)` —
+which proves the `checked_mul` path returns an error instead of wrapping.
+
+No capability entry is needed in `src-tauri/capabilities/main.json`: app-defined
+commands are not permission-gated (`read_file` / `terminal_create` have no entry
+either), and the plugin's own JS commands are never invoked from the renderer.
+
+**Verify:** `cargo test` (the new module's tests), `cargo check`,
+`cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` from
+`packages/app-tauri/src-tauri`, then QA step 8 on a packaged build.

--- a/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
+++ b/docs/plans/2026-07-28-todo-282-copy-image-context-menu-plan.md
@@ -49,20 +49,26 @@ recorded as D10.
 - **The worktree has no `node_modules`, and nothing outside the task graph installs
   them.** The lane's only setup step creates the worktree and stamps the tracker, so
   the install needs an owner *inside* the graph: **Task 1 runs `pnpm install` from
-  the worktree root as its first step**, and group `copy-menu-shared-tests` carries
-  `depends_on: ['clipboard-core-tests']` so it can never start before that install
-  finishes. One install, one owner, never two at once in the same workspace. No other
-  task re-runs it. Serializing those two groups costs nothing: from wave 2 on the
-  graph is a chain anyway.
-- **Only Task 13 runs the package-wide typecheck.**
-  `pnpm --filter @qlan-ro/mainframe-ui typecheck` compiles the whole package,
-  test files included, so it cannot pass in a group that has just committed tests
-  against modules that do not exist yet — `clipboard-core-tests` and `menu-tests`
-  both do, and `copy-menu-shared-tests` runs concurrently with a group whose files
-  are mid-edit. **This overrides the generic "typecheck + affected tests green"
-  expectation for every group except `image-context-menu`.** Each group below states
-  its own exit contract; a group meets that contract and returns, and Task 13 runs
-  the single package-wide typecheck once every other group has landed.
+  the worktree root as its first step.** No other task re-runs it.
+- **The group graph is a pure chain; no two groups ever run at once.** Each group
+  names its predecessor in `depends_on`, including
+  `copy-menu-shared-tests → clipboard-lib`, which is a scheduling edge rather than a
+  code one. Two shared-worktree hazards force it. First, `pnpm install` must not run
+  twice at once in one workspace, and Task 1 owns the only install. Second, **every
+  group commits, and `.husky/pre-commit` runs `npx lint-staged`** — concurrent
+  commits in one worktree commingle each other's staged files, a failure this repo
+  has already paid for once. Serializing costs one wave: the only two groups that
+  could have overlapped were `clipboard-lib` and `copy-menu-shared-tests`.
+- **Which groups run the package-wide typecheck.**
+  `pnpm --filter @qlan-ro/mainframe-ui typecheck` compiles the whole package, test
+  files included, so it cannot pass in a group that has just committed red tests
+  importing modules that do not exist yet: `clipboard-core-tests` (Tasks 1-3) and
+  `menu-tests` (Task 10) must **not** run it. **Every other group must.** Because
+  the graph is serialized, no other group's files are ever mid-edit, so
+  `clipboard-lib`, `copy-menu-shared-tests` and `copy-menu-shared` each compile the
+  package cleanly and a type error surfaces in the group that owns the file instead
+  of in the last wave. Each group below states its own exit contract, and Task 13
+  runs the final package-wide typecheck once everything has landed.
 - **The implement stage needs no Rust and never runs `cargo`.** The one step that
   does — the D7 webview gate — is a **qa-stage** step, not an implement task
   (D14). Its cost is stated there: a cold `packages/app-tauri/src-tauri` build in
@@ -226,6 +232,14 @@ for text (`writeToClipboard(text): Promise<boolean>` in
 widened only so the `DOMException` message can reach the toast description.
 `useMenuCopyFeedback.onCopySelect` consumes `result.ok` directly.
 
+The same reasoning deletes `classifyImageSource` and its `ImageSourceKind` union.
+`'remote'` and `'unsupported'` are never told apart in production — D5 makes both
+non-copyable — and the union's only consumer, `canCopyImage`, collapses the result
+to a boolean. It would exist solely to be asserted. `canCopyImage(src)` is therefore
+the data-URL regex test AND `imageClipboardSupported()`, and nothing else is
+exported. The source kinds do not go untested: they stay as rows of Task 1's truth
+table, which is where the gating rule belongs.
+
 **D12 — `CopyMenuItem` is extracted and all three copy menus migrate in this pass.**
 The item markup (`copied → Check` / `failed → AlertTriangle` / `idle → Copy`, plus
 the label ternary) already exists twice —
@@ -293,14 +307,14 @@ remote-fetch ruling the brief deferred. That is separate work.
 
 ```ts
 // packages/ui/src/lib/clipboard/image-source.ts
-export type ImageSourceKind = 'data-url' | 'remote' | 'unsupported';
-export function classifyImageSource(src: string): ImageSourceKind;
-export function decodeDataUrl(src: string): { mediaType: string; bytes: Uint8Array<ArrayBuffer> } | null;
+export interface DecodedDataUrl { mediaType: string; bytes: Uint8Array<ArrayBuffer> }
+export function decodeDataUrl(src: string): DecodedDataUrl | null;
 export function imageClipboardSupported(): boolean;
 export function canCopyImage(src: string): boolean;
 
 // packages/ui/src/lib/clipboard/write-image.ts
-export function writeImageToClipboard(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<void>;
+/** `src` is the original `data:image/*` URL; `decoded` is its payload. */
+export function writeImageToClipboard(src: string, decoded: DecodedDataUrl): Promise<void>;
 
 // packages/ui/src/lib/clipboard/copy-image.ts
 /** `message` is present only on failure, and only when a reason is worth showing. */
@@ -343,14 +357,14 @@ tests green"):
   named under *Verify* fails for exactly the stated reason.
 - **Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck`.** It is
   package-wide and would report `TS2307` on `../image-source`, `../write-image`
-  and `../copy-image` — modules this group is not allowed to create. Task 13 owns
-  the single package-wide typecheck (Constraints).
+  and `../copy-image` — modules this group is not allowed to create. `clipboard-lib`
+  runs the first passing package-wide typecheck, and Task 13 the last (Constraints).
 - **Do not create `image-source.ts`, `write-image.ts` or `copy-image.ts`, not even
   as empty stubs, to make the imports resolve.** Those three files belong to group
   `clipboard-lib`; touching them here breaks the no-shared-files assumption that
   `parallel_safe` rests on and hands `clipboard-lib` a file it did not write.
 
-### Task 1 — Install the workspace, then source classification and gating tests (RED)
+### Task 1 — Install the workspace, then decode and gating tests (RED)
 
 **First step, before anything else in this group:** run `pnpm install` from the
 worktree root. It is the only install in the whole graph (Constraints); every later
@@ -361,10 +375,6 @@ group so it cannot race the install.
 (node environment; no DOM).
 
 Cover, with hardcoded expectations (no logic mirrored from the implementation):
-- `classifyImageSource` → `'data-url'` for `data:image/png;base64,…` and
-  `data:image/jpeg;base64,…`; `'remote'` for `http://…` and `https://…`;
-  `'unsupported'` for `file:///…`, `blob:…`, `asset://…`, `''`, and a non-image
-  data URI (`data:text/plain;base64,…`).
 - `decodeDataUrl` → `{ mediaType: 'image/png', bytes }` for a known 1×1 PNG data
   URI, asserting the first eight bytes are the PNG signature
   (`137 80 78 71 13 10 26 10`) and the byte length matches the base64 payload;
@@ -373,9 +383,13 @@ Cover, with hardcoded expectations (no logic mirrored from the implementation):
 - `imageClipboardSupported` → `false` with no `ClipboardItem` global; `false` with
   `ClipboardItem` present but no `navigator.clipboard.write`; `true` with both.
   Install and remove the globals with `vi.stubGlobal` / `vi.unstubAllGlobals`.
-- `canCopyImage` truth table over `{data-url, remote} × {supported, unsupported}` —
-  only `data-url` + supported is `true`. This is the gate D11 makes authoritative,
-  so the table is the only place the gating rule is asserted.
+- `canCopyImage` truth table — the sources crossed with host support. Sources:
+  `data:image/png;base64,…` and `data:image/jpeg;base64,…` (copyable);
+  `http://…`, `https://…`, `file:///…`, `blob:…`, `asset://…`, `''`, and a non-image
+  data URI (`data:text/plain;base64,…`) (not copyable). Every source is `false` when
+  `imageClipboardSupported()` is `false`; only the two `data:image/*` rows are `true`
+  when it is. This is the gate D11 makes authoritative and the only place the source
+  kinds are asserted, since `classifyImageSource` no longer exists (D11).
 
 ### Task 2 — Clipboard write tests (RED)
 
@@ -408,48 +422,54 @@ separately. Pick one and say which in the file header.)
 The async body of `write` still records its call synchronously, so the activation
 assertion holds.
 
-**jsdom has no object-URL API — stub it by assignment, not `vi.spyOn`.** Verified
-against this repo's jsdom (29.1.1): `URL.createObjectURL` and `URL.revokeObjectURL`
-are both `undefined`, unlike `toBlob`, which exists. `reencodeToPng` calls
-`createObjectURL` as its first statement, so without these stubs the JPEG re-encode
-case and all three re-encode-failure cases throw a `TypeError` before reaching the
-behavior they exist to pin — and the balance assertion below cannot be written as
-`vi.spyOn(URL, 'createObjectURL')`, which throws on a property that does not exist.
-Install by assignment and remove in teardown, since there is nothing to restore:
+**No object-URL stubs are needed.** `reencodeToPng` assigns the source `data:` URL
+straight to `img.src` (Task 5), so nothing in this module calls
+`URL.createObjectURL` — which is just as well, since this repo's jsdom (29.1.1)
+defines neither `createObjectURL` nor `revokeObjectURL`, and `vi.spyOn` throws on a
+property that does not exist.
+
+**`decode()` has that same gap; `naturalWidth` does not.** Verified against this
+repo's jsdom: `HTMLImageElement.prototype.decode` is `undefined`, so install it by
+assignment and delete it in teardown, while `naturalWidth`/`naturalHeight` are real
+prototype accessors and take an ordinary getter spy. The `decode` stub is also where
+the JPEG case reads `this.src`, since the `<img>` is never in the document:
 
 ```ts
+let seenSrc = '';
 beforeEach(() => {
-  URL.createObjectURL = vi.fn(() => 'blob:test');
-  URL.revokeObjectURL = vi.fn();
+  HTMLImageElement.prototype.decode = vi.fn(function (this: HTMLImageElement) {
+    seenSrc = this.src;
+    return Promise.resolve();
+  });
+  vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(2);
+  vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(1);
 });
-afterEach(() => {
-  Reflect.deleteProperty(URL, 'createObjectURL');
-  Reflect.deleteProperty(URL, 'revokeObjectURL');
-});
+afterEach(() => Reflect.deleteProperty(HTMLImageElement.prototype, 'decode'));
 ```
 
+Every call passes the data URL and its decoded payload:
+`writeImageToClipboard(PNG_DATA_URI, { mediaType: 'image/png', bytes })`.
+
 Cases:
-- **PNG passthrough:** `writeImageToClipboard(bytes, 'image/png')` calls `write`
-  once with a single `ClipboardItem`; the item's `image/png` value resolves to a
-  `Blob` of `type === 'image/png'` and `size === bytes.length`; no canvas is
-  touched (spy on `document.createElement` or on the stubbed `getContext`).
+- **PNG passthrough:** calls `write` once with a single `ClipboardItem`; the item's
+  `image/png` value resolves to a `Blob` of `type === 'image/png'` and
+  `size === bytes.length`; no canvas is touched (spy on `document.createElement` or
+  on the stubbed `getContext`).
 - **Activation ordering:** `navigator.clipboard.write` has already been called
   **synchronously** when `writeImageToClipboard` returns — assert the spy's call
   count is 1 before awaiting the returned promise. This is the test that pins the
   user-activation requirement from D4; without it a later refactor to `async`
   silently breaks copy in WebKit.
-- **JPEG re-encode:** with `HTMLImageElement.prototype.decode` stubbed to resolve
-  (setting `naturalWidth`/`naturalHeight`), `HTMLCanvasElement.prototype.getContext`
-  stubbed to a fake 2d context with a `drawImage` spy, and
-  `HTMLCanvasElement.prototype.toBlob` stubbed to hand back a PNG blob:
-  `writeImageToClipboard(bytes, 'image/jpeg')` still calls `write` synchronously,
-  and the item's value resolves to the re-encoded PNG blob. Assert the two object-URL
-  mocks installed above are balanced (`createObjectURL` and `revokeObjectURL` each
-  called once, with the revoke receiving `'blob:test'`).
-- **Re-encode failure:** a rejecting `decode()` rejects the promise
-  `writeImageToClipboard` returned (via the adopting stub above), and the object URL
-  is still revoked. Same for a `null` 2d context and for a `toBlob` that yields
-  `null`.
+- **JPEG re-encode:** with the `decode`/`naturalWidth` stubs above,
+  `HTMLCanvasElement.prototype.getContext` stubbed to a fake 2d context with a
+  `drawImage` spy, and `HTMLCanvasElement.prototype.toBlob` stubbed to hand back a
+  PNG blob: `writeImageToClipboard(JPEG_DATA_URI, { mediaType: 'image/jpeg', bytes })`
+  still calls `write` synchronously, and the item's value resolves to the re-encoded
+  PNG blob. Also assert `seenSrc === JPEG_DATA_URI` — the `<img>` gets the original
+  data URL, which is what replaces the object-URL round trip.
+- **Re-encode failure:** a `decode` stub that rejects makes the promise
+  `writeImageToClipboard` returned reject too (via the adopting `write` stub above).
+  Same for a `null` 2d context and for a `toBlob` that yields `null`.
 
 ### Task 3 — Copy orchestration tests (RED)
 
@@ -459,8 +479,9 @@ Cases:
 `vi.mock('../write-image')` so no DOM is needed; use the real `image-source`. Per
 D11 there are no host/source-kind cases here — that gate is Task 1's truth table.
 Cases:
-- **Happy path** → `writeImageToClipboard` receives exactly the decoded bytes and
-  the media type from the data URI; the result is `{ ok: true }` with no `message`.
+- **Happy path** → `writeImageToClipboard` receives the src unchanged as its first
+  argument and, as its second, the decoded record whose `mediaType` and `bytes` come
+  from the data URI; the result is `{ ok: true }` with no `message`.
 - **Synchronous write** → `writeImageToClipboard` has been called once before the
   returned promise is awaited (the D4 activation rule, pinned at this layer too).
 - **Malformed base64 data URI** (`decodeDataUrl` returns `null`) →
@@ -482,21 +503,34 @@ the test; if any file passes, it is asserting nothing.
 
 ## Group 2 — `clipboard-lib` (core) · depends on: `clipboard-core-tests`
 
+**Exit contract for this group:**
+
+- **Done** = the three modules below exist and are committed, the whole
+  `src/lib/clipboard` suite is green (Task 6's *Verify*), and
+  `pnpm --filter @qlan-ro/mainframe-ui typecheck` **passes**. This group owns the
+  three files Group 1's red tests import, so it is the first point at which the
+  package compiles again and the first place a type error in them can surface. Run
+  it here; do not defer it to Task 13.
+- Nothing else in the package is mid-edit: the graph is serialized (Constraints), so
+  a failure in this typecheck is this group's own.
+- **Touch nothing outside `packages/ui/src/lib/clipboard/`.** The test files stay as
+  Group 1 committed them; if one of them looks wrong, the implementation is wrong.
+
 ### Task 4 — `image-source.ts`
 
 **File:** `packages/ui/src/lib/clipboard/image-source.ts` — **new.**
 
-Pure, no DOM writes. `classifyImageSource` matches
-`^data:image\/[a-zA-Z0-9.+-]+;base64,` for `'data-url'` and `^https?:` for
-`'remote'`; everything else is `'unsupported'`. `decodeDataUrl` splits on the
+Pure, no DOM writes. Three exports and one module-level constant — the copyable-source
+regex, `/^data:image\/[a-zA-Z0-9.+-]+;base64,/`, which is not exported and has no
+classifier wrapped around it (D11). `decodeDataUrl` splits on the
 first `,`, verifies the prefix shape, `atob`s the payload inside a `try`
 (returning `null` on `InvalidCharacterError` — an `/* expected */`-commented catch,
 since a malformed URI is data, not a fault), and copies char codes into a
 `new Uint8Array(len)`, whose inferred type is already `Uint8Array<ArrayBuffer>` —
-declare the return that way and no copy is needed. `imageClipboardSupported` is the
-two-term global check from D6 — guard both terms so it is safe to call in a node
-test. `canCopyImage` is the conjunction of the kind check and
-`imageClipboardSupported()`.
+declare the return that way (as `DecodedDataUrl`) and no copy is needed.
+`imageClipboardSupported` is the two-term global check from D6 — guard both terms so
+it is safe to call in a node test. `canCopyImage(src)` is one line:
+`COPYABLE_SRC.test(src) && imageClipboardSupported()`.
 
 **Verify:** `vitest run src/lib/clipboard/__tests__/image-source.test.ts` green.
 
@@ -505,30 +539,35 @@ test. `canCopyImage` is the conjunction of the kind check and
 **File:** `packages/ui/src/lib/clipboard/write-image.ts` — **new.**
 
 ```ts
-export function writeImageToClipboard(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<void> {
+export function writeImageToClipboard(src: string, decoded: DecodedDataUrl): Promise<void> {
   const png =
-    mediaType === 'image/png'
-      ? Promise.resolve(new Blob([bytes], { type: 'image/png' }))
-      : reencodeToPng(bytes, mediaType);
+    decoded.mediaType === 'image/png'
+      ? Promise.resolve(new Blob([decoded.bytes], { type: 'image/png' }))
+      : reencodeToPng(src);
   return navigator.clipboard.write([new ClipboardItem({ 'image/png': png })]);
 }
 ```
 
-The `Uint8Array<ArrayBuffer>` annotation is required for both `Blob` constructions
-to typecheck (Constraints). One comment, on the promise value: WebKit accepts only
-`image/png` on write, and takes a promise so the re-encode can finish after the user
-gesture. Private
-`reencodeToPng(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<Blob>`:
-1. `const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }))` — blob
-   URLs are same-origin, so the canvas is never tainted.
-2. `const img = new Image(); img.src = url; await img.decode();` — `decode()` over
+The `Uint8Array<ArrayBuffer>` annotation on `DecodedDataUrl.bytes` is what lets the
+`Blob` construction typecheck (Constraints). One comment, on the promise value:
+WebKit accepts only `image/png` on write, and takes a promise so the re-encode can
+finish after the user gesture. Private `reencodeToPng(src: string): Promise<Blob>`:
+1. `const img = new Image(); img.src = src; await img.decode();` — `decode()` over
    `createImageBitmap`/`OffscreenCanvas` because every webview the shell ships on
    supports it.
-3. Draw onto a `document.createElement('canvas')` sized to
+2. Draw onto a `document.createElement('canvas')` sized to
    `naturalWidth × naturalHeight`; throw when either is `0` or `getContext('2d')`
    returns `null`.
-4. `canvas.toBlob(resolve, 'image/png')`, rejecting when it yields `null`.
-5. `URL.revokeObjectURL(url)` in a `finally`.
+3. `canvas.toBlob(resolve, 'image/png')`, rejecting when it yields `null`.
+
+**The re-encode loads the original `data:` URL directly; it does not rebuild a
+`Blob` and an object URL from the bytes it was just handed.** `src` is a
+`data:image/*` URL by construction — `canCopyImage` is the only gate and it admits
+nothing else (D5) — the shell's CSP already allows it
+(`img-src 'self' blob: data:` in `packages/app-tauri/src-tauri/tauri.conf.json:31`),
+and a `data:` URL does not taint the canvas, so `toBlob` succeeds. Reusing it drops
+an allocation, the `URL.createObjectURL`/`revokeObjectURL` pair and the `finally`
+that had to balance them, plus the jsdom stubs those forced on Task 2.
 
 Keep each function under 50 lines; if `reencodeToPng` crowds, split the canvas step
 into a second private helper in the same file.
@@ -540,9 +579,9 @@ into a second private helper in the same file.
 **File:** `packages/ui/src/lib/clipboard/copy-image.ts` — **new.**
 
 The exact ladder the Task 3 tests pin, and nothing more (D11 — no host or
-source-kind re-check): `decodeDataUrl(src)` → `writeImageToClipboard`, with
-`.then(onOk, onErr)` rather than `await` (D4's activation rule; carry one comment
-saying so).
+source-kind re-check): `decodeDataUrl(src)` → `writeImageToClipboard(src, decoded)`,
+with `.then(onOk, onErr)` rather than `await` (D4's activation rule; carry one
+comment saying so).
 
 - `decodeDataUrl` returns `null` → `console.warn('[copy-image] could not decode the image source')`,
   then `{ ok: false, message: 'That image could not be decoded.' }`.
@@ -555,32 +594,37 @@ saying so).
 No toast here: the component owns user-facing feedback so this module stays callable
 outside React.
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard`
-all green — the clipboard suite alone, and nothing wider.
+**Verify (whole group):**
 
-**Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck` here.** That command is
-package-wide, and this group runs in the same worktree, concurrently, with group
-`copy-menu-shared`. With `noUnusedLocals: true` (`packages/ui/tsconfig.json:16`), any
-half-applied Task 9 state — `CopyPathItem` deleted before `lib/ui/CopyMenuItem.tsx`
-exists, or the now-unused `Check`/`Copy`/`AlertTriangle`/`CopyStatus`/`ContextMenuItem`
-imports not yet dropped from `MessagePathContextMenu.tsx` and `link-with-preview.tsx`
-— would fail this group on code it does not own and end the wave. Task 13 owns the
-package-wide typecheck, and by then both groups have landed.
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/lib/clipboard` all green —
+  the clipboard suite, and nothing wider.
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes (the group's exit contract).
+  It is package-wide, which is the point: no other group is running, and these three
+  modules are what Group 1's tests could not resolve.
 
 ---
 
-## Group 3 — `copy-menu-shared-tests` (test) · depends on: `clipboard-core-tests`
+## Group 3 — `copy-menu-shared-tests` (test) · depends on: `clipboard-core-tests`, `clipboard-lib`
 
-The dependency is the **install**, not the code: this group shares no file with
-`clipboard-core-tests` and reads none of its output, but Task 1 owns the one
-`pnpm install` and two concurrent installs in one workspace is the race the
-Constraints rule out. Nothing here needs `lib/clipboard`.
+Both edges are **scheduling, not code**: this group shares no file with either and
+reads no output of either — nothing here needs `lib/clipboard`.
+`clipboard-core-tests` owns the graph's one `pnpm install` (Task 1).
+`clipboard-lib` is named because it and this group would otherwise be the graph's
+only concurrent pair, racing twice in one worktree: over that install, and over
+`.husky/pre-commit`'s `npx lint-staged`, which commingles the staged files of
+concurrent commits (Constraints).
 
-**Exit contract for this group:** done = the cases below are written and committed,
-cases 1-2 fail for the stated reason, case 3 and every pre-existing case in the file
-pass. Skip the package-wide typecheck (Constraints): this group runs concurrently
-with `clipboard-lib`, whose files are mid-edit, so a package-wide compile here fails
-on code this group does not own. Task 13 owns it.
+**Exit contract for this group:**
+
+- **Done** = the three cases below are written and committed, cases 1-2 fail for the
+  reason named under *Verify*, and case 3 plus every pre-existing case in the file
+  pass.
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck` **passes** and is run here. Unlike
+  Groups 1 and 5, this group imports nothing that does not exist: the hook and its
+  harness are already in the tree, and the new cases are red on *behavior*, not on a
+  missing module.
+- **Do not touch `lib/ui/use-menu-copy-feedback.ts`** — the generation token is
+  Task 8's, in the next group.
 
 ### Task 7 — Stale-settlement tests for `useMenuCopyFeedback` (RED)
 
@@ -614,6 +658,18 @@ Do not touch `use-menu-copy-feedback.ts` — the generation token is Task 8's.
 ## Group 4 — `copy-menu-shared` (ui) · depends on: `copy-menu-shared-tests`
 
 Read the `mainframe-design-system` skill before touching `CopyMenuItem`'s markup.
+
+**Exit contract for this group:**
+
+- **Done** = Tasks 8 and 9 are committed, the two *Verify* runs below are green with
+  **no test file edited**, and `pnpm --filter @qlan-ro/mainframe-ui typecheck`
+  **passes**. This group deletes `CopyPathItem` and rewrites two shipped menus under
+  `noUnusedLocals: true` (`packages/ui/tsconfig.json:16`), so a stranded
+  `Check`/`Copy`/`AlertTriangle`/`CopyStatus`/`ContextMenuItem` import is a
+  compile error and this is the group that owns it. The graph is serialized, so
+  nothing else is mid-edit.
+- Migrating a menu's markup is behavior-preserving by definition here: if a shipped
+  suite needs an edit to stay green, the extraction drifted — fix the extraction.
 
 ### Task 8 — Generation token in `useMenuCopyFeedback`
 
@@ -681,7 +737,8 @@ here means the extraction changed something it should not have.
   the reason named under *Verify*.
 - **Do not run `pnpm --filter @qlan-ro/mainframe-ui typecheck`** — package-wide, and
   it would report `TS2307` on `../ImageContextMenu`, which this group must not
-  create. Task 13 owns the single package-wide typecheck (Constraints).
+  create. `image-context-menu` typechecks this file once it exists, and Task 13 runs
+  the final package-wide typecheck (Constraints).
 - **Do not create `ImageContextMenu.tsx`, not even as a stub, to make the import
   resolve, and do not edit `LightboxSurface.tsx`.** Both belong to group
   `image-context-menu`; writing them here breaks the no-shared-files assumption
@@ -734,14 +791,32 @@ Cases:
    appears. This covers the **user turn's attachment gallery** (`InlineImageThumbs`).
    Cases 6 and 7 are the two render paths this change covers, and they are the two
    the design gate named; the brief's third, markdown, is out per D15.
-8. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
+8. **Nested inside `MessagePathContextMenu` — the composition that actually ships.**
+   Render
+   `<MessagePathContextMenu><ZoomableImage src={PNG_DATA_URI} /></MessagePathContextMenu>`
+   (`AssistantMessage.tsx:110` wraps every non-nested message's parts this way), open
+   the lightbox, `fireEvent.contextMenu` on `chat-image-zoom-image`, and assert
+   `image-context-menu` is in the DOM **and** `tool-card-path-copy-absolute` is not.
+   Seed `useActiveBasesStore` and stub `window.getSelection` the way
+   `messages/__tests__/MessagePathContextMenu.test.tsx` does — it renders the real
+   component with the real zustand store.
+
+   Case 6 renders `ZoomableImage` alone, so nothing there pins this. The lightbox is
+   a Dialog portal, but **React synthetic events propagate through portals along the
+   React tree**, so every right-click on the lightbox image also reaches
+   `MessagePathContextMenu.handleContextMenu`, which runs `setPath(null)` and
+   `suppressRadixTrigger`. Today only ordering keeps the two menus from both opening
+   (see Task 11), and ordering is exactly the kind of thing a later refactor breaks
+   silently — this repo already paid for nested triggers once in
+   `parts/link-with-preview.tsx:82-85`.
+9. **Menu dismissal does not dismiss the lightbox** — with the `ZoomableImage`
    dialog open and the menu open, press `Escape` once: the menu closes and
    `chat-image-zoom-dialog` is still in the DOM. Then assert a plain click on
    `chat-image-zoom-image` (no menu open) still closes the dialog, so the existing
    dismissal contract survives the `asChild` wrap.
-9. **Dismissing the menu with an outside pointer does not dismiss the lightbox** —
+10. **Dismissing the menu with an outside pointer does not dismiss the lightbox** —
    the interaction risk the design gate named, and the one QA step 6 would otherwise
-   own alone. Open the `ZoomableImage` dialog and the menu as in case 8, let the
+   own alone. Open the `ZoomableImage` dialog and the menu as in case 9, let the
    pending timers run once (the suite uses
    `vi.useFakeTimers({ shouldAdvanceTime: true })` like
    `MessagePathContextMenu.test.tsx`; Radix registers its document `pointerdown`
@@ -761,7 +836,7 @@ Cases:
    this case: keep it as a `it.skip` naming the jsdom limitation, record the
    downgrade as a decision in the lane result, and leave QA step 6 as the only
    coverage.
-10. **A copy that settles after the menu closed does not close the lightbox** (D13,
+11. **A copy that settles after the menu closed does not close the lightbox** (D13,
     the integration counterpart to Task 7). Open the `ZoomableImage` dialog and the
     menu, mock `copyImageToClipboard` to a **deferred** promise, click `image-copy`,
     press `Escape` to dismiss the menu only, then settle the deferred copy and
@@ -811,6 +886,21 @@ the shadcn `ContextMenu onOpenChange={handleOpenChange}` /
 `data-testid="image-context-menu"` goes on `ContextMenuContent` (D3). No separator
 and no reserved second group.
 
+**The trigger gets no `onContextMenu` guard, unlike `link-with-preview.tsx:82-85`.**
+State the reason in the file's header comment, because the absence is the surprising
+part. This trigger nests inside `MessagePathContextMenu` (`AssistantMessage.tsx:110`)
+and React carries the synthetic event through the Dialog portal to it, but the inner
+trigger runs first and Radix's own `onContextMenu` ends with
+`event.preventDefault()`; the outer trigger composes its handler with
+`composeEventHandlers(props.onContextMenu, …, { checkForDefaultPrevented: true })`,
+so the outer menu never opens. The outer's own `handleContextMenu` still runs, and
+both of its effects are inert here: `setPath(null)` is a no-op state write, and
+`suppressRadixTrigger` re-sets a flag already set. It cannot resolve a path either —
+it looks one up with `closest('[data-file-path]')`, which walks the **DOM**, and the
+lightbox image's DOM ancestry is the portal on `document.body`, not the message.
+`link-with-preview` needed `stopPropagation` because it is a real trigger inside the
+message's own DOM; this one is not. Task 10 case 8 is what keeps that true.
+
 **Verify:** cases 1-5 of Task 10 pass.
 
 ### Task 12 — Wrap the lightbox image
@@ -824,7 +914,7 @@ untouched: Radix's `asChild` slot composes the ref, so
 still works. Add nothing to the props interface — the surface already receives
 `src`.
 
-**Verify:** cases 6-10 of Task 10 pass;
+**Verify:** cases 6-11 of Task 10 pass;
 `vitest run src/features/chat/parts/__tests__/ZoomableImage.test.tsx src/features/chat/parts/__tests__/ImageLightbox.test.tsx`
 still green.
 
@@ -924,7 +1014,7 @@ Appendix A as the fix.
 5. Right-click transcript text, a code block, and the composer → unchanged.
 6. Close the menu with Escape and with an outside click → the lightbox stays open;
    clicking the image itself still closes the lightbox. The outside *click* is the
-   half Task 10 case 9 cannot reach — jsdom ignores the `pointer-events: none` Radix
+   half Task 10 case 10 cannot reach — jsdom ignores the `pointer-events: none` Radix
    puts on `body` — so this step is its only coverage; run it deliberately. Then
    click **Copy Image** and immediately press Escape; wait two seconds → the lightbox
    is still open (D13).
@@ -950,7 +1040,7 @@ Appendix A as the fix.
 - **Radix menu inside a Radix dialog.** Both portal to `document.body` at `z-50`;
   the menu mounts later so it stacks above. Escape ordering is layer-based, which is
   what makes D13's late-settlement bug possible; covered by Task 7, Task 10 cases
-  8-10, and QA step 6. Case 9 covers outside-pointer dismissal only as far as jsdom
+  9-11, and QA step 6. Case 10 covers outside-pointer dismissal only as far as jsdom
   allows — a real closing *click* is gated by `pointer-events: none`, which jsdom
   does not honor, so that half stays with QA step 6.
 - **`CopyMenuItem` touches two shipped menus.** The migration is behavior-preserving
@@ -1053,9 +1143,9 @@ Tests: `lib/host/__tests__/tauri-adapter.test.ts` gains one case (`clipboard.wri
 
 **File:** `packages/ui/src/lib/clipboard/decode-image.ts` — replaces `write-image.ts`.
 
-`decodeToRgba(bytes: Uint8Array<ArrayBuffer>, mediaType: string): Promise<{ rgba: Uint8Array<ArrayBuffer>; width: number; height: number }>`
-is A5's version of Task 5's `reencodeToPng`: same object-URL → `img.decode()` →
-canvas pipeline, ending at
+`decodeToRgba(src: string): Promise<{ rgba: Uint8Array<ArrayBuffer>; width: number; height: number }>`
+is A5's version of Task 5's `reencodeToPng`: the same `img.src = src` →
+`img.decode()` → canvas pipeline off the original data URL, ending at
 `{ rgba: new Uint8Array(imageData.data.buffer.slice(0)), width, height }` instead of
 `toBlob` — `buffer.slice(0)` yields a real `ArrayBuffer`, so the annotation holds
 without a further copy. Its test file (`__tests__/decode-image.test.ts`, jsdom

--- a/packages/ui/src/features/chat/messages/MessagePathContextMenu.tsx
+++ b/packages/ui/src/features/chat/messages/MessagePathContextMenu.tsx
@@ -12,10 +12,10 @@
  * message. See `suppressRadixTrigger` for how that fall-through is kept.
  */
 import { useState, type ReactNode } from 'react';
-import { Check, Copy, AlertTriangle } from 'lucide-react';
-import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from '@/components/ui/context-menu';
+import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from '@/components/ui/context-menu';
 import { useActiveBasesStore } from '@/store/active-bases-store';
-import { useMenuCopyFeedback, type CopyStatus } from '@/lib/ui/use-menu-copy-feedback';
+import { useMenuCopyFeedback } from '@/lib/ui/use-menu-copy-feedback';
+import { CopyMenuItem } from '@/lib/ui/CopyMenuItem';
 import { writeToClipboard } from '@/lib/editor/copy-reference';
 import { toFileRef } from '@/lib/files/file-ref';
 
@@ -34,27 +34,6 @@ import { toFileRef } from '@/lib/files/file-ref';
  */
 function suppressRadixTrigger(event: React.MouseEvent): void {
   event.defaultPrevented = true;
-}
-
-function CopyPathItem({
-  testId,
-  label,
-  status,
-  onSelect,
-}: {
-  testId: string;
-  label: string;
-  status: CopyStatus;
-  onSelect: (event: Event) => void;
-}) {
-  return (
-    <ContextMenuItem data-testid={testId} onSelect={onSelect}>
-      {status === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
-      {status === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
-      {status === 'idle' && <Copy className="mr-2 size-3.5" />}
-      {status === 'copied' ? 'Copied' : status === 'failed' ? 'Copy failed' : label}
-    </ContextMenuItem>
-  );
 }
 
 export function MessagePathContextMenu({ children }: { children: ReactNode }) {
@@ -85,13 +64,13 @@ export function MessagePathContextMenu({ children }: { children: ReactNode }) {
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <CopyPathItem
+        <CopyMenuItem
           testId="tool-card-path-copy-absolute"
           label="Copy Absolute Path"
           status={statusFor('tool-card-path-copy-absolute')}
           onSelect={copyAbsolute}
         />
-        <CopyPathItem
+        <CopyMenuItem
           testId="tool-card-path-copy-relative"
           label="Copy Relative Path"
           status={statusFor('tool-card-path-copy-relative')}

--- a/packages/ui/src/features/chat/parts/ImageContextMenu.tsx
+++ b/packages/ui/src/features/chat/parts/ImageContextMenu.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * ImageContextMenu — right-click an opened image to copy the bitmap itself.
+ *
+ * Mounts nothing when the source or the host can't be served (`canCopyImage`):
+ * a one-item menu whose only item is dead is worse than no menu, and the
+ * right-click falls through to the webview's own menu exactly as before.
+ *
+ * The trigger gets no `onContextMenu` guard, unlike `link-with-preview.tsx`.
+ * This trigger nests inside `MessagePathContextMenu`, and React carries the
+ * synthetic event through the Dialog portal to it — but the inner trigger runs
+ * first and Radix's own handler ends with `preventDefault()`, which the outer
+ * trigger honors via `checkForDefaultPrevented`, so the outer menu never opens.
+ * The outer's own handler is inert here: it resolves paths through
+ * `closest('[data-file-path]')`, and the lightbox image's DOM ancestry is the
+ * portal on `document.body`, not the message.
+ */
+import type { ReactNode } from 'react';
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/context-menu';
+import { CopyMenuItem } from '@/lib/ui/CopyMenuItem';
+import { useMenuCopyFeedback } from '@/lib/ui/use-menu-copy-feedback';
+import { canCopyImage } from '@/lib/clipboard/image-source';
+import { copyImageToClipboard } from '@/lib/clipboard/copy-image';
+import { mfToast } from '@/lib/toast';
+
+interface ImageContextMenuProps {
+  src: string;
+  children: ReactNode;
+}
+
+export function ImageContextMenu({ src, children }: ImageContextMenuProps) {
+  const { statusFor, handleOpenChange, onCopySelect } = useMenuCopyFeedback();
+
+  if (!canCopyImage(src)) return <>{children}</>;
+
+  // No `await` before the call: WebKit only honors a clipboard write inside the
+  // click's user activation.
+  const handleCopy = async () => {
+    const result = await copyImageToClipboard(src);
+    if (!result.ok) mfToast.error('Could not copy the image', { description: result.message });
+    return result.ok;
+  };
+
+  return (
+    <ContextMenu onOpenChange={handleOpenChange}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent data-testid="image-context-menu" className="w-44">
+        <CopyMenuItem
+          testId="image-copy"
+          label="Copy Image"
+          status={statusFor('image-copy')}
+          onSelect={onCopySelect('image-copy', handleCopy)}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/packages/ui/src/features/chat/parts/LightboxSurface.tsx
+++ b/packages/ui/src/features/chat/parts/LightboxSurface.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, type MouseEvent, type ReactNode } from 'react';
 import { DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { ImageContextMenu } from './ImageContextMenu';
 
 interface LightboxSurfaceProps {
   testId: string;
@@ -29,13 +30,15 @@ export function LightboxSurface({ testId, imageTestId, src, alt = '', onDismiss,
       className="max-w-[92vw] border-none bg-transparent p-0 shadow-none"
     >
       <DialogTitle className="sr-only">Image preview</DialogTitle>
-      <img
-        ref={imageRef}
-        data-testid={imageTestId}
-        src={src}
-        alt={alt}
-        className="mx-auto max-h-[88vh] max-w-full rounded-md object-contain"
-      />
+      <ImageContextMenu src={src}>
+        <img
+          ref={imageRef}
+          data-testid={imageTestId}
+          src={src}
+          alt={alt}
+          className="mx-auto max-h-[88vh] max-w-full rounded-md object-contain"
+        />
+      </ImageContextMenu>
       {children}
     </DialogContent>
   );

--- a/packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx
+++ b/packages/ui/src/features/chat/parts/__tests__/ImageContextMenu.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * RED phase (Group `menu-tests`): `../ImageContextMenu` does not exist yet.
+ * Every case below fails on module resolution until Group `image-context-menu`
+ * adds it — that failure, and only that failure, is expected here.
+ *
+ * Mock strategy: the real `lib/clipboard/image-source` gate runs unmocked (a
+ * `beforeEach` installs `ClipboardItem` + `navigator.clipboard.write` so
+ * `canCopyImage` reports true for `data:image/*` sources); `copyImageToClipboard`
+ * and `mfToast` are mocked at the module boundary. Radix context menus open on
+ * `fireEvent.contextMenu` per the shipped precedent (`SessionContextMenu.test.tsx`,
+ * `MessagePathContextMenu.test.tsx`), and the delayed-close timer is driven with
+ * fake timers the same way `MessagePathContextMenu.test.tsx` does.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ImageContextMenu } from '../ImageContextMenu';
+import { ZoomableImage } from '../ZoomableImage';
+import { ImageLightbox } from '../ImageLightbox';
+import { MessagePathContextMenu } from '../../messages/MessagePathContextMenu';
+import { useActiveBasesStore } from '@/store/active-bases-store';
+import { copyImageToClipboard } from '@/lib/clipboard/copy-image';
+import { mfToast } from '@/lib/toast';
+
+vi.mock('@/lib/clipboard/copy-image', () => ({ copyImageToClipboard: vi.fn() }));
+vi.mock('@/lib/toast', () => ({ mfToast: { error: vi.fn() } }));
+
+const PNG_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const HTTPS_SRC = 'https://example.com/photo.png';
+
+function Fixture({ src }: { src: string }) {
+  return (
+    <ImageContextMenu src={src}>
+      <img data-testid="fixture-image" src={src} alt="" />
+    </ImageContextMenu>
+  );
+}
+
+/** Lets the copy promise settle so the copy feedback lands. */
+async function flushCopy(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function stubClipboardSupport() {
+  vi.stubGlobal('ClipboardItem', class {});
+  Object.defineProperty(navigator, 'clipboard', { value: { write: vi.fn() }, configurable: true });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubClipboardSupport();
+  vi.mocked(copyImageToClipboard).mockReset();
+  vi.mocked(mfToast.error).mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ImageContextMenu — mounting the menu', () => {
+  it('opens image-context-menu with a Copy Image item for a copyable data URI on a supported host', () => {
+    render(<Fixture src={PNG_DATA_URI} />);
+
+    fireEvent.contextMenu(screen.getByTestId('fixture-image'));
+
+    const menu = screen.getByTestId('image-context-menu');
+    expect(menu).toBeInTheDocument();
+    expect(screen.getByTestId('image-copy').textContent).toContain('Copy Image');
+  });
+
+  it('mounts no menu for an unsupported https source, even though the host supports image-clipboard writes', () => {
+    render(<Fixture src={HTTPS_SRC} />);
+
+    fireEvent.contextMenu(screen.getByTestId('fixture-image'));
+
+    expect(screen.queryByTestId('image-context-menu')).toBeNull();
+    expect(screen.getByTestId('fixture-image')).toBeInTheDocument();
+  });
+
+  it('mounts no menu for a copyable data URI when the host has no ClipboardItem support', () => {
+    vi.unstubAllGlobals();
+    Object.defineProperty(navigator, 'clipboard', { value: { write: vi.fn() }, configurable: true });
+
+    render(<Fixture src={PNG_DATA_URI} />);
+    fireEvent.contextMenu(screen.getByTestId('fixture-image'));
+
+    expect(screen.queryByTestId('image-context-menu')).toBeNull();
+    expect(screen.getByTestId('fixture-image')).toBeInTheDocument();
+  });
+});
+
+describe('ImageContextMenu — copy outcome', () => {
+  it('calls copyImageToClipboard synchronously with the click, then reports Copied with no error toast', async () => {
+    vi.mocked(copyImageToClipboard).mockResolvedValue({ ok: true });
+    render(<Fixture src={PNG_DATA_URI} />);
+    fireEvent.contextMenu(screen.getByTestId('fixture-image'));
+
+    fireEvent.click(screen.getByTestId('image-copy'));
+
+    // D4 user-activation: the call must precede any await/waitFor.
+    expect(copyImageToClipboard).toHaveBeenCalledTimes(1);
+    expect(copyImageToClipboard).toHaveBeenCalledWith(PNG_DATA_URI);
+
+    await flushCopy();
+
+    expect(screen.getByTestId('image-copy').textContent).toContain('Copied');
+    expect(mfToast.error).not.toHaveBeenCalled();
+  });
+
+  it('reports Copy failed and raises mfToast.error carrying the failure reason', async () => {
+    vi.mocked(copyImageToClipboard).mockResolvedValue({ ok: false, message: 'boom' });
+    render(<Fixture src={PNG_DATA_URI} />);
+    fireEvent.contextMenu(screen.getByTestId('fixture-image'));
+
+    fireEvent.click(screen.getByTestId('image-copy'));
+    await flushCopy();
+
+    expect(screen.getByTestId('image-copy').textContent).toContain('Copy failed');
+    expect(mfToast.error).toHaveBeenCalledTimes(1);
+    expect(mfToast.error).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ description: 'boom' }));
+  });
+});
+
+describe('ImageContextMenu — both LightboxSurface render paths', () => {
+  it('appears on the assistant image-part path (ZoomableImage → LightboxSurface)', async () => {
+    render(<ZoomableImage src={PNG_DATA_URI} />);
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    await screen.findByTestId('chat-image-zoom-dialog');
+
+    fireEvent.contextMenu(screen.getByTestId('chat-image-zoom-image'));
+
+    expect(screen.getByTestId('image-context-menu')).toBeInTheDocument();
+  });
+
+  it('appears on the user-gallery path (ImageLightbox → LightboxSurface)', () => {
+    render(<ImageLightbox images={[{ src: PNG_DATA_URI }]} index={0} onIndexChange={vi.fn()} />);
+
+    fireEvent.contextMenu(screen.getByTestId('image-lightbox-current'));
+
+    expect(screen.getByTestId('image-context-menu')).toBeInTheDocument();
+  });
+});
+
+describe('ImageContextMenu — nested inside MessagePathContextMenu', () => {
+  beforeEach(() => {
+    useActiveBasesStore.setState({ bases: { worktreePath: '/w', projectPath: '/p' }, scopeKey: null });
+    vi.spyOn(window, 'getSelection').mockReturnValue({ toString: () => '' } as unknown as Selection);
+  });
+
+  it('opens only the image menu, never the outer message-path menu, on the lightbox image', async () => {
+    render(
+      <MessagePathContextMenu>
+        <ZoomableImage src={PNG_DATA_URI} />
+      </MessagePathContextMenu>,
+    );
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    await screen.findByTestId('chat-image-zoom-dialog');
+
+    fireEvent.contextMenu(screen.getByTestId('chat-image-zoom-image'));
+
+    expect(screen.getByTestId('image-context-menu')).toBeInTheDocument();
+    expect(screen.queryByTestId('tool-card-path-copy-absolute')).toBeNull();
+  });
+});
+
+describe('ImageContextMenu — dismissal does not reach the lightbox', () => {
+  async function openDialogAndMenu() {
+    render(<ZoomableImage src={PNG_DATA_URI} />);
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    await screen.findByTestId('chat-image-zoom-dialog');
+    fireEvent.contextMenu(screen.getByTestId('chat-image-zoom-image'));
+    await screen.findByTestId('image-context-menu');
+  }
+
+  it('Escape closes only the menu; the lightbox dialog stays open, and a later plain click still dismisses it', async () => {
+    await openDialogAndMenu();
+
+    fireEvent.keyDown(screen.getByTestId('image-context-menu'), { key: 'Escape' });
+    expect(screen.queryByTestId('image-context-menu')).toBeNull();
+    expect(screen.getByTestId('chat-image-zoom-dialog')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-image'));
+    expect(screen.queryByTestId('chat-image-zoom-dialog')).toBeNull();
+  });
+
+  it('an outside pointerdown that closes the menu does not close the lightbox', async () => {
+    await openDialogAndMenu();
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByTestId('image-context-menu')).toBeNull();
+    expect(screen.getByTestId('chat-image-zoom-dialog')).toBeInTheDocument();
+  });
+
+  it('a copy that settles after the menu was dismissed does not close the lightbox (D13)', async () => {
+    let resolveCopy: (outcome: { ok: boolean }) => void = () => undefined;
+    vi.mocked(copyImageToClipboard).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCopy = resolve;
+      }),
+    );
+    await openDialogAndMenu();
+
+    fireEvent.click(screen.getByTestId('image-copy'));
+    fireEvent.keyDown(screen.getByTestId('image-context-menu'), { key: 'Escape' });
+    expect(screen.queryByTestId('image-context-menu')).toBeNull();
+
+    resolveCopy({ ok: true });
+    await flushCopy();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByTestId('chat-image-zoom-dialog')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/features/chat/parts/link-with-preview.tsx
+++ b/packages/ui/src/features/chat/parts/link-with-preview.tsx
@@ -7,12 +7,12 @@
  * the whole component map.
  */
 import React, { useCallback, useState } from 'react';
-import { AlertTriangle, Check, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from '@/components/ui/context-menu';
 import { useHost } from '@/lib/host';
 import { useMenuCopyFeedback } from '@/lib/ui/use-menu-copy-feedback';
+import { CopyMenuItem } from '@/lib/ui/CopyMenuItem';
 import { writeToClipboard } from '@/lib/editor/copy-reference';
 
 /**
@@ -87,12 +87,7 @@ export function LinkWithPreview({
           </ContextMenuTrigger>
         </TooltipTrigger>
         <ContextMenuContent>
-          <ContextMenuItem data-testid="chat-link-copy" onSelect={handleMenuCopy}>
-            {menuStatus === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
-            {menuStatus === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
-            {menuStatus === 'idle' && <Copy className="mr-2 size-3.5" />}
-            {menuStatus === 'copied' ? 'Copied' : menuStatus === 'failed' ? 'Copy failed' : 'Copy link'}
-          </ContextMenuItem>
+          <CopyMenuItem testId="chat-link-copy" label="Copy link" status={menuStatus} onSelect={handleMenuCopy} />
           <ContextMenuItem data-testid="chat-link-open" onClick={handleOpen}>
             Open link
           </ContextMenuItem>

--- a/packages/ui/src/features/viewers/__tests__/ImageViewer.contextMenu.test.tsx
+++ b/packages/ui/src/features/viewers/__tests__/ImageViewer.contextMenu.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * ImageViewer's context-menu reachability — the Files-surface mount point.
+ *
+ * `ImageViewer.test.tsx` mocks `ZoomableImage` away for its own rendering
+ * contract, so it never proves the real `ZoomableImage → LightboxSurface →
+ * ImageContextMenu` chain reaches the Files surface. This suite renders the
+ * real `ZoomableImage` (no mock) and asserts the menu opens, closing the gap
+ * without pulling the Radix dialog into the mocked regression suite.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImageViewer } from '../ImageViewer';
+
+vi.mock('@/store/surface-intents', () => ({
+  emitSurfaceIntent: vi.fn(),
+}));
+
+const PNG_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+beforeEach(() => {
+  vi.stubGlobal('ClipboardItem', class {});
+  Object.defineProperty(navigator, 'clipboard', { value: { write: vi.fn() }, configurable: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ImageViewer — image context menu reachability (Files surface)', () => {
+  it('opens the image context menu on the opened image', async () => {
+    render(<ImageViewer src={PNG_DATA_URI} path="/a/b/test.png" />);
+
+    fireEvent.click(screen.getByTestId('chat-image-zoom-trigger'));
+    await screen.findByTestId('chat-image-zoom-dialog');
+
+    fireEvent.contextMenu(screen.getByTestId('chat-image-zoom-image'));
+
+    expect(screen.getByTestId('image-context-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('image-copy').textContent).toContain('Copy Image');
+  });
+});

--- a/packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts
+++ b/packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts
@@ -21,6 +21,9 @@ describe('copyImageToClipboard', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // `restoreAllMocks` restores spies but leaves a vi.mock'ed module fn's call
+    // history, which the synchronous-call count below reads.
+    mockedWrite.mockReset();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 

--- a/packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts
+++ b/packages/ui/src/lib/clipboard/__tests__/copy-image.test.ts
@@ -1,0 +1,79 @@
+/**
+ * RED phase (Group `clipboard-core-tests`): `../copy-image` does not exist
+ * yet. Every case below fails on module resolution until Group `clipboard-lib`
+ * adds it — that failure, and only that failure, is expected here.
+ *
+ * `../write-image` is mocked; per D11 `copy-image.ts` does no host/source-kind
+ * checking of its own (that gate is `canCopyImage`'s), so no DOM is needed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { copyImageToClipboard } from '../copy-image';
+import { writeImageToClipboard } from '../write-image';
+
+vi.mock('../write-image');
+
+const PNG_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const mockedWrite = vi.mocked(writeImageToClipboard);
+
+describe('copyImageToClipboard', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves { ok: true } and forwards src unchanged as the only argument', async () => {
+    mockedWrite.mockResolvedValue(undefined);
+
+    const result = await copyImageToClipboard(PNG_DATA_URI);
+
+    expect(mockedWrite.mock.calls[0]).toEqual([PNG_DATA_URI]);
+    expect(mockedWrite).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('calls writeImageToClipboard synchronously, before the returned promise settles', () => {
+    mockedWrite.mockResolvedValue(undefined);
+
+    const promise = copyImageToClipboard(PNG_DATA_URI);
+
+    expect(mockedWrite).toHaveBeenCalledTimes(1);
+    return promise;
+  });
+
+  it('turns a synchronous throw into a failure result and logs one tagged warning', async () => {
+    mockedWrite.mockImplementation(() => {
+      throw new Error('bad source');
+    });
+
+    const result = await copyImageToClipboard(PNG_DATA_URI);
+
+    expect(result).toEqual({ ok: false, message: 'bad source' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain('[copy-image]');
+  });
+
+  it('turns a rejection into a failure result and logs one tagged warning', async () => {
+    mockedWrite.mockRejectedValue(new Error('boom'));
+
+    const result = await copyImageToClipboard(PNG_DATA_URI);
+
+    expect(result).toEqual({ ok: false, message: 'boom' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('produces a non-empty message for a non-Error rejection', async () => {
+    mockedWrite.mockRejectedValue('nope');
+
+    const result = await copyImageToClipboard(PNG_DATA_URI);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toBeTruthy();
+  });
+});

--- a/packages/ui/src/lib/clipboard/__tests__/image-source.test.ts
+++ b/packages/ui/src/lib/clipboard/__tests__/image-source.test.ts
@@ -1,0 +1,107 @@
+/**
+ * RED phase (Group `clipboard-core-tests`): `../image-source` does not exist
+ * yet. Every case below fails on module resolution until Group `clipboard-lib`
+ * adds it — that failure, and only that failure, is expected here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { canCopyImage, decodeDataUrl, imageClipboardSupported } from '../image-source';
+
+const PNG_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+const PNG_BYTE_LENGTH = 70;
+const JPEG_DATA_URI = 'data:image/jpeg;base64,AAAA';
+
+describe('decodeDataUrl', () => {
+  it('decodes a PNG data URI to its media type and raw bytes', () => {
+    const decoded = decodeDataUrl(PNG_DATA_URI);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.mediaType).toBe('image/png');
+    expect(Array.from(decoded!.bytes.slice(0, 8))).toEqual(PNG_SIGNATURE);
+    expect(decoded!.bytes.length).toBe(PNG_BYTE_LENGTH);
+  });
+
+  it('returns null for a non-base64 data URI', () => {
+    expect(decodeDataUrl('data:image/svg+xml,<svg/>')).toBeNull();
+  });
+
+  it('returns null for a non-image data URI', () => {
+    expect(decodeDataUrl('data:text/plain;base64,aGVsbG8=')).toBeNull();
+  });
+
+  it('returns null for malformed base64', () => {
+    expect(decodeDataUrl('data:image/png;base64,!!!')).toBeNull();
+  });
+});
+
+describe('imageClipboardSupported', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is false when ClipboardItem is not defined', () => {
+    vi.stubGlobal('navigator', { clipboard: { write: vi.fn() } });
+
+    expect(imageClipboardSupported()).toBe(false);
+  });
+
+  it('is false when ClipboardItem exists but navigator.clipboard.write does not', () => {
+    vi.stubGlobal('ClipboardItem', class {});
+    vi.stubGlobal('navigator', { clipboard: {} });
+
+    expect(imageClipboardSupported()).toBe(false);
+  });
+
+  it('is true when both ClipboardItem and navigator.clipboard.write exist', () => {
+    vi.stubGlobal('ClipboardItem', class {});
+    vi.stubGlobal('navigator', { clipboard: { write: vi.fn() } });
+
+    expect(imageClipboardSupported()).toBe(true);
+  });
+});
+
+describe('canCopyImage', () => {
+  const COPYABLE_SOURCES: Array<[string, string]> = [
+    ['data:image/png', PNG_DATA_URI],
+    ['data:image/jpeg', JPEG_DATA_URI],
+  ];
+  const NOT_COPYABLE_SOURCES: Array<[string, string]> = [
+    ['http', 'http://example.com/image.png'],
+    ['https', 'https://example.com/image.png'],
+    ['file', 'file:///Users/x/image.png'],
+    ['blob', 'blob:https://example.com/1234-uuid'],
+    ['asset', 'asset://localhost/image.png'],
+    ['empty string', ''],
+    ['non-image data URI', 'data:text/plain;base64,aGVsbG8='],
+  ];
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('when the host has no image-clipboard support', () => {
+    beforeEach(() => {
+      vi.stubGlobal('navigator', { clipboard: {} });
+    });
+
+    it.each([...COPYABLE_SOURCES, ...NOT_COPYABLE_SOURCES])('%s is not copyable: %s', (_label, src) => {
+      expect(canCopyImage(src)).toBe(false);
+    });
+  });
+
+  describe('when the host supports image-clipboard writes', () => {
+    beforeEach(() => {
+      vi.stubGlobal('ClipboardItem', class {});
+      vi.stubGlobal('navigator', { clipboard: { write: vi.fn() } });
+    });
+
+    it.each(COPYABLE_SOURCES)('%s is copyable', (_label, src) => {
+      expect(canCopyImage(src)).toBe(true);
+    });
+
+    it.each(NOT_COPYABLE_SOURCES)('%s is not copyable', (_label, src) => {
+      expect(canCopyImage(src)).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/lib/clipboard/__tests__/write-image.test.ts
+++ b/packages/ui/src/lib/clipboard/__tests__/write-image.test.ts
@@ -24,7 +24,7 @@ class FakeClipboardItem {
 
 async function copiedBlob(write: ReturnType<typeof vi.fn>): Promise<Blob> {
   const item = write.mock.calls[0]![0][0] as FakeClipboardItem;
-  return item.values['image/png'];
+  return item.values['image/png']!;
 }
 
 describe('writeImageToClipboard', () => {

--- a/packages/ui/src/lib/clipboard/__tests__/write-image.test.ts
+++ b/packages/ui/src/lib/clipboard/__tests__/write-image.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+/**
+ * RED phase (Group `clipboard-core-tests`): `../write-image` does not exist
+ * yet. Every case below fails on module resolution until Group `clipboard-lib`
+ * adds it — that failure, and only that failure, is expected here.
+ *
+ * `write` adopts the ClipboardItem's `image/png` value (rather than ignoring
+ * it) so a rejecting re-encode surfaces through the promise
+ * `writeImageToClipboard` returns instead of orphaning as an unhandled
+ * rejection — see plan Task 2.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writeImageToClipboard } from '../write-image';
+
+const PNG_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+const PNG_BYTE_LENGTH = 70;
+const JPEG_DATA_URI = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/';
+const BAD_PNG_DATA_URI = 'data:image/png;base64,!!!';
+
+class FakeClipboardItem {
+  constructor(readonly values: Record<string, Blob | Promise<Blob>>) {}
+}
+
+async function copiedBlob(write: ReturnType<typeof vi.fn>): Promise<Blob> {
+  const item = write.mock.calls[0]![0][0] as FakeClipboardItem;
+  return item.values['image/png'];
+}
+
+describe('writeImageToClipboard', () => {
+  let write: ReturnType<typeof vi.fn>;
+  let seenSrc: string;
+
+  beforeEach(() => {
+    seenSrc = '';
+    write = vi.fn(async (items: FakeClipboardItem[]) => {
+      await items[0]!.values['image/png'];
+    });
+    vi.stubGlobal('ClipboardItem', FakeClipboardItem);
+    vi.stubGlobal('navigator', { clipboard: { write } });
+
+    HTMLImageElement.prototype.decode = vi.fn(function (this: HTMLImageElement) {
+      seenSrc = this.src;
+      return Promise.resolve();
+    });
+    vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(2);
+    vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(HTMLImageElement.prototype, 'decode');
+  });
+
+  it('writes decoded PNG bytes directly, without touching the canvas', async () => {
+    const createElementSpy = vi.spyOn(document, 'createElement');
+
+    await writeImageToClipboard(PNG_DATA_URI);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    const blob = await copiedBlob(write);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/png');
+    expect(blob.size).toBe(PNG_BYTE_LENGTH);
+    expect(createElementSpy).not.toHaveBeenCalledWith('canvas');
+  });
+
+  it('calls navigator.clipboard.write synchronously, before the returned promise settles', () => {
+    const promise = writeImageToClipboard(PNG_DATA_URI);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    return promise;
+  });
+
+  it('re-encodes a non-PNG source through a canvas and still writes synchronously', async () => {
+    const drawImage = vi.fn();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => ({ drawImage }) as unknown as CanvasRenderingContext2D,
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb: BlobCallback) =>
+      cb(new Blob(['fake-png-bytes'], { type: 'image/png' })),
+    );
+    const atobSpy = vi.spyOn(globalThis, 'atob');
+
+    const promise = writeImageToClipboard(JPEG_DATA_URI);
+    expect(write).toHaveBeenCalledTimes(1);
+    await promise;
+
+    const blob = await copiedBlob(write);
+    expect(blob.type).toBe('image/png');
+    expect(seenSrc).toBe(JPEG_DATA_URI);
+    expect(drawImage).toHaveBeenCalledTimes(1);
+    expect(atobSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the image fails to decode', async () => {
+    HTMLImageElement.prototype.decode = vi.fn(() => Promise.reject(new Error('decode failed')));
+
+    await expect(writeImageToClipboard(JPEG_DATA_URI)).rejects.toThrow('decode failed');
+  });
+
+  it('rejects when the canvas has no 2d context', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+
+    await expect(writeImageToClipboard(JPEG_DATA_URI)).rejects.toThrow();
+  });
+
+  it('rejects when the canvas cannot produce a blob', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => ({ drawImage: vi.fn() }) as unknown as CanvasRenderingContext2D,
+    );
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb: BlobCallback) => cb(null));
+
+    await expect(writeImageToClipboard(JPEG_DATA_URI)).rejects.toThrow();
+  });
+
+  it('throws synchronously for a malformed PNG source, without calling navigator.clipboard.write', () => {
+    expect(() => writeImageToClipboard(BAD_PNG_DATA_URI)).toThrow(/.+/);
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/lib/clipboard/copy-image.ts
+++ b/packages/ui/src/lib/clipboard/copy-image.ts
@@ -1,0 +1,30 @@
+import { writeImageToClipboard } from './write-image';
+
+/** `message` is present only on failure, and only when a reason is worth showing. */
+export interface CopyImageOutcome {
+  ok: boolean;
+  message?: string;
+}
+
+/**
+ * Copies `src` to the system clipboard. Assumes `canCopyImage(src)` already
+ * gated the call (D11) — this module does no host or source-kind checking of
+ * its own.
+ *
+ * Not `async`, and deliberately `.then(...)` rather than `await`:
+ * `writeImageToClipboard` must run inside the click's user activation, and an
+ * `await` here would end it before the call happens.
+ */
+export function copyImageToClipboard(src: string): Promise<CopyImageOutcome> {
+  try {
+    return writeImageToClipboard(src).then(() => ({ ok: true }), onErr);
+  } catch (err) {
+    return Promise.resolve(onErr(err));
+  }
+}
+
+function onErr(err: unknown): CopyImageOutcome {
+  console.warn('[copy-image] copy failed', err);
+  const message = err instanceof Error && err.message ? err.message : 'The clipboard refused the image.';
+  return { ok: false, message };
+}

--- a/packages/ui/src/lib/clipboard/image-source.ts
+++ b/packages/ui/src/lib/clipboard/image-source.ts
@@ -1,0 +1,43 @@
+/**
+ * image-source — decode `data:image/*` URIs and gate which sources this
+ * host can copy to the clipboard. Pure; no clipboard or canvas writes here.
+ */
+
+const COPYABLE_SRC = /^data:image\/[a-zA-Z0-9.+-]+;base64,/;
+
+export interface DecodedDataUrl {
+  mediaType: string;
+  bytes: Uint8Array<ArrayBuffer>;
+}
+
+/** Decodes a `data:image/*;base64,...` URI; `null` for anything it can't parse. */
+export function decodeDataUrl(src: string): DecodedDataUrl | null {
+  const match = COPYABLE_SRC.exec(src);
+  if (!match) return null;
+
+  const comma = src.indexOf(',');
+  const base64 = src.slice(comma + 1);
+  const mediaType = src.slice('data:'.length, src.indexOf(';'));
+
+  try {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return { mediaType, bytes };
+  } catch {
+    // Malformed base64 is data, not a fault — the caller treats null as "not copyable".
+    return null;
+  }
+}
+
+/** Whether this webview exposes the async Clipboard API's image write. */
+export function imageClipboardSupported(): boolean {
+  return typeof ClipboardItem !== 'undefined' && typeof navigator?.clipboard?.write === 'function';
+}
+
+/** The single gate: `src` is a copyable data URI AND the host can write images. */
+export function canCopyImage(src: string): boolean {
+  return COPYABLE_SRC.test(src) && imageClipboardSupported();
+}

--- a/packages/ui/src/lib/clipboard/write-image.ts
+++ b/packages/ui/src/lib/clipboard/write-image.ts
@@ -1,0 +1,59 @@
+import { decodeDataUrl } from './image-source';
+
+/**
+ * Writes a `data:image/*` URI to the system clipboard as PNG bytes.
+ *
+ * Not `async`: WebKit requires `navigator.clipboard.write` to run inside the
+ * user activation of the click that triggered it, and an `await` before the
+ * call would end that activation. The PNG branch decodes and constructs the
+ * blob synchronously; a non-PNG source is re-encoded through a canvas, whose
+ * promise rides inside the `ClipboardItem` value instead of being awaited here.
+ *
+ * @throws synchronously when `src` is a malformed `image/png` data URI —
+ * before any clipboard call, so a bad source never touches the clipboard.
+ */
+export function writeImageToClipboard(src: string): Promise<void> {
+  const png = src.startsWith('data:image/png;base64,') ? Promise.resolve(pngBlobFromDataUrl(src)) : reencodeToPng(src);
+  return navigator.clipboard.write([new ClipboardItem({ 'image/png': png })]);
+}
+
+function pngBlobFromDataUrl(src: string): Blob {
+  const decoded = decodeDataUrl(src);
+  if (!decoded) throw new Error('That image could not be decoded.');
+  return new Blob([decoded.bytes], { type: 'image/png' });
+}
+
+async function reencodeToPng(src: string): Promise<Blob> {
+  const img = new Image();
+  img.src = src;
+  await img.decode();
+
+  const canvas = drawToCanvas(img);
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('The image could not be re-encoded as PNG.'));
+        return;
+      }
+      resolve(blob);
+    }, 'image/png');
+  });
+}
+
+function drawToCanvas(img: HTMLImageElement): HTMLCanvasElement {
+  const { naturalWidth, naturalHeight } = img;
+  if (!naturalWidth || !naturalHeight) {
+    throw new Error('The image has no dimensions to copy.');
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = naturalWidth;
+  canvas.height = naturalHeight;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('This browser has no 2D canvas context.');
+  }
+  ctx.drawImage(img, 0, 0);
+  return canvas;
+}

--- a/packages/ui/src/lib/ui/CopyMenuItem.tsx
+++ b/packages/ui/src/lib/ui/CopyMenuItem.tsx
@@ -1,0 +1,31 @@
+/**
+ * A ContextMenu copy item that reports its own outcome in place: the label
+ * becomes "Copied" or "Copy failed" for as long as `useMenuCopyFeedback` keeps
+ * the menu open, so a copy never confirms a write that did not land.
+ *
+ * Lives beside the hook that owns `CopyStatus`, because every copy menu in the
+ * app pairs the two — the message path menu, the markdown link menu, and the
+ * image menu would otherwise carry three copies of this markup.
+ */
+import { AlertTriangle, Check, Copy } from 'lucide-react';
+import { ContextMenuItem } from '@/components/ui/context-menu';
+import type { CopyStatus } from '@/lib/ui/use-menu-copy-feedback';
+
+export interface CopyMenuItemProps {
+  testId: string;
+  /** Shown while idle; the settled states replace it. */
+  label: string;
+  status: CopyStatus;
+  onSelect: (event: Event) => void;
+}
+
+export function CopyMenuItem({ testId, label, status, onSelect }: CopyMenuItemProps) {
+  return (
+    <ContextMenuItem data-testid={testId} onSelect={onSelect}>
+      {status === 'copied' && <Check className="mr-2 size-3.5 text-mf-success" />}
+      {status === 'failed' && <AlertTriangle className="mr-2 size-3.5 text-destructive" />}
+      {status === 'idle' && <Copy className="mr-2 size-3.5" />}
+      {status === 'copied' ? 'Copied' : status === 'failed' ? 'Copy failed' : label}
+    </ContextMenuItem>
+  );
+}

--- a/packages/ui/src/lib/ui/__tests__/use-menu-copy-feedback.test.tsx
+++ b/packages/ui/src/lib/ui/__tests__/use-menu-copy-feedback.test.tsx
@@ -171,4 +171,75 @@ describe('useMenuCopyFeedback', () => {
     );
     expect(escapeCalls).toHaveLength(0);
   });
+
+  it('ignores a successful settle that lands after the menu was already closed', async () => {
+    const dispatchSpy = vi.spyOn(document, 'dispatchEvent');
+    let settle: ((value: boolean) => void) | undefined;
+    const pending: Run = () => new Promise<boolean>((resolve) => (settle = resolve));
+    render(<Harness runA={pending} runB={ok} />);
+
+    fireEvent.click(screen.getByTestId('item-a'));
+    await flush();
+    fireEvent.click(screen.getByTestId('close-menu'));
+
+    dispatchSpy.mockClear();
+    await act(async () => {
+      settle?.(true);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    const escapeCalls = dispatchSpy.mock.calls.filter(
+      ([event]) => event instanceof KeyboardEvent && event.key === 'Escape',
+    );
+    expect(escapeCalls).toHaveLength(0);
+    expect(screen.getByTestId('item-a').textContent).toBe('Copy A');
+  });
+
+  it('ignores a failed settle that lands after the menu was already closed', async () => {
+    const dispatchSpy = vi.spyOn(document, 'dispatchEvent');
+    let settle: ((value: boolean) => void) | undefined;
+    const pending: Run = () => new Promise<boolean>((resolve) => (settle = resolve));
+    render(<Harness runA={pending} runB={ok} />);
+
+    fireEvent.click(screen.getByTestId('item-a'));
+    await flush();
+    fireEvent.click(screen.getByTestId('close-menu'));
+
+    dispatchSpy.mockClear();
+    await act(async () => {
+      settle?.(false);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    const escapeCalls = dispatchSpy.mock.calls.filter(
+      ([event]) => event instanceof KeyboardEvent && event.key === 'Escape',
+    );
+    expect(escapeCalls).toHaveLength(0);
+    expect(screen.getByTestId('item-a').textContent).toBe('Copy A');
+  });
+
+  it('still reports a copy started after the menu was closed', async () => {
+    const dispatchSpy = vi.spyOn(document, 'dispatchEvent');
+    render(<Harness runA={ok} runB={ok} />);
+
+    fireEvent.click(screen.getByTestId('close-menu'));
+    dispatchSpy.mockClear();
+
+    fireEvent.click(screen.getByTestId('item-a'));
+    await flush();
+
+    expect(screen.getByTestId('item-a').textContent).toBe('Copied');
+
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    const escapeCalls = dispatchSpy.mock.calls.filter(
+      ([event]) => event instanceof KeyboardEvent && event.key === 'Escape' && event.bubbles,
+    );
+    expect(escapeCalls).toHaveLength(1);
+  });
 });

--- a/packages/ui/src/lib/ui/use-menu-copy-feedback.ts
+++ b/packages/ui/src/lib/ui/use-menu-copy-feedback.ts
@@ -13,6 +13,10 @@
  *
  * Extracted from LinkWithPreview (markdown-text.tsx) so the message path
  * menu (MessagePathContextMenu) doesn't paste the mechanism a second time.
+ *
+ * A generation token drops settlements that land after the menu closed: the
+ * Escape they would schedule fires with the menu gone, and inside a Dialog the
+ * Dialog is then the topmost dismissable layer and closes instead.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -30,6 +34,7 @@ export function useMenuCopyFeedback(delayMs = 900): UseMenuCopyFeedback {
   const [settled, setSettled] = useState<{ id: string; ok: boolean } | null>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const mountedRef = useRef(true);
+  const generationRef = useRef(0);
 
   const closeMenu = useCallback(() => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -37,6 +42,7 @@ export function useMenuCopyFeedback(delayMs = 900): UseMenuCopyFeedback {
 
   const handleOpenChange = useCallback((open: boolean) => {
     if (!open) {
+      generationRef.current += 1;
       clearTimeout(closeTimeoutRef.current);
       setSettled(null);
     }
@@ -53,8 +59,9 @@ export function useMenuCopyFeedback(delayMs = 900): UseMenuCopyFeedback {
   const onCopySelect = useCallback(
     (id: string, run: () => Promise<boolean>) => (event: Event) => {
       event.preventDefault();
+      const generation = generationRef.current;
       void run().then((ok) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || generation !== generationRef.current) return;
         setSettled({ id, ok });
         clearTimeout(closeTimeoutRef.current);
         closeTimeoutRef.current = setTimeout(closeMenu, delayMs);


### PR DESCRIPTION
## Summary
Right-clicking an opened image now offers Copy Image, writing the bitmap to the system clipboard.

## Artifact links
None.

## Review
Verdict: APPROVED in an earlier run of this lane, carried over on re-entry and not re-run.

## QA
7/7

## Decisions
[plan] Carried over from the prior run of this lane, not re-run here. Lane re-entered at "qa" on operator instruction because the previous QA was blocked by its environment, not by the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)