### PR TITLE
fix(agents): make the QA harness work in a frozen worktree

### DIFF
--- a/.agents/cleanup-test.sh
+++ b/.agents/cleanup-test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Kill stale test-worktree dev processes. Protected: production daemon on 31415.
-# Run ONCE per fleet (orchestrator) or once before a single-branch launch.
+# Reached only via `test-env.sh reset` — an explicit, ONCE-per-fleet operation.
+# `up` must never call it: the sweep is range-wide, so with several lanes in
+# flight whichever one launched second used to kill the others' apps mid-run.
+# Scoped teardown of a single run is `test-env.sh down`.
 #
 # Targets are found by PORT, not by process name: name matching stopped matching
 # anything when the Node daemon was retired, so this script kept reporting

--- a/.agents/launch-test-browser.sh
+++ b/.agents/launch-test-browser.sh
@@ -4,13 +4,22 @@
 # native shell surfaces). Blocks until ready; prints READY + facts. Bring-up is
 # 1-2 minutes on a warm worktree, several more if the daemon compiles cold.
 # Engine: playwright-cli fresh browser at APP_URL.
+#   MF_TARGET  checkout to act on (default: this script's checkout)
+#   MF_MODE    prepare = build only, no launch; up = build then launch
 set -euo pipefail
 
-PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+PROJECT_ROOT="${MF_TARGET:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+MODE="${MF_MODE:-up}"
 cd "$PROJECT_ROOT"
 
-# 1. Isolated ports + install + types build.
-bash scripts/setup-ports.sh
+# 1. Isolated ports + install + types build. setup-ports.sh regenerates .env on
+# every call, so only run it when absent — re-allocating mid-worktree would
+# orphan a run already listening on the old ports.
+if [ ! -f .env ]; then
+  bash scripts/setup-ports.sh
+else
+  pnpm install --frozen-lockfile
+fi
 
 # 2. Load the isolated ports.
 set -a
@@ -28,6 +37,13 @@ UI_LOG="/tmp/mf-ui-${DAEMON_PORT}.log"
 # seconds. `cargo sweep`/`cargo clean --profile dev` reclaim it afterwards.
 echo "Building mainframe-daemon (cold builds take several minutes)…"
 cargo build --manifest-path packages/core-rs/Cargo.toml -p mainframe-daemon
+
+if [ "$MODE" = prepare ]; then
+  echo "PREPARED"
+  echo "DAEMON_PORT=$DAEMON_PORT"
+  echo "VITE_PORT=$VITE_PORT"
+  exit 0
+fi
 
 DAEMON_PORT="$DAEMON_PORT" \
 MAINFRAME_DATA_DIR="$MAINFRAME_DATA_DIR" \

--- a/.agents/launch-test-tauri.sh
+++ b/.agents/launch-test-tauri.sh
@@ -2,62 +2,91 @@
 # Launch the Tauri target for test-worktree: fresh-worktree provisioning,
 # isolated env, background launch, readiness wait. Blocks until ready; prints
 # READY + facts, or exits 1 with the log tail.
+#   MF_TARGET  checkout to act on (default: this script's checkout)
+#   MF_MODE    prepare = provision only, no launch; up = provision then launch
 set -euo pipefail
 
-PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+PROJECT_ROOT="${MF_TARGET:-$(cd "$(dirname "$0")/.." && pwd -P)}"
+MODE="${MF_MODE:-up}"
 cd "$PROJECT_ROOT"
 
-export DAEMON_PORT="${DAEMON_PORT:-31500}"
+# Isolated ports, from this checkout's generated .env — the same source the
+# browser target and stop-test.sh use. Sourcing after the fact is deliberate: it
+# overrides an ambient DAEMON_PORT (a shell that inherited the production 31415
+# used to block the whole run) and keeps parallel checkouts off each other's
+# ports. setup-ports.sh regenerates on every call, so only run it when absent.
+if [ ! -f .env ]; then
+  bash scripts/setup-ports.sh
+else
+  pnpm install --frozen-lockfile
+fi
+set -a
+# shellcheck disable=SC1091
+. ./.env
+set +a
 export MAINFRAME_DATA_DIR="${MAINFRAME_DATA_DIR:-$HOME/.mainframe_dev}"
