### PR TITLE
fix: provision the daemon sidecar on tauri:dev

### DIFF
--- a/.agents/launch-test-tauri.sh
+++ b/.agents/launch-test-tauri.sh
@@ -10,18 +10,23 @@ cd "$PROJECT_ROOT"
 export DAEMON_PORT="${DAEMON_PORT:-31500}"
 export MAINFRAME_DATA_DIR="${MAINFRAME_DATA_DIR:-$HOME/.mainframe_dev}"
 VITE_PORT="${VITE_PORT:-5174}"
-LOG="/tmp/mf-tauri-dev-${DAEMON_PORT}.log"
 
-# Guard: never let the embedded daemon race the production port.
+# Never let the embedded daemon race the production port. A caller asking for
+# 31415 has almost always inherited it from an ambient env rather than meaning
+# it, so fall back instead of refusing — refusing turns a polluted shell into a
+# blocked QA run.
 if [ "$DAEMON_PORT" = "31415" ]; then
-  echo "REFUSED: DAEMON_PORT=31415 is the production daemon" >&2
-  exit 2
+  echo "WARNING: DAEMON_PORT=31415 is the production daemon — using 31500 instead" >&2
+  export DAEMON_PORT=31500
 fi
+
+LOG="/tmp/mf-tauri-dev-${DAEMON_PORT}.log"
 
 # Fresh-worktree provisioning (idempotent). --frozen-lockfile is load-bearing:
 # a plain install re-resolves the workspace, and in a worktree the
 # `packages/mobile` submodule isn't populated, so pnpm strips it from the
 # lockfile. Frozen installs fine without it and never writes the file.
+# The daemon sidecar is provisioned by `tauri:dev` itself, not here.
 pnpm install --frozen-lockfile
 cd packages/app-tauri
 