-VITE_PORT="${VITE_PORT:-5174}"
 
-# Never let the embedded daemon race the production port. A caller asking for
-# 31415 has almost always inherited it from an ambient env rather than meaning
-# it, so fall back instead of refusing — refusing turns a polluted shell into a
-# blocked QA run.
-if [ "$DAEMON_PORT" = "31415" ]; then
-  echo "WARNING: DAEMON_PORT=31415 is the production daemon — using 31500 instead" >&2
-  export DAEMON_PORT=31500
+if [ "${DAEMON_PORT:-}" = "31415" ] || [ -z "${DAEMON_PORT:-}" ]; then
+  echo "REFUSED: .env must allocate a non-production DAEMON_PORT — re-run scripts/setup-ports.sh" >&2
+  exit 1
 fi
 
 LOG="/tmp/mf-tauri-dev-${DAEMON_PORT}.log"
 
-# Fresh-worktree provisioning (idempotent). --frozen-lockfile is load-bearing:
-# a plain install re-resolves the workspace, and in a worktree the
-# `packages/mobile` submodule isn't populated, so pnpm strips it from the
-# lockfile. Frozen installs fine without it and never writes the file.
-# The daemon sidecar is provisioned by `tauri:dev` itself, not here.
-pnpm install --frozen-lockfile
+# `externalBin` is resolved by src-tauri's build script, so a checkout that has
+# never provisioned the sidecar fails `tauri dev` at a build.rs panic that reads
+# as a Rust compile error. Every fresh worktree is in that state. Provision from
+# the checkout under test — the daemon under test must be its branch's daemon,
+# not the primary checkout's.
+TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+if [ ! -f "packages/app-tauri/src-tauri/binaries/mainframe-daemon-${TRIPLE}" ]; then
+  echo "Provisioning the daemon sidecar for ${TRIPLE} (cold builds take several minutes)…"
+  pnpm --filter @qlan-ro/mainframe-app-tauri run provision:rust-daemon
+fi
+
+if [ "$MODE" = prepare ]; then
+  echo "PREPARED"
+  echo "DAEMON_PORT=$DAEMON_PORT"
+  echo "VITE_PORT=$VITE_PORT"
+  exit 0
+fi
+
 cd packages/app-tauri
 
 # `pnpm tauri:dev` is the whole stack: it compiles+runs the Rust shell, starts
 # Vite (its beforeDevCommand, on VITE_PORT), and the shell spawns the daemon.
-# First cold compile ~10-15 min; a warm per-worktree target links in a couple.
 # nohup + disown so the app survives THIS script exiting — lets the caller run
 # the script synchronously (block until READY, return) without reaping the app.
 nohup pnpm tauri:dev > "$LOG" 2>&1 &
+APP_PID=$!
 disown 2>/dev/null || true
 
-# Readiness: Vite answers on localhost (NOT 127.0.0.1 — Vite 6 binds ::1),
-# then the daemon answers on its isolated port.
-deadline=$((SECONDS + 600))
-until curl -sf "http://localhost:${VITE_PORT}" >/dev/null 2>&1; do
-  if [ $SECONDS -ge $deadline ]; then
-    echo "LAUNCH_FAILED: Vite not ready on :${VITE_PORT} after 600s — log tail:" >&2
-    tail -40 "$LOG" >&2
-    exit 1
-  fi
-  sleep 3
-done
-deadline=$((SECONDS + 120))
-until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/projects" >/dev/null 2>&1; do
-  if [ $SECONDS -ge $deadline ]; then
-    echo "LAUNCH_FAILED: daemon not ready on :${DAEMON_PORT} — log tail:" >&2
-    tail -40 "$LOG" >&2
-    exit 1
-  fi
-  sleep 2
-done
+# Readiness. Deadlines are generous because a cold worktree pays a full Rust
+# compile here; the real failure signal is the launcher dying, so poll for that
+# too rather than waiting out a timeout on a run that is already dead.
+wait_for() {
+  what="$1"; url="$2"; deadline=$((SECONDS + $3))
+  until curl -sf "$url" >/dev/null 2>&1; do
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+      echo "LAUNCH_FAILED: tauri:dev exited before $what was ready — log tail:" >&2
+      tail -40 "$LOG" >&2
+      exit 1
+    fi
+    if [ $SECONDS -ge $deadline ]; then
+      echo "LAUNCH_FAILED: $what not ready after $3s — log tail:" >&2
+      tail -40 "$LOG" >&2
+      exit 1
+    fi
+    sleep 3
+  done
+}
+
+# Vite is tauri's beforeDevCommand, so it answers first; the Rust shell compiles
+# after it and only then spawns the daemon. A cold shell build is the long pole —
+# the daemon wait, not the Vite wait, is what has to cover it.
+# localhost, NOT 127.0.0.1 — Vite 6 binds ::1.
+wait_for "Vite on :${VITE_PORT}" "http://localhost:${VITE_PORT}" 600
+wait_for "daemon on :${DAEMON_PORT}" "http://127.0.0.1:${DAEMON_PORT}/api/projects" 1800
 
 echo "READY"
 echo "DAEMON_PORT=$DAEMON_PORT"

--- a/.agents/stop-test.sh
+++ b/.agents/stop-test.sh
@@ -8,15 +8,18 @@
 # zsh, or sh regardless of how it's invoked.
 set -uo pipefail
 
-PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+PROJECT_ROOT="${MF_TARGET:-$(cd "$(dirname "$0")/.." && pwd -P)}"
 PROTECTED_PORT=31415
 
 if [ "$#" -gt 0 ]; then
   PORTS="$*"
-else
+elif [ -f "$PROJECT_ROOT/.env" ]; then
   # shellcheck disable=SC1091
-  [ -f "$PROJECT_ROOT/.env" ] && . "$PROJECT_ROOT/.env"
-  PORTS="${DAEMON_PORT:-31500} ${VITE_PORT:-5174} 9222"
+  . "$PROJECT_ROOT/.env"
+  PORTS="${DAEMON_PORT} ${VITE_PORT} 9222"
+else
+  echo "STOP_SKIPPED: no $PROJECT_ROOT/.env — nothing was launched from this checkout" >&2
+  exit 0
 fi
 
 for port in $PORTS; do

--- a/.agents/test-env.sh
+++ b/.agents/test-env.sh
@@ -1,37 +1,68 @@
 #!/usr/bin/env bash
 # Test environment for mainframe — test-worktree skill contract. Thin dispatcher over
 # the per-target launch scripts (which own build, isolated ports, and readiness waits).
-#   test-env.sh up [tauri|browser]   default: tauri
-#   test-env.sh down [port ...]      port-scoped; defaults to this checkout's .env ports
+#   test-env.sh prepare [tauri|browser]  install + types + sidecar + ports, no launch
+#   test-env.sh up [tauri|browser]       prepare (idempotent) then launch; default: tauri
+#   test-env.sh down [port ...]          port-scoped; defaults to the target's .env ports
+#   test-env.sh reset                    fleet-wide sweep of the test port ranges
+# Every verb accepts `--worktree <path>` to act on another checkout.
 # Targets: tauri = native shell via tauri-mcp bridge (max 1);
 # browser = renderer+daemon only, cheapest — use when no scenario needs the native shell.
 # Project QA knowledge (fixtures, seeding, gotchas): .agents/test-worktree.md, ui-selectors.md
 set -uo pipefail
-AGENTS="$(cd "$(dirname "$0")" && pwd -P)"
-ROOT="$(cd "$AGENTS/.." && pwd -P)"
 
-up() {
-  target="${1:-tauri}"
-  case "$target" in
-    tauri)
-      bash "$AGENTS/cleanup-test.sh" || exit 1   # singleton: bridge tracks one dev app
-      bash "$AGENTS/launch-test-tauri.sh" || exit 1
-      echo "ENGINE=tauri-mcp" ;;
-    browser)
-      # No cleanup: ports are isolated per run; parallel browser runs are legal.
-      bash "$AGENTS/launch-test-browser.sh" || exit 1
-      echo "ENGINE=playwright-cli" ;;
-    *) echo "unknown target '$target' (tauri|browser)" >&2; exit 64 ;;
+AGENTS="$(cd "$(dirname "$0")" && pwd -P)"
+
+verb="${1:-}"
+[ "$#" -gt 0 ] && shift
+target=""
+worktree=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --worktree) worktree="${2:-}"; shift 2 ;;
+    *) target="${target:+$target }$1"; shift ;;
   esac