--- a/.agents/test-worktree.md
+++ b/.agents/test-worktree.md
@@ -18,12 +18,13 @@ pick one per run (user's ask → diff paths → default).
 - Engine: `tauri-mcp` (the WKWebView has no CDP). Dev builds compile the
   bridge in (`pnpm tauri:dev` → `cargo tauri dev --features mcp-bridge`).
 - Launch: `script: .agents/launch-test-tauri.sh` — run it EXACTLY ONCE. It
-  owns fresh-worktree provisioning (provision:node / bundle:daemon), the
-  isolated env (`DAEMON_PORT=31500`, `MAINFRAME_DATA_DIR=~/.mainframe_dev`;
-  refuses 31415), the background `tauri:dev` (first run compiles Rust, up to
-  10 min), and the readiness wait. It blocks until ready and prints `READY` +
-  facts (ports, APP_URL, LOG), or exits 1 with the log tail — do not
-  re-launch on failure, read the printed tail.
+  owns the workspace install, the isolated env (`DAEMON_PORT=31500`,
+  `MAINFRAME_DATA_DIR=~/.mainframe_dev`; an inherited 31415 falls back to
+  31500 with a warning), the background `tauri:dev` (first run compiles Rust
+  and provisions the daemon sidecar, up to 10 min), and the readiness wait. It
+  blocks until ready and prints `READY` + facts (ports, APP_URL, LOG), or
+  exits 1 with the log tail — do not re-launch on failure, read the printed
+  tail.
 - After READY: confirm the app appears in the bridge's `list_devices`.
 - Diff paths: `packages/app-tauri/`, `packages/ui/`.
 - Bridge quirks (verified 2026-07-09): selector-based tools

--- a/.changeset/tauri-dev-provisions-sidecar.md
+++ b/.changeset/tauri-dev-provisions-sidecar.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+`pnpm tauri:dev` now provisions the daemon sidecar when it is missing, so a checkout that has never built one starts instead of failing in `build.rs` with an unexplained missing-resource panic.

--- a/packages/app-tauri/scripts/tauri-dev.mjs
+++ b/packages/app-tauri/scripts/tauri-dev.mjs
@@ -1,5 +1,6 @@
 /**
- * `tauri dev` wrapper — threads VITE_PORT into Tauri's devUrl.
+ * `tauri dev` wrapper — provisions the daemon sidecar, then threads VITE_PORT
+ * into Tauri's devUrl.
  *
  * tauri.conf.json's `build.devUrl` is static (http://localhost:5174), but the dev
  * launch configs (and per-worktree port allocation) may run the ui Vite on a
@@ -9,6 +10,40 @@
  * static config. The dev overlay file (withGlobalTauri) is still merged first.
  */
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * `externalBin` is resolved by src-tauri's build script, so a checkout that has
+ * never provisioned the sidecar fails `tauri dev` at a build.rs panic ("resource
+ * path binaries/mainframe-daemon-<triple> doesn't exist") — which reads as a Rust
+ * compile error rather than a missing artifact. Every fresh worktree is in that
+ * state, so provision on absence.
+ *
+ * The cargo build this triggers is not extra work: dev resolves the daemon from
+ * packages/core-rs/target/{release,debug} (resolve_rust_daemon_bin), so a fresh
+ * worktree needs that build to reach Connected either way. On absence only,
+ * though — dev never runs this copy, so refreshing it each launch would buy
+ * nothing. Run `pnpm bundle` to refresh it deliberately.
+ */
+function provisionSidecarIfMissing() {
+  const triple = execFileSync('rustc', ['-vV'], { encoding: 'utf8' })
+    .split('\n')
+    .find((l) => l.startsWith('host:'))
+    ?.slice('host:'.length)
+    .trim();
+  if (!triple) throw new Error('could not read the host triple from `rustc -vV`');
+
+  if (existsSync(join(here, '..', 'src-tauri', 'binaries', `mainframe-daemon-${triple}`))) return;
+
+  console.log(`[tauri:dev] no daemon sidecar for ${triple} — provisioning (first build is slow)…`);
+  execFileSync('node', [join(here, 'provision-rust-daemon.mjs')], { stdio: 'inherit' });
+}
+
+provisionSidecarIfMissing();
 
 const port = process.env.VITE_PORT ?? '5174';
 const devUrl = `http://localhost:${port}`;


### PR DESCRIPTION
## Problem

`src-tauri/tauri.conf.json` declares `externalBin: ["binaries/mainframe-daemon"]`, and src-tauri's build script resolves that path at compile time. A checkout that has never provisioned the binary therefore fails `tauri dev` with:

```
resource path binaries/mainframe-daemon-aarch64-apple-darwin doesn't exist
```

— a build.rs panic, which reads as a Rust compile error rather than a missing artifact. Every fresh worktree is in that state, so `.agents/launch-test-tauri.sh` timed out waiting for a Vite server that would never come up. QA lanes hit this, reported `0/N`, and blocked on setup rather than on the branch under test.

## Fix

`scripts/tauri-dev.mjs` checks for the host-triple sidecar and runs `provision-rust-daemon.mjs` when it is absent. Fixing it here rather than in the QA launch script covers every `tauri:dev` consumer.

The cargo build this triggers is not extra work: in dev the shell resolves the daemon from `packages/core-rs/target/{release,debug}` (`resolve_rust_daemon_bin`), so a fresh worktree needs that build to reach Connected either way. On absence only, though — dev never runs the `binaries/` copy, so refreshing it each launch would buy nothing. `pnpm bundle` still refreshes it deliberately.

Two adjacent items from the same incident:

- `launch-test-tauri.sh` refused to start under `DAEMON_PORT=31415`. Callers reach that value by inheriting a polluted env, not by intent, so it now falls back to 31500 with a warning — the guard's purpose (never race the production daemon) is preserved without converting a stray env var into a blocked QA run.
- `.agents/test-worktree.md` claimed the launch script owns daemon provisioning. It never did; the description now matches.

## Verification

Both branches exercised end to end against a stubbed `cargo`:

- sidecar absent → provision runs, binary lands at `src-tauri/binaries/mainframe-daemon-aarch64-apple-darwin`, `cargo tauri dev` follows
- sidecar present → provision skipped entirely, `VITE_PORT` still threaded into `devUrl`

`node --check` on the wrapper, `bash -n` on the launch script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)