-  # Normalize facts for the skill (launch scripts already printed the detailed set).
-  # shellcheck disable=SC1091
-  [ -f "$ROOT/.env" ] && . "$ROOT/.env"
-  echo "PORTS=${DAEMON_PORT:-} ${VITE_PORT:-}"
-  echo "LOG=/tmp/mf-daemon-${DAEMON_PORT:-unknown}.log"
+done
+
+# The checkout under test. Defaults to the one holding this script.
+TARGET="$(cd "${worktree:-$AGENTS/..}" && pwd -P)" || exit 1
+
+# The scripts themselves come from the PRIMARY checkout, never from the branch
+# under test. A worktree is created off origin/main at lane start and then frozen,
+# so a harness fix committed today never reaches a worktree branched yesterday —
+# which is how a fixed provisioning bug kept failing QA runs for days.
+common_dir="$(git -C "$TARGET" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+if [ -n "$common_dir" ]; then
+  primary="$(cd "$common_dir/.." && pwd -P)"
+  if [ "$primary/.agents" != "$AGENTS" ] && [ -x "$primary/.agents/test-env.sh" ]; then
+    echo "HARNESS=$primary/.agents (target: $TARGET)"
+    exec bash "$primary/.agents/test-env.sh" "$verb" $target --worktree "$TARGET"
+  fi
+fi
+
+export MF_TARGET="$TARGET"
+
+launcher() {
+  case "${1:-tauri}" in
+    tauri) echo "$AGENTS/launch-test-tauri.sh tauri-mcp" ;;
+    browser) echo "$AGENTS/launch-test-browser.sh playwright-cli" ;;
+    *) echo "unknown target '$1' (tauri|browser)" >&2; return 64 ;;
+  esac
 }
 
-case "${1:-}" in
-  up) shift; up "$@" ;;
-  down) shift; exec bash "$AGENTS/stop-test.sh" "$@" ;;
-  *) echo "usage: $0 up [tauri|browser] | down [port ...]" >&2; exit 64 ;;
+run() {
+  mode="$1"
+  resolved="$(launcher "${2:-tauri}")" || exit 64
+  script="${resolved% *}"; engine="${resolved##* }"
+  MF_MODE="$mode" bash "$script" || exit 1
+  [ "$mode" = up ] && echo "ENGINE=$engine"
+  return 0
+}
+
+case "$verb" in
+  prepare) run prepare "${target:-tauri}" ;;
+  up) run up "${target:-tauri}" ;;
+  down) exec bash "$AGENTS/stop-test.sh" $target ;;
+  reset) exec bash "$AGENTS/cleanup-test.sh" ;;
+  *) echo "usage: $0 prepare|up [tauri|browser] | down [port ...] | reset [--worktree <path>]" >&2; exit 64 ;;
 esac

--- a/.agents/test-worktree.md
+++ b/.agents/test-worktree.md
@@ -17,14 +17,17 @@ pick one per run (user's ask → diff paths → default).
   spawns the daemon itself.
 - Engine: `tauri-mcp` (the WKWebView has no CDP). Dev builds compile the
   bridge in (`pnpm tauri:dev` → `cargo tauri dev --features mcp-bridge`).
-- Launch: `script: .agents/launch-test-tauri.sh` — run it EXACTLY ONCE. It
-  owns the workspace install, the isolated env (`DAEMON_PORT=31500`,
-  `MAINFRAME_DATA_DIR=~/.mainframe_dev`; an inherited 31415 falls back to
-  31500 with a warning), the background `tauri:dev` (first run compiles Rust
-  and provisions the daemon sidecar, up to 10 min), and the readiness wait. It
-  blocks until ready and prints `READY` + facts (ports, APP_URL, LOG), or
-  exits 1 with the log tail — do not re-launch on failure, read the printed
-  tail.
+- Launch: `script: .agents/launch-test-tauri.sh` — run it EXACTLY ONCE, via
+  `test-env.sh up tauri`. It owns the workspace install, the isolated env from
+  the generated `.env` (which overrides an inherited `DAEMON_PORT`, so a shell
+  polluted with the production 31415 no longer blocks the run), sidecar
+  provisioning, the background `tauri:dev`, and the readiness wait. It blocks
+  until ready and prints `READY` + facts (ports, APP_URL, LOG), or exits 1 with
+  the log tail — do not re-launch on failure, read the printed tail. A cold
+  worktree compiles the daemon *and* the native shell here; the wait allows for
+  that and fails fast if `tauri:dev` dies, so a long silence is a build, not a
+  hang. Run `test-env.sh prepare tauri` ahead of time to pay that cost outside
+  the run.
 - After READY: confirm the app appears in the bridge's `list_devices`.
 - Diff paths: `packages/app-tauri/`, `packages/ui/`.
 - Bridge quirks (verified 2026-07-09): selector-based tools
@@ -78,9 +81,10 @@ Limits for multi-branch runs (consumed by the skill's Fleet Mode):
   but they DO share `~/.mainframe_dev`; scenarios that assert on global DB
   state (project/chat counts) belong in sequential runs.
 - **Process kills in a fleet:** the Cleanup section below kills ANY listener in
-  the test port ranges — including live test runs — so it runs exactly once
-  (orchestrator, before any env exists). Per-branch teardown uses the Stop /
-  Restart section, which is scoped to that worktree's own `.env` ports and is
+  the test port ranges — including live test runs — so it is reachable only as
+  `test-env.sh reset` and runs exactly once (orchestrator, before any env
+  exists). `up` never calls it. Per-branch teardown uses the Stop / Restart
+  section, which is scoped to that worktree's own `.env` ports and is
   parallel-safe.
 - Protected port `31415` applies to every run, always.
 
@@ -94,11 +98,12 @@ Verify any candidate PID does not hold `31415` before sending SIGKILL.
 
 ## Environment
 
-`.env` is **generated** by `scripts/setup-ports.sh` (invoked from
-`launch-test-browser.sh`), not hand-written. It always holds isolated free
-ports — the `31415`/`5173` defaults below are the *production* values and are
-deliberately never used for a test worktree. The tauri target doesn't
-generate `.env`; it sets its own isolated ports directly (see Target: tauri).
+`.env` is **generated** by `scripts/setup-ports.sh` (invoked from both launch
+scripts on first use), not hand-written. It always holds isolated free ports —
+the `31415`/`5173` defaults below are the *production* values and are
+deliberately never used for a test worktree. Both targets read the same `.env`,
+so the facts a run prints, the ports it listens on, and the ports `down` tears
+down are always the same set.
 
 | Variable | Used by | Source | Isolated range / value |
 |---|---|---|---|
@@ -115,13 +120,15 @@ Production defaults (never used here): `DAEMON_PORT=31415`, `VITE_PORT=5173`,
 ## Cleanup (Kill Stale Dev Processes)
 
 ```
-script: .agents/cleanup-test.sh
+script: .agents/test-env.sh reset
 ```
 
-Run the script exactly as-is — it kills stale `run dev` wrappers and CDP
-9222 while skipping anything on the protected port 31415, retries once, and
-exits nonzero if processes survive. Fleet runs execute it exactly once
-(orchestrator), never per-branch.
+Run it exactly as-is — it kills stale `run dev` wrappers and CDP 9222 while
+skipping anything on the protected port 31415, retries once, and exits nonzero
+if processes survive. It sweeps the whole test port range, so it takes every
+other checkout's live run with it: fleet runs execute it exactly once
+(orchestrator, before any env exists), never per-branch, and `up` never calls
+it.
 
 **Never use `pkill -f "mainframe"` unfiltered** — it can hit the production app. The commands above specifically target `run dev` processes and skip anything on port 31415.
 
@@ -209,11 +216,11 @@ Rules learned from live runs (2026-07-09 fleet):
 ## Stop / Restart
 
 ```
-script: .agents/stop-test.sh [port ...]
+script: .agents/test-env.sh down [port ...]
 ```
 
-Port-scoped, parallel-safe teardown of one run — defaults to this checkout's
-`.env` ports (plus port `9222`, a harmless no-op check now that nothing binds
+Port-scoped, parallel-safe teardown of one run — defaults to the target
+checkout's `.env` ports (plus port `9222`, a harmless no-op check now that nothing binds
 it); pass explicit ports to override. Refuses the protected port 31415;
 exits nonzero if a port stays held. Always kills the full port set for
 exactly this run — never kill a single port and expect the rest of the run

--- a/.changeset/qa-harness-worktree-provisioning.md
+++ b/.changeset/qa-harness-worktree-provisioning.md
@@ -1,0 +1,9 @@
+---
+---
+
+Agent QA harness only (`.agents/`), no shipped package behavior: `test-env.sh` now
+re-execs from the primary checkout so a worktree frozen on an older branch runs the
+current scripts; both launch targets read the checkout's own `.env` instead of
+hardcoded ports, provision the daemon sidecar when it is missing, gain a `prepare`
+mode, and fail fast when the launcher dies; `up` no longer runs the fleet-wide port
+sweep that killed sibling lanes mid-run.


### PR DESCRIPTION
## Problem

Every QA lane runs in a worktree branched off `origin/main` at lane start, so the harness it executes is whatever `.agents/` looked like on that day. A fix landed on main never reaches the worktrees already in flight.

That is not hypothetical: `88f1da1a` (sidecar provisioning, 2026-07-28 14:48) never reached the seven worktrees branched before it. One QA agent ran 13:26–13:33 — 75 minutes before that fix existed — spent 106 tool calls and its full budget on bring-up, and reached zero scenarios. Six other worktrees still print `REFUSED: DAEMON_PORT=31415` today. The same breakage hits a human running the script by hand.

Four more defects sat underneath:

- `launch-test-tauri.sh` hardcoded 31500/5174 and never sourced `.env`, while `test-env.sh` printed `PORTS=`/`LOG=` *from* `.env`. Three worktrees carry non-default ports (31599, 32370, 31770), so the facts contract lied and `stop-test.sh` reported `STOP_OK` with the app still running.
- `up` called the range-wide `cleanup-test.sh` on every launch, despite that script's own "run ONCE per fleet" header. With parallel lanes, whichever launched second killed the others mid-run.
- The daemon readiness deadline was 120s. Vite is tauri's `beforeDevCommand` and answers first; the 10–15 minute cold Rust build happens after it, before the daemon exists.
- Lane Setup did only `git worktree add`, so the cold build landed inside QA's own turn loop at the end of the lane.

## Changes

- **`test-env.sh` re-execs from the primary checkout.** Resolves it via `git rev-parse --path-format=absolute --git-common-dir` and hands off with `--worktree <target>`, so the branch under test no longer supplies its own harness. Adds a `prepare` verb (provision without launching) and routes every verb through the same launch scripts a human calls by hand.
- **Both launch targets source the target checkout's `.env`** instead of hardcoding ports, and refuse an ambient production `DAEMON_PORT` rather than using it.
- **The tauri target provisions the daemon sidecar when missing.** Without it a fresh worktree fails `tauri dev` at a `build.rs` panic that reads as a Rust compile error.
- **Readiness waits fail fast**, printing the log tail when the launcher exits, instead of polling out a deadline on a run that is already dead. The daemon deadline now covers the cold build.
- **`up` no longer runs the fleet-wide sweep.** It is reachable only as `test-env.sh reset`; scoped teardown is `test-env.sh down`.

## Not in this PR

Two files live outside the repo and took effect immediately, so they are not covered by the changeset:

- `~/.agents/skills/test-worktree/SKILL.md` — teaches the primary-checkout invocation. Load-bearing: it is what makes an agent sitting in a stale worktree reach for the primary's script at all.
- `~/.claude/skills/todo-lane/workflows/todo-lane.js` — lane Setup backgrounds `test-env.sh prepare tauri --worktree …`, the same entry point used by hand, so warm-up overlaps plan+implement. QA re-runs it idempotently if it failed.

## Test plan

Harness scripts only — no shipped package behavior, so CI covers nothing here. Verified by hand:

- `prepare tauri` — 3.8s warm, reports `DAEMON_PORT=32252 VITE_PORT=5739` read from `.env`
- `prepare browser` — 21s, `PREPARED` after the daemon build
- relocation — a throwaway worktree carrying the script prints `HARNESS=…/mainframe/.agents (target: …)` and hands off
- `up bogus` → exit 64; `down` on a checkout without `.env` → `STOP_SKIPPED` exit 0; `down 31415` → `REFUSED: 31415 is protected` exit 2
- `bash -n` clean on all five scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)