### PR TITLE
feat(ui): open arbitrary URLs in a Preview/Run tab (#281)

### DIFF
--- a/.changeset/preview-open-urls.md
+++ b/.changeset/preview-open-urls.md
@@ -1,0 +1,6 @@
+---
+"@qlan-ro/mainframe-app-tauri": minor
+"@qlan-ro/mainframe-ui": minor
+---
+
+The Run surface can open any http/https URL in a tab, tunnelling loopback URLs on a remote daemon.

--- a/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
+++ b/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
@@ -1,0 +1,811 @@
+# Implementation plan — URL tabs in the Run surface (#281)
+
+**Spec:** [`docs/specs/2026-07-28-todo-281-preview-open-urls.md`](../specs/2026-07-28-todo-281-preview-open-urls.md)
+**Branch:** `todo/281-preview-open-urls`
+**Packages:** `@qlan-ro/mainframe-ui` (all TypeScript work), `@qlan-ro/mainframe-app-tauri` (capability + Rust test only).
+**No change to `packages/core-rs`, `packages/types`, or `packages/mobile`.**
+
+## Goal
+
+Give the Run surface a new tab kind — `url` — that points the webview engine the app already
+owns at any `http`/`https` address the user names, with no launch configuration and no running
+process behind it. The tab is created from two entry points that funnel through one path (the Run
+tab strip's `+` menu / the empty-state Run picker, and the chat localhost chip's new "Open in
+Mainframe" row), keeps every preview control except run/stop/restart and the console drawer, and
+survives a restart. On a remote daemon a loopback URL is routed through the existing per-port quick
+tunnel strictly as a consumer: the tab checks port eligibility locally, adopts a ready tunnel with
+no wait, waits for the DNS check only when it watched the tunnel come up, carries the original
+path/query/fragment onto the tunnel origin, and stops a tunnel on close only when it started it and
+no other URL tab still needs the port. The preview bridge's remote-origin allowlist widens to
+`http://*:*` / `https://*:*` so inspect, region capture, and navigation tracking work on every
+origin — which also repairs the launch-config preview tabs, where those controls are silently dead
+today on any non-localhost URL.
+
+## Constraints carried from CLAUDE.md
+
+- Max **300 lines/file**, **50 lines/function**. Several tasks below exist purely to keep files
+  under the cap — do not merge them.
+- `data-testid` on every interactive element, `<surface>-<element>` kebab-case, keyed by domain id
+  (tab id), never by array index.
+- Single canonical type: the `url` tab kind stays renderer layout state (`packages/ui/src/store/run-pane.ts`).
+  The spec **declines** promoting it to `@qlan-ro/mainframe-types` and declines any Rust type.
+- Pure logic outside React and unit-tested; no `@ts-ignore`; no silent catches (`console.warn` with a
+  tag is the desktop convention in this package).
+- **Changeset required** before committing (Task 13).
+- No leftovers: dead code found while editing a file is removed in the same pass (Task 16 removes
+  `processStopped`).
+
+## Verified facts this plan is built on
+
+Each was read in the worktree; do not re-derive them.
+
+1. `RunTabKind` is `'preview' | 'console' | 'terminal' | 'code' | 'diff' | 'skill' | 'viewer'`
+   (`packages/ui/src/store/run-pane.ts:11`). `addRunTab` already dedups launch tabs **across every
+   pane** before the `paneId` lookup, so URL dedup extends the same block.
+2. `useLayoutStore.addRunTab` calls `placeInLayout(layout, 'run')` (`packages/ui/src/store/layout.ts:264`),
+   so adding a tab reveals the Run surface — AC4's "reveals the Run surface if it was hidden" needs
+   no extra `toggleSurface`.
+3. The webview label is generated inside the host adapter as `preview-${++tabSeq}`
+   (`packages/ui/src/lib/host/tauri-preview.ts:32`) and never contains the URL. AC16 therefore
+   constrains only the **Run tab id** we mint.
+4. `usePreviewLifecycle` gates mounting on `status === 'running' && port !== null`
+   (`packages/ui/src/features/preview/use-preview-lifecycle.ts:75`). A URL tab has neither, so the
+   mount/navigate/reanchor/destroy logic must be extracted rather than duplicated.
+5. `usePreviewLifecycle` returns `processStopped`, which **no caller reads** (only its own file
+   mentions it). It is dead code.
+6. Launch-preview tunnels (`useSandboxStore.tunnelUrls`, keyed by `(scopeKey, config)`) are a
+   *different* mechanism from the per-port quick tunnels (`store/port-tunnels.ts`, keyed by port).
+   URL tabs use only the latter. Do not touch `resolve-preview-url.ts` or `use-tunnel-fallback.ts`.
+7. Daemon rejection strings, verbatim, from
+   `packages/core-rs/crates/mainframe-server/src/routes/tunnel_ports.rs`:
+   `"Port must be 1024 or higher"` and `"Cannot tunnel the daemon's own port"` (`MIN_PORT: u16 = 1024`).
+   `packages/types/src/smart-actions/port-tunnels.ts` already exports the matching pure predicate
+   `isTunnelEligiblePort(port, daemonPort)` and `classifyLocalhostUrl(href)`.
+8. `GET /api/tunnel/ports` reports `state: "ready"` only for a registry `Entry::Ready`, which is
+   reached after `TunnelManager::start` resolves — i.e. after the DNS check. This is the premise of
+   spec decision D11 and of the "adopting never waits" rule.
+9. `store/port-tunnels.ts` currently collapses the `ready` and `dns_verified` WS events into one
+   `{ state: 'ready' }` entry, so the DNS signal is presently unobservable to the renderer.
+10. `tauri::utils::acl::RemoteUrlPattern` is public and ungated (`tauri-utils-2.9.2/src/acl/mod.rs:277`),
+    `tauri` re-exports it as `tauri::utils`, and `url = "2"` is already a direct dependency of
+    `packages/app-tauri/src-tauri`. **AC11's Rust test needs no new dependency** — this supersedes an
+    earlier assumption that `urlpattern` had to be added as a dev-dependency.
+11. `usePreviewOcclusion` scans all `[data-radix-popper-content-wrapper]`, `[role=dialog|menu|listbox]`,
+    and `[data-preview-overlay]` nodes against the anchor rect, so any overlay built from the existing
+    Radix primitives is covered with no new wiring.
+12. Existing call sites of the `terminalIds*` helpers: `store/layout.ts` (×3),
+    `lib/daemon/dispose-daemon-session.ts` (×1), plus three test files.
+
+## New and changed files
+
+**New (all under `packages/ui/src/`):**
+
+| File | Purpose |
+|---|---|
+| `features/url-tab/url-tab-id.ts` | `urlTabId(url)`, `urlTabTitle(url)` — pure |
+| `features/url-tab/resolve-url-target.ts` | `resolveUrlTabTarget()`, `composeTunnelUrl()`, `portRejectionReason()` — pure |
+| `features/url-tab/url-tunnel-ownership.ts` | pure consumer registry reducers |
+| `features/url-tab/tunnel-consumers.ts` | stateful wrapper over the pure registry + `stopPortTunnel` |
+| `features/url-tab/use-url-tab-tunnel.ts` | the React hook (start request, watchdog, DNS reload) |
+| `features/url-tab/UrlTabInstance.tsx` | the tab body |
+| `features/url-tab/UrlTabToolbar.tsx` | toolbar without process controls |
+| `features/url-tab/UrlTabBodyState.tsx` | pending / rejected / failed / stopped / loaded bodies |
+| `features/preview/use-webview-mount.ts` | extracted mount lifecycle |
+| `layout/RunUrlEntry.tsx` | the inline URL entry, shared by the strip and the picker |
+| `store/url-tunnel-cleanup.ts` | layout-facing release helper (mirrors `terminal-cleanup.ts`) |
+| `store/url-tab-intent-subscriber.ts` | the `open-url-tab` intent boundary |
+
+**Changed:** `store/run-pane.ts`, `store/layout.ts`, `store/layout-persist.ts`, `store/port-tunnels.ts`,
+`store/surface-intents.ts`, `lib/daemon/dispose-daemon-session.ts`,
+`features/preview/{normalize-url,use-preview-lifecycle,use-preview-address,PreviewUrlBar,PreviewToolbar,PreviewInstance}.*`,
+`layout/{RunTabStrip,SurfacePicker,RunTabPill,SurfaceHost}.tsx`, `layout/surfaces/RunSurface.tsx`,
+`features/chat/smart-actions/UrlChip.tsx`,
+`packages/app-tauri/src-tauri/capabilities/preview.json`,
+`packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs`.
+
+---
+
+## Group A — `test-pure-red` (red phase; must be observed failing)
+
+These tests are written **before** the code in Group B and must fail when written. Tests importing
+a module that does not exist yet fail at collection — that is the intended red. Run each file with
+`pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>` (never the whole suite; batches hit the
+cross-file `React.act` failure).
+
+### Task 1 — Normalizer rejects non-http(s) (D2, AC6)
+
+**File:** `packages/ui/src/features/preview/__tests__/normalize-url.test.ts` (extend).
+
+Add cases asserting `normalizePreviewUrl` returns `null` for: `''`, `'   '`, `'not a url'`,
+`'file:///etc/passwd'`, `'javascript://x'`, `'ssh://host'`, `'data:text/html,x'`. Keep the existing
+passing cases (`'localhost:3000'` → `'http://localhost:3000/'`, scheme preserved for
+`https://example.com`). Add `'HTTP://Example.com'` → normalized `http://example.com/` (scheme test is
+case-insensitive).
+
+**Verify:** the new cases fail (today the function returns a URL string for `file://` and `ssh://`);
+the pre-existing cases still pass.
+
+### Task 2 — URL tab model, dedup, and tab-id conformance (AC13, AC16, edge cases)
+
+**Files (new):** `packages/ui/src/store/__tests__/run-pane-url-tab.test.ts`,
+`packages/ui/src/features/url-tab/__tests__/url-tab-id.test.ts`.
+
+`run-pane-url-tab.test.ts` asserts against `addRunTab` / `releaseRunScope` / the new
+`tabIdsForScope`:
+- adding a `{ kind: 'url', url: 'http://localhost:5173/' }` tab appends and focuses it;
+- adding the same normalized URL **in the same scope** returns a state with the same tab count and
+  the existing tab active (no duplicate), including when the existing tab lives in a **different
+  pane** than the `paneId` argument;
+- the same URL with a **different `scopeKey`** creates a second tab;
+- two URL tabs on the same port with different paths are two tabs;
+- `releaseRunScope` removes URL tabs of that scope and leaves the others;
+- `tabIdsInRun(run, 'url')` / `tabIdsInPane(run, paneId, 'url')` / `tabIdsForScope(run, scope, 'url')`
+  return only URL tab ids, and the same functions with `'terminal'` return the terminal ids.
+
+`url-tab-id.test.ts` asserts:
+- `urlTabId('http://localhost:5173/a/b?q=1#frag')` matches `/^[A-Za-z0-9_-]+$/`;
+- two calls for the same URL produce different ids (uniqueness);
+- `urlTabTitle('http://localhost:5173/a?q=1')` === `'localhost:5173'`;
+- `urlTabTitle('https://example.com/x')` === `'example.com'` (no port when it is the scheme default).
+
+**Verify:** both files fail — `url-tab-id.ts` does not exist and `'url'` is not a valid `RunTabKind`.
+
+### Task 3 — Persistence sanitizer keeps URL tabs (D4, AC14)
+
+**File:** `packages/ui/src/store/__tests__/layout-persist.test.ts` (extend).
+
+Assert `sanitizeRun` keeps a `kind: 'url'` tab **with its `url` and `title` intact** while still
+stripping `preview`, `console`, and `terminal`; and that a pane containing only a URL tab survives
+instead of being dropped.
+
+**Verify:** fails — `SAFE_RUN_TAB_KINDS` does not contain `'url'`.
+
+### Task 4 — Port-tunnel store carries the DNS flag (D11)
+
+**File:** `packages/ui/src/store/__tests__/port-tunnels.test.ts` (extend).
+
+Assert:
+- a `ready` event produces `{ state: 'ready', url, dnsVerified: false }`;
+- a following `dns_verified` event produces `{ state: 'ready', url, dnsVerified: true }` and keeps
+  the known url when the event carries none;
+- a `dns_verified` event arriving with no prior `ready` still yields `dnsVerified: true`;
+- `applyPortTunnelSnapshot` marks a `state: 'ready'` entry `dnsVerified: true` (fact 8) and leaves a
+  `starting` entry without the flag.
+
+Keep the existing "treats dns_verified as ready" expectations working.
+
+**Verify:** the new assertions fail — the field does not exist.
+
+### Task 5 — Tunnel-state resolution (AC7, AC8, AC9, AC10, D11–D14)
+
+**File (new):** `packages/ui/src/features/url-tab/__tests__/resolve-url-target.test.ts`.
+
+Table-drive `resolveUrlTabTarget(input)` over the contract in Task 11. Required cases:
+- local daemon, any URL → `{ kind: 'direct', url }` (including a loopback URL);
+- remote daemon, non-loopback URL (`https://example.com/x`, `http://192.168.1.5:3000/`) → `direct`;
+- remote + loopback + `daemonPort === null` → `pending`;
+- remote + loopback port `22` → `{ kind: 'rejected', reason: 'Port must be 1024 or higher' }`;
+- remote + loopback port equal to `daemonPort` → `{ kind: 'rejected', reason: "Cannot tunnel the daemon's own port" }`;
+- remote + eligible port + no entry + `everHadEntry: false` → `pending` naming the port;
+- remote + entry `{ state: 'starting' }` → `pending`;
+- remote + entry ready with url + `watching: false` (adopting) → `tunnelled`, **regardless of
+  `dnsVerified`** (AC8);
+- remote + entry ready + `watching: true` + `dnsVerified: false` + `startResolved: false` → `pending`;
+- same, plus `dnsVerified: true` → `tunnelled`;
+- same, plus `startResolved: true` → `tunnelled`;
+- remote + entry `{ state: 'error', error: 'boom' }` → `{ kind: 'failed', error: 'boom' }`;
+- error entry with no message → `failed` with `'Tunnel failed to start'`;
+- `timedOut: true` while still pending → `failed` with the stated timeout text;
+- **non-terminal failure:** `timedOut: true` **and** a ready+gate-open entry → `tunnelled` (AC9's
+  "a URL that arrives after the failure body replaces it");
+- entry `undefined` with `everHadEntry: true` → `{ kind: 'stopped', port }` (D14);
+- `composeTunnelUrl('https://x.trycloudflare.com', 'http://localhost:5173/a/b?q=1#f')` →
+  `'https://x.trycloudflare.com/a/b?q=1#f'` (D12), and an origin-only original URL →
+  `'https://x.trycloudflare.com/'`.
+
+**Verify:** fails — the module does not exist.
+
+### Task 6 — Tunnel ownership on close (D10, AC12)
+
+**File (new):** `packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts`.
+
+Against the pure reducers in Task 12:
+- `releaseConsumers` on a tab that **started** its tunnel and is the only consumer of the port →
+  `stop` lists that port;
+- a tab that **adopted** (started `false`) and is the only consumer → `stop` is empty;
+- two tabs on one port, the starter released while the other remains → `stop` is empty;
+- both released together → `stop` lists the port once, not twice;
+- releasing an unknown tab id is a no-op and returns the same state reference;
+- `clearConsumers` empties the registry and returns no ports to stop.
+
+**Verify:** fails — the module does not exist.
+
+---
+
+## Group B — `core` (pure logic, stores, wiring)
+
+Turns Group A green. Every task here ends with the named test file passing.
+
+### Task 7 — Restrict normalization to http/https (D2)
+
+**File:** `packages/ui/src/features/preview/normalize-url.ts`.
+
+After `new URL(withScheme)` succeeds, return `null` unless `protocol` is `http:` or `https:`.
+Keep the bare-host → `http://` prefixing. Update the file's doc comment to say why (the address bar
+could point a child webview at `file://`).
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/preview/__tests__/normalize-url.test.ts` green.
+
+### Task 8 — `url` tab kind, dedup, kind-parameterized id helpers
+
+**File:** `packages/ui/src/store/run-pane.ts` (currently 207 lines; stays well under 300).
+
+1. Add `'url'` to `RunTabKind`.
+2. Add `url?: string` to `RunTab` with a doc line: normalized committed URL for a `url` tab; the
+   tab's identity for dedup and persistence; **never** a tunnel URL.
+3. Generalize the dedup block in `addRunTab` into a small `dedupMatcher(tab): ((t: RunTab) => boolean) | null`
+   helper returning the launch-tab matcher for `preview`/`console` with a `config`, the
+   `kind === 'url' && t.url === tab.url && t.scopeKey === tab.scopeKey` matcher for a `url` tab with a
+   `url`, and `null` otherwise. `addRunTab` keeps its existing across-all-panes scan and must stay
+   under 50 lines.
+4. Replace `terminalIdsInRun` / `terminalIdsInPane` / `terminalIdsForScope` with
+   `tabIdsInRun(run, kind)` / `tabIdsInPane(run, paneId, kind)` / `tabIdsForScope(run, scopeKey, kind)`
+   (`kind: RunTabKind`). Three near-identical pairs would otherwise exist — the hygiene rule
+   requires the extraction.
+5. Update the call sites (fact 12): `store/layout.ts` ×3 (`'terminal'` argument),
+   `lib/daemon/dispose-daemon-session.ts` ×1, and mechanically rename in
+   `store/__tests__/run-pane-terminal.test.ts`, `store/__tests__/run-pane-release-scope.test.ts`,
+   and the `vi.mock('../../../store/run-pane', …)` factory in
+   `lib/daemon/__tests__/dispose-daemon-session.test.ts`. These three test edits are renames only —
+   no assertion changes.
+
+**Verify:** `vitest run src/store/__tests__/run-pane-url-tab.test.ts src/store/__tests__/run-pane-terminal.test.ts src/store/__tests__/run-pane-release-scope.test.ts` and
+`vitest run src/lib/daemon/__tests__/dispose-daemon-session.test.ts` all green.
+
+### Task 9 — Persist URL tabs (D4)
+
+**File:** `packages/ui/src/store/layout-persist.ts`.
+
+Add `'url'` to `SAFE_RUN_TAB_KINDS` and update the comment above it: a URL tab's whole identity is a
+string, so it carries no live handle. Nothing else changes — `sanitizeRun` copies the tab object, so
+`url` and `title` survive.
+
+**Verify:** `vitest run src/store/__tests__/layout-persist.test.ts` green.
+
+### Task 10 — Surface the DNS check to the renderer (D11)
+
+**File:** `packages/ui/src/store/port-tunnels.ts`.
+
+Add `dnsVerified?: boolean` to `PortTunnelEntry` with a comment stating it is a **reload trigger**,
+not a gate — a tunnel the daemon lists as ready has already passed the check. In
+`applyPortTunnelEvent`, split the collapsed arm: `ready` writes `dnsVerified: false` (preserving an
+existing `true` if one is already recorded, so a late duplicate `ready` cannot un-verify a tunnel);
+`dns_verified` writes `dnsVerified: true`. Both keep the existing url-fallback behaviour. In
+`applyPortTunnelSnapshot`, set `dnsVerified: true` for `state === 'ready'` entries.
+`reportPortTunnelError`'s never-downgrade-a-ready-tunnel rule is unchanged.
+
+**Verify:** `vitest run src/store/__tests__/port-tunnels.test.ts` green.
+
+### Task 11 — Pure tunnel-state resolution + tab identity
+
+**Files (new):** `packages/ui/src/features/url-tab/resolve-url-target.ts`,
+`packages/ui/src/features/url-tab/url-tab-id.ts`.
+
+`url-tab-id.ts`:
+```ts
+export function urlTabId(url: string): string;   // `url-${sanitizedHost}-${crypto.randomUUID().slice(0, 8)}`
+export function urlTabTitle(url: string): string; // host, plus `:port` when the port is not the scheme default
+```
+Sanitize with `.replace(/[^A-Za-z0-9_-]/g, '_')`, mirroring `features/run/run-tab-for-config.ts`. On
+an unparseable URL (defensive only — callers normalize first) fall back to `url-${uuid8}` /
+the raw input.
+
+`resolve-url-target.ts` exports:
+```ts
+export type UrlTabTarget =
+  | { kind: 'direct'; url: string }
+  | { kind: 'tunnelled'; url: string }
+  | { kind: 'pending'; port: number }
+  | { kind: 'rejected'; port: number; reason: string }
+  | { kind: 'failed'; error: string }
+  | { kind: 'stopped'; port: number };
+
+export interface UrlTabTunnelInput {
+  url: string;                 // normalized, user-committed
+  isLocal: boolean;
+  daemonPort: number | null;   // the DAEMON's own port from the tunnel snapshot, not the HTTP client port
+  entry: PortTunnelEntry | undefined;
+  watching: boolean;           // this tab attached while the tunnel was absent or starting
+  startResolved: boolean;      // this tab's own POST /tunnel/ports/start returned a url
+  timedOut: boolean;           // the 120s watchdog fired
+  everHadEntry: boolean;       // an entry existed for this port and then disappeared
+}
+
+export const URL_TAB_TUNNEL_TIMEOUT_MS = 120_000;
+export function resolveUrlTabTarget(input: UrlTabTunnelInput): UrlTabTarget;
+export function composeTunnelUrl(tunnelOrigin: string, originalUrl: string): string;
+export function portRejectionReason(port: number, daemonPort: number): string | null;
+```
+
+`portRejectionReason` returns the daemon's strings verbatim (fact 7): `port < 1024` →
+`'Port must be 1024 or higher'`; `port === daemonPort` → `"Cannot tunnel the daemon's own port"`;
+any other ineligibility per `isTunnelEligiblePort` → `` `Port ${port} cannot be tunnelled` ``;
+otherwise `null`.
+
+`resolveUrlTabTarget` evaluates in this exact order (split the tail into a `resolveEntryTarget`
+helper to stay under 50 lines per function):
+1. `isLocal` → `direct`.
+2. `classifyLocalhostUrl(url) === null` → `direct`.
+3. `daemonPort === null` → `pending`.
+4. `portRejectionReason(...) !== null` → `rejected`.
+5. `entry === undefined` → `everHadEntry ? stopped : pending`.
+6. `entry.state === 'error'` → `failed` with `entry.error ?? 'Tunnel failed to start'`.
+7. `entry.state === 'ready' && entry.url` and the gate is open
+   (`!watching || startResolved || entry.dnsVerified === true`) → `tunnelled` with
+   `composeTunnelUrl(entry.url, url)`.
+8. anything else → `timedOut ? failed('The tunnel did not produce a URL within 120 seconds') : pending`.
+
+Step 7 preceding step 8 is what makes the failure non-terminal (AC9).
+
+`composeTunnelUrl` takes the origin of `tunnelOrigin` and appends `pathname + search + hash` of
+`originalUrl` (D12); on a parse failure it returns `tunnelOrigin` unchanged.
+
+**Verify:** `vitest run src/features/url-tab/__tests__/resolve-url-target.test.ts src/features/url-tab/__tests__/url-tab-id.test.ts` green.
+
+### Task 12 — Tunnel ownership registry + layout release wiring (D10, AC12)
+
+**Files (new):** `packages/ui/src/features/url-tab/url-tunnel-ownership.ts`,
+`packages/ui/src/features/url-tab/tunnel-consumers.ts`,
+`packages/ui/src/store/url-tunnel-cleanup.ts`.
+**Files (changed):** `packages/ui/src/store/layout.ts`, `packages/ui/src/lib/daemon/dispose-daemon-session.ts`.
+
+`url-tunnel-ownership.ts` — pure, no I/O:
+```ts
+export interface ConsumerRecord { port: number; started: boolean; daemonHttpPort: number }
+export interface ConsumerState { byTab: Record<string, ConsumerRecord> }
+export const emptyConsumerState: ConsumerState;
+export function addConsumer(state: ConsumerState, tabId: string, rec: ConsumerRecord): ConsumerState;
+export function releaseConsumers(
+  state: ConsumerState,
+  tabIds: string[],
+): { next: ConsumerState; stop: Array<{ port: number; daemonHttpPort: number }> };
+export function clearConsumers(state: ConsumerState): ConsumerState;
+```
+`releaseConsumers` removes the tabs first, then for each removed record with `started === true`
+whose port has **no remaining consumer**, emits one stop entry — deduplicated by port. Returns the
+same state reference when nothing was removed.
+
+The record carries `daemonHttpPort` (the value `useDaemonPort()` gave the tab at registration)
+because the release path runs outside React and there is no module-level accessor for it.
+
+`tunnel-consumers.ts` — module-level `ConsumerState` plus
+`registerUrlTunnelConsumer(tabId, rec)`, `releaseUrlTunnelConsumers(tabIds)` (calls
+`stopPortTunnel(daemonHttpPort, port)` for each stop entry, `.catch` logged with a
+`[url-tab]` tag — never a silent catch), and `clearUrlTunnelConsumers()`.
+Registration is idempotent per tab id: re-registering the same tab replaces its record and must not
+flip `started` from `true` to `false`.
+
+`store/url-tunnel-cleanup.ts` — a one-import shim over `features/url-tab/tunnel-consumers`, mirroring
+`store/terminal-cleanup.ts`, so `layout.ts` never imports a feature store and no import cycle forms.
+
+`store/layout.ts` — call `releaseUrlTunnels(tabIdsInRun(run, 'url'))` in `toggleSurface` when Run is
+being hidden (beside the existing `killAndDisposeCachedTerminals`), `releaseUrlTunnels([tabId])` in
+`closeRunTab` when the closed tab's `kind === 'url'`, `releaseUrlTunnels(tabIdsInPane(run, paneId, 'url'))`
+in `closePane`, and `releaseUrlTunnels(tabIdsForScope(run, scopeKey, 'url'))` in `releaseRunScope`.
+
+`lib/daemon/dispose-daemon-session.ts` — add a `try/catch` step calling `clearUrlTunnelConsumers()`.
+**It must not stop anything**: a daemon switch would send the stop to the wrong daemon, layout
+storage and `resetPortTunnels()` are already daemon-scoped, and the spec's daemon-switch edge case
+only requires re-resolution. Record that reason in a one-line comment.
+
+**Verify:** `vitest run src/features/url-tab/__tests__/url-tunnel-ownership.test.ts` green;
+`vitest run src/store/__tests__/layout.test.ts src/store/__tests__/layout.terminal-cleanup.test.ts src/store/__tests__/layout-release-scope.test.ts`
+still green.
+
+### Task 13 — Changeset
+
+**File:** `.changeset/<generated>.md` via `pnpm changeset`.
+
+Minor bump for `@qlan-ro/mainframe-ui` and `@qlan-ro/mainframe-app-tauri`. One user-facing sentence:
+the Run surface can open any http/https URL in a tab, tunnelling loopback URLs on a remote daemon.
+No package other than those two changes.
+
+**Verify:** the file exists and names both packages.
+
+---
+
+## Group C — `rust` (capability widening; independent of all TypeScript work)
+
+### Task 14 — Widen the preview bridge's remote-origin allowlist (D1, AC11)
+
+**File:** `packages/app-tauri/src-tauri/capabilities/preview.json`.
+
+Replace `remote.urls` with exactly `["http://*:*", "https://*:*"]`. **Not** `http://*` /
+`https://*`: Tauri's `RemoteUrlPattern` fills in a missing search, hash, and path with `*` but
+leaves the port component empty, and an empty port matches only the scheme's default port — those
+patterns would not match `http://localhost:5173/` (fact 10, spec D1).
+
+Rewrite `description`: the current text justifies the narrow scope and would be a false statement
+after this change. New text states that preview and URL tabs load arbitrary user-named `http`/`https`
+origins, that every such origin may call the four bridge callbacks, that no other scheme matches
+because the scheme component stays literal, and that the accepted risk is a hostile page fabricating
+an inspect payload into the agent's context.
+
+Leave `webviews` and `permissions` untouched. Leave `is_allowed_external_scheme`
+(`src/preview/mod.rs`) untouched — it is what still rejects `file:`, `javascript:`, and `ssh:` for
+the OS opener.
+
+**Verify:** `cd packages/app-tauri/src-tauri && cargo check` passes.
+
+### Task 15 — Rust tests for the widened patterns (AC11)
+
+**File:** `packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs` (test module).
+
+Update `preview_capability_grants_bridge_commands_to_preview_webviews`: its
+`urls.contains(&"http://localhost:*")` / `"http://127.0.0.1:*"` assertions are now false. Replace
+them with `urls.contains(&"http://*:*")` and `urls.contains(&"https://*:*")` and an assertion that
+`remote.urls` has exactly two entries. Keep the `webviews[0] == "preview-*"` and the four-permission
+assertions unchanged.
+
+Add `preview_capability_patterns_match_every_http_origin`: parse each pattern via
+`"http://*:*".parse::<tauri::utils::acl::RemoteUrlPattern>()` and assert that at least one pattern
+`test`s true for `tauri::Url::parse` of `http://localhost:5173/path`,
+`http://192.168.1.5:3000/a?b=1`, `https://example.com:8443/a`, and `https://example.com/x`, and false
+for `file:///etc/passwd` and `ssh://host`.
+*If `RemoteUrlPattern` turns out not to be reachable through the `tauri::utils` re-export in this
+Tauri version, add `urlpattern = "0.3"` and `regex = "1"` to `[dev-dependencies]` (both already
+resolved in `Cargo.lock`) and construct the pattern the same way `RemoteUrlPattern::from_str` does.
+Do not change the runtime dependency list.*
+
+Add `external_open_scheme_guard_still_rejects_dangerous_schemes` asserting
+`is_allowed_external_scheme` is `false` for `file:///etc/passwd`, `javascript:alert(1)`, and
+`ssh://host`, and `true` for `http://x` and `https://x` — the widened allowlist must not be read as
+widening the opener.
+
+**Verify:** `cd packages/app-tauri/src-tauri && cargo test preview_capability && cargo test external_open_scheme_guard`.
+
+---
+
+## Group D — `ui-tab` (the tab itself)
+
+### Task 16 — Extract the webview mount lifecycle
+
+**Files:** `packages/ui/src/features/preview/use-webview-mount.ts` (new),
+`packages/ui/src/features/preview/use-preview-lifecycle.ts`.
+
+`useWebviewMount({ url, anchorRef, containerRef, projectId, device }): PreviewHandle | null` owns
+everything currently inside `usePreviewLifecycle`'s effect below the status gate: destroy when `url`
+goes `null` after having been non-null, mount on first non-null `url`, `reanchor` when the mount
+element changes, `navigate` on a URL change, and the unmount cleanup that destroys the handle.
+
+`usePreviewLifecycle` becomes a thin wrapper: it computes
+`url = status === 'running' && port !== null ? resolvedUrl : null`, delegates to `useWebviewMount`,
+and keeps `pendingTunnel` (`status === 'running' && port !== null && resolvedUrl === null`).
+**Delete `processStopped`** — no caller reads it (fact 5).
+
+Behaviour must be byte-identical for preview tabs: a `running → stopped` transition still destroys
+the handle; a `null` status still destroys it.
+
+**Files also touched:** `packages/ui/src/features/preview/__tests__/use-preview-lifecycle.test.ts` —
+drop `processStopped` assertions if any exist; every other assertion must pass unchanged. Add a
+`__tests__/use-webview-mount.test.ts` covering mount-on-first-url, navigate-on-url-change,
+reanchor-on-element-change, destroy-on-null-url, and destroy-on-unmount.
+
+**Verify:** `vitest run src/features/preview/__tests__/use-preview-lifecycle.test.ts src/features/preview/__tests__/use-webview-mount.test.ts src/features/preview/__tests__/PreviewInstance.test.tsx` green.
+
+### Task 17 — Address bar seeds from a URL and reloads what is displayed (D9, D13)
+
+**Files:** `packages/ui/src/features/preview/use-preview-address.ts`,
+`packages/ui/src/features/preview/PreviewUrlBar.tsx`,
+`packages/ui/src/features/preview/PreviewToolbar.tsx`,
+`packages/ui/src/features/preview/PreviewInstance.tsx`.
+
+`usePreviewAddress(handle, seedUrl: string | null)` replaces the `port` parameter: it seeds
+`currentUrl` from `seedUrl` and re-seeds when `seedUrl` changes. The `onNavigate` reflection is
+unchanged. Callers that had a port pass `` port !== null ? `http://localhost:${port}` : null ``.
+
+`PreviewUrlBar` props become `{ handle, seedUrl, enabled }` (`enabled` replaces `isRunning`, whose
+name no longer fits a tab with no process). `handleReload` navigates to `currentUrl` and no-ops when
+it is empty — it must not re-derive `http://localhost:${port}` (D13). `handleOpenBrowser` uses
+`currentUrl` only. The four testids (`preview-url-reload`, `preview-url-input`,
+`preview-url-open-browser`, `preview-url-clear-cache`) are unchanged — the URL tab reuses this
+component and inherits them.
+
+`PreviewToolbar` passes `seedUrl` through and keeps its own `port` prop only for the pieces that
+still need it. `PreviewInstance` supplies the seed.
+
+**Files also touched:** `packages/ui/src/features/preview/__tests__/use-preview-address.test.ts`
+and `PreviewUrlBar.test.tsx` and `PreviewToolbar.test.tsx` — update to the new props; add a case
+asserting reload navigates to the **navigated-to** URL, not `localhost:<port>`, after an
+`onNavigate` event.
+
+**Verify:** `vitest run src/features/preview/__tests__/use-preview-address.test.ts src/features/preview/__tests__/PreviewUrlBar.test.tsx src/features/preview/__tests__/PreviewToolbar.test.tsx` green.
+
+### Task 18 — `useUrlTabTunnel` hook
+
+**File (new):** `packages/ui/src/features/url-tab/use-url-tab-tunnel.ts`.
+
+`useUrlTabTunnel({ tabId, url }): { target: UrlTabTarget; retry: () => void }`.
+
+Reads `useDaemonIsLocal()`, `useDaemonPort()` (HTTP client port), `useTunnelDaemonPort()` (the
+daemon's own port, for eligibility), `useActiveIdentity().chatId`, and
+`usePortTunnel(port)` for the classified loopback port (skip the subscription entirely when the URL
+is not loopback or the daemon is local).
+
+State it owns, all feeding `resolveUrlTabTarget`:
+- `watchingRef` — set `true` on the first render at which an entry is absent or `starting` **and** a
+  start is needed; never set `false` afterwards for the life of the tab.
+- `startResolved` — set when this tab's `startPortTunnel` POST resolves.
+- `everHadEntry` — set once an entry has been seen; drives the `stopped` state (D14).
+- `timedOut` — a 120 s (`URL_TAB_TUNNEL_TIMEOUT_MS`) watchdog started when the target first becomes
+  `pending`, cleared when it leaves `pending`.
+
+Effects:
+- **Start request.** When the target is `pending`, `entry === undefined`, `daemonPort !== null`,
+  `chatId` is present, and no request is in flight for this tab, POST
+  `startPortTunnel(httpPort, { port, chatId })`; on rejection call `reportPortTunnelError(port, message)`
+  (which is the single funnel for both the POST rejection and the WS error, so the toast is not
+  doubled). Never issue a second start while an entry exists — an entry in `starting` means another
+  consumer's start is in flight and this tab joins it (spec "Tunnel adopted mid-start").
+- **DNS reload trigger.** When `entry.dnsVerified` transitions to `true` while the target is already
+  `tunnelled` **and** the tab loaded before verification, fire the caller-provided reload once
+  (expose it as a `reloadNonce` counter in the return so `UrlTabInstance` can re-navigate). Exactly
+  once per transition (D11 / spec step 5).
+- **Consumer registration.** Call `registerUrlTunnelConsumer(tabId, { port, started: watchingRef.current && startedByThisTab, daemonHttpPort })`
+  whenever the port or the started flag changes. `started` is `true` only when this tab issued the
+  POST itself — a tab that merely joined another consumer's start counts as adopted (D10's
+  err-toward-leaving-it-up rule).
+- **`retry`** resets `timedOut`, `startResolved`, and the in-flight flag so the start effect runs
+  again. It never runs automatically (D14).
+
+Keep the file under 300 lines and each effect under 50; extract the watchdog into a small local hook
+if it grows.
+
+### Task 19 — `UrlTabBodyState`
+
+**File (new):** `packages/ui/src/features/url-tab/UrlTabBodyState.tsx`.
+
+Props `{ target, device, inspectActive, anchorRef, onRetry }`. Renders, per `target.kind`:
+- `direct` / `tunnelled` → the loaded body, structurally identical to `PreviewBodyState`'s
+  `status === 'running'` branch (desktop frame vs the 230×420 phone frame, the inspect outline and
+  the "Click an element" badge), with the anchor div. testid `url-tab-body-loaded`.
+- `pending` → spinner plus `` `Starting a tunnel for port ${target.port}…` ``. testid `url-tab-body-pending`.
+- `rejected` → the reason text verbatim, no Retry (nothing to retry). testid `url-tab-body-rejected`.
+- `failed` → the error text plus a **Retry** button, testids `url-tab-body-failed` and
+  `url-tab-retry`.
+- `stopped` → "The tunnel for port N was stopped" plus the same Retry. testid `url-tab-body-stopped`.
+
+Use `mainframe-design-system` tokens; mirror `PreviewBodyState`'s classes rather than inventing new
+ones. Never render a blank body — every `UrlTabTarget` variant has a branch (AC9).
+
+### Task 20 — `UrlTabToolbar` and `UrlTabInstance`
+
+**Files (new):** `packages/ui/src/features/url-tab/UrlTabToolbar.tsx`,
+`packages/ui/src/features/url-tab/UrlTabInstance.tsx`.
+
+`UrlTabToolbar` renders `PreviewUrlBar` + `PreviewDeviceToggle` + `PreviewCaptureCluster` and **no**
+`PreviewRunControl` and no console drawer (AC5) — the controls are absent, not disabled. testid
+`url-tab-toolbar`. `enabled` is `handle !== null`.
+
+`UrlTabInstance({ tabId, url, visible, scopeKey, projectId })` mirrors `PreviewInstance` minus the
+launch plumbing:
+- `const { target, retry, reloadNonce } = useUrlTabTunnel({ tabId, url })`;
+- `const loadUrl = target.kind === 'direct' || target.kind === 'tunnelled' ? target.url : null`;
+- `const handle = useWebviewMount({ url: loadUrl, anchorRef, containerRef, projectId, device })`;
+- `usePreviewGeometry({ handle, anchorRef, containerRef, active: visible, status: loadUrl ? 'running' : null })`
+  — pass the shape the hook already expects; if its `status` parameter is launch-specific, widen it to
+  a boolean `mounted` flag and update the two call sites in the same pass rather than faking a status;
+- `usePreviewOcclusion(anchorRef, loadUrl !== null && (handle?.compositesAboveDom ?? false))`;
+- `usePreviewVisibility` and `usePreviewCapture` exactly as `PreviewInstance` uses them, so captures
+  and inspect results reach the active chat unchanged;
+- a `useEffect` on `reloadNonce` that re-navigates the handle to `loadUrl` (the DNS reload, spec step 5);
+- root testid `url-tab-instance-${tabId}`; `CaptureAnnotationPopover` mounted as in `PreviewInstance`.
+
+Both files stay under 300 lines; the annotation/capture block is already a hook, so no new
+decomposition should be needed.
+
+### Task 21 — Render the kind in the Run surface
+
+**Files:** `packages/ui/src/layout/surfaces/RunSurface.tsx`, `packages/ui/src/layout/RunTabPill.tsx`.
+
+`RunTabBody` gains a `tab.kind === 'url'` arm **above** the file-guest fallback, rendering
+`<UrlTabInstance tabId={tab.id} url={tab.url ?? ''} visible={active} scopeKey={tabScope ?? undefined} projectId={projectId} />`.
+A URL tab with no `url` (corrupt persisted state) renders the `rejected`-style body via an empty
+normalized URL rather than falling through to the placeholder (AC3). The `<kind>: <title>`
+placeholder must remain reachable for `code`/`diff`/`skill`/`viewer`.
+
+`RunTabPill.tabGlyph` gains a `Globe` (lucide) for `'url'`, coloured `text-mf-surface-run` when
+active like the other Run-owned kinds (spec: "a globe glyph, distinct from the preview eye"). The
+`live && config` Stop branch is untouched — a URL tab has no `config`, so it never shows a Stop.
+
+**Verify:** `vitest run src/layout/__tests__/RunSurface.tab-scope.test.tsx src/layout/__tests__/RunSurface.preview-port.test.tsx` still green; `pnpm --filter @qlan-ro/mainframe-ui typecheck`.
+
+---
+
+## Group E — `ui-entrypoints` (the two creation paths)
+
+### Task 22 — `open-url-tab` intent and its subscriber (D6)
+
+**Files:** `packages/ui/src/store/surface-intents.ts`,
+`packages/ui/src/store/url-tab-intent-subscriber.ts` (new),
+`packages/ui/src/layout/SurfaceHost.tsx`.
+
+Add `| { type: 'open-url-tab'; url: string; paneId?: string }` to `SurfaceIntent`, documented as
+"Open (or focus) a URL tab in the Run surface".
+
+`subscribeToUrlTabIntents()` mirrors `terminal-intent-subscriber.ts` but is fully synchronous:
+normalize with `normalizePreviewUrl` (a second guard — the entry points already normalize; a
+`null` result is dropped with a tagged `console.warn`), read `scopeKey` from
+`useActiveBasesStore.getState()`, and call
+`useLayoutStore.getState().addRunTab({ id: urlTabId(url), kind: 'url', title: urlTabTitle(url), url, scopeKey }, paneId)`.
+No `toggleSurface` call — `addRunTab` already reveals Run (fact 2). No disposal path is needed: a URL
+tab creates nothing before the tab exists, so a `false` return only needs the tagged warn.
+
+This subscriber is the **single creation path** both entry points use; neither entry point may call
+`addRunTab` directly.
+
+`SurfaceHost.tsx` mounts it in a `useEffect` beside `subscribeToTerminalIntents()`.
+
+**Verify:** `vitest run src/store/__tests__/surface-intents.test.ts` green; add nothing here — the
+behavioural test lands in Task 30.
+
+### Task 23 — `RunUrlEntry`, the shared inline entry
+
+**File (new):** `packages/ui/src/layout/RunUrlEntry.tsx`.
+
+`RunUrlEntry({ paneId, onDone })` renders a single inline input, placeholder `localhost:3000`,
+autofocused on mount. Enter normalizes with `normalizePreviewUrl`; on success it emits
+`{ type: 'open-url-tab', url: normalized, paneId }` and calls `onDone()`; on failure it applies the
+address bar's invalid treatment (`text-destructive ring-1 ring-destructive rounded-sm`, copied from
+`PreviewUrlBar`) and emits nothing — including for empty or whitespace-only input (AC6). Escape and
+blur call `onDone()` without emitting. Typing clears the invalid state.
+
+testids: `run-tab-url-entry` on the wrapper, `run-tab-url-entry-input` on the input (AC15).
+
+It lives in `layout/` because both consumers are layout components and it only emits an intent — it
+does not read layout state.
+
+### Task 24 — "URL…" in the `+` menu (AC1)
+
+**File:** `packages/ui/src/layout/RunTabStrip.tsx`.
+
+`RunAddMenu` gains a `MenuRow` labelled `URL…` with a `Globe` icon, placed directly under the
+"New terminal" row and above the launch-config divider, testid `run-pane-open-url-${paneId}`.
+Choosing it closes the popover and sets strip-local state that swaps the tab-pill row for
+`<RunUrlEntry paneId={pane.id} onDone={…} />`. The entry sits **in the strip**, above the webview
+region, so it is never occluded (spec edge case). Update the file's testid docblock.
+
+Watch the 300-line cap: `RunTabStrip.tsx` is 210 lines and gains ~25. If it crosses 300, extract
+`RunAddMenu` into `layout/RunAddMenu.tsx` in the same pass.
+
+**Verify:** `vitest run src/layout/__tests__/RunTabStrip.test.tsx` still green (adjust it only if the
+new row breaks an existing menu-shape assertion).
+
+### Task 25 — "Open URL…" in the empty-state picker (AC2)
+
+**File:** `packages/ui/src/layout/SurfacePicker.tsx`.
+
+`RunPickerContent` gains a `PickerRow` labelled `Open URL…` with a `Globe` icon, testid
+`run-picker-open-url`, above "New terminal". Choosing it replaces the row with `<RunUrlEntry onDone={…} />`
+**in place** (no `paneId` — the surface has no pane yet), matching "reveals the same inline input in
+place".
+
+**Verify:** `vitest run src/layout/__tests__/SurfacePicker.test.tsx` still green.
+
+### Task 26 — The chip's open control becomes a menu (D7, AC4)
+
+**File:** `packages/ui/src/features/chat/smart-actions/UrlChip.tsx`.
+
+Replace the single open button with a `DropdownMenu` (the existing shadcn primitive — it renders
+through `[data-radix-popper-content-wrapper]`, which `usePreviewOcclusion` already covers, fact 11).
+The trigger keeps `data-testid="smart-action-url-open"` and its dynamic `title`/`aria-label` so the
+existing `url-chip.test.tsx` assertions on the trigger keep meaning. Rows, in order:
+
+1. **Open in Mainframe** — testid `smart-action-url-open-in-app` — emits
+   `{ type: 'open-url-tab', url: href }`. No tunnel logic here: the tab owns tunnelling, and the chip
+   must not start one on this path.
+2. **Open in browser** — testid `smart-action-url-open-browser` — calls the existing `open()` from
+   `useUrlTunnel`, preserving today's behaviour exactly (local: direct open; remote: tunnel-then-open).
+
+`badgeFor`, `busy`, and `smart-action-url-stop-tunnel` are unchanged. `busy` disables the trigger as
+before. `UrlChip.tsx` must not import `layout/` — the intent bus is the boundary.
+
+**Verify:** `vitest run src/features/chat/smart-actions/__tests__/url-chip.test.tsx` green (update it
+to open the menu before asserting the browser-open behaviour).
+
+---
+
+## Group F — `test` (behavioural coverage of the built UI)
+
+All files here are **new**; the tasks above own every pre-existing test file they had to touch.
+
+### Task 27 — URL tab body and instance
+
+**Files (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`,
+`packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx`.
+
+`UrlTabBodyState`: one case per `UrlTabTarget` variant asserting the right testid renders and that
+`rejected` shows the daemon text with **no** Retry while `failed` and `stopped` show Retry.
+
+`UrlTabInstance` (fake host adapter, `lib/host/fake-adapter.ts`): mounts the webview for a `direct`
+target; renders **no** run/stop/restart control and no console drawer, and does render the address
+bar, reload, open-in-browser, clear-cache, device toggle, inspect, and region-capture controls
+(AC5); the root testid is `url-tab-instance-<tabId>`.
+
+### Task 28 — Run surface renders the kind and scopes it
+
+**File (new):** `packages/ui/src/layout/__tests__/RunSurface.url-tab.test.tsx`.
+
+A `url` tab renders `UrlTabInstance` and never the `<kind>: <title>` placeholder (AC3); a `code` tab
+still renders the placeholder; a URL tab stamped with scope A does not render under scope B and
+disappears when that scope is released (AC13, mirroring `RunSurface.tab-scope.test.tsx`).
+
+### Task 29 — Entry points
+
+**Files (new):** `packages/ui/src/layout/__tests__/RunUrlEntry.test.tsx`,
+`packages/ui/src/features/chat/smart-actions/__tests__/url-chip-menu.test.tsx`.
+
+`RunUrlEntry`: committing `localhost:5173` emits one `open-url-tab` intent with
+`http://localhost:5173/`; each of `''`, `'   '`, `'not a url'`, `'file:///etc/passwd'`,
+`'javascript://x'` emits nothing and applies the invalid class; Escape emits nothing and calls
+`onDone`.
+
+`url-chip-menu`: the menu lists **Open in Mainframe above Open in browser** (assert DOM order, AC4);
+"Open in Mainframe" emits the intent and does not call `startPortTunnel`; "Open in browser" still
+calls the pre-existing opener.
+
+### Task 30 — Creation path, dedup, and tunnel release through the stores
+
+**File (new):** `packages/ui/src/store/__tests__/url-tab-intent-subscriber.test.ts`.
+
+- Emitting `open-url-tab` twice for the same URL yields exactly **one** tab, active both times (AC4).
+- Emitting it while Run is hidden lands the tab **and** places `run` in the layout (AC4's reveal).
+- Closing a URL tab whose tunnel it started calls `stopPortTunnel` once with that port; closing one
+  of two tabs sharing a port calls it zero times; closing a tab that adopted the chip's tunnel calls
+  it zero times (AC12) — drive these through `useLayoutStore.closeRunTab` with the consumer registry
+  seeded, mocking `lib/api/tunnel-ports`.
+- `releaseRunScope` on a scope holding an exclusively-started tunnel stops it (spec edge case).
+
+### Task 31 — Full verification sweep (AC18)
+
+Run and record:
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck`
+- `pnpm --filter @qlan-ro/mainframe-ui test` (full suite; if the known cross-file `React.act` batch
+  failure appears, re-run the affected files individually and note it — do not "fix" it here)
+- `cd packages/app-tauri/src-tauri && cargo check`
+- confirm `git status` shows a `.changeset/*.md` and **no** change under `packages/core-rs/`,
+  `packages/types/`, or `packages/mobile` (AC7's "the diff adds no route and changes no file under
+  `packages/core-rs`")
+- confirm every new interactive element carries a testid in the AC15 list and none is keyed by array
+  index
+- confirm no file added or modified exceeds 300 lines and no function exceeds 50 (AC17)
+
+---
+
+## Manual verification (not automatable — spec: the Tauri automation bridge stops answering once a
+child webview exists)
+
+Run `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR` and
+`DAEMON_PORT` (never the defaults — a stray launch hijacks the real `~/.mainframe`), then check:
+
+1. With no launch config, `+` → **URL…** → `localhost:5173` renders the dev server (AC1).
+2. Inspect and region capture deliver to chat from `http://localhost:5173/` and from a public
+   `https://` site (AC11) — the two origins the old allowlist excluded.
+3. On a remote daemon: a loopback URL on port 22 shows "Port must be 1024 or higher" and no request
+   is made (AC10, checkable in the daemon log); an eligible port shows pending, then loads the tunnel
+   origin **with the original path and query** (AC7); a second tab on that port loads with no pending
+   (AC8).
+4. Quit and relaunch: the tab is back with its title, loads on activation, and the address bar shows
+   the typed URL, never a tunnel URL (AC14).
+
+## Risks
+
+- **Widening `remote.urls` is the one hard-to-reverse change.** Any `http`/`https` page a user opens
+  can call the four bridge commands, including fabricating an inspect payload that reaches the
+  agent's context. The spec accepted this at the design gate (D1); Task 14 records it in the
+  capability description so it is not later rediscovered as a bug.
+- **`RemoteUrlPattern` re-export.** Task 15 names a concrete fallback if the `tauri::utils` path does
+  not resolve in this Tauri version.
+- **The DNS gate depends on the daemon's `ready`-means-verified semantics** for the REST snapshot
+  (fact 8). If that ever changes, an adopting tab could load an unresolvable name — the single
+  automatic reload on `dns_verified` (Task 18) is the safety net, not the gate.

--- a/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
+++ b/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
@@ -267,15 +267,21 @@ Table-drive `resolveUrlTabTarget(input)` over the contract in Task 11. Required 
 - remote + entry ready + `watching: true` + `dnsVerified: false` + `startUrl: null` → `pending`;
 - same, plus `dnsVerified: true` → `tunnelled`;
 - same, plus `startUrl` set → `tunnelled` (the tab's own POST answered);
-- remote + eligible port + **`entry === undefined`** + `startUrl` set → `tunnelled` composed from
-  `startUrl`, whether `everHadEntry` is `true` or `false` — the daemon returns an existing tunnel's
-  URL with no broadcast, so the store may never gain an entry (fact 14);
+- remote + eligible port + **`entry === undefined`** + `everHadEntry: false` + `startUrl` set →
+  `tunnelled` composed from `startUrl` — the daemon returns an existing tunnel's URL with no
+  broadcast, so the store may never gain an entry (fact 14);
 - remote + entry `{ state: 'error', error: 'boom' }` → `{ kind: 'failed', error: 'boom' }`;
 - error entry with no message → `failed` with `'Tunnel failed to start'`;
 - `timedOut: true` while still pending → `failed` with the stated timeout text;
 - **non-terminal failure:** `timedOut: true` **and** a ready+gate-open entry → `tunnelled` (AC9's
   "a URL that arrives after the failure body replaces it");
 - entry `undefined` with `everHadEntry: true` and `startUrl: null` → `{ kind: 'stopped', port }` (D14);
+- entry `undefined` with `everHadEntry: true` and **`startUrl` set** → `{ kind: 'stopped', port }` as
+  well. This is the canonical §7 case, so it is not an edge row: the tab POSTed, the entry went
+  `ready`, the page loaded, and the user then pressed Stop on the chat chip — the `stopped` WS event
+  runs `clearEntry(port)` (verified in `store/port-tunnels.ts`) while `startUrl` still holds the now
+  dead tunnel URL. `everHadEntry` outranks `startUrl` so the tab reports the stop and offers Retry
+  instead of re-mounting a 502 page (D14, AC9);
 - **the four post-Retry inputs** (the states Task 18's `retry` produces, PD1) each resolve to
   `pending`, so the start effect can fire again: `{ entry: undefined, everHadEntry: false,
   startUrl: null, timedOut: false }` after a rejected start; the same after an externally stopped
@@ -298,7 +304,12 @@ Against the pure reducers in Task 12:
 - two tabs on one port, the starter released while the other remains → `stop` is empty;
 - both released together → `stop` lists the port once, not twice;
 - releasing an unknown tab id is a no-op and returns the same state reference;
-- `clearConsumers` empties the registry and returns no ports to stop.
+- `clearConsumers` empties the registry and returns no ports to stop;
+- `addConsumer` re-registering a tab on the **same** port with `started: false` keeps `started: true`
+  (Retry never demotes an owner);
+- `addConsumer` re-registering a tab on a **different** port takes the new `started` verbatim, both
+  `true → false` and `false → true`, so a retarget cannot carry ownership onto a tunnel the tab
+  merely adopted (D10, AC12).
 
 **Verify:** fails — the module does not exist.
 
@@ -449,10 +460,18 @@ helper to stay under 50 lines per function):
 2. `classifyLocalhostUrl(url) === null` → `direct`.
 3. `daemonPort === null` → `pending`.
 4. `portRejectionReason(...) !== null` → `rejected`.
-5. `entry === undefined` → `startUrl !== null ? tunnelled(composeTunnelUrl(startUrl, url))`, else
-   `everHadEntry ? stopped : pending`. The `startUrl` branch exists because a start POST that adopts a
-   tunnel the daemon already holds returns its URL and broadcasts nothing (fact 14) — without it a tab
-   whose entry Retry just cleared would wait for an event that never arrives.
+5. `entry === undefined` → `everHadEntry ? stopped : (startUrl !== null ? tunnelled(composeTunnelUrl(startUrl, url)) : pending)`.
+   The two branches answer two different histories, and **`everHadEntry` must be tested first**:
+   - `everHadEntry === true` means an entry for this port existed during this attempt and is now gone,
+     which happens only when the daemon broadcast `stopped` and the store ran `clearEntry(port)`. The
+     tunnel is dead no matter what this tab's own POST once returned, so the tab reports `stopped` and
+     offers Retry (D14, spec behaviour §7). Testing `startUrl` first would swallow this: every tab that
+     ever reached `pending` issues a start (the effect has no `entry === undefined` guard, Task 18), so
+     nearly every tab holds a non-null `startUrl` and would keep mounting the dead tunnel URL forever.
+   - `everHadEntry === false` with a `startUrl` means the POST answered from a tunnel the daemon
+     already held: it returns that URL and broadcasts nothing (fact 14), so no entry will ever appear.
+     Without this branch a tab whose entry Retry just cleared — the attempt reset sets `everHadEntry`
+     back to `false` — would wait for an event that never arrives.
 6. `entry.state === 'error'` → `failed` with `entry.error ?? 'Tunnel failed to start'`.
 7. `entry.state === 'ready' && (entry.url ?? startUrl)` and the gate is open
    (`!watching || startUrl !== null || entry.dnsVerified === true`) → `tunnelled` with
@@ -519,8 +538,17 @@ because the release path runs outside React and there is no module-level accesso
 `registerUrlTunnelConsumer(tabId, rec)`, `releaseUrlTunnelConsumers(tabIds)` (calls
 `stopPortTunnel(daemonHttpPort, port)` for each stop entry, `.catch` logged with a
 `[url-tab]` tag — never a silent catch), and `clearUrlTunnelConsumers()`.
-Registration is idempotent per tab id: re-registering the same tab replaces its record and must not
-flip `started` from `true` to `false`.
+Registration is idempotent per tab id, and the rule is **keyed by port**:
+- re-registering a tab on the port it already holds replaces the record but must not flip `started`
+  from `true` to `false` — an owner stays an owner across a Retry (D10);
+- re-registering it on a **different** port (the address-bar retarget, Task 33) takes the new
+  `started` value verbatim, in both directions. The old port's ownership says nothing about the new
+  one, and carrying `true` across would let the tab stop a tunnel on the new port that it only
+  adopted. Implement it as: preserve the old `started` only when `rec.port === existing.port`.
+
+The retarget drops the tab out of the old port's consumer set without stopping that port's tunnel.
+That is D10's err-toward-leaving-it-up rule applied to a live tunnel a user may still be using from
+the chat chip; a retarget is not a close.
 
 `store/url-tunnel-cleanup.ts` — a one-import shim over `features/url-tab/tunnel-consumers`, mirroring
 `store/terminal-cleanup.ts`, so `layout.ts` never imports a feature store and no import cycle forms.
@@ -711,12 +739,13 @@ daemon's own port, for eligibility), `useActiveIdentity().chatId`, and
 `usePortTunnel(port)` for the classified loopback port (skip the subscription entirely when the URL
 is not loopback or the daemon is local).
 
-**Every piece of state below is per *attempt*.** `attempt` is a counter the tab bumps on Retry; the
-hook holds the flags in one object replaced wholesale, and a `useEffect` on `[attempt, port]` resets
-them. Keying on `attempt` — not on `target.kind === 'pending'` or on `entry === undefined` — is what
-makes Retry work in all four states it is reachable from (PD1).
+**Every piece of resolver state below is per *attempt*.** `attempt` is a counter the tab bumps on
+Retry; the hook holds the flags in one object replaced wholesale, and a `useEffect` on
+`[attempt, port]` resets them. Keying on `attempt` — not on `target.kind === 'pending'` or on
+`entry === undefined` — is what makes Retry work in all four states it is reachable from (PD1). The
+one exception is `ownedRef`, which is per *port*.
 
-State it owns, all feeding `resolveUrlTabTarget`:
+State it owns — everything but `ownedRef` feeds `resolveUrlTabTarget`:
 - `watchingRef` — set `true` on the first render of the attempt at which an entry is absent or
   `starting` **and** a start is needed; never set `false` within the attempt.
 - `startUrl` — the URL this tab's own `startPortTunnel` POST resolved with, `null` until it does.
@@ -725,6 +754,11 @@ State it owns, all feeding `resolveUrlTabTarget`:
   `pending`, cleared when it leaves `pending`.
 - `startedForAttemptRef` — the attempt number whose start POST has been issued, so the effect fires
   once per attempt rather than once per tab.
+- `ownedRef` — the ownership observation that feeds the consumer registration, **not** the resolver:
+  `true` once the start effect has fired at a moment when `entry === undefined`. The reset effect
+  clears it only when `port` changes, never on an attempt bump, so a Retry cannot demote an owner
+  (D10) and Task 12's same-port idempotency rule agrees with it. A port change resets it to the value
+  observed on the new port, which is why Task 12 drops the preserve rule across ports.
 
 Effects:
 - **Start request.** When the target is `pending`, `daemonPort !== null`, `chatId` is present, and
@@ -736,15 +770,22 @@ Effects:
   another consumer's start joins it and a POST on a live tunnel returns its URL, in neither case
   spawning a second cloudflared (fact 14). Adopting mid-start therefore still holds (spec "Tunnel
   adopted mid-start"), and the tab gains a URL source for the case where the daemon has a tunnel but
-  will never broadcast about it again.
+  will never broadcast about it again. In the same statement that stamps `startedForAttemptRef`,
+  record `ownedRef.current ||= entry === undefined` — an observation taken as the POST goes out, not a
+  gate on sending it.
 - **DNS reload trigger.** When `entry.dnsVerified` transitions to `true` while the target is already
   `tunnelled` **and** the tab loaded before verification, fire the caller-provided reload once
   (expose it as a `reloadNonce` counter in the return so `UrlTabInstance` can re-navigate). Exactly
   once per transition (D11 / spec step 5).
-- **Consumer registration.** Call `registerUrlTunnelConsumer(tabId, { port, started: watchingRef.current && startedByThisTab, daemonHttpPort })`
-  whenever the port or the started flag changes. `started` is `true` only when this tab issued the
-  POST itself — a tab that merely joined another consumer's start counts as adopted (D10's
-  err-toward-leaving-it-up rule).
+- **Consumer registration.** Call `registerUrlTunnelConsumer(tabId, { port, started: ownedRef.current, daemonHttpPort })`
+  whenever the port or `ownedRef.current` changes. `started` is `true` only when this tab's start
+  effect fired at a moment when **no entry existed for the port** — the tab observed itself creating
+  the tunnel. Issuing the POST is not enough on its own: in the spec's "Tunnel adopted mid-start" case
+  the chip has already put a `starting` entry in the store, the tab's POST joins that in-flight start
+  (fact 14), and registering `started: true` there would make `releaseConsumers` kill the chip's
+  tunnel on tab close while the chip still shows its badge and Stop control — the exact inversion of
+  AC12. The daemon cannot disambiguate for us: `POST /api/tunnel/ports/start` answers `{ url, port }`
+  for a create, a join, and an adopt alike, and D5 declines any daemon change.
 - **`retry`** — the only way out of `failed` and `stopped`, and it never runs automatically (D14):
   ```ts
   function retry() {
@@ -765,9 +806,9 @@ Effects:
   `rejected` is the one failure body with **no** Retry — the port is ineligible, and retrying it would
   re-issue a request the client already knows the daemon refuses (AC10).
 
-  Retry does not clear the consumer registration's `started` flag: a tab that has ever issued a start
-  POST for the port stays an owner (D10), and Task 12's registration is idempotent and never flips
-  `started` back to `false`.
+  Retry does not clear the consumer registration's `started` flag: `ownedRef` survives an attempt
+  bump, so a tab that has ever been observed creating this port's tunnel stays its owner (D10), and
+  Task 12's same-port registration never flips `started` back to `false`.
 
 Keep the file under 300 lines and each effect under 50; extract the watchdog into a small local hook
 if it grows.
@@ -971,6 +1012,11 @@ Two more `UrlTabInstance` cases, both regressions this plan's review caught:
   `failed`, and again with a tab whose `url` is `''` (`invalid`), `preview-url-input` is **not**
   `disabled`; committing `localhost:5173` in it calls the mocked `setUrlTabTarget` once with the
   normalized URL and never calls `host.preview.mount` with the old value (spec §6, D9, AC14).
+- **Adopting mid-start registers as an adopter.** With a `{ state: 'starting' }` entry already in
+  `usePortTunnelsStore` for the port (the chat chip's start), mounting the tab still issues its
+  `startPortTunnel` POST but registers with `started: false` — assert through the mocked
+  `registerUrlTunnelConsumer`, then unmount the tab and assert `stopPortTunnel` was never called
+  (D10, AC12). With no entry present at mount, the same tab registers `started: true`.
 - **Retry re-requests.** With the target `failed` from an `{ state: 'error' }` entry, clicking
   `url-tab-retry` clears the entry from `usePortTunnelsStore` and issues exactly one
   `startPortTunnel` call (mock `lib/api/tunnel-ports`); with the target `stopped` (entry gone after

--- a/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
+++ b/docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md
@@ -75,6 +75,23 @@ Each was read in the worktree; do not re-derive them.
     Radix primitives is covered with no new wiring.
 12. Existing call sites of the `terminalIds*` helpers: `store/layout.ts` (×3),
     `lib/daemon/dispose-daemon-session.ts` (×1), plus three test files.
+13. `store/layout.ts` is **317 lines today** — already over the 300-line cap before this work adds a
+    line to it. Task 32 decomposes it first; every later task that edits it lands on the smaller file.
+14. The daemon's `PortTunnelRegistry::start` is **single-flight and idempotent per port**
+    (`plan_start`, `packages/core-rs/crates/mainframe-launch/src/port_tunnel_registry.rs`): a second
+    POST while an entry is `Starting` joins the in-flight start (`StartAction::Wait`), and one on a
+    live `Ready` entry returns the existing URL (`StartAction::Existing`) **without spawning anything
+    and without broadcasting a `tunnel:status` event**. Two consequences the plan relies on: a client
+    guard against issuing a second start is not what prevents a duplicate tunnel, and a client that
+    waits only for WS events can wait forever for a tunnel the daemon already holds. The start POST's
+    own `{ url }` response (`lib/api/tunnel-ports.ts` `startPortTunnel`) is therefore a first-class
+    URL source, not just a signal.
+15. `classifyLocalhostUrl('')` returns `null` (`new URL('')` throws), and `isTunnelEligiblePort` is
+    never reached for it — so an empty or unparseable stored URL cannot be expressed by any
+    tunnel-shaped target. Task 11 gives it its own `invalid` variant instead.
+16. `store/port-tunnels.ts`'s `clearEntry(port)` is module-private, and `UrlChip`'s `badgeFor(undefined, false)`
+    renders **no badge** while `canStop` is `false` — so removing a non-`ready` entry returns every chip
+    on that port to its pre-tunnel appearance rather than to a wrong one.
 
 ## New and changed files
 
@@ -94,6 +111,7 @@ Each was read in the worktree; do not re-derive them.
 | `layout/RunUrlEntry.tsx` | the inline URL entry, shared by the strip and the picker |
 | `store/url-tunnel-cleanup.ts` | layout-facing release helper (mirrors `terminal-cleanup.ts`) |
 | `store/url-tab-intent-subscriber.ts` | the `open-url-tab` intent boundary |
+| `store/layout-placement.ts` | the layout types + pure placement helpers lifted out of `layout.ts` (Task 32) |
 
 **Changed:** `store/run-pane.ts`, `store/layout.ts`, `store/layout-persist.ts`, `store/port-tunnels.ts`,
 `store/surface-intents.ts`, `lib/daemon/dispose-daemon-session.ts`,
@@ -102,6 +120,44 @@ Each was read in the worktree; do not re-derive them.
 `features/chat/smart-actions/UrlChip.tsx`,
 `packages/app-tauri/src-tauri/capabilities/preview.json`,
 `packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs`.
+
+## Execution groups
+
+The names below are the ones the lane schedules. `parallel_safe` is a file-collision flag only;
+`depends_on` names the groups whose output this one reads or verifies.
+
+| Group | Tasks | Kind | parallel_safe | depends_on |
+|---|---|---|---|---|
+| `test-pure-red` | 1–6 | test | yes | — |
+| `core` | 7–13, 32, 33 | core | yes | `test-pure-red` |
+| `rust` | 14, 15 | core | yes | — |
+| `ui-tab` | 16–21 | ui | yes | `core` |
+| `ui-entrypoints` | 22–26 | ui | yes | `core` |
+| `test-ui` | 27–31 | test | yes | `core`, `rust`, `ui-tab`, `ui-entrypoints` |
+
+`test-ui` depends on `rust` because Task 31's sweep runs `cargo check` and asserts the diff's package
+boundaries — it verifies the widened capability, so running it before Task 14/15 would record a green
+sweep that never saw them.
+
+## Plan-level decisions
+
+- **PD1. Retry re-drives the start POST and resets every per-attempt flag, keyed on an attempt nonce.**
+  The daemon is the single-flight point (fact 14), so the earlier `entry === undefined` guard bought no
+  safety and made Retry inert in three of its four reachable states. Task 18 owns the trace.
+- **PD2. Retry may clear a non-`ready` port-tunnel entry; a `ready` entry is never cleared.** A shared
+  `error` or `starting` entry is a stale local marker, and dropping it returns the chat chip to its
+  pre-tunnel appearance (fact 16). Dropping a `ready` entry would take a live tunnel's URL away from
+  the chip, which `reportPortTunnelError` already refuses to do.
+- **PD3. Committing a URL in a URL tab's address bar rewrites the tab's `url` through the layout store
+  (Task 33), keeping the tab id.** The id is the webview label's source and the tunnel-consumer key;
+  minting a new one would remount the webview and orphan the registration. The typed URL is the tab's
+  identity for dedup, persistence, and re-resolution (D9, AC14).
+- **PD4. The address bar reflects in-page navigation but only Enter changes the tab's identity.** A
+  tunnelled tab therefore displays the tunnel origin once loaded — honest browser behaviour — while
+  what persists and re-seeds is always `tab.url`, never a tunnel URL (AC14, and the spec's deferred
+  "preserving in-page navigation across a restart").
+- **PD5. AC17's 300-line cap is honoured on `store/layout.ts` by decomposing it (Task 32), not by
+  scoping the rule to new files.** It is 317 lines today (fact 13) and this work adds to it.
 
 ---
 
@@ -142,6 +198,15 @@ the pre-existing cases still pass.
 - `tabIdsInRun(run, 'url')` / `tabIdsInPane(run, paneId, 'url')` / `tabIdsForScope(run, scope, 'url')`
   return only URL tab ids, and the same functions with `'terminal'` return the terminal ids.
 
+Same file, against the new `retargetUrlTab(run, tabId, url, title)` reducer (Task 8 item 5):
+- retargeting a URL tab to a new URL updates that tab's `url` and `title` **in place** and keeps its
+  `id` (PD3);
+- retargeting to the URL it already holds returns the same `RunState` reference;
+- when another URL tab **in the same scope** already holds the target URL, the source tab is left
+  untouched and the holder is activated in its own pane (D8's dedup, applied to a retarget);
+- a tab in a different scope holding that URL does not block the retarget;
+- an unknown `tabId`, or a tab whose `kind` is not `'url'`, returns the same reference.
+
 `url-tab-id.test.ts` asserts:
 - `urlTabId('http://localhost:5173/a/b?q=1#frag')` matches `/^[A-Za-z0-9_-]+$/`;
 - two calls for the same URL produce different ids (uniqueness);
@@ -172,15 +237,24 @@ Assert:
 - `applyPortTunnelSnapshot` marks a `state: 'ready'` entry `dnsVerified: true` (fact 8) and leaves a
   `starting` entry without the flag.
 
+Same file, against the new `clearPortTunnelEntry(port)` export (Task 10, PD2):
+- clearing an `error` entry removes the key, bumps `generation`, and returns `true`;
+- clearing a `starting` entry does the same;
+- clearing a `ready` entry is a **no-op**: the entry keeps its `state`, `url`, and `dnsVerified`, the
+  function returns `false`, and `generation` is unchanged;
+- clearing a port with no entry returns `false` and leaves the state reference untouched.
+
 Keep the existing "treats dns_verified as ready" expectations working.
 
-**Verify:** the new assertions fail — the field does not exist.
+**Verify:** the new assertions fail — neither the field nor the export exists.
 
 ### Task 5 — Tunnel-state resolution (AC7, AC8, AC9, AC10, D11–D14)
 
 **File (new):** `packages/ui/src/features/url-tab/__tests__/resolve-url-target.test.ts`.
 
 Table-drive `resolveUrlTabTarget(input)` over the contract in Task 11. Required cases:
+- `url: ''`, `url: '   '`, `url: 'not a url'` → `{ kind: 'invalid', url }` on **both** a local and a
+  remote daemon (the variant is resolved ahead of the locality check, fact 15);
 - local daemon, any URL → `{ kind: 'direct', url }` (including a loopback URL);
 - remote daemon, non-loopback URL (`https://example.com/x`, `http://192.168.1.5:3000/`) → `direct`;
 - remote + loopback + `daemonPort === null` → `pending`;
@@ -190,15 +264,23 @@ Table-drive `resolveUrlTabTarget(input)` over the contract in Task 11. Required 
 - remote + entry `{ state: 'starting' }` → `pending`;
 - remote + entry ready with url + `watching: false` (adopting) → `tunnelled`, **regardless of
   `dnsVerified`** (AC8);
-- remote + entry ready + `watching: true` + `dnsVerified: false` + `startResolved: false` → `pending`;
+- remote + entry ready + `watching: true` + `dnsVerified: false` + `startUrl: null` → `pending`;
 - same, plus `dnsVerified: true` → `tunnelled`;
-- same, plus `startResolved: true` → `tunnelled`;
+- same, plus `startUrl` set → `tunnelled` (the tab's own POST answered);
+- remote + eligible port + **`entry === undefined`** + `startUrl` set → `tunnelled` composed from
+  `startUrl`, whether `everHadEntry` is `true` or `false` — the daemon returns an existing tunnel's
+  URL with no broadcast, so the store may never gain an entry (fact 14);
 - remote + entry `{ state: 'error', error: 'boom' }` → `{ kind: 'failed', error: 'boom' }`;
 - error entry with no message → `failed` with `'Tunnel failed to start'`;
 - `timedOut: true` while still pending → `failed` with the stated timeout text;
 - **non-terminal failure:** `timedOut: true` **and** a ready+gate-open entry → `tunnelled` (AC9's
   "a URL that arrives after the failure body replaces it");
-- entry `undefined` with `everHadEntry: true` → `{ kind: 'stopped', port }` (D14);
+- entry `undefined` with `everHadEntry: true` and `startUrl: null` → `{ kind: 'stopped', port }` (D14);
+- **the four post-Retry inputs** (the states Task 18's `retry` produces, PD1) each resolve to
+  `pending`, so the start effect can fire again: `{ entry: undefined, everHadEntry: false,
+  startUrl: null, timedOut: false }` after a rejected start; the same after an externally stopped
+  tunnel; the same after a 120 s timeout whose `starting` entry was cleared; and
+  `{ entry: undefined, everHadEntry: false, timedOut: false }` after a timeout that never had an entry;
 - `composeTunnelUrl('https://x.trycloudflare.com', 'http://localhost:5173/a/b?q=1#f')` →
   `'https://x.trycloudflare.com/a/b?q=1#f'` (D12), and an origin-only original URL →
   `'https://x.trycloudflare.com/'`.
@@ -238,7 +320,7 @@ could point a child webview at `file://`).
 
 ### Task 8 — `url` tab kind, dedup, kind-parameterized id helpers
 
-**File:** `packages/ui/src/store/run-pane.ts` (currently 207 lines; stays well under 300).
+**File:** `packages/ui/src/store/run-pane.ts` (207 lines today; ~245 after this task, still under 300).
 
 1. Add `'url'` to `RunTabKind`.
 2. Add `url?: string` to `RunTab` with a doc line: normalized committed URL for a `url` tab; the
@@ -252,7 +334,17 @@ could point a child webview at `file://`).
    `tabIdsInRun(run, kind)` / `tabIdsInPane(run, paneId, kind)` / `tabIdsForScope(run, scopeKey, kind)`
    (`kind: RunTabKind`). Three near-identical pairs would otherwise exist — the hygiene rule
    requires the extraction.
-5. Update the call sites (fact 12): `store/layout.ts` ×3 (`'terminal'` argument),
+5. Add the pure retarget reducer used by the address bar (PD3):
+   ```ts
+   export function retargetUrlTab(run: RunState, tabId: string, url: string, title: string): RunState;
+   ```
+   It finds the tab across every pane; returns `run` unchanged when the id is unknown, the tab's
+   `kind` is not `'url'`, or its `url` already equals `url`. When another `url` tab **in the same
+   `scopeKey`** already holds `url`, it activates that tab in its own pane and leaves the source tab
+   alone (D8). Otherwise it replaces the tab's `url` and `title` in place, keeping the `id` — the id
+   is the webview label's source and the tunnel-consumer key. The caller supplies `title` so
+   `run-pane.ts` stays free of feature imports.
+6. Update the call sites (fact 12): `store/layout.ts` ×3 (`'terminal'` argument),
    `lib/daemon/dispose-daemon-session.ts` ×1, and mechanically rename in
    `store/__tests__/run-pane-terminal.test.ts`, `store/__tests__/run-pane-release-scope.test.ts`,
    and the `vi.mock('../../../store/run-pane', …)` factory in
@@ -284,6 +376,19 @@ existing `true` if one is already recorded, so a late duplicate `ready` cannot u
 `applyPortTunnelSnapshot`, set `dnsVerified: true` for `state === 'ready'` entries.
 `reportPortTunnelError`'s never-downgrade-a-ready-tunnel rule is unchanged.
 
+Also export the module-private `clearEntry` as a guarded public function (PD2), because Task 18's
+`retry` has no other way to drop the stale entry that pins a URL tab in `failed`:
+```ts
+/** Drops a non-live entry so a consumer can retry. Refuses a `ready` entry. Returns whether it cleared. */
+export function clearPortTunnelEntry(port: number): boolean;
+```
+It returns `false` without touching state when the entry is `ready` or absent, and otherwise removes
+the key and bumps `generation` exactly as `clearEntry` does. Document the shared-badge consequence in
+the doc comment: every `UrlChip` on that port re-renders with no badge and no Stop control (fact 16),
+which is the chip's pre-tunnel appearance — the cleared entry was a stale failure or a start the
+daemon has since abandoned, and the next `tunnel:status` event repopulates it. A `ready` entry is
+refused for the same reason `reportPortTunnelError` refuses to downgrade one.
+
 **Verify:** `vitest run src/store/__tests__/port-tunnels.test.ts` green.
 
 ### Task 11 — Pure tunnel-state resolution + tab identity
@@ -308,7 +413,8 @@ export type UrlTabTarget =
   | { kind: 'pending'; port: number }
   | { kind: 'rejected'; port: number; reason: string }
   | { kind: 'failed'; error: string }
-  | { kind: 'stopped'; port: number };
+  | { kind: 'stopped'; port: number }
+  | { kind: 'invalid'; url: string };
 
 export interface UrlTabTunnelInput {
   url: string;                 // normalized, user-committed
@@ -316,7 +422,7 @@ export interface UrlTabTunnelInput {
   daemonPort: number | null;   // the DAEMON's own port from the tunnel snapshot, not the HTTP client port
   entry: PortTunnelEntry | undefined;
   watching: boolean;           // this tab attached while the tunnel was absent or starting
-  startResolved: boolean;      // this tab's own POST /tunnel/ports/start returned a url
+  startUrl: string | null;     // the url this tab's own POST /tunnel/ports/start returned
   timedOut: boolean;           // the 120s watchdog fired
   everHadEntry: boolean;       // an entry existed for this port and then disappeared
 }
@@ -334,23 +440,54 @@ otherwise `null`.
 
 `resolveUrlTabTarget` evaluates in this exact order (split the tail into a `resolveEntryTarget`
 helper to stay under 50 lines per function):
+0. `normalizePreviewUrl(url) === null` → `{ kind: 'invalid', url }`. This runs **ahead of the locality
+   check** because no other variant can express an unusable URL: `classifyLocalhostUrl('')` returns
+   `null`, which would otherwise fall out of step 2 as `direct` with an empty `url` and hand
+   `WebviewUrl::External(Url::parse(""))` to the Tauri shell (fact 15). Callers normalize before
+   creating a tab, so the only live source is corrupt persisted state (Task 21).
 1. `isLocal` → `direct`.
 2. `classifyLocalhostUrl(url) === null` → `direct`.
 3. `daemonPort === null` → `pending`.
 4. `portRejectionReason(...) !== null` → `rejected`.
-5. `entry === undefined` → `everHadEntry ? stopped : pending`.
+5. `entry === undefined` → `startUrl !== null ? tunnelled(composeTunnelUrl(startUrl, url))`, else
+   `everHadEntry ? stopped : pending`. The `startUrl` branch exists because a start POST that adopts a
+   tunnel the daemon already holds returns its URL and broadcasts nothing (fact 14) — without it a tab
+   whose entry Retry just cleared would wait for an event that never arrives.
 6. `entry.state === 'error'` → `failed` with `entry.error ?? 'Tunnel failed to start'`.
-7. `entry.state === 'ready' && entry.url` and the gate is open
-   (`!watching || startResolved || entry.dnsVerified === true`) → `tunnelled` with
-   `composeTunnelUrl(entry.url, url)`.
+7. `entry.state === 'ready' && (entry.url ?? startUrl)` and the gate is open
+   (`!watching || startUrl !== null || entry.dnsVerified === true`) → `tunnelled` with
+   `composeTunnelUrl(entry.url ?? startUrl, url)`.
 8. anything else → `timedOut ? failed('The tunnel did not produce a URL within 120 seconds') : pending`.
 
-Step 7 preceding step 8 is what makes the failure non-terminal (AC9).
+Step 5's `startUrl` branch and step 7 preceding step 8 are what make the failure non-terminal (AC9).
 
 `composeTunnelUrl` takes the origin of `tunnelOrigin` and appends `pathname + search + hash` of
 `originalUrl` (D12); on a parse failure it returns `tunnelOrigin` unchanged.
 
 **Verify:** `vitest run src/features/url-tab/__tests__/resolve-url-target.test.ts src/features/url-tab/__tests__/url-tab-id.test.ts` green.
+
+### Task 32 — Decompose `store/layout.ts` before it grows (AC17, PD5)
+
+**Order:** runs **before** Task 12 and Task 33, which both add lines to `layout.ts`.
+**Files:** `packages/ui/src/store/layout-placement.ts` (new), `packages/ui/src/store/layout.ts`.
+
+`layout.ts` is 317 lines today (fact 13) — already over the cap this plan's final sweep enforces.
+Move, with no behaviour change, the layout value types and the pure placement helpers into
+`store/layout-placement.ts`: the `SurfaceId`, `RepositionTarget`, and `WorkspaceLayout` types, plus
+`insertTop`, `placeInLayout`, `removeSurface`, `repositionInLayout`, `layoutCanSplit`,
+`litSurfaceCount`, and `isSurfaceFloor` (`layout.ts:22–123`). They touch no store state, which is why
+this is the seam rather than the mutators — the four Run-tab mutators all close over `get()` and
+`writeWorkspace`, so lifting them would mean inventing an injection shape for a line count this
+extraction already buys.
+
+`layout.ts` imports what it uses and **re-exports the public surface unchanged** so no call site moves:
+`export type { SurfaceId, RepositionTarget, WorkspaceLayout } from './layout-placement';` and
+`export { isSurfaceFloor, layoutCanSplit, litSurfaceCount } from './layout-placement';` (a `export type`
+form is required — the package is `verbatimModuleSyntax`). Fourteen files import these from
+`@/store/layout`; none of them changes.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/store/__tests__/layout.test.ts src/layout/__tests__/use-surface-drag.test.ts` green with no edits to either file;
+`pnpm --filter @qlan-ro/mainframe-ui typecheck`; `wc -l packages/ui/src/store/layout.ts` reports under 250.
 
 ### Task 12 — Tunnel ownership registry + layout release wiring (D10, AC12)
 
@@ -401,6 +538,35 @@ only requires re-resolution. Record that reason in a one-line comment.
 **Verify:** `vitest run src/features/url-tab/__tests__/url-tunnel-ownership.test.ts` green;
 `vitest run src/store/__tests__/layout.test.ts src/store/__tests__/layout.terminal-cleanup.test.ts src/store/__tests__/layout-release-scope.test.ts`
 still green.
+
+### Task 33 — `setUrlTabTarget`, the address bar's write path (D9, PD3)
+
+**Files:** `packages/ui/src/store/layout.ts`,
+`packages/ui/src/store/__tests__/url-tab-retarget.test.ts` (new).
+
+Add one action to `LayoutStore`:
+```ts
+/** Point a URL tab at a newly committed URL. The tab's id — and its webview — survive. */
+setUrlTabTarget: (tabId: string, url: string, title: string) => void;
+```
+It reads `run`, returns early when `run` is `null`, calls `retargetUrlTab` (Task 8 item 5), and
+`writeWorkspace`s only when the reducer returned a different reference. It does not touch `layout` —
+the tab already exists, so there is nothing to reveal. Keep it under 10 lines; Task 32 has already
+made room.
+
+This is the only way a URL tab's identity changes after creation. `UrlTabInstance` (Task 20) calls it
+from the address bar's commit handler; the changed `tab.url` flows back down as a new `url` prop,
+which re-drives `useUrlTabTunnel` and `useWebviewMount` — so a URL typed while the tab sits in
+`failed`, `stopped`, `pending`, `rejected`, or `invalid` re-runs tunnel resolution and dedup instead of
+being lost (spec behaviour §6, AC14).
+
+`url-tab-retarget.test.ts` drives the store, not the reducer: committing a new URL on a URL tab
+updates `run` and persists through `writeWorkspace`; committing the URL a sibling tab in the same
+scope already holds activates that sibling and leaves the source tab's `url` alone; committing on a
+`terminal` tab id is a no-op.
+
+**Verify:** `vitest run src/store/__tests__/url-tab-retarget.test.ts` green;
+`vitest run src/store/__tests__/layout.test.ts` still green.
 
 ### Task 13 — Changeset
 
@@ -504,12 +670,23 @@ reanchor-on-element-change, destroy-on-null-url, and destroy-on-unmount.
 `currentUrl` from `seedUrl` and re-seeds when `seedUrl` changes. The `onNavigate` reflection is
 unchanged. Callers that had a port pass `` port !== null ? `http://localhost:${port}` : null ``.
 
-`PreviewUrlBar` props become `{ handle, seedUrl, enabled }` (`enabled` replaces `isRunning`, whose
-name no longer fits a tab with no process). `handleReload` navigates to `currentUrl` and no-ops when
-it is empty — it must not re-derive `http://localhost:${port}` (D13). `handleOpenBrowser` uses
-`currentUrl` only. The four testids (`preview-url-reload`, `preview-url-input`,
-`preview-url-open-browser`, `preview-url-clear-cache`) are unchanged — the URL tab reuses this
-component and inherits them.
+`PreviewUrlBar` props become `{ handle, seedUrl, enabled, onCommitUrl? }`:
+
+- `enabled` replaces `isRunning`, whose name no longer fits a tab with no process, and it now gates
+  **only** the text input and the status dot. The three icon buttons gate on
+  `const canAct = enabled && handle !== null` — for a preview tab that is today's behaviour plus a
+  handle check the actions already no-op'd on, and for a URL tab it is what lets the input stay live
+  while nothing is mounted.
+- `onCommitUrl?: (url: string) => void`. When it is supplied, Enter normalizes with
+  `normalizePreviewUrl` and calls `onCommitUrl(normalized)` **instead of** `navigateTo` — the owner
+  re-drives the mount, so there is exactly one navigation and no race between an optimistic navigate
+  and a changed `seedUrl`. Invalid input keeps the existing invalid treatment and calls nothing. When
+  `onCommitUrl` is absent (the preview tab) the current `navigateTo(draft)` path is untouched.
+
+`handleReload` navigates to `currentUrl` and no-ops when it is empty — it must not re-derive
+`http://localhost:${port}` (D13). `handleOpenBrowser` uses `currentUrl` only. The four testids
+(`preview-url-reload`, `preview-url-input`, `preview-url-open-browser`, `preview-url-clear-cache`) are
+unchanged — the URL tab reuses this component and inherits them.
 
 `PreviewToolbar` passes `seedUrl` through and keeps its own `port` prop only for the pieces that
 still need it. `PreviewInstance` supplies the seed.
@@ -517,7 +694,9 @@ still need it. `PreviewInstance` supplies the seed.
 **Files also touched:** `packages/ui/src/features/preview/__tests__/use-preview-address.test.ts`
 and `PreviewUrlBar.test.tsx` and `PreviewToolbar.test.tsx` — update to the new props; add a case
 asserting reload navigates to the **navigated-to** URL, not `localhost:<port>`, after an
-`onNavigate` event.
+`onNavigate` event; add two `onCommitUrl` cases — with a `null` handle and `enabled` true, Enter on
+valid input calls `onCommitUrl` once and `handle.navigate` never, and Enter on `file:///etc/passwd`
+calls neither and shows the invalid treatment.
 
 **Verify:** `vitest run src/features/preview/__tests__/use-preview-address.test.ts src/features/preview/__tests__/PreviewUrlBar.test.tsx src/features/preview/__tests__/PreviewToolbar.test.tsx` green.
 
@@ -525,28 +704,39 @@ asserting reload navigates to the **navigated-to** URL, not `localhost:<port>`, 
 
 **File (new):** `packages/ui/src/features/url-tab/use-url-tab-tunnel.ts`.
 
-`useUrlTabTunnel({ tabId, url }): { target: UrlTabTarget; retry: () => void }`.
+`useUrlTabTunnel({ tabId, url }): { target: UrlTabTarget; retry: () => void; reloadNonce: number }`.
 
 Reads `useDaemonIsLocal()`, `useDaemonPort()` (HTTP client port), `useTunnelDaemonPort()` (the
 daemon's own port, for eligibility), `useActiveIdentity().chatId`, and
 `usePortTunnel(port)` for the classified loopback port (skip the subscription entirely when the URL
 is not loopback or the daemon is local).
 
+**Every piece of state below is per *attempt*.** `attempt` is a counter the tab bumps on Retry; the
+hook holds the flags in one object replaced wholesale, and a `useEffect` on `[attempt, port]` resets
+them. Keying on `attempt` — not on `target.kind === 'pending'` or on `entry === undefined` — is what
+makes Retry work in all four states it is reachable from (PD1).
+
 State it owns, all feeding `resolveUrlTabTarget`:
-- `watchingRef` — set `true` on the first render at which an entry is absent or `starting` **and** a
-  start is needed; never set `false` afterwards for the life of the tab.
-- `startResolved` — set when this tab's `startPortTunnel` POST resolves.
-- `everHadEntry` — set once an entry has been seen; drives the `stopped` state (D14).
+- `watchingRef` — set `true` on the first render of the attempt at which an entry is absent or
+  `starting` **and** a start is needed; never set `false` within the attempt.
+- `startUrl` — the URL this tab's own `startPortTunnel` POST resolved with, `null` until it does.
+- `everHadEntry` — set once an entry has been seen during this attempt; drives the `stopped` state (D14).
 - `timedOut` — a 120 s (`URL_TAB_TUNNEL_TIMEOUT_MS`) watchdog started when the target first becomes
   `pending`, cleared when it leaves `pending`.
+- `startedForAttemptRef` — the attempt number whose start POST has been issued, so the effect fires
+  once per attempt rather than once per tab.
 
 Effects:
-- **Start request.** When the target is `pending`, `entry === undefined`, `daemonPort !== null`,
-  `chatId` is present, and no request is in flight for this tab, POST
-  `startPortTunnel(httpPort, { port, chatId })`; on rejection call `reportPortTunnelError(port, message)`
-  (which is the single funnel for both the POST rejection and the WS error, so the toast is not
-  doubled). Never issue a second start while an entry exists — an entry in `starting` means another
-  consumer's start is in flight and this tab joins it (spec "Tunnel adopted mid-start").
+- **Start request.** When the target is `pending`, `daemonPort !== null`, `chatId` is present, and
+  `startedForAttemptRef.current !== attempt`, stamp the ref and POST
+  `startPortTunnel(httpPort, { port, chatId })`; on resolve store the returned `url` in `startUrl`; on
+  rejection call `reportPortTunnelError(port, message)` (which is the single funnel for both the POST
+  rejection and the WS error, so the toast is not doubled). There is deliberately **no
+  `entry === undefined` guard**: the daemon's registry is the single-flight point — a POST during
+  another consumer's start joins it and a POST on a live tunnel returns its URL, in neither case
+  spawning a second cloudflared (fact 14). Adopting mid-start therefore still holds (spec "Tunnel
+  adopted mid-start"), and the tab gains a URL source for the case where the daemon has a tunnel but
+  will never broadcast about it again.
 - **DNS reload trigger.** When `entry.dnsVerified` transitions to `true` while the target is already
   `tunnelled` **and** the tab loaded before verification, fire the caller-provided reload once
   (expose it as a `reloadNonce` counter in the return so `UrlTabInstance` can re-navigate). Exactly
@@ -555,11 +745,36 @@ Effects:
   whenever the port or the started flag changes. `started` is `true` only when this tab issued the
   POST itself — a tab that merely joined another consumer's start counts as adopted (D10's
   err-toward-leaving-it-up rule).
-- **`retry`** resets `timedOut`, `startResolved`, and the in-flight flag so the start effect runs
-  again. It never runs automatically (D14).
+- **`retry`** — the only way out of `failed` and `stopped`, and it never runs automatically (D14):
+  ```ts
+  function retry() {
+    clearPortTunnelEntry(port);   // no-op on a ready entry (PD2)
+    setAttempt((n) => n + 1);     // resets watching / startUrl / everHadEntry / timedOut / startedForAttempt
+  }
+  ```
+  Trace, because the previous shape was inert in three of these four (spec behaviour §6 and §7, AC9,
+  D14):
+
+  | How the tab got there | State before Retry | After `retry()` |
+  |---|---|---|
+  | Start POST rejected | `{ state: 'error' }` entry → `failed` | entry cleared, `everHadEntry` false → `pending` → start fires |
+  | Tunnel stopped from the chip | no entry, `everHadEntry` true → `stopped` | `everHadEntry` false → `pending` → start fires |
+  | 120 s timeout, entry stuck `starting` | `starting` entry → `failed` | entry cleared, `timedOut` false → `pending` → start fires; the daemon joins its own in-flight start or answers with the live URL, which lands in `startUrl` |
+  | 120 s timeout, no entry | no entry → `failed` | `timedOut` false → `pending` → start fires |
+
+  `rejected` is the one failure body with **no** Retry — the port is ineligible, and retrying it would
+  re-issue a request the client already knows the daemon refuses (AC10).
+
+  Retry does not clear the consumer registration's `started` flag: a tab that has ever issued a start
+  POST for the port stays an owner (D10), and Task 12's registration is idempotent and never flips
+  `started` back to `false`.
 
 Keep the file under 300 lines and each effect under 50; extract the watchdog into a small local hook
 if it grows.
+
+**Verify:** covered behaviourally by Task 27's `UrlTabInstance` retry cases and by the post-Retry
+resolver rows in Task 5; there is no separate hook test (the hook is React-bound glue over pure logic
+that is already table-driven).
 
 ### Task 19 — `UrlTabBodyState`
 
@@ -574,6 +789,9 @@ Props `{ target, device, inspectActive, anchorRef, onRetry }`. Renders, per `tar
 - `failed` → the error text plus a **Retry** button, testids `url-tab-body-failed` and
   `url-tab-retry`.
 - `stopped` → "The tunnel for port N was stopped" plus the same Retry. testid `url-tab-body-stopped`.
+- `invalid` → "This tab's saved address can't be opened" plus the raw stored value, no Retry —
+  retrying resolves nothing; the address bar above is the way out (Task 20 keeps it live). testid
+  `url-tab-body-invalid`.
 
 Use `mainframe-design-system` tokens; mirror `PreviewBodyState`'s classes rather than inventing new
 ones. Never render a blank body — every `UrlTabTarget` variant has a branch (AC9).
@@ -585,12 +803,24 @@ ones. Never render a blank body — every `UrlTabTarget` variant has a branch (A
 
 `UrlTabToolbar` renders `PreviewUrlBar` + `PreviewDeviceToggle` + `PreviewCaptureCluster` and **no**
 `PreviewRunControl` and no console drawer (AC5) — the controls are absent, not disabled. testid
-`url-tab-toolbar`. `enabled` is `handle !== null`.
+`url-tab-toolbar`.
+
+It passes `enabled={true}` unconditionally — **not** `handle !== null`. A URL tab's address bar is the
+tab's escape hatch: the spec requires it live in `failed` and `stopped` ("the user can type a
+different URL out of the failure state", §6) and it is the only exit from `invalid`, and in none of
+those states is a webview mounted. The three icon buttons still dim on their own `handle` check inside
+`PreviewUrlBar` (Task 17). It also passes `seedUrl={url}` — the tab's committed URL, never the tunnel
+URL — and `onCommitUrl`.
 
 `UrlTabInstance({ tabId, url, visible, scopeKey, projectId })` mirrors `PreviewInstance` minus the
 launch plumbing:
 - `const { target, retry, reloadNonce } = useUrlTabTunnel({ tabId, url })`;
-- `const loadUrl = target.kind === 'direct' || target.kind === 'tunnelled' ? target.url : null`;
+- `const loadUrl = target.kind === 'direct' || target.kind === 'tunnelled' ? target.url : null` — the
+  other five kinds, `invalid` included, mount nothing;
+- `onCommitUrl` = `(next) => useLayoutStore.getState().setUrlTabTarget(tabId, next, urlTabTitle(next))`
+  behind a `useLayoutStore((s) => s.setUrlTabTarget)` selector (no `getState()` reach-through). The
+  store rewrites `tab.url`, the new value arrives as the `url` prop, and `useUrlTabTunnel` +
+  `useWebviewMount` re-resolve from it — one path for a URL typed in any state (PD3);
 - `const handle = useWebviewMount({ url: loadUrl, anchorRef, containerRef, projectId, device })`;
 - `usePreviewGeometry({ handle, anchorRef, containerRef, active: visible, status: loadUrl ? 'running' : null })`
   — pass the shape the hook already expects; if its `status` parameter is launch-specific, widen it to
@@ -610,9 +840,11 @@ decomposition should be needed.
 
 `RunTabBody` gains a `tab.kind === 'url'` arm **above** the file-guest fallback, rendering
 `<UrlTabInstance tabId={tab.id} url={tab.url ?? ''} visible={active} scopeKey={tabScope ?? undefined} projectId={projectId} />`.
-A URL tab with no `url` (corrupt persisted state) renders the `rejected`-style body via an empty
-normalized URL rather than falling through to the placeholder (AC3). The `<kind>: <title>`
-placeholder must remain reachable for `code`/`diff`/`skill`/`viewer`.
+A URL tab with no `url` (corrupt persisted state) passes `''` down and lands on the resolver's
+`invalid` variant (Task 11 step 0), which renders `url-tab-body-invalid` with a live address bar —
+it never falls through to the placeholder (AC3) and never reaches `host.preview.mount` with an
+unparseable URL. The `<kind>: <title>` placeholder must remain reachable for
+`code`/`diff`/`skill`/`viewer`.
 
 `RunTabPill.tabGlyph` gains a `Globe` (lucide) for `'url'`, coloured `text-mf-surface-run` when
 active like the other Run-owned kinds (spec: "a globe glyph, distinct from the preview eye"). The
@@ -715,22 +947,34 @@ to open the menu before asserting the browser-open behaviour).
 
 ---
 
-## Group F — `test` (behavioural coverage of the built UI)
+## Group F — `test-ui` (behavioural coverage of the built UI)
 
 All files here are **new**; the tasks above own every pre-existing test file they had to touch.
+This group runs after `core`, `rust`, `ui-tab`, and `ui-entrypoints` — Task 31 verifies all four.
 
 ### Task 27 — URL tab body and instance
 
 **Files (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`,
 `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx`.
 
-`UrlTabBodyState`: one case per `UrlTabTarget` variant asserting the right testid renders and that
-`rejected` shows the daemon text with **no** Retry while `failed` and `stopped` show Retry.
+`UrlTabBodyState`: one case per `UrlTabTarget` variant — all seven — asserting the right testid
+renders and that `rejected` and `invalid` show their text with **no** Retry while `failed` and
+`stopped` show Retry.
 
 `UrlTabInstance` (fake host adapter, `lib/host/fake-adapter.ts`): mounts the webview for a `direct`
 target; renders **no** run/stop/restart control and no console drawer, and does render the address
 bar, reload, open-in-browser, clear-cache, device toggle, inspect, and region-capture controls
 (AC5); the root testid is `url-tab-instance-<tabId>`.
+
+Two more `UrlTabInstance` cases, both regressions this plan's review caught:
+- **The bar stays live with nothing mounted.** With the tunnel store seeded so the target resolves to
+  `failed`, and again with a tab whose `url` is `''` (`invalid`), `preview-url-input` is **not**
+  `disabled`; committing `localhost:5173` in it calls the mocked `setUrlTabTarget` once with the
+  normalized URL and never calls `host.preview.mount` with the old value (spec §6, D9, AC14).
+- **Retry re-requests.** With the target `failed` from an `{ state: 'error' }` entry, clicking
+  `url-tab-retry` clears the entry from `usePortTunnelsStore` and issues exactly one
+  `startPortTunnel` call (mock `lib/api/tunnel-ports`); with the target `stopped` (entry gone after
+  one was seen), clicking it likewise issues one start (PD1, spec §7).
 
 ### Task 28 — Run surface renders the kind and scopes it
 
@@ -768,7 +1012,8 @@ calls the pre-existing opener.
 
 ### Task 31 — Full verification sweep (AC18)
 
-Run and record:
+This task verifies the `rust` group's output as well as the TypeScript groups' — that is why `test-ui`
+carries `rust` in `depends_on`. Run and record:
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck`
 - `pnpm --filter @qlan-ro/mainframe-ui test` (full suite; if the known cross-file `React.act` batch
   failure appears, re-run the affected files individually and note it — do not "fix" it here)
@@ -778,7 +1023,9 @@ Run and record:
   `packages/core-rs`")
 - confirm every new interactive element carries a testid in the AC15 list and none is keyed by array
   index
-- confirm no file added or modified exceeds 300 lines and no function exceeds 50 (AC17)
+- confirm no file added or modified exceeds 300 lines and no function exceeds 50 (AC17) — run it as
+  `git diff --name-only main...HEAD -- '*.ts' '*.tsx' | xargs wc -l | sort -n`, and note that
+  `store/layout.ts` entered this work at 317 lines and leaves it under 250 via Task 32
 
 ---
 
@@ -795,8 +1042,11 @@ Run `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_
    is made (AC10, checkable in the daemon log); an eligible port shows pending, then loads the tunnel
    origin **with the original path and query** (AC7); a second tab on that port loads with no pending
    (AC8).
-4. Quit and relaunch: the tab is back with its title, loads on activation, and the address bar shows
-   the typed URL, never a tunnel URL (AC14).
+4. Quit and relaunch: the tab is back with its title, loads on activation, and the address bar seeds
+   with the typed URL — the stored value is never a tunnel URL (AC14). On a tunnelled tab the bar then
+   follows the page to the tunnel origin once it loads (PD4); what persists is still `tab.url`.
+5. In a tab left in the failure state, type a different URL into the address bar and press Enter: it
+   loads, the tab's title follows, and the new URL survives a relaunch (spec §6, D9).
 
 ## Risks
 
@@ -809,3 +1059,8 @@ Run `pnpm tauri:dev` from `packages/app-tauri` with an isolated `MAINFRAME_DATA_
 - **The DNS gate depends on the daemon's `ready`-means-verified semantics** for the REST snapshot
   (fact 8). If that ever changes, an adopting tab could load an unresolvable name — the single
   automatic reload on `dns_verified` (Task 18) is the safety net, not the gate.
+- **Retry mutates shared state.** `clearPortTunnelEntry` (PD2) is keyed by port, so one tab's Retry
+  drops the badge every `UrlChip` on that port was showing. The guard is that it refuses a `ready`
+  entry, so only a stale `error` or an abandoned `starting` is ever removed, and the next
+  `tunnel:status` event restores the truth. If this proves confusing in use, the narrower fix is a
+  per-consumer failure marker rather than re-narrowing Retry.

--- a/docs/plans/2026-07-29-todo-281-preview-open-urls-plan.md
+++ b/docs/plans/2026-07-29-todo-281-preview-open-urls-plan.md
@@ -1,350 +1,553 @@
-# Implementation plan — URL tabs in the Run surface (#281), remaining work
+# Implementation plan — #281 URL tabs: rework the tunnel-ownership state machine
 
-**Spec:** [`docs/specs/2026-07-28-todo-281-preview-open-urls.md`](../specs/2026-07-28-todo-281-preview-open-urls.md)
-**Supersedes:** [`docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md`](2026-07-28-todo-281-preview-open-urls-plan.md) —
-that plan's Groups A–E are **implemented and committed** on this branch. This plan re-scopes to what
-is genuinely left: Group F (behavioural UI coverage) plus the verification sweep.
-**Branch:** `todo/281-preview-open-urls` · **Worktree:** `.worktrees/todo-281-preview-open-urls`
-**Packages:** `@qlan-ro/mainframe-ui` only. Nothing under `packages/core-rs`, `packages/types`, or
-`packages/mobile` changes; `packages/app-tauri/src-tauri` is already done and is only *verified* here.
+**Spec:** [`docs/specs/2026-07-28-todo-281-preview-open-urls.md`](../specs/2026-07-28-todo-281-preview-open-urls.md) — the
+contract at stake is **D10** (stop a tunnel on close only when this tab started it and no other URL tab
+uses that port) and **AC12** (closing an exclusively-started tab stops the tunnel; an adopted or shared
+one stays up).
+**Branch:** `todo/281-preview-open-urls` · **Worktree:** `.worktrees/todo-281-preview-open-urls` · **HEAD when written:** `fadec137`
+**Packages:** `@qlan-ro/mainframe-ui` only. No file under `packages/core-rs`, `packages/types`,
+`packages/mobile`, or `packages/app-tauri/src-tauri` changes.
 
 ## Goal
 
-Give the Run surface a `url` tab kind that points the webview engine the app already owns at any
-`http`/`https` address the user names — no launch configuration, no running process. Two entry points
-(the Run tab strip's `+` menu and the empty-state Run picker, plus the chat localhost chip's "Open in
-Mainframe" row) funnel through one creation path that dedups by normalized URL within a launch scope;
-the tab keeps every preview control except run/stop/restart and the console drawer, persists across a
-restart, and on a remote daemon routes a loopback address through the existing per-port quick tunnel
-strictly as a consumer. The feature code for all of that is on the branch. What is missing is the
-behavioural test layer that proves the composed components behave as the spec's acceptance criteria
-require, and the sweep that records typecheck, tests, `cargo`, and the diff's package boundaries.
+Every user-visible part of #281 is built, tested, and committed (see *Landed work*). What is not settled is
+the one piece of state behind AC12: whether a URL tab may stop the port tunnel it is looking at. Four review
+rounds each patched that decision at a different call site, and each patch opened an adjacent hole, because
+the decision has never had a model — it is spread across a `useState`, two refs, three effects, and a
+promise callback, and it reads *client-produced* signals as if they were daemon truth. This plan replaces
+that scatter with one explicit, pure state machine: a claim keyed by `(daemon, port)`, moved only by signals
+that actually say something about what the daemon holds, with the watchdog, the resolved target, and
+client-written error entries excluded by construction. The five ownership cases the four fix commits
+defended stay green, and the two defects round 5 found are closed by the model rather than by another guard.
 
-## Status: what is already on the branch
+## Landed work — do NOT redo any of it
 
-Audited in the worktree on 2026-07-29 against `origin/main` (`ca7cda36`). Every row below was read,
-not inferred.
+Every commit below is on this branch and needs no re-implementation. The implement stage re-enters at
+**Group A** of this plan.
 
-| Prev. group | Tasks | Landed as | What it produced |
-|---|---|---|---|
-| `test-pure-red` | 1–6 | `736c6677`, `208df5cf`, `ee9a31a0`, `76288d95`, `be9e800d`, `114b4f56` | Pure/store tests: `normalize-url`, `run-pane-url-tab`, `layout-persist`, `port-tunnels`, `resolve-url-target`, `url-tunnel-ownership` |
-| `core` | 7–13, 32, 33 | `22134eaa`, `fc64cfae`, `27e5fad2`, `d4c25ed0`, `a598b031`, `18b03c1e`, `3c4e6026`, `1c8c6476`, `af6c0e62` | `url` kind + dedup, `tabIds*` generalization, persistence, `dnsVerified`, `resolve-url-target.ts`, `layout-placement.ts`, tunnel-ownership registry, `setUrlTabTarget`, changeset |
-| `rust` | 14, 15 | `a129e0de` | `capabilities/preview.json` → `["http://*:*", "https://*:*"]` + three `bridge_plugin.rs` tests (pattern span, scheme guard, capability shape) |
-| `ui-tab` | 16–21 | `9d5bb5b7`, `67e5586b`, `df82a058`, `06467698`, `b6fd61c2`, `8289641b` | `use-webview-mount.ts` extraction, `PreviewUrlBar` seed/commit rework, `use-url-tab-tunnel.ts`, `UrlTabBodyState`, `UrlTabToolbar`, `UrlTabInstance`, the `RunSurface` arm |
-| `ui-entrypoints` | 22–26 | `62d4498c`, `9858d7d0`, `a991b9cf`, `09527a40`, `fe3da1bd` | `open-url-tab` intent + subscriber, `RunUrlEntry`, the `+` menu row, the picker row, the chip's open menu |
+| Stage | Commits | Result |
+|---|---|---|
+| Spec | `ea663a48`, `59f697d9`, `cc4ebffd` | `docs/specs/2026-07-28-todo-281-preview-open-urls.md` |
+| Plans | `687adebe`, `f61fb193`, `917d501b`, `8968443d` | this file and its predecessor |
+| Red-phase pure tests | `736c6677`, `208df5cf`, `ee9a31a0`, `76288d95`, `be9e800d`, `114b4f56` | normalizer, tab model, persistence, store DNS flag, target resolution, ownership registry |
+| Core (UI logic) | `22134eaa`, `fc64cfae`, `27e5fad2`, `d4c25ed0`, `a598b031`, `18b03c1e`, `3c4e6026`, `1c8c6476`, `af6c0e62` | `url` tab kind, dedup, persistence, `dnsVerified`, `resolve-url-target.ts`, `layout-placement.ts`, the ownership registry, `setUrlTabTarget`, **the changeset** |
+| Rust | `a129e0de` | `capabilities/preview.json` widened + three `bridge_plugin.rs` tests |
+| UI tab | `9d5bb5b7`, `67e5586b`, `df82a058`, `06467698`, `b6fd61c2`, `8289641b` | mount extraction, address bar, `use-url-tab-tunnel.ts`, body states, toolbar, instance, the `RunSurface` arm |
+| UI entry points | `62d4498c`, `9858d7d0`, `a991b9cf`, `09527a40`, `fe3da1bd` | intent + subscriber, `RunUrlEntry`, `+` menu row, picker row, chip menu |
+| Behavioural coverage (Groups A–F of the previous plan) | `0397ed01`, `32841dc7`, `8c18c340`, `acbc3771`, `dece270c`, `f2dcd072` | `RunSurface.url-tab`, `UrlTabBodyState`, entry points, toolbar/address bar, store creation + release, tunnel adoption/retry/DNS |
+| Ownership fixes, rounds 1–4 | `68d1f1fd`, `16186c63`, `2dfc073c`, `fadec137` | the four point fixes this plan consolidates |
 
-**Verification run today, before writing this plan:**
+**`.changeset/preview-open-urls.md` already exists (`af6c0e62`). Do not add a second changeset.** This rework
+is a correction inside the same unreleased feature; the existing entry covers it.
 
-- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean.
-- `pnpm --filter @qlan-ro/mainframe-ui test` — **561 files, 5253 tests, all passing.**
-- `git status` — clean tree; `.changeset/preview-open-urls.md` present.
+## The two defects this rework must close
 
-**Not yet done, and the reason this plan exists:** the previous lane died (agent unreachable) in the
-wave that would have run Group F. No test asserts the *composed* behaviour — that `UrlTabInstance`
-renders the address bar and omits the process controls, that the Run surface routes the `url` kind,
-that the entry points emit one intent, that closing a tab releases exactly the tunnel it owns.
-Acceptance criteria AC1–AC5, AC9, AC12–AC13, AC15 are implemented but unproven.
+Round 5, verbatim in the lane result, both in
+`packages/ui/src/features/url-tab/use-url-tab-tunnel.ts`:
 
-## Constraints (from `CLAUDE.md` and `packages/ui/CLAUDE.md`)
+1. **`:130-136`** — the start POST's `.catch` revokes ownership without the `attemptRef.current === at`
+   guard the `.then` at `:127` carries. A hung attempt-1 POST that rejects after attempt 2 has succeeded
+   nulls attempt 2's live claim; `releaseUrlTunnelConsumers` then issues no stop and cloudflared leaks.
+2. **`:144-146`** — the disown effect keys off `target.kind === 'failed'`, which the 120 s watchdog also
+   produces. The daemon is still holding this tab's tunnel; the claim is dropped anyway; the tunnel comes up
+   seconds later, the tab loads, the user never retries, and nothing re-claims. Same leak, different path.
 
-- Max **300 lines/file**, **50 lines/function** — Task 2 and Task 3 exist as separate files for
-  exactly this reason; do not merge them.
-- Tests live beside their subject in `__tests__/`. `.test.tsx` runs under jsdom, `.test.ts` under
-  node (`vitest.config.ts` projects). A DOM-touching `.test.ts` needs a `// @vitest-environment jsdom`
-  pragma — none of the tasks below should need one.
-- Run single files (`pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>`); large multi-suite
-  runs hit the known cross-file `React.act` failure.
-- `data-testid` on every interactive element, keyed by tab id, never by array index.
-- No `@ts-ignore`; no silent catches; delete dead code found in a file you edit.
-- The changeset already exists — **do not add a second one.**
+**The reviewer's reading is confirmed by the code.** `UrlTabTarget.failed` has exactly two producers —
+`resolve-url-target.ts:56` (`entry.state === 'error'`) and `:62` (`timedOut`, a client timer) — and the spec
+makes the second one explicitly non-terminal: D11 calls the 120 s watchdog "non-terminal" and AC9 requires
+that "a URL that arrives after the failure body replaces it with the loaded page, with no user action". A
+signal the spec defines as non-terminal cannot be evidence that the daemon holds nothing.
 
-## Verified facts the tests must be written against
+**Do not implement the two point fixes the reviewer proposed.** They are locally correct and were the
+fifth round of the same move. The ruling is that the model is underspecified; fix the model.
 
-Read in the worktree on 2026-07-29. Do not re-derive; do not guess an API.
+## The actual state space
 
-1. **`UrlTabBodyState`** (`features/url-tab/UrlTabBodyState.tsx`) takes
-   `{ target, device, inspectActive, anchorRef, onRetry }` and renders exactly one of:
-   `url-tab-body-loaded` (for `direct` **and** `tunnelled`), `url-tab-body-pending`,
-   `url-tab-body-rejected`, `url-tab-body-failed`, `url-tab-body-stopped`, `url-tab-body-invalid`.
-   `url-tab-retry` appears only in `failed` and `stopped`. `url-tab-inspect-active-indicator` appears
-   only when `inspectActive` and the body is loaded.
-2. **`UrlTabTarget`** (`features/url-tab/resolve-url-target.ts`) is a 7-member union:
-   `direct{url}`, `tunnelled{url}`, `pending{port}`, `rejected{port,reason}`, `failed{error}`,
-   `stopped{port}`, `invalid{url}`. `URL_TAB_TUNNEL_TIMEOUT_MS = 120_000`.
-3. **`UrlTabInstance`** props: `{ tabId, url, visible, scopeKey?, projectId? }`; root testid
-   `url-tab-instance-<tabId>`. It commits an address-bar edit through
-   `useLayoutStore.getState().setUrlTabTarget(tabId, next, urlTabTitle(next))`.
-4. **`UrlTabToolbar`** renders `PreviewUrlBar` with `enabled` hardcoded true (`preview-url-input` is
-   never `disabled`), `PreviewDeviceToggle`, and `PreviewCaptureCluster` with
-   `isRunning={handle !== null}`. Testids reachable from it: `preview-url-input`,
-   `preview-url-reload`, `preview-url-open-browser`, `preview-url-clear-cache`,
-   `preview-capture-cluster`, `preview-toolbar-inspect`, `preview-toolbar-capture`,
-   `preview-toolbar-region`, `preview-device-toggle`, `preview-device-desktop`,
-   `preview-device-mobile`, `preview-capture-cluster`, `url-tab-toolbar`. **Absent by
-   construction:** `preview-toolbar` and the `PreviewRunControl` pair `preview-run-start` /
-   `preview-run-stop`. Note `preview-url-reload` renders but is `disabled` while no handle is
-   mounted — assert presence, not enabled state.
-5. **The mount seam** is `useHost().preview.mount(el, url, { projectId, device })` inside
-   `features/preview/use-webview-mount.ts`. Mock `@/lib/host` and return a handle stub; set
-   `compositesAboveDom: false` on the stub so `usePreviewOcclusion` stays inert in jsdom.
-   `useWebviewMount` destroys the handle on unmount and on `url === null`.
-6. **`useUrlTabTunnel`** reads: `useDaemonIsLocal()` (`@/lib/daemon/use-daemon-is-local`),
-   `useDaemonPort()` (`@/features/sessions/runtime/daemon-port-context`) for the HTTP port,
-   `useTunnelDaemonPort()` (from `@/store/port-tunnels`, backed by `usePortTunnelsStore.daemonPort`),
-   `useActiveIdentity().chatId`, `usePortTunnelsStore.byPort[port]`. It calls
-   `startPortTunnel(httpPort, { port, chatId })` from `@/lib/api/tunnel-ports` and
-   `registerUrlTunnelConsumer(tabId, { port, started, daemonHttpPort })` from
-   `@/features/url-tab/tunnel-consumers`.
-7. **Ownership**: `started: true` only when no entry existed for that port at the moment this tab's
-   start fired; a Retry never demotes an owner (`addConsumer` in `url-tunnel-ownership.ts`).
-   `releaseUrlTunnelConsumers` calls `stopPortTunnel(daemonHttpPort, port)` only for a removed
-   **owner** whose port has no remaining consumer.
-8. **`clearPortTunnelEntry(port)`** (in `@/store/port-tunnels`) refuses to clear a `ready` entry and
-   returns whether it cleared. `retry()` calls it, then bumps the attempt counter.
-9. **`composeTunnelUrl`** puts the original path/query/hash on the tunnel origin, so a tab on
-   `http://localhost:5173/app?x=1` with tunnel origin `https://abc.trycloudflare.com` mounts
-   `https://abc.trycloudflare.com/app?x=1`.
-10. **`RunSurface`**'s fallback for an unhandled kind renders `` `${tab.kind}: ${tab.title}` `` as
-    plain text (`layout/surfaces/RunSurface.tsx:159`). `RunSurface.tab-scope.test.tsx` is the model
-    for scope filtering and for the stub-every-body-component mock set.
-11. **`RunUrlEntry`** (`layout/RunUrlEntry.tsx`) emits `emitSurfaceIntent({ type: 'open-url-tab', url,
-    paneId })` with the **normalized** URL, sets an invalid state (`aria-invalid`, `text-destructive
-    ring-1 ring-destructive`) without emitting when `normalizePreviewUrl` returns null, and calls
-    `onDone` on commit, Escape, and blur. Testids `run-tab-url-entry`, `run-tab-url-entry-input`.
-12. **The chip menu** (`features/chat/smart-actions/UrlChip.tsx`): trigger `smart-action-url-open`,
-    rows `smart-action-url-open-in-app` (first, "Open in Mainframe") and
-    `smart-action-url-open-browser` (second). The in-app row emits the intent and must not start a
-    tunnel. `url-chip.test.tsx` already drives the browser row through the menu and explicitly defers
-    row-order coverage to a separate file — that file is Task 5.
-13. **The subscriber** (`store/url-tab-intent-subscriber.ts`) normalizes again, reads `scopeKey` from
-    `useActiveBasesStore`, and calls `useLayoutStore.getState().addRunTab({ id: urlTabId(url), kind:
-    'url', title: urlTabTitle(url), url, scopeKey }, paneId)`. `addRunTab` internally runs
-    `placeInLayout(layout, 'run')`, so no `toggleSurface` is needed for AC4's "reveals Run".
-14. **Release sites** in `store/layout.ts`: `closeRunTab` (single tab), `closePane`, `releaseRunScope`,
-    and `toggleSurface('run')` when Run was lit — each calls `releaseUrlTunnels(...)` from
-    `store/url-tunnel-cleanup.ts`. `disposeDaemonSession` calls `clearUrlTunnelConsumers()`, which
-    deliberately stops nothing.
-15. **The registry is module-level state.** Any test touching it must call
-    `clearUrlTunnelConsumers()` in `beforeEach`, or ownership leaks between cases.
-16. **jsdom setup** (`src/__tests__/setup.ts`) already stubs `ResizeObserver`, `localStorage`, and
-    Range rects; both vitest projects load it.
+### What a claim means
 
-## Scope guard for parallel groups
+A claim is this tab's evidence that **the daemon currently holds a tunnel, on this daemon, on this port,
+that this tab caused to exist**. It is the only input to `started` in
+`registerUrlTunnelConsumer(tabId, { port, started, daemonHttpPort })`, and `started` is the only thing that
+lets `releaseConsumers` stop a tunnel.
 
-The two test groups are file-disjoint and may run at the same time. If a test exposes a real defect
-in the landed code, fix it **inside your group's lane** and say so in the commit body:
+Creation evidence is a client-side inference: the daemon's `POST /api/tunnel/ports/start`
+(`packages/core-rs/crates/mainframe-server/src/routes/tunnel_ports.rs:39`) answers `{ url, port }`
+identically whether it created the tunnel or joined an existing one, and any daemon change is `declined` by
+the spec. So "this tab created it" means **the store held no entry for the port at the moment this tab's
+start POST went out** — the same inference the landed code makes, now stated once instead of implied in
+three places.
 
-- `test-url-tab-view` may repair files under `packages/ui/src/features/url-tab/`.
-- `test-run-surface-entry` may repair files under `packages/ui/src/layout/`,
-  `packages/ui/src/store/`, and `packages/ui/src/features/chat/smart-actions/`.
-- A defect outside your lane (notably `features/preview/*`) is **reported, not edited** — `verify`
-  owns cross-lane repairs so the two groups never collide on a file.
+### The signals, and which of them are authoritative
 
-Never weaken an assertion to make a test pass. A test that contradicts the spec is a finding.
+| Signal | Source | Authoritative about "the daemon holds this tab's tunnel"? |
+|---|---|---|
+| Start POST issued while `byPort[port] === undefined` | client inference over daemon state | **Yes** — the only creation evidence available |
+| Start POST resolves `{ url }` | daemon | **No** — identical for a joined tunnel; presentation only (`flags.startUrl`) |
+| Start POST rejects **with a daemon-reported failure** | daemon | **Yes, for its own attempt only** — the daemon removes the entry and stops the child on its own error paths (`port_tunnel_registry.rs:139-146`), so nothing was created for that request |
+| Start POST rejects **at transport level** (daemon killed, socket dropped) | neither | **No** — a tunnel may well exist. `startPortTunnel` throws a bare `Error` (`lib/api/tunnel-ports.ts:24-28`), so the two are indistinguishable today; see *Risks* |
+| `entry.state === 'starting' \| 'ready'` | daemon (`tunnel:status`, REST seed) | **Yes** — a tunnel exists on the port |
+| `entry.state === 'error'` written by `applyPortTunnelEvent` | daemon | **Yes** — the daemon holds no live tunnel on the port |
+| `entry.state === 'error'` written by a **rejected client start POST** | client | **No** — see below; the third producer the model must not confuse with the daemon |
+| `entry === undefined` *after* an entry was seen | daemon (`stopped` → `clearEntry`) | **Yes** — the tunnel is gone |
+| `entry === undefined` with none ever seen | nothing | **No** — the start may still be in flight |
+| `clearPortTunnelEntry(port)` from `retry()`, **when it actually clears** | client | **No** — a local presentation reset; the daemon was told nothing |
+| `timedOut` (the 120 s watchdog) | client timer | **No** — D11 non-terminal, AC9 requires recovery |
+| `target.kind` (any value) | derived | **No** — a projection that folds locality, daemon-port availability, URL validity, port eligibility, the watchdog and the attempt flags together with the entry |
+| Committed URL's port changes (retarget), or becomes `null` | user | **Yes about abandonment** — this tab stops being a consumer of the old port |
+| Daemon switch (`httpPort` changes) | user | **Yes about abandonment** — a claim is against one daemon |
+| Close / pane close / scope release / Run hidden | layout store | Outside the machine — handled by `releaseUrlTunnelConsumers` |
 
----
+**An `error` entry has three producers, only one of them the daemon.** `reportPortTunnelError`
+(`store/port-tunnels.ts:116`) is called by `applyPortTunnelEvent` (`:159`, daemon), by this hook's `.catch`
+(`use-url-tab-tunnel.ts:135`, client), and by the **chat chip's** `.catch`
+(`features/chat/smart-actions/use-url-tunnel.ts:85`, client). It refuses to overwrite only a `ready` entry
+(`:117`), so while this tab's tunnel is `starting`, a chip's rejected start POST on the same port writes
+`error`, and a model that reads `error` as daemon truth revokes a live claim — defect 2's failure mode
+through a different door. A client-written error entry therefore has to carry a marker, and only unmarked
+(daemon-sourced) errors may move the claim. Note the reverse case is now merely cosmetic: a foreign client
+error can still flip *this* tab's body to `failed` while its own tunnel is `starting`, but AC9's
+late-URL recovery replaces that body when the tunnel comes up, and the claim never moves.
 
-## Group A — `test-url-tab-view`
+### States and transitions
 
-### Task 1 — `UrlTabBodyState` renders one explicit state per target
+Three states. `sawEntry` exists only to tell "gone" from "not there yet".
 
-**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`
+- `null` — unclaimed.
+- `{ httpPort, port, attempt, sawEntry: false }` — a start was issued for a port the store showed empty; the
+  daemon has not yet been observed holding anything.
+- `{ httpPort, port, attempt, sawEntry: true }` — the daemon has been observed holding a tunnel on the port
+  since this claim was made.
 
-Pure render tests; no store, no host. Build `anchorRef` with `createRef<HTMLDivElement>()`.
+| Signal | Matching claim (`httpPort` + `port` equal) | No matching claim |
+|---|---|---|
+| `rebind { httpPort, port }` | keep | drop any non-matching claim |
+| `start-issued { attempt, entryExisted }` | `{ ...claim, attempt, sawEntry: entryExisted }` — an owner survives Retry (D10) | `entryExisted ? null : { httpPort, port, attempt, sawEntry: false }` — either way a stale other-port claim is dropped |
+| `start-rejected { attempt }` | `claim.attempt === attempt ? null : claim` — **defect 1** | unchanged |
+| `daemon-state 'starting' \| 'ready'` | `{ ...claim, sawEntry: true }` | unchanged |
+| `daemon-state 'error'` | `null` | unchanged |
+| `daemon-state 'absent'` | `claim.sawEntry ? null : claim` | unchanged |
+| `daemon-state 'unknown'` (an entry exists, written by a client) | unchanged | unchanged |
+| `local-clear` | `{ ...claim, sawEntry: false }` | unchanged |
 
-- `direct` and `tunnelled` → `url-tab-body-loaded`; assert once for `device="desktop"` and once for
-  `device="mobile"` (both must render the anchor div).
-- `inspectActive` true on a loaded body → `url-tab-inspect-active-indicator` present; false → absent.
-- `pending{port: 5173}` → `url-tab-body-pending`, text contains `5173`, **no** `url-tab-retry`.
-- `rejected{port: 22, reason: 'Port must be 1024 or higher'}` → `url-tab-body-rejected` showing the
-  reason **verbatim**, no `url-tab-retry` (AC10: a rejection is not a retryable failure).
-- `failed{error: 'cloudflared exited with code 1'}` → `url-tab-body-failed` showing that text, plus
-  `url-tab-retry`; clicking it calls `onRetry` exactly once (AC9).
-- `stopped{port: 5173}` → `url-tab-body-stopped` naming the port, plus a working `url-tab-retry`.
-- `invalid{url: ''}` → `url-tab-body-invalid` with no mono URL line; `invalid{url: 'not a url'}` →
-  the same body **with** that text rendered; neither shows Retry.
+There is no timeout signal in the union — **defect 2 is closed by the type**, not by a condition.
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`
+Four consequences to state, not to discover later:
 
-### Task 2 — `UrlTabInstance`: toolbar composition and the live address bar
+- **`claim.sawEntry` and `AttemptFlags.everHadEntry` stay separate.** They look alike and are not: `everHadEntry`
+  is per *attempt* and drives the `stopped` presentation body (D14); `sawEntry` is per *claim* and survives
+  Retry. Merging them re-creates the presentation/truth conflation this rework removes.
+- **`local-clear` is dispatched only when `clearPortTunnelEntry` actually cleared.** It is why Retry never
+  blinks: without it the entry-observation effect reads the local clear as `absent` after `sawEntry`,
+  revokes, and only re-claims a render later — a window in which a close would leak the tunnel. But
+  `clearPortTunnelEntry` no-ops on a `ready` entry (`store/port-tunnels.ts:99`), and Retry **is** reachable
+  with one: `resolveEntryTarget` returns `failed` on `timedOut` whenever a `ready` entry carries no URL and
+  the gate is closed (`resolve-url-target.ts:58-62`). Dispatching `local-clear` unconditionally would zero
+  `sawEntry` while the daemon still holds the tunnel, so a later real `stopped` would not revoke — and the
+  next foreign tunnel on that port would be stopped by this tab.
+- **The claim is keyed by `(httpPort, port)`**, which states the invariant that a claim is against one
+  daemon. Today's `ownedPort` does not carry it; in practice `disposeDaemonSession` drives a keyed remount,
+  so the reducer state goes away on a switch regardless — the field makes the rule explicit rather than
+  incidental.
+- **Signal order inside a commit is pinned, and the table does not depend on it.** `useTunnelClaim` is
+  called before `useTunnelAttempt`, so its `rebind`/`daemon-state` effects are registered — and therefore
+  run — ahead of the same commit's `start-issued`; and `start-issued` drops a non-matching claim in both
+  branches, so the reducer is correct even if that ordering is ever disturbed.
 
-**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx`
+### Ordering rules that must survive the rewrite
 
-Mocks (fact 5, 6): `@/lib/host` (mount spy returning a handle stub with `compositesAboveDom: false`
-and `navigate` resolving), `@/features/sessions/use-active-identity` →
-`{ projectId: 'proj-A', chatId: 'chat-1' }`, `@/features/sessions/runtime/daemon-port-context` →
-`useDaemonPort: () => 31415`, `@/lib/daemon/use-daemon-is-local` → a mutable local flag,
-`@/lib/api/tunnel-ports` → `startPortTunnel`/`stopPortTunnel` spies. Use the **real**
-`usePortTunnelsStore` and the **real** `useLayoutStore`, seeded via `setState`.
+- **Registration reads the claim against this render's port.** On the render where `port` flips, the claim
+  still names the old port, so `started` computes `false` immediately — this is `16186c63`'s stale-proof
+  property. Do not "fix" it by dispatching `rebind` before the render; the release of the abandoned port is
+  `addConsumer`'s job and is already correct.
+- **The `.catch` keeps an attempt guard as well.** The reducer's attempt check protects the claim; the guard
+  protects `reportPortTunnelError` from writing a stale attempt's error over the live attempt's state. They
+  cover different concerns, and with error provenance in place the reducer is genuinely correct without the
+  guard — Task 2's pure test proves it.
 
-- **Local daemon, `http://localhost:5173/`** → `host.preview.mount` called once with that URL and
-  `{ projectId: 'proj-A', device: 'desktop' }`; root `url-tab-instance-<tabId>` present;
-  `url-tab-body-loaded` present (AC1).
-- **Control inventory** (AC5): `preview-url-input`, `preview-url-reload`, `preview-url-open-browser`,
-  `preview-url-clear-cache`, `preview-toolbar-inspect`, `preview-toolbar-capture`,
-  `preview-toolbar-region` are all in the DOM under `url-tab-toolbar`; assert `queryByTestId` is
-  null for `preview-run-start`, `preview-run-stop`, and `preview-toolbar` (the preview tab's own
-  toolbar — a URL tab must render `UrlTabToolbar`, never `PreviewToolbar`, which is where the
-  process controls live). The console is a separate `console` tab kind, not a drawer, so there is
-  nothing further to assert absent inside this component.
-- **The bar stays live with nothing mounted** (spec §6, D9): seed `useLayoutStore` with a run holding
-  this `url` tab, set the daemon remote and the port entry to `{ state: 'error', error: 'boom' }` so
-  the target resolves `failed`; assert `preview-url-input` is **not** `disabled`, then type
-  `localhost:5173` and press Enter and assert `useLayoutStore.getState()`'s tab now carries
-  `url: 'http://localhost:5173/'` and the matching title — and that `host.preview.mount` was never
-  called in this case.
-- **Invalid tab** (`url: ''`) → `url-tab-body-invalid`, `mount` never called, input still enabled
-  (AC6's "invalid input never mounts a webview", in its persisted-tab form).
-- **Device toggle** flips the mount option: switching to mobile re-renders with the mobile frame and
-  does not call `mount` a second time (the handle is reanchored, not recreated).
-- **Unmount destroys**: unmount the tree and assert the handle stub's `destroy` was called (AC12's
-  "closing a URL tab destroys its webview", at the component seam).
+## The five ownership cases that must stay green
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabInstance.test.tsx`
+All five live in `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx`
+and run the **real** consumer registry with only `startPortTunnel`/`stopPortTunnel` mocked. Enumerated from
+the file, not from the commit messages:
 
-### Task 3 — `UrlTabInstance`: tunnel adoption, ownership, retry, DNS reload
+1. *"retarget onto an already-tunnelled port never adopts as owner"* — retarget 5173 → 4000 stops 5173 and
+   never stops 4000 on release (`68d1f1fd`, `16186c63`).
+2. *"an externally-restarted tunnel on the owned port is never this tab's to stop"* — owned entry goes
+   `ready`, then disappears, then someone else's `ready` lands; release stops nothing (`2dfc073c`).
+3. *"a port abandoned via retarget is never re-adopted as owned on return"* — retarget away, a foreign tunnel
+   appears, retarget back; release stops nothing (`2dfc073c`).
+4. *"a start POST that itself fails never leaves this tab owning the port"* — the POST rejects, the chip
+   starts its own tunnel; release stops nothing (`fadec137`).
+5. *"a live tunnel that dies with a daemon-side error is never this tab's to stop once restarted"* — entry
+   goes `error`, someone else restarts; release stops nothing (`fadec137`).
 
-**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx`
+Case 5 writes its `error` entry with a raw `usePortTunnelsStore.setState`, i.e. with no provenance marker at
+all — **which is why a daemon error must carry no marker.** Provenance is recorded as the *exception*
+(`errorOrigin: 'client'`), so an unmarked error entry, from the daemon or from a raw test `setState`, keeps
+revoking claims and case 5 stays green for the right reason. Marking daemon errors instead would both invert
+this default and break three `toEqual` assertions in the store's own suite (Task 1).
 
-Same mock set as Task 2, plus a spy on `registerUrlTunnelConsumer`
-(`vi.mock('@/features/url-tab/tunnel-consumers')`). Daemon remote for every case
-(`useDaemonIsLocal → false`), `usePortTunnelsStore.setState({ daemonPort: 31415 })`, tab URL
-`http://localhost:5173/app?x=1`.
+Two more, in `__tests__/UrlTabInstance.tunnel.test.tsx`, pin the positive side and must also stay green:
+*"a fresh start owns the tunnel"* (`started: true`) and *"adopting a mid-start tunnel issues its own start
+but does not own it"* (`started: false`).
 
-- **Fresh start owns the tunnel** (D10, AC12): no entry for 5173 at mount → body is
-  `url-tab-body-pending`, `startPortTunnel` called once with `(31415, { port: 5173, chatId: 'chat-1' })`,
-  and `registerUrlTunnelConsumer` called with `started: true`.
-- **Adopting mid-start does not own it**: seed `{ 5173: { state: 'starting' } }` before mount → the
-  tab still issues its start (the daemon is the single-flight point) but registers `started: false`.
-- **A ready tunnel skips pending and carries the path** (D12, AC8): seed
-  `{ 5173: { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true } }` → no
-  pending body, `mount` called with `https://abc.trycloudflare.com/app?x=1`.
-- **DNS reload fires exactly once** (D11): same seed but `dnsVerified: false`; after mount, flip the
-  entry to `dnsVerified: true` and assert the handle's `navigate` was called once with the same
-  composed URL; flipping other fields afterwards adds no further `navigate`.
-- **Port rejection short-circuits** (AC10): tab URL `http://localhost:22/` → `url-tab-body-rejected`
-  reading `Port must be 1024 or higher`, and `startPortTunnel` **never called**. Repeat for the
-  daemon's own port (`31415`) expecting `Cannot tunnel the daemon's own port`.
-- **Retry re-requests** (PD1, AC9): entry `{ state: 'error', error: 'boom' }` → `url-tab-body-failed`;
-  click `url-tab-retry` → the entry is gone from `usePortTunnelsStore` and exactly one further
-  `startPortTunnel` call was made.
-- **A ready entry survives Retry** (PD2): with `{ state: 'ready', url, dnsVerified: true }` the body
-  is loaded and there is no Retry to click — assert `url-tab-retry` is absent, guarding the rule that
-  a live tunnel is never cleared.
+The pure registry tests in `__tests__/url-tunnel-ownership.test.ts` stay green untouched — `addConsumer`,
+`releaseConsumers`, and `clearConsumers` keep their current semantics. **This rework changes no behaviour in
+`url-tunnel-ownership.ts`.**
 
-Keep the file under 300 lines; factor the seed/mount boilerplate into local helpers.
+## Constraints
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx`
+- Max **300 lines/file**, 50 lines/function. `UrlTabInstance.tunnel-retarget-ownership.test.tsx` is already
+  262 lines, so the new regressions go in a **new sibling file** — appending would breach the limit.
+- Tests sit in `__tests__/` beside their subject. `.test.tsx` runs under jsdom, `.test.ts` under node. A
+  non-`*.test.*` helper file in `__tests__/` is **not** collected by either project (`vitest.config.ts`
+  includes only `src/**/*.test.tsx` and `src/**/*.test.ts`), so a shared harness is safe there.
+- Run single files: `pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>`. Large batches hit the known
+  cross-file `React.act` failure.
+- No `@ts-ignore`, no silent catches, no dead code left behind; comments say *why*.
+- `vi.mock(...)` calls are hoisted per module — they **cannot** move into a shared harness. Only the handle
+  stub, host setup, store seeding, and the render wrapper can.
 
 ---
 
-## Group B — `test-run-surface-entry`
+## Group A — `claim-model`
 
-### Task 4 — The Run surface renders the kind and scopes it
+**kind:** ui · **parallel_safe:** yes (no file overlaps another group) · **depends_on:** —
 
-**File (new):** `packages/ui/src/layout/__tests__/RunSurface.url-tab.test.tsx`
+### Task 1 — Give an error entry its provenance
 
-Copy the mock set from `RunSurface.tab-scope.test.tsx` (fact 10) and add a stub for
-`@/features/url-tab/UrlTabInstance` that captures props.
+**Files (edited):** `packages/ui/src/store/port-tunnels.ts`,
+`packages/ui/src/store/__tests__/port-tunnels.test.ts`
 
-- A `url` tab renders the stub and **never** the `` `${kind}: ${title}` `` placeholder (AC3).
-- The stub receives `tabId`, `url`, `visible`, `scopeKey`, `projectId` threaded from the tab and the
-  active identity.
-- A `code` tab still renders the placeholder — proving the assertion above is not vacuous.
-- A `url` tab stamped with a non-matching `scopeKey` renders nothing, and one stamped with the active
-  scope renders (AC13).
-- After `releaseRunScope(activeScope)` the tab is gone from the DOM (AC13's release half).
+Write the two store cases first (they fail), then make them pass:
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/layout/__tests__/RunSurface.url-tab.test.tsx`
+- `PortTunnelEntry` gains `errorOrigin?: 'client'` — a marker, not an enum, documented as "set only when a
+  client `.catch` wrote this `error`; its absence means the daemon did, and only a daemon-sourced error is
+  evidence about what the daemon holds".
+- `reportPortTunnelError(port, message, origin: 'daemon' | 'client' = 'daemon')` writes the key **only when
+  `origin === 'client'`**. A daemon-origin error must keep producing the exact entry it produces today —
+  `{ state: 'error', error }` and nothing more — because `store/__tests__/port-tunnels.test.ts` asserts whole
+  error entries with `toEqual` in three places (`:80`, `:85`, `:248`), and stamping `errorOrigin: 'daemon'`
+  on every error would break all three. Those assertions are the contract; do not relax them.
+- New cases: a client-origin call stores `errorOrigin: 'client'`; a daemon-origin call stores **no such key**
+  (`expect(entry).toEqual({ state: 'error', error: … })`). Everything else in that file — the `ready`
+  no-downgrade guard (`:117`), the 1 s toast dedupe — is unchanged, and its existing cases must stay green.
+- The doc comment on `reportPortTunnelError` states the invariant for future callers: **the default is
+  `'daemon'`, so any new client-side `.catch` caller must pass `'client'` explicitly.** A client error that
+  silently defaults to daemon origin revokes live claims — the exact conflation this rework removes.
 
-### Task 5 — Both entry points emit one intent
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/store/__tests__/port-tunnels.test.ts` green.
 
-**Files (new):** `packages/ui/src/layout/__tests__/RunUrlEntry.test.tsx`,
-`packages/ui/src/features/chat/smart-actions/__tests__/url-chip-menu.test.tsx`
+### Task 2 — Red: the claim reducer's state table
 
-`RunUrlEntry` (fact 11) — mock `@/store/surface-intents`:
+**File (new):** `packages/ui/src/features/url-tab/__tests__/tunnel-claim.test.ts` (node env)
 
-- Typing `localhost:5173` + Enter emits exactly one `{ type: 'open-url-tab', url:
-  'http://localhost:5173/', paneId }` and calls `onDone`.
-- Each of `''`, `'   '`, `'not a url'`, `'file:///etc/passwd'`, `'javascript:alert(1)'` emits
-  **nothing**, leaves the field mounted, and sets `aria-invalid` (AC6, and D2's http/https-only rule
-  at the entry point).
-- Typing after an invalid attempt clears the invalid state.
-- Escape emits nothing and calls `onDone`.
-- Omitting `paneId` (the empty-state picker case) emits the intent with `paneId: undefined`.
+Write the transition table above as tests against a module that does not exist yet; it fails to resolve,
+which is the red phase. One case per row, plus the sequences that matter:
 
-`url-chip-menu` (fact 12) — reuse `url-chip.test.tsx`'s mock scaffolding, do not duplicate its
-tunnelling assertions:
+- `start-issued` with `entryExisted: false` and no claim creates `{ httpPort, port, attempt, sawEntry: false }`;
+  with `entryExisted: true` it creates nothing.
+- `start-issued` on an existing matching claim keeps it and rebinds `attempt` (D10 across Retry).
+- `start-issued` for port B while a claim names port A returns `null` — in both `entryExisted` branches, so
+  the table holds independently of effect ordering.
+- `start-rejected` with `claim.attempt === attempt` revokes; **with a lower `attempt` it does not** — the
+  round-5 defect 1 sequence at the model level: issue attempt 0, `local-clear`, issue attempt 1, observe
+  `ready`, then reject attempt 0 → the claim survives with `sawEntry: true`.
+- `daemon-state 'error'` revokes; `'absent'` revokes only after `sawEntry`; `'absent'` before any entry keeps
+  the claim; `'starting'`/`'ready'` set `sawEntry`.
+- `daemon-state 'unknown'` is a no-op in every state, and `entryDaemonState({ state: 'error', errorOrigin: 'client' })`
+  returns `'unknown'` while an unmarked `{ state: 'error' }` returns `'error'`. Name the case for what it
+  defends: a chip's rejected start POST must not revoke this tab's live claim.
+- `local-clear` clears `sawEntry` and keeps the claim; a following `'absent'` therefore does not revoke.
+- `rebind` to a different `port` or a different `httpPort` drops the claim; to the same pair keeps it.
+- Every signal for a non-matching `(httpPort, port)` that the table calls "unchanged" returns the **same
+  reference**.
+- `claimOwns(null, …)` is false; `claimOwns(claim, httpPort, port)` is true only on an exact match.
+- `entryDaemonState(undefined) === 'absent'`; `'starting'` and `'ready'` map to themselves.
+- **No watchdog case exists** — add a comment stating that defect 2 is closed by the signal union having no
+  timeout member, so a future reader does not add one.
 
-- Opening `smart-action-url-open` lists **Open in Mainframe above Open in browser** — assert DOM
-  order, not just presence (AC4, D7).
-- Selecting the in-app row emits one `open-url-tab` intent with the chip's `href` and calls
-  neither `startPortTunnel` nor the OS opener.
-- Selecting the browser row still calls the pre-existing opener.
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/tunnel-claim.test.ts`
+fails with an unresolved import of `../tunnel-claim`.
 
-**Verify:** run both files individually with `vitest run`.
+### Task 3 — Green: the pure reducer
 
-### Task 6 — Creation path, dedup, and tunnel release through the stores
+**File (new):** `packages/ui/src/features/url-tab/tunnel-claim.ts`
 
-**File (new):** `packages/ui/src/store/__tests__/url-tab-intent-subscriber.test.ts` (node env)
+Exports, exactly:
 
-Real `useLayoutStore`, `useActiveBasesStore`, `usePortTunnelsStore`, and the real
-`tunnel-consumers` registry; mock only `@/lib/api/tunnel-ports`. Call
-`clearUrlTunnelConsumers()` and reset the layout store in `beforeEach` (fact 15).
+```ts
+export type DaemonPortState = 'absent' | 'starting' | 'ready' | 'error' | 'unknown';
+export interface TunnelClaim { httpPort: number; port: number; attempt: number; sawEntry: boolean }
+export type ClaimSignal =
+  | { type: 'rebind'; httpPort: number; port: number | null }
+  | { type: 'start-issued'; httpPort: number; port: number; attempt: number; entryExisted: boolean }
+  | { type: 'start-rejected'; httpPort: number; port: number; attempt: number }
+  | { type: 'daemon-state'; httpPort: number; port: number; state: DaemonPortState }
+  | { type: 'local-clear'; httpPort: number; port: number };
+export function entryDaemonState(entry: PortTunnelEntry | undefined): DaemonPortState;
+export function claimReducer(claim: TunnelClaim | null, signal: ClaimSignal): TunnelClaim | null;
+export function claimOwns(claim: TunnelClaim | null, httpPort: number, port: number | null): boolean;
+```
 
-- `subscribeToUrlTabIntents()` + one `open-url-tab` emit creates one `url` tab whose id matches
-  `/^url-[A-Za-z0-9_-]+$/` (AC16 — the id is the webview label) and whose `url` is normalized.
-- Emitting the same URL twice yields **one** tab, active both times (AC4's "focuses rather than
-  stacks"); a different scope yields a second tab (AC13).
-- Emitting while Run is not in the layout leaves `run` placed in `layout` afterwards (AC4's reveal,
-  fact 13).
-- Emitting an unnormalizable URL creates no tab.
-- The returned unsubscribe stops further intents from creating tabs.
-- **Release** (AC12, D10), driving `useLayoutStore` with consumers registered by hand via
-  `registerUrlTunnelConsumer`:
-  - closing a tab registered `started: true`, sole consumer of 5173 → `stopPortTunnel` called once
-    with `(31415, 5173)`;
-  - closing one of two tabs on 5173 → `stopPortTunnel` **not** called;
-  - closing a tab registered `started: false` (adopted the chip's tunnel) → not called;
-  - `releaseRunScope(scope)` holding an exclusively-started tunnel → called once;
-  - `closePane` and `toggleSurface('run')` (Run lit) each release the pane's/run's URL tabs — one
-    case per site, so a future edit that drops a call site fails here (fact 14).
+`'unknown'` means "an entry exists but says nothing about the daemon" — today, only a client-written error.
+No React import; `PortTunnelEntry` comes in via `import type` (this module is imported by a **node**-project
+test, and a value import would drag zustand, `lib/daemon/ws-client`, and sonner into it). The module header
+states what a claim means, names D10/AC12, and records the three facts a reader must not undo: the union
+carries no timeout signal, `start-rejected` is attempt-scoped, and a client-written error is `'unknown'`.
 
-**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/store/__tests__/url-tab-intent-subscriber.test.ts`
+**Verify:** the Task 2 file passes; `pnpm --filter @qlan-ro/mainframe-ui typecheck` is clean.
 
 ---
 
-## Group C — `verify`
+## Group B — `claim-regressions-red`
 
-### Task 7 — Full verification sweep
+**kind:** test · **parallel_safe:** yes (one new harness + one new test file; touches nothing else) · **depends_on:** —
 
-Runs after both test groups; it verifies their output and the already-landed Rust arm. Record each
-result in the group's commit body or the lane result — a sweep whose output nobody wrote down did not
-happen.
+### Task 4 — Red: the round-5 sequences and the Retry-on-`ready` rule
 
-1. `pnpm --filter @qlan-ro/mainframe-ui typecheck` — must be clean.
-2. `pnpm --filter @qlan-ro/mainframe-ui test` — full suite. If the known cross-file `React.act`
-   batch failure appears, re-run the affected files individually and note it; do not "fix" it here.
-3. `cd packages/app-tauri/src-tauri && cargo test --lib preview::bridge_plugin` — the three tests
-   added by `a129e0de` (pattern span, scheme guard, capability shape) must pass. The worktree's
-   `target/` is already warm (~2.3 GB); do **not** set `CARGO_TARGET_DIR`. If the `tauri::utils::acl::RemoteUrlPattern`
-   re-export fails to resolve in this toolchain, add `urlpattern = "0.3"` + `regex = "1"` as
-   **dev-dependencies only** (both already in `Cargo.lock`) and reproduce the assertion — do not
-   delete the test.
-4. `git diff --name-only origin/main...HEAD` must show **no** path under `packages/core-rs/`,
-   `packages/types/`, or `packages/mobile` (spec: no daemon change), and exactly one `.changeset/`
-   file (`preview-open-urls.md`).
-5. Testid audit: every interactive element added by this feature carries a `data-testid` —
-   `run-pane-open-url-<paneId>`, `run-picker-open-url`, `run-tab-url-entry`,
-   `run-tab-url-entry-input`, `url-tab-toolbar`, `url-tab-retry`, `url-tab-instance-<tabId>`,
-   `url-tab-body-*`, `smart-action-url-open-in-app`, `smart-action-url-open-browser`. Confirm none is
-   keyed by array index. Note in the sweep that a URL tab's strip pill uses the shared
-   `run-tab-<id>` testid, which resolves to `run-tab-url-<host>-<uuid>` because `urlTabId` prefixes
-   the id with `url-` — this satisfies the spec's `run-tab-url-<tabId>` without a special case.
-6. Size audit: `git diff --name-only origin/main...HEAD -- '*.ts' '*.tsx' | xargs wc -l | sort -n` —
-   no file over 300 lines; spot-check that no function added by this work exceeds 50.
+**Files (new):**
+`packages/ui/src/features/url-tab/__tests__/url-tab-tunnel-harness.tsx`,
+`packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx`
 
-**Exit:** all six recorded, everything green.
+The harness exports what the third copy of this scaffolding would otherwise duplicate (the
+"extract at 3+ duplications" rule): a `makeFakeHandle()` returning the `PreviewHandle` stub with
+`compositesAboveDom: false`, an `installFakeHost()` returning `{ fakeHost, fakeHandle }`, `seedStores()`
+(sandbox + `usePortTunnelsStore` at `{ byPort: {}, daemonPort: 31415, generation: 0 }` + a fresh layout),
+`setPortEntry`, and `renderTab(url, { tabId })` with the `HostProvider` wrapper. It exports **no** `vi.mock`
+calls; those stay in each test file (hoisting).
+
+The new test file mocks `@/features/sessions/use-active-identity`,
+`@/features/sessions/runtime/daemon-port-context`, `@/lib/daemon/use-daemon-is-local`, and
+`@/lib/api/tunnel-ports` exactly as the retarget-ownership file does, runs the **real**
+`tunnel-consumers` registry, and calls `clearUrlTunnelConsumers()` in `beforeEach`.
+
+**Case (a) — a hung attempt-1 POST rejects after a successful retry.** RED at `fadec137`.
+
+- `startPortTunnel` is `mockImplementationOnce(() => new Promise((_, reject) => { rejectFirst = reject; }))`
+  then `mockResolvedValue({ url: 'https://abc.trycloudflare.com' })`.
+- Render on `http://localhost:5173/`; the daemon reports `{ state: 'error', error: 'boom' }` for 5173; the
+  body is `url-tab-body-failed`.
+- `await act(async () => { fireEvent.click(screen.getByTestId('url-tab-retry')); })` — the second start's
+  `.then` needs a microtask flush before the next step. Assert `startPortTunnel` has now been called twice.
+- The daemon reports `{ state: 'ready', url, dnsVerified: true }`; the body is `url-tab-body-loaded`.
+- Reject attempt 1's promise inside `await act(async () => …)`.
+- Assert: the body is still `url-tab-body-loaded`, and after `releaseUrlTunnelConsumers(['t1'])`,
+  `stopPortTunnel` **was** called with `(31415, 5173)`.
+
+**Case (b) — the watchdog fires, then the tunnel becomes ready.** RED at `fadec137`.
+
+- `vi.useFakeTimers()` before `render` (the watchdog is a `setTimeout`), `vi.useRealTimers()` in `afterEach`.
+- `startPortTunnel` returns a promise that never settles.
+- Render; the daemon reports `{ state: 'starting' }`; advance by `URL_TAB_TUNNEL_TIMEOUT_MS` (imported from
+  `../resolve-url-target`, never hardcoded) inside `act`; assert `url-tab-body-failed`.
+- The daemon then reports `{ state: 'ready', url, dnsVerified: true }`; assert `url-tab-body-loaded`.
+- Assert that after `releaseUrlTunnelConsumers(['t1'])`, `stopPortTunnel` **was** called with `(31415, 5173)`.
+
+**Case (c) — Retry pressed while the entry is `ready`, then a real teardown.** Green at `fadec137` and green
+after; it pins the conditional `local-clear` rule, and it is red against an unconditional one. Say so in the
+commit body so nobody deletes it as redundant.
+
+- Fake timers as in (b); `startPortTunnel` returns a **never-settling** promise, as in (b). It must not
+  resolve: a resolved start sets `flags.startUrl`, which opens `resolveEntryTarget`'s gate
+  (`resolve-url-target.ts:59`) and renders `tunnelled`, so `url-tab-retry` would never appear and the case
+  would assert nothing.
+- Render; the daemon reports `{ state: 'ready', url: 'https://abc.trycloudflare.com' }` with **`dnsVerified`
+  absent** — a `ready` entry the closed DNS gate keeps out of `tunnelled`; advance
+  `URL_TAB_TUNNEL_TIMEOUT_MS`; assert `url-tab-body-failed`.
+- Click `url-tab-retry` inside `await act(async () => …)` — `clearPortTunnelEntry` no-ops on the `ready`
+  entry (`store/port-tunnels.ts:99`), so no `local-clear` fires and `sawEntry` stays `true`.
+- The daemon then reports the tunnel stopped (delete the 5173 entry), and a foreign `ready` entry appears on
+  5173.
+- Assert that after `releaseUrlTunnelConsumers(['t1'])`, `stopPortTunnel` was **not** called with
+  `(31415, 5173)`.
+
+**Verify:**
+`pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx`
+→ (a) and (b) fail, (c) passes. Then
+`… vitest run src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx` and
+`… vitest run src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx` → both fully green (this task
+adds no shared state, so they must be untouched).
+
+---
+
+## Group C — `claim-rewire`
+
+**kind:** ui · **parallel_safe:** yes (no file overlaps Group A or B) · **depends_on:** `claim-model`, `claim-regressions-red`
+
+`use-url-tab-tunnel.ts` is 180 lines with a 121-line hook body today, and the rework leaves it around 84 —
+still over the project's hard **50 lines/function** rule, which Task 9 gates on. So the rewire is also a
+decomposition: the hook ends up as composition plus registration, and each extracted piece has one job. The
+budgets below are targets to hit, not estimates to report; if any lands over 50, decompose further rather
+than shipping a known violation.
+
+| Function | Home | Body budget |
+|---|---|---|
+| `useUrlTabTunnel` | `use-url-tab-tunnel.ts` | ~30 — resolve inputs, compose, register |
+| `useTunnelAttempt` | `use-tunnel-attempt.ts` | ~40 — attempt counter, flags, target, watchdog, `retry` |
+| `useStartRequest` | `use-tunnel-attempt.ts` (module-private) | ~25 — the start POST and its two claim signals |
+| `useTunnelClaim` | `use-tunnel-claim.ts` | ~20 |
+| `useDnsReload` | `use-dns-reload.ts` | ~18 |
+
+### Task 5 — Extract the two hooks the rework needs
+
+**Files (new):** `packages/ui/src/features/url-tab/use-tunnel-claim.ts`,
+`packages/ui/src/features/url-tab/use-dns-reload.ts`
+
+`useTunnelClaim`:
+
+```ts
+export function useTunnelClaim({ httpPort, port, entry }: {
+  httpPort: number;
+  port: number | null;
+  entry: PortTunnelEntry | undefined;
+}): { owns: boolean; note: (signal: ClaimSignal) => void };
+```
+
+- `const [claim, note] = useReducer(claimReducer, null)`.
+- One effect on `[httpPort, port]` dispatching `{ type: 'rebind', httpPort, port }`.
+- One effect on `[httpPort, port, entry]` dispatching
+  `{ type: 'daemon-state', httpPort, port, state: entryDaemonState(entry) }` when `port !== null`.
+- `owns = claimOwns(claim, httpPort, port)`.
+- `note` is the raw dispatch on purpose: every caller stamps the `httpPort`/`port`/`attempt` it is *acting
+  on*, so a late promise callback carries its issue-time identity instead of the current render's. Say that
+  in the header.
+
+`useDnsReload({ targetKind, dnsVerified }): number` lifts `use-url-tab-tunnel.ts:153-172` verbatim —
+`reloadNonce`, `loadedBeforeDnsRef`, and the effect. Nothing else in the hook reads that state, so the seam
+is clean. Behaviour is unchanged: exactly one reload when DNS verifies after the tab already loaded (D11),
+covered by the existing `UrlTabInstance.tunnel.test.tsx` case.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean (both modules are unreferenced at this
+point, which is expected — Task 6 wires them).
+
+### Task 6 — Extract the attempt lifecycle onto the claim
+
+**Files:** `packages/ui/src/features/url-tab/use-tunnel-attempt.ts` (new),
+`packages/ui/src/features/url-tab/use-url-tab-tunnel.ts` (edited)
+
+Move the per-attempt machinery out of the hook and put the claim signals in it as it moves. One task, not
+two: the move and the rewire cannot be separated without leaving a state that does not compile.
+
+`use-tunnel-attempt.ts` exports one hook and keeps a second module-private:
+
+```ts
+export function useTunnelAttempt(args: {
+  url: string; isLocal: boolean; daemonPort: number | null;
+  httpPort: number; chatId: string | null; port: number | null;
+  entry: PortTunnelEntry | undefined; active: boolean;
+  note: (signal: ClaimSignal) => void;
+}): { target: UrlTabTarget; retry: () => void };
+```
+
+- It owns `attempt`, `AttemptFlags` (moved verbatim, `FRESH` included), `attemptRef`, the attempt-reset
+  effect, the `everHadEntry` effect, the `target` memo, `isPending`, the watchdog, and `retry`. Computing
+  `target` here is what breaks the circularity — `isPending` derives from the flags this hook owns, so
+  nothing has to be threaded back in from the caller.
+- The reset effect loses its retarget branch: `prevPortRef`/`setOwnedPort(null)` are gone, because a
+  retarget is now `rebind`, dispatched by `useTunnelClaim`.
+- `retry()`: `if (port !== null && clearPortTunnelEntry(port)) note({ type: 'local-clear', httpPort, port })`
+  — **conditional**, for the reason in *States and transitions*; `setAttempt` still runs unconditionally.
+- `useStartRequest` (module-private, same file) holds the start effect. It takes values and callbacks only —
+  `{ enabled, port, httpPort, daemonPort, chatId, entry, attempt, note, onStartUrl }` — and keeps its own
+  `startedForAttemptRef` and a ref mirroring the latest `attempt`. No `setFlags` and no ref from the caller
+  crosses the boundary; a stale-attempt resolution reaches the caller only through `onStartUrl`, which the
+  hook calls after its own guard. Inside:
+  - `note({ type: 'start-issued', httpPort, port, attempt, entryExisted: entry !== undefined })` replaces
+    `if (entry === undefined) setOwnedPort(port)`.
+  - `.catch` guards its **whole** body on the attempt being current (matching the `.then`), then
+    `note({ type: 'start-rejected', httpPort, port, attempt: at })` and
+    `reportPortTunnelError(port, message(err), 'client')`.
+
+In `use-url-tab-tunnel.ts`, what remains is: `isLocal`/`httpPort`/`daemonPort`/`chatId`/`port`/`entry`,
+`useTunnelClaim({ httpPort, port, entry })` **declared before** `useTunnelAttempt` (the ordering pinned in
+*States and transitions*), `useTunnelAttempt(…, note)`, `useDnsReload`, the registration effect, and the
+return. Delete `ownedPort`, `setOwnedPort`, `prevPortRef`, the `stopped || failed` disown effect, and the
+DNS-reload block. Rewrite the module header: ownership lives in `tunnel-claim.ts`, the attempt lifecycle in
+`use-tunnel-attempt.ts`, and this file composes them. Keep `flags.everHadEntry` where it moved and say there
+why it is not `sawEntry`.
+
+Registration effect: `started: owns`, deps `[active, tabId, port, owns, httpPort]`, plus a `port === null`
+arm calling `releaseUrlTunnelConsumers([tabId])` under the same `active` gate. The effect returns early
+today, which leaves a stale `{ port, started: true }` record behind and contradicts "the claim is the only
+input to `started`". Which transitions actually reach that arm: `useDaemonIsLocal` reads
+`useActiveDaemon().target.kind` (`lib/daemon/use-daemon-is-local.ts:11`), so it flips only on a real daemon
+switch — and that path already calls `clearUrlTunnelConsumers()` before the keyed remount, so the arm is
+belt-and-braces there. The live trigger is a retarget to a URL that no longer classifies as loopback (the
+address bar accepts any URL), where stopping the abandoned tunnel is exactly right.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean; `grep -rn "ownedPort" packages/ui/src`
+returns nothing.
+
+### Task 7 — The chip's error origin, and the comments that still name `ownedPort`
+
+**Files (edited):** `packages/ui/src/features/chat/smart-actions/use-url-tunnel.ts`,
+`packages/ui/src/features/url-tab/url-tunnel-ownership.ts` (comment only),
+`packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts` (comment only)
+
+In `features/chat/smart-actions/use-url-tunnel.ts:85`, pass `'client'` as the third argument, with a
+one-line reason: a rejected start POST from the chip is not evidence about a tunnel another surface owns.
+
+The header of `url-tunnel-ownership.ts` and the comment at `url-tunnel-ownership.test.ts:68-71` both name
+`ownedPort`, which no longer exists; retarget them at the claim reducer. No behaviour change in either file,
+and no assertion in the test file changes.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/url-tunnel-ownership.test.ts`
+and each file under `src/features/chat/smart-actions/__tests__/` green.
+
+### Task 8 — Green sweep of the url-tab suite, and fold the two older files onto the harness
+
+**Files (edited):**
+`packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx`,
+`packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx`
+
+First run all nine url-tab test files and confirm green, Group B's included. Only then replace the
+duplicated handle/host/store scaffolding in the two older files with the Task 4 harness — **no assertion, no
+case name, and no seeded value may change**, and both files must be green before and after the swap. If the
+swap turns anything red, revert the swap (not the model) and report it.
+
+**Verify:** each of
+`tunnel-claim.test.ts`, `url-tunnel-ownership.test.ts`, `resolve-url-target.test.ts`, `url-tab-id.test.ts`,
+`UrlTabBodyState.test.tsx`, `UrlTabInstance.test.tsx`, `UrlTabInstance.tunnel.test.tsx`,
+`UrlTabInstance.tunnel-retarget-ownership.test.tsx`, `UrlTabInstance.tunnel-claim-lifecycle.test.tsx`
+runs green individually under
+`pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/<file>`, plus
+`src/store/__tests__/port-tunnels.test.ts` and the chip's own tests under
+`src/features/chat/smart-actions/__tests__/`.
+
+---
+
+## Group D — `verify`
+
+**kind:** test · **parallel_safe:** yes (edits nothing) · **depends_on:** `claim-rewire`
+
+### Task 9 — Verification sweep
+
+Record every result in the group's commit body or the lane result.
+
+1. `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean.
+2. `pnpm --filter @qlan-ro/mainframe-ui test` — full suite. If the known cross-file `React.act` batch failure
+   appears, re-run the affected files individually and say so; do not "fix" it here.
+3. `git diff --name-only origin/main...HEAD` — no path under `packages/core-rs/`, `packages/types/`,
+   `packages/mobile`, or `packages/app-tauri/src-tauri/` is added by *this rework* (the Rust arm landed
+   earlier in `a129e0de` and is untouched), and `.changeset/` still contains exactly one file for this
+   branch, `preview-open-urls.md`.
+4. `grep -rn "target.kind === 'failed'\|target.kind === 'stopped'" packages/ui/src/features/url-tab` — the
+   only hits are presentation (`UrlTabBodyState`, the body-state tests). No ownership decision reads
+   `target`.
+5. Size audit: every file added or edited here is under 300 lines and **every function under 50**
+   (`git diff --name-only --diff-filter=d origin/main...HEAD -- '*.ts' '*.tsx' | xargs wc -l` for the files,
+   then read the five hooks in Group C's budget table). This is a hard project rule with no allowance: a
+   function over 50 lines is decomposed here, not reported as a known deviation.
+6. Re-read the two round-5 findings against the new code and state, in one line each, which construct closes
+   them (`start-rejected` attempt scoping; the absence of a timeout signal in `ClaimSignal`), plus the third
+   error producer the model now separates (`errorOrigin: 'client'` → `'unknown'`).
+7. `grep -rn "reportPortTunnelError(" packages/ui/src` — exactly three production call sites
+   (`store/port-tunnels.ts`'s own `applyPortTunnelEvent`, the url-tab start request, the chat chip), of which
+   the two client ones pass `'client'`. A fourth caller, or a client caller without the argument, is a
+   defect: the default is daemon origin and silently revokes claims.
+
+**Exit:** all seven recorded, everything green.
 
 ---
 
@@ -352,44 +555,66 @@ happen.
 
 | Group | Tasks | Kind | parallel_safe | depends_on |
 |---|---|---|---|---|
-| `test-url-tab-view` | 1–3 | test | yes | — |
-| `test-run-surface-entry` | 4–6 | test | yes | — |
-| `verify` | 7 | test | yes | `test-url-tab-view`, `test-run-surface-entry` |
+| `claim-model` | 1–3 | ui | yes | — |
+| `claim-regressions-red` | 4 | test | yes | — |
+| `claim-rewire` | 5–8 | ui | yes | `claim-model`, `claim-regressions-red` |
+| `verify` | 9 | test | yes | `claim-rewire` |
 
-Both test groups write only new files, in disjoint directories, against implementation that is
-already at HEAD — so neither is a red-phase group and neither depends on the other. `verify` depends
-on both because it runs the suite they extend and audits the whole diff.
+`parallel_safe` is a file-collision flag only: no two groups write the same file. Actual concurrency is
+`claim-model` alongside `claim-regressions-red`; the other two are gated by `depends_on`. TDD order is
+task order — the reducer's table (2) precedes the reducer (3), and the component regressions (4) precede
+the rewire (5–8) and are red until it lands.
 
-## Manual verification (not automatable)
+## Decisions taken in this plan
 
-The Tauri automation bridge stops answering once a child webview exists, so mounted-webview behaviour
-is checked by hand. Run `pnpm tauri:dev` from `packages/app-tauri` with an isolated
-`MAINFRAME_DATA_DIR` **and** `DAEMON_PORT` — never the defaults; a stray launch hijacks the real
-`~/.mainframe` and port 31415.
-
-1. With no launch config, `+` → **URL…** → `localhost:5173` renders the dev server (AC1).
-2. Inspect and region capture deliver to chat from `http://localhost:5173/` **and** from a public
-   `https://` site (AC11) — the two origins the old allowlist excluded.
-3. On a remote daemon: a loopback URL on port 22 shows "Port must be 1024 or higher" with no request
-   in the daemon log (AC10); an eligible port shows pending, then loads the tunnel origin **with the
-   original path and query** (AC7); a second tab on that port loads with no pending (AC8).
-4. Quit and relaunch: the tab returns with its title, loads on activation, and the address bar seeds
-   with the typed URL — never a tunnel URL (AC14).
-5. In a tab left in the failure state, type a different URL and press Enter: it loads, the title
-   follows, and the new URL survives a relaunch (spec §6, D9).
+- **The `.catch` keeps its attempt guard even though the reducer no longer needs one.** The guard's job is
+  the store write; the reducer's is the claim. Task 2 proves the reducer stands alone.
+- **The claim carries `httpPort`.** It costs one field and turns "a claim is against one daemon" from an
+  incidental property of the remount into a stated rule.
+- **Provenance goes on the entry, not on the call site.** `entryDaemonState` is a pure function of the
+  entry; making the *reader* guess who wrote an error would put the conflation back where it was.
+- **Provenance is a marker (`errorOrigin?: 'client'`), not a two-valued field.** Recording only the exception
+  keeps a daemon error byte-identical to today's entry, which is what the store suite's three whole-entry
+  `toEqual` assertions pin, and makes "unmarked means daemon" the type's statement rather than a convention.
+- **The rewire is also a decomposition.** `useUrlTabTunnel` would land at ~84 lines even after the ownership
+  state leaves it, against a hard 50-line rule. Rather than ship a known violation or ask for an exception,
+  Task 6 lifts the attempt lifecycle into `use-tunnel-attempt.ts` (with the start request module-private
+  beside it) and leaves the hook as composition plus registration. The seam is callbacks and values only —
+  no setter and no ref crosses it — so the extraction cannot become a new place for ownership to leak into.
 
 ## Risks
 
-- **The widened `remote.urls` is the one hard-to-reverse change and it is already committed.** Any
-  `http`/`https` page a user opens can call the four bridge commands, including fabricating an
-  inspect payload that reaches the agent's context. The spec accepted this at the design gate (D1)
-  and `capabilities/preview.json`'s description records it in-tree. Task 7 only confirms the tests
-  still hold; re-litigating the decision is out of scope here.
-- **`registerUrlTunnelConsumer` is module-level state.** A test that forgets `clearUrlTunnelConsumers()`
-  passes alone and fails in a batch, or worse, the reverse. Fact 15 is not optional.
-- **Retry clears a shared port entry** (PD2), so one tab's Retry drops the badge every `UrlChip` on
-  that port shows. It refuses `ready` entries, so only a stale `error` or an abandoned `starting`
-  is ever removed and the next `tunnel:status` event restores the truth. Task 3's last case pins the
-  refusal.
-- **A test that fails against landed code is a finding, not a nuisance.** Follow the scope guard:
-  repair in your lane, report anything outside it.
+- **A transport-level start rejection is treated as a daemon failure.** `startPortTunnel` throws a bare
+  `Error`, so "the daemon refused" and "the socket died" are indistinguishable; `start-rejected` revokes in
+  both cases. The failure mode is a *missed* stop, never a wrongful one, which is the direction D10 says to
+  err in. Typing the API error is the real fix and is out of scope here.
+- **Creation evidence is inferred, not reported.** If `seedPortTunnels` skips its snapshot (a WS event
+  overtook the fetch, `store/port-tunnels-seed.ts:23`) while `daemonPort` is set anyway, a tab can start
+  against an empty `byPort` and claim a tunnel the daemon already held. Narrow, pre-existing, and unfixable
+  client-side; the daemon's start route returns no created/joined flag.
+- **The daemon-state effect observes entry *values*, not every write.** It reacts to `entry` changing, so two
+  store writes inside one React batch are seen as one value: a WS `stopped` (entry deleted) followed in the
+  same tick by a chip's client error on the same port is observed only as `'unknown'`, and the `'absent'`
+  revocation is missed until the next real transition. The window is one tick and needs two producers writing
+  the same port in it; it applies to every transition equally, and the failure mode is a missed stop rather
+  than a wrongful one. Widening the model to a write log would mean subscribing to store events instead of
+  state — a larger change than this rework, and not one the two defects call for.
+- **Two daemons on the same HTTP port number are indistinguishable to the claim.** Accepted, not fixed —
+  fixing it needs a daemon identity the client does not have, and the spec declines daemon changes.
+- **Fake timers in cases (b) and (c) are the only ones in this suite.** Enable them before `render` and
+  restore in `afterEach`, or the watchdog either never fires or leaks into a neighbouring test.
+- **A test that fails against the reworked code is a finding, not a nuisance.** Never weaken an assertion to
+  get green; the five prior cases are the regression contract for four rounds of review.
+
+## Manual verification (unchanged, not automatable)
+
+The Tauri automation bridge stops answering once a child webview exists. Run `pnpm tauri:dev` from
+`packages/app-tauri` with an isolated `MAINFRAME_DATA_DIR` **and** `DAEMON_PORT` — never the defaults.
+Against a remote daemon, the three sequences this rework is about:
+
+1. Open a URL tab on a fresh eligible port, wait past the pending state until it loads, then close the tab —
+   the port disappears from `GET /api/tunnel/ports` (AC12).
+2. Open a URL tab whose tunnel is slow enough to trip the 120 s watchdog, let it load afterwards, then close
+   the tab — the port must still disappear. That is defect 2, by hand.
+3. With a URL tab tunnelling port N, click the chat chip for the same port and let its start fail. The tab
+   must keep its claim: close it and the port must disappear.

--- a/docs/plans/2026-07-29-todo-281-preview-open-urls-plan.md
+++ b/docs/plans/2026-07-29-todo-281-preview-open-urls-plan.md
@@ -1,0 +1,395 @@
+# Implementation plan — URL tabs in the Run surface (#281), remaining work
+
+**Spec:** [`docs/specs/2026-07-28-todo-281-preview-open-urls.md`](../specs/2026-07-28-todo-281-preview-open-urls.md)
+**Supersedes:** [`docs/plans/2026-07-28-todo-281-preview-open-urls-plan.md`](2026-07-28-todo-281-preview-open-urls-plan.md) —
+that plan's Groups A–E are **implemented and committed** on this branch. This plan re-scopes to what
+is genuinely left: Group F (behavioural UI coverage) plus the verification sweep.
+**Branch:** `todo/281-preview-open-urls` · **Worktree:** `.worktrees/todo-281-preview-open-urls`
+**Packages:** `@qlan-ro/mainframe-ui` only. Nothing under `packages/core-rs`, `packages/types`, or
+`packages/mobile` changes; `packages/app-tauri/src-tauri` is already done and is only *verified* here.
+
+## Goal
+
+Give the Run surface a `url` tab kind that points the webview engine the app already owns at any
+`http`/`https` address the user names — no launch configuration, no running process. Two entry points
+(the Run tab strip's `+` menu and the empty-state Run picker, plus the chat localhost chip's "Open in
+Mainframe" row) funnel through one creation path that dedups by normalized URL within a launch scope;
+the tab keeps every preview control except run/stop/restart and the console drawer, persists across a
+restart, and on a remote daemon routes a loopback address through the existing per-port quick tunnel
+strictly as a consumer. The feature code for all of that is on the branch. What is missing is the
+behavioural test layer that proves the composed components behave as the spec's acceptance criteria
+require, and the sweep that records typecheck, tests, `cargo`, and the diff's package boundaries.
+
+## Status: what is already on the branch
+
+Audited in the worktree on 2026-07-29 against `origin/main` (`ca7cda36`). Every row below was read,
+not inferred.
+
+| Prev. group | Tasks | Landed as | What it produced |
+|---|---|---|---|
+| `test-pure-red` | 1–6 | `736c6677`, `208df5cf`, `ee9a31a0`, `76288d95`, `be9e800d`, `114b4f56` | Pure/store tests: `normalize-url`, `run-pane-url-tab`, `layout-persist`, `port-tunnels`, `resolve-url-target`, `url-tunnel-ownership` |
+| `core` | 7–13, 32, 33 | `22134eaa`, `fc64cfae`, `27e5fad2`, `d4c25ed0`, `a598b031`, `18b03c1e`, `3c4e6026`, `1c8c6476`, `af6c0e62` | `url` kind + dedup, `tabIds*` generalization, persistence, `dnsVerified`, `resolve-url-target.ts`, `layout-placement.ts`, tunnel-ownership registry, `setUrlTabTarget`, changeset |
+| `rust` | 14, 15 | `a129e0de` | `capabilities/preview.json` → `["http://*:*", "https://*:*"]` + three `bridge_plugin.rs` tests (pattern span, scheme guard, capability shape) |
+| `ui-tab` | 16–21 | `9d5bb5b7`, `67e5586b`, `df82a058`, `06467698`, `b6fd61c2`, `8289641b` | `use-webview-mount.ts` extraction, `PreviewUrlBar` seed/commit rework, `use-url-tab-tunnel.ts`, `UrlTabBodyState`, `UrlTabToolbar`, `UrlTabInstance`, the `RunSurface` arm |
+| `ui-entrypoints` | 22–26 | `62d4498c`, `9858d7d0`, `a991b9cf`, `09527a40`, `fe3da1bd` | `open-url-tab` intent + subscriber, `RunUrlEntry`, the `+` menu row, the picker row, the chip's open menu |
+
+**Verification run today, before writing this plan:**
+
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean.
+- `pnpm --filter @qlan-ro/mainframe-ui test` — **561 files, 5253 tests, all passing.**
+- `git status` — clean tree; `.changeset/preview-open-urls.md` present.
+
+**Not yet done, and the reason this plan exists:** the previous lane died (agent unreachable) in the
+wave that would have run Group F. No test asserts the *composed* behaviour — that `UrlTabInstance`
+renders the address bar and omits the process controls, that the Run surface routes the `url` kind,
+that the entry points emit one intent, that closing a tab releases exactly the tunnel it owns.
+Acceptance criteria AC1–AC5, AC9, AC12–AC13, AC15 are implemented but unproven.
+
+## Constraints (from `CLAUDE.md` and `packages/ui/CLAUDE.md`)
+
+- Max **300 lines/file**, **50 lines/function** — Task 2 and Task 3 exist as separate files for
+  exactly this reason; do not merge them.
+- Tests live beside their subject in `__tests__/`. `.test.tsx` runs under jsdom, `.test.ts` under
+  node (`vitest.config.ts` projects). A DOM-touching `.test.ts` needs a `// @vitest-environment jsdom`
+  pragma — none of the tasks below should need one.
+- Run single files (`pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>`); large multi-suite
+  runs hit the known cross-file `React.act` failure.
+- `data-testid` on every interactive element, keyed by tab id, never by array index.
+- No `@ts-ignore`; no silent catches; delete dead code found in a file you edit.
+- The changeset already exists — **do not add a second one.**
+
+## Verified facts the tests must be written against
+
+Read in the worktree on 2026-07-29. Do not re-derive; do not guess an API.
+
+1. **`UrlTabBodyState`** (`features/url-tab/UrlTabBodyState.tsx`) takes
+   `{ target, device, inspectActive, anchorRef, onRetry }` and renders exactly one of:
+   `url-tab-body-loaded` (for `direct` **and** `tunnelled`), `url-tab-body-pending`,
+   `url-tab-body-rejected`, `url-tab-body-failed`, `url-tab-body-stopped`, `url-tab-body-invalid`.
+   `url-tab-retry` appears only in `failed` and `stopped`. `url-tab-inspect-active-indicator` appears
+   only when `inspectActive` and the body is loaded.
+2. **`UrlTabTarget`** (`features/url-tab/resolve-url-target.ts`) is a 7-member union:
+   `direct{url}`, `tunnelled{url}`, `pending{port}`, `rejected{port,reason}`, `failed{error}`,
+   `stopped{port}`, `invalid{url}`. `URL_TAB_TUNNEL_TIMEOUT_MS = 120_000`.
+3. **`UrlTabInstance`** props: `{ tabId, url, visible, scopeKey?, projectId? }`; root testid
+   `url-tab-instance-<tabId>`. It commits an address-bar edit through
+   `useLayoutStore.getState().setUrlTabTarget(tabId, next, urlTabTitle(next))`.
+4. **`UrlTabToolbar`** renders `PreviewUrlBar` with `enabled` hardcoded true (`preview-url-input` is
+   never `disabled`), `PreviewDeviceToggle`, and `PreviewCaptureCluster` with
+   `isRunning={handle !== null}`. Testids reachable from it: `preview-url-input`,
+   `preview-url-reload`, `preview-url-open-browser`, `preview-url-clear-cache`,
+   `preview-capture-cluster`, `preview-toolbar-inspect`, `preview-toolbar-capture`,
+   `preview-toolbar-region`, `preview-device-toggle`, `preview-device-desktop`,
+   `preview-device-mobile`, `preview-capture-cluster`, `url-tab-toolbar`. **Absent by
+   construction:** `preview-toolbar` and the `PreviewRunControl` pair `preview-run-start` /
+   `preview-run-stop`. Note `preview-url-reload` renders but is `disabled` while no handle is
+   mounted — assert presence, not enabled state.
+5. **The mount seam** is `useHost().preview.mount(el, url, { projectId, device })` inside
+   `features/preview/use-webview-mount.ts`. Mock `@/lib/host` and return a handle stub; set
+   `compositesAboveDom: false` on the stub so `usePreviewOcclusion` stays inert in jsdom.
+   `useWebviewMount` destroys the handle on unmount and on `url === null`.
+6. **`useUrlTabTunnel`** reads: `useDaemonIsLocal()` (`@/lib/daemon/use-daemon-is-local`),
+   `useDaemonPort()` (`@/features/sessions/runtime/daemon-port-context`) for the HTTP port,
+   `useTunnelDaemonPort()` (from `@/store/port-tunnels`, backed by `usePortTunnelsStore.daemonPort`),
+   `useActiveIdentity().chatId`, `usePortTunnelsStore.byPort[port]`. It calls
+   `startPortTunnel(httpPort, { port, chatId })` from `@/lib/api/tunnel-ports` and
+   `registerUrlTunnelConsumer(tabId, { port, started, daemonHttpPort })` from
+   `@/features/url-tab/tunnel-consumers`.
+7. **Ownership**: `started: true` only when no entry existed for that port at the moment this tab's
+   start fired; a Retry never demotes an owner (`addConsumer` in `url-tunnel-ownership.ts`).
+   `releaseUrlTunnelConsumers` calls `stopPortTunnel(daemonHttpPort, port)` only for a removed
+   **owner** whose port has no remaining consumer.
+8. **`clearPortTunnelEntry(port)`** (in `@/store/port-tunnels`) refuses to clear a `ready` entry and
+   returns whether it cleared. `retry()` calls it, then bumps the attempt counter.
+9. **`composeTunnelUrl`** puts the original path/query/hash on the tunnel origin, so a tab on
+   `http://localhost:5173/app?x=1` with tunnel origin `https://abc.trycloudflare.com` mounts
+   `https://abc.trycloudflare.com/app?x=1`.
+10. **`RunSurface`**'s fallback for an unhandled kind renders `` `${tab.kind}: ${tab.title}` `` as
+    plain text (`layout/surfaces/RunSurface.tsx:159`). `RunSurface.tab-scope.test.tsx` is the model
+    for scope filtering and for the stub-every-body-component mock set.
+11. **`RunUrlEntry`** (`layout/RunUrlEntry.tsx`) emits `emitSurfaceIntent({ type: 'open-url-tab', url,
+    paneId })` with the **normalized** URL, sets an invalid state (`aria-invalid`, `text-destructive
+    ring-1 ring-destructive`) without emitting when `normalizePreviewUrl` returns null, and calls
+    `onDone` on commit, Escape, and blur. Testids `run-tab-url-entry`, `run-tab-url-entry-input`.
+12. **The chip menu** (`features/chat/smart-actions/UrlChip.tsx`): trigger `smart-action-url-open`,
+    rows `smart-action-url-open-in-app` (first, "Open in Mainframe") and
+    `smart-action-url-open-browser` (second). The in-app row emits the intent and must not start a
+    tunnel. `url-chip.test.tsx` already drives the browser row through the menu and explicitly defers
+    row-order coverage to a separate file — that file is Task 5.
+13. **The subscriber** (`store/url-tab-intent-subscriber.ts`) normalizes again, reads `scopeKey` from
+    `useActiveBasesStore`, and calls `useLayoutStore.getState().addRunTab({ id: urlTabId(url), kind:
+    'url', title: urlTabTitle(url), url, scopeKey }, paneId)`. `addRunTab` internally runs
+    `placeInLayout(layout, 'run')`, so no `toggleSurface` is needed for AC4's "reveals Run".
+14. **Release sites** in `store/layout.ts`: `closeRunTab` (single tab), `closePane`, `releaseRunScope`,
+    and `toggleSurface('run')` when Run was lit — each calls `releaseUrlTunnels(...)` from
+    `store/url-tunnel-cleanup.ts`. `disposeDaemonSession` calls `clearUrlTunnelConsumers()`, which
+    deliberately stops nothing.
+15. **The registry is module-level state.** Any test touching it must call
+    `clearUrlTunnelConsumers()` in `beforeEach`, or ownership leaks between cases.
+16. **jsdom setup** (`src/__tests__/setup.ts`) already stubs `ResizeObserver`, `localStorage`, and
+    Range rects; both vitest projects load it.
+
+## Scope guard for parallel groups
+
+The two test groups are file-disjoint and may run at the same time. If a test exposes a real defect
+in the landed code, fix it **inside your group's lane** and say so in the commit body:
+
+- `test-url-tab-view` may repair files under `packages/ui/src/features/url-tab/`.
+- `test-run-surface-entry` may repair files under `packages/ui/src/layout/`,
+  `packages/ui/src/store/`, and `packages/ui/src/features/chat/smart-actions/`.
+- A defect outside your lane (notably `features/preview/*`) is **reported, not edited** — `verify`
+  owns cross-lane repairs so the two groups never collide on a file.
+
+Never weaken an assertion to make a test pass. A test that contradicts the spec is a finding.
+
+---
+
+## Group A — `test-url-tab-view`
+
+### Task 1 — `UrlTabBodyState` renders one explicit state per target
+
+**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`
+
+Pure render tests; no store, no host. Build `anchorRef` with `createRef<HTMLDivElement>()`.
+
+- `direct` and `tunnelled` → `url-tab-body-loaded`; assert once for `device="desktop"` and once for
+  `device="mobile"` (both must render the anchor div).
+- `inspectActive` true on a loaded body → `url-tab-inspect-active-indicator` present; false → absent.
+- `pending{port: 5173}` → `url-tab-body-pending`, text contains `5173`, **no** `url-tab-retry`.
+- `rejected{port: 22, reason: 'Port must be 1024 or higher'}` → `url-tab-body-rejected` showing the
+  reason **verbatim**, no `url-tab-retry` (AC10: a rejection is not a retryable failure).
+- `failed{error: 'cloudflared exited with code 1'}` → `url-tab-body-failed` showing that text, plus
+  `url-tab-retry`; clicking it calls `onRetry` exactly once (AC9).
+- `stopped{port: 5173}` → `url-tab-body-stopped` naming the port, plus a working `url-tab-retry`.
+- `invalid{url: ''}` → `url-tab-body-invalid` with no mono URL line; `invalid{url: 'not a url'}` →
+  the same body **with** that text rendered; neither shows Retry.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabBodyState.test.tsx`
+
+### Task 2 — `UrlTabInstance`: toolbar composition and the live address bar
+
+**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx`
+
+Mocks (fact 5, 6): `@/lib/host` (mount spy returning a handle stub with `compositesAboveDom: false`
+and `navigate` resolving), `@/features/sessions/use-active-identity` →
+`{ projectId: 'proj-A', chatId: 'chat-1' }`, `@/features/sessions/runtime/daemon-port-context` →
+`useDaemonPort: () => 31415`, `@/lib/daemon/use-daemon-is-local` → a mutable local flag,
+`@/lib/api/tunnel-ports` → `startPortTunnel`/`stopPortTunnel` spies. Use the **real**
+`usePortTunnelsStore` and the **real** `useLayoutStore`, seeded via `setState`.
+
+- **Local daemon, `http://localhost:5173/`** → `host.preview.mount` called once with that URL and
+  `{ projectId: 'proj-A', device: 'desktop' }`; root `url-tab-instance-<tabId>` present;
+  `url-tab-body-loaded` present (AC1).
+- **Control inventory** (AC5): `preview-url-input`, `preview-url-reload`, `preview-url-open-browser`,
+  `preview-url-clear-cache`, `preview-toolbar-inspect`, `preview-toolbar-capture`,
+  `preview-toolbar-region` are all in the DOM under `url-tab-toolbar`; assert `queryByTestId` is
+  null for `preview-run-start`, `preview-run-stop`, and `preview-toolbar` (the preview tab's own
+  toolbar — a URL tab must render `UrlTabToolbar`, never `PreviewToolbar`, which is where the
+  process controls live). The console is a separate `console` tab kind, not a drawer, so there is
+  nothing further to assert absent inside this component.
+- **The bar stays live with nothing mounted** (spec §6, D9): seed `useLayoutStore` with a run holding
+  this `url` tab, set the daemon remote and the port entry to `{ state: 'error', error: 'boom' }` so
+  the target resolves `failed`; assert `preview-url-input` is **not** `disabled`, then type
+  `localhost:5173` and press Enter and assert `useLayoutStore.getState()`'s tab now carries
+  `url: 'http://localhost:5173/'` and the matching title — and that `host.preview.mount` was never
+  called in this case.
+- **Invalid tab** (`url: ''`) → `url-tab-body-invalid`, `mount` never called, input still enabled
+  (AC6's "invalid input never mounts a webview", in its persisted-tab form).
+- **Device toggle** flips the mount option: switching to mobile re-renders with the mobile frame and
+  does not call `mount` a second time (the handle is reanchored, not recreated).
+- **Unmount destroys**: unmount the tree and assert the handle stub's `destroy` was called (AC12's
+  "closing a URL tab destroys its webview", at the component seam).
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabInstance.test.tsx`
+
+### Task 3 — `UrlTabInstance`: tunnel adoption, ownership, retry, DNS reload
+
+**File (new):** `packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx`
+
+Same mock set as Task 2, plus a spy on `registerUrlTunnelConsumer`
+(`vi.mock('@/features/url-tab/tunnel-consumers')`). Daemon remote for every case
+(`useDaemonIsLocal → false`), `usePortTunnelsStore.setState({ daemonPort: 31415 })`, tab URL
+`http://localhost:5173/app?x=1`.
+
+- **Fresh start owns the tunnel** (D10, AC12): no entry for 5173 at mount → body is
+  `url-tab-body-pending`, `startPortTunnel` called once with `(31415, { port: 5173, chatId: 'chat-1' })`,
+  and `registerUrlTunnelConsumer` called with `started: true`.
+- **Adopting mid-start does not own it**: seed `{ 5173: { state: 'starting' } }` before mount → the
+  tab still issues its start (the daemon is the single-flight point) but registers `started: false`.
+- **A ready tunnel skips pending and carries the path** (D12, AC8): seed
+  `{ 5173: { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true } }` → no
+  pending body, `mount` called with `https://abc.trycloudflare.com/app?x=1`.
+- **DNS reload fires exactly once** (D11): same seed but `dnsVerified: false`; after mount, flip the
+  entry to `dnsVerified: true` and assert the handle's `navigate` was called once with the same
+  composed URL; flipping other fields afterwards adds no further `navigate`.
+- **Port rejection short-circuits** (AC10): tab URL `http://localhost:22/` → `url-tab-body-rejected`
+  reading `Port must be 1024 or higher`, and `startPortTunnel` **never called**. Repeat for the
+  daemon's own port (`31415`) expecting `Cannot tunnel the daemon's own port`.
+- **Retry re-requests** (PD1, AC9): entry `{ state: 'error', error: 'boom' }` → `url-tab-body-failed`;
+  click `url-tab-retry` → the entry is gone from `usePortTunnelsStore` and exactly one further
+  `startPortTunnel` call was made.
+- **A ready entry survives Retry** (PD2): with `{ state: 'ready', url, dnsVerified: true }` the body
+  is loaded and there is no Retry to click — assert `url-tab-retry` is absent, guarding the rule that
+  a live tunnel is never cleared.
+
+Keep the file under 300 lines; factor the seed/mount boilerplate into local helpers.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx`
+
+---
+
+## Group B — `test-run-surface-entry`
+
+### Task 4 — The Run surface renders the kind and scopes it
+
+**File (new):** `packages/ui/src/layout/__tests__/RunSurface.url-tab.test.tsx`
+
+Copy the mock set from `RunSurface.tab-scope.test.tsx` (fact 10) and add a stub for
+`@/features/url-tab/UrlTabInstance` that captures props.
+
+- A `url` tab renders the stub and **never** the `` `${kind}: ${title}` `` placeholder (AC3).
+- The stub receives `tabId`, `url`, `visible`, `scopeKey`, `projectId` threaded from the tab and the
+  active identity.
+- A `code` tab still renders the placeholder — proving the assertion above is not vacuous.
+- A `url` tab stamped with a non-matching `scopeKey` renders nothing, and one stamped with the active
+  scope renders (AC13).
+- After `releaseRunScope(activeScope)` the tab is gone from the DOM (AC13's release half).
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/layout/__tests__/RunSurface.url-tab.test.tsx`
+
+### Task 5 — Both entry points emit one intent
+
+**Files (new):** `packages/ui/src/layout/__tests__/RunUrlEntry.test.tsx`,
+`packages/ui/src/features/chat/smart-actions/__tests__/url-chip-menu.test.tsx`
+
+`RunUrlEntry` (fact 11) — mock `@/store/surface-intents`:
+
+- Typing `localhost:5173` + Enter emits exactly one `{ type: 'open-url-tab', url:
+  'http://localhost:5173/', paneId }` and calls `onDone`.
+- Each of `''`, `'   '`, `'not a url'`, `'file:///etc/passwd'`, `'javascript:alert(1)'` emits
+  **nothing**, leaves the field mounted, and sets `aria-invalid` (AC6, and D2's http/https-only rule
+  at the entry point).
+- Typing after an invalid attempt clears the invalid state.
+- Escape emits nothing and calls `onDone`.
+- Omitting `paneId` (the empty-state picker case) emits the intent with `paneId: undefined`.
+
+`url-chip-menu` (fact 12) — reuse `url-chip.test.tsx`'s mock scaffolding, do not duplicate its
+tunnelling assertions:
+
+- Opening `smart-action-url-open` lists **Open in Mainframe above Open in browser** — assert DOM
+  order, not just presence (AC4, D7).
+- Selecting the in-app row emits one `open-url-tab` intent with the chip's `href` and calls
+  neither `startPortTunnel` nor the OS opener.
+- Selecting the browser row still calls the pre-existing opener.
+
+**Verify:** run both files individually with `vitest run`.
+
+### Task 6 — Creation path, dedup, and tunnel release through the stores
+
+**File (new):** `packages/ui/src/store/__tests__/url-tab-intent-subscriber.test.ts` (node env)
+
+Real `useLayoutStore`, `useActiveBasesStore`, `usePortTunnelsStore`, and the real
+`tunnel-consumers` registry; mock only `@/lib/api/tunnel-ports`. Call
+`clearUrlTunnelConsumers()` and reset the layout store in `beforeEach` (fact 15).
+
+- `subscribeToUrlTabIntents()` + one `open-url-tab` emit creates one `url` tab whose id matches
+  `/^url-[A-Za-z0-9_-]+$/` (AC16 — the id is the webview label) and whose `url` is normalized.
+- Emitting the same URL twice yields **one** tab, active both times (AC4's "focuses rather than
+  stacks"); a different scope yields a second tab (AC13).
+- Emitting while Run is not in the layout leaves `run` placed in `layout` afterwards (AC4's reveal,
+  fact 13).
+- Emitting an unnormalizable URL creates no tab.
+- The returned unsubscribe stops further intents from creating tabs.
+- **Release** (AC12, D10), driving `useLayoutStore` with consumers registered by hand via
+  `registerUrlTunnelConsumer`:
+  - closing a tab registered `started: true`, sole consumer of 5173 → `stopPortTunnel` called once
+    with `(31415, 5173)`;
+  - closing one of two tabs on 5173 → `stopPortTunnel` **not** called;
+  - closing a tab registered `started: false` (adopted the chip's tunnel) → not called;
+  - `releaseRunScope(scope)` holding an exclusively-started tunnel → called once;
+  - `closePane` and `toggleSurface('run')` (Run lit) each release the pane's/run's URL tabs — one
+    case per site, so a future edit that drops a call site fails here (fact 14).
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/store/__tests__/url-tab-intent-subscriber.test.ts`
+
+---
+
+## Group C — `verify`
+
+### Task 7 — Full verification sweep
+
+Runs after both test groups; it verifies their output and the already-landed Rust arm. Record each
+result in the group's commit body or the lane result — a sweep whose output nobody wrote down did not
+happen.
+
+1. `pnpm --filter @qlan-ro/mainframe-ui typecheck` — must be clean.
+2. `pnpm --filter @qlan-ro/mainframe-ui test` — full suite. If the known cross-file `React.act`
+   batch failure appears, re-run the affected files individually and note it; do not "fix" it here.
+3. `cd packages/app-tauri/src-tauri && cargo test --lib preview::bridge_plugin` — the three tests
+   added by `a129e0de` (pattern span, scheme guard, capability shape) must pass. The worktree's
+   `target/` is already warm (~2.3 GB); do **not** set `CARGO_TARGET_DIR`. If the `tauri::utils::acl::RemoteUrlPattern`
+   re-export fails to resolve in this toolchain, add `urlpattern = "0.3"` + `regex = "1"` as
+   **dev-dependencies only** (both already in `Cargo.lock`) and reproduce the assertion — do not
+   delete the test.
+4. `git diff --name-only origin/main...HEAD` must show **no** path under `packages/core-rs/`,
+   `packages/types/`, or `packages/mobile` (spec: no daemon change), and exactly one `.changeset/`
+   file (`preview-open-urls.md`).
+5. Testid audit: every interactive element added by this feature carries a `data-testid` —
+   `run-pane-open-url-<paneId>`, `run-picker-open-url`, `run-tab-url-entry`,
+   `run-tab-url-entry-input`, `url-tab-toolbar`, `url-tab-retry`, `url-tab-instance-<tabId>`,
+   `url-tab-body-*`, `smart-action-url-open-in-app`, `smart-action-url-open-browser`. Confirm none is
+   keyed by array index. Note in the sweep that a URL tab's strip pill uses the shared
+   `run-tab-<id>` testid, which resolves to `run-tab-url-<host>-<uuid>` because `urlTabId` prefixes
+   the id with `url-` — this satisfies the spec's `run-tab-url-<tabId>` without a special case.
+6. Size audit: `git diff --name-only origin/main...HEAD -- '*.ts' '*.tsx' | xargs wc -l | sort -n` —
+   no file over 300 lines; spot-check that no function added by this work exceeds 50.
+
+**Exit:** all six recorded, everything green.
+
+---
+
+## Execution groups
+
+| Group | Tasks | Kind | parallel_safe | depends_on |
+|---|---|---|---|---|
+| `test-url-tab-view` | 1–3 | test | yes | — |
+| `test-run-surface-entry` | 4–6 | test | yes | — |
+| `verify` | 7 | test | yes | `test-url-tab-view`, `test-run-surface-entry` |
+
+Both test groups write only new files, in disjoint directories, against implementation that is
+already at HEAD — so neither is a red-phase group and neither depends on the other. `verify` depends
+on both because it runs the suite they extend and audits the whole diff.
+
+## Manual verification (not automatable)
+
+The Tauri automation bridge stops answering once a child webview exists, so mounted-webview behaviour
+is checked by hand. Run `pnpm tauri:dev` from `packages/app-tauri` with an isolated
+`MAINFRAME_DATA_DIR` **and** `DAEMON_PORT` — never the defaults; a stray launch hijacks the real
+`~/.mainframe` and port 31415.
+
+1. With no launch config, `+` → **URL…** → `localhost:5173` renders the dev server (AC1).
+2. Inspect and region capture deliver to chat from `http://localhost:5173/` **and** from a public
+   `https://` site (AC11) — the two origins the old allowlist excluded.
+3. On a remote daemon: a loopback URL on port 22 shows "Port must be 1024 or higher" with no request
+   in the daemon log (AC10); an eligible port shows pending, then loads the tunnel origin **with the
+   original path and query** (AC7); a second tab on that port loads with no pending (AC8).
+4. Quit and relaunch: the tab returns with its title, loads on activation, and the address bar seeds
+   with the typed URL — never a tunnel URL (AC14).
+5. In a tab left in the failure state, type a different URL and press Enter: it loads, the title
+   follows, and the new URL survives a relaunch (spec §6, D9).
+
+## Risks
+
+- **The widened `remote.urls` is the one hard-to-reverse change and it is already committed.** Any
+  `http`/`https` page a user opens can call the four bridge commands, including fabricating an
+  inspect payload that reaches the agent's context. The spec accepted this at the design gate (D1)
+  and `capabilities/preview.json`'s description records it in-tree. Task 7 only confirms the tests
+  still hold; re-litigating the decision is out of scope here.
+- **`registerUrlTunnelConsumer` is module-level state.** A test that forgets `clearUrlTunnelConsumers()`
+  passes alone and fails in a batch, or worse, the reverse. Fact 15 is not optional.
+- **Retry clears a shared port entry** (PD2), so one tab's Retry drops the badge every `UrlChip` on
+  that port shows. It refuses `ready` entries, so only a stale `error` or an abandoned `starting`
+  is ever removed and the next `tunnel:status` event restores the truth. Task 3's last case pins the
+  refusal.
+- **A test that fails against landed code is a finding, not a nuisance.** Follow the scope guard:
+  repair in your lane, report anything outside it.

--- a/docs/specs/2026-07-28-todo-281-preview-open-urls.md
+++ b/docs/specs/2026-07-28-todo-281-preview-open-urls.md
@@ -1,0 +1,257 @@
+# URL tabs in the Run surface (#281)
+
+## Problem
+
+The Run surface can already show a live web page, but only one the app launched itself. A preview tab is
+bound to a launch configuration: it mounts its webview when that config's process reports `running` on a
+known port, and destroys it the moment the process stops. Every other way a URL reaches the user — a
+localhost link an agent prints in chat, a port a teammate mentions, a page served by something Mainframe
+did not start — ends at the OS browser. The app owns a webview engine and cannot point it anywhere.
+
+This is sharpest on a remote daemon. Mainframe can now open an ad-hoc Cloudflare tunnel for a port on the
+daemon machine, but the only thing it does with the resulting URL is hand it to the local OS browser. The
+work happens on one machine, the window that should show it is on another, and the surface built to display
+running web pages cannot display this one.
+
+## Behavior
+
+### Creating a URL tab
+
+A URL tab is created from two places, both funnelling through one path:
+
+- **The Run tab strip.** The `+` menu gains a **URL…** row beside "New terminal" and the launch configs.
+  Choosing it reveals an inline input in the tab strip — not a dialog — with the placeholder
+  `localhost:3000`. Enter commits, Escape cancels and restores the strip. When the Run surface is empty
+  (no tabs), the same action lives as an **Open URL…** row in the Run picker and reveals the same inline
+  input in place.
+- **The localhost chip in chat.** The chip's open control becomes a two-row menu: **Open in Mainframe**
+  first, **Open in browser** second. "Open in Mainframe" creates or focuses a URL tab, reveals the Run
+  surface if it is hidden, and focuses the tab. The chip's tunnel badge, its "Stop tunnel" control, and its
+  browser behavior are otherwise unchanged.
+
+Creating a URL tab requires no launch configuration and no running process. Input is normalized the way the
+existing address bar normalizes it: whitespace trimmed, `http://` added when no scheme is present, and only
+`http`/`https` accepted. Anything else — unparseable text, `file://`, `javascript:`, `ssh://` — is rejected
+inline, with the invalid treatment the address bar already uses, and no webview is mounted.
+
+Opening a URL that normalizes to one an existing URL tab in the same launch scope already holds focuses that
+tab instead of stacking a second one. Comparison is on the normalized URL, not the raw input.
+
+### The tab itself
+
+A URL tab looks like a preview tab with the process controls removed. It keeps: the address bar (editable,
+and updated by navigations that happen inside the page), reload, open-in-OS-browser, clear cache, the
+desktop/mobile device toggle, element inspect, and region capture. Captures and inspect results go to the
+active chat exactly as they do from a preview tab.
+
+Run/stop/restart and the console drawer are **absent**, not disabled — there is no launch config for them to
+act on. The tab's title is the URL's host and port. Its pill carries a globe glyph, distinct from the
+preview eye.
+
+The webview mounts as soon as the tab has a loadable URL and stays mounted regardless of any launch
+process's state. Reload reloads the URL currently displayed rather than re-deriving one from a port.
+
+URL tabs belong to the launch scope of the session that created them, are shown only in that scope, and are
+released with it — the same rules every other Run tab follows.
+
+### Remote daemons and tunnels
+
+On a **local** daemon, every URL loads directly and the word "tunnel" never appears.
+
+On a **remote** daemon, a URL naming a loopback host (`localhost`, `127.0.0.1`, `[::1]`) points at the
+daemon machine and is not reachable from the app's machine. The tab then uses the existing per-port quick
+tunnel, scoped to the active chat:
+
+1. If the port is one the tunnel service refuses — below 1024, or the daemon's own port — the tab shows
+   that specific reason and stops. No request is made.
+2. Otherwise the tab adopts an existing tunnel for that port, or requests one, and shows a pending state
+   naming the port and saying a tunnel is coming up. It never shows a blank webview while waiting.
+3. Pending ends when the tunnel is ready **and its hostname has been verified as resolvable**. The tab then
+   loads the tunnel origin carrying over the original URL's path, query, and fragment.
+4. A tunnel that reports an error, or that produces nothing within 60 seconds, puts the tab into a failure
+   state that shows the daemon's own error text and a **Retry**. The address bar stays live, so the user can
+   type a different URL out of the failure state.
+5. If the tunnel is stopped from somewhere else (the chat chip, settings) while a tab is using it, the tab
+   says the tunnel was stopped and offers Retry. It does not silently re-request.
+
+A remote-daemon URL that is not loopback (a public site, a LAN host) loads directly, with no tunnel.
+
+### Inspect and region capture on any origin
+
+Element inspect, region capture, and in-page navigation tracking work on every `http`/`https` origin a tab
+loads, not only on localhost and tunnel hosts. This also fixes existing preview tabs, where typing a
+non-localhost URL into the address bar today leaves the inspect and capture buttons silently dead. Opening a
+page in the OS browser from inside a previewed page stays restricted to `http`/`https`.
+
+### Closing and restarting
+
+Closing a URL tab destroys its webview. If that tab requested the tunnel it was using, and no other URL tab
+is still using that port, the tunnel is stopped; a tunnel the tab merely adopted, or one another tab still
+needs, stays up.
+
+URL tabs survive an app restart. They rehydrate unmounted and load on first activation. A rehydrated tab
+resolves its tunnel from scratch — the stored value is the URL the user typed, never a tunnel URL.
+
+## Not Included
+
+- `deferred` — Browser features: history, a back/forward stack, bookmarks, downloads, devtools, multiple
+  windows.
+- `deferred` — Per-URL cookie and storage partitioning beyond the session isolation the preview webview
+  already provides.
+- `deferred` — Preserving a URL tab's in-page navigation across a restart; a rehydrated tab reloads the URL
+  the user committed, not the last page it was on.
+- `deferred` — Refactoring the chat chip's browser opener to carry the original path onto the tunnel origin;
+  the tab does this, the chip keeps its current behavior.
+- `declined` — Any daemon change. The tunnel start/stop/list endpoints, their validation, and their status
+  events are consumed as they stand. No new route, no Rust daemon type, no envelope work.
+- `declined` — Changing how launch-config preview tabs derive their URL, or their run/stop/restart/console
+  behavior. Only the shared reload and address-bar validation change, and identically for both kinds.
+- `declined` — Promoting the URL tab kind into the shared types package. It is renderer layout state.
+- `platform` — The mobile client.
+- `platform` — Live automated driving of a mounted webview. The Tauri automation bridge stops answering once
+  a child webview exists.
+
+## Edge cases
+
+- **Input without a scheme** — `localhost:3000` becomes `http://localhost:3000/`.
+- **Non-http(s) scheme** — `file:///etc/passwd`, `javascript://x`, `ssh://host` are rejected inline. This
+  closes the same hole in the existing preview address bar, which accepts them today.
+- **Empty or whitespace-only input** — treated as invalid; Enter does nothing visible except the invalid
+  state.
+- **Same port, different paths** — two URL tabs on `:3000` with different paths are two tabs sharing one
+  tunnel. Closing one leaves the tunnel up for the other.
+- **Duplicate across panes** — dedup looks at every pane in the scope, not just the one being added to.
+- **Duplicate across scopes** — the same URL under a different project or worktree is a different tab.
+- **Port the service refuses** — `http://localhost:22` on a remote daemon shows "Port must be 1024 or
+  higher"-class text, not a generic failure. The check runs before any request; a rejection that still
+  arrives from the daemon replaces it verbatim.
+- **Tunnel ready but DNS not yet propagated** — the daemon reports a usable URL up to ~30 s before its
+  hostname resolves. The tab stays pending through that window rather than loading a page that cannot
+  resolve.
+- **Daemon switch with URL tabs open** — layout and tunnels are scoped per daemon; tabs re-resolve locality
+  against the daemon that is now active.
+- **Scope released while a tunnel is up** — the tab is removed like any other; its exclusively-owned tunnel
+  is stopped on the same rule as an explicit close.
+- **Overlay over the webview** — the inline entry input sits in the tab strip, above the webview region, so
+  it is not occluded. Any popover or menu this feature adds over the tab body must hide the webview through
+  the existing occlusion path first.
+- **A page that never loads** — a 502 from the tunnel edge or a dead dev server renders inside the webview.
+  That is the page's error, not a tab state; the tab stays loaded and the address bar stays usable.
+
+## Acceptance criteria
+
+1. With no launch configuration defined and no process running, the `+` menu's **URL…** row opens an inline
+   input in the Run tab strip; committing `localhost:5173` creates a tab whose webview displays that page.
+2. With the Run surface empty, the Run picker offers **Open URL…**, and it produces the same inline input and
+   the same tab.
+3. Selecting the URL kind never reaches the Run surface's fallback placeholder — the tab renders the real
+   view, and no rendered Run tab shows a `<kind>: <title>` placeholder for any kind in the union.
+4. The chat localhost chip's open control shows a menu with **Open in Mainframe** listed above **Open in
+   browser**. Choosing "Open in Mainframe" twice for the same URL yields exactly one Run tab, focused both
+   times, and reveals the Run surface if it was hidden.
+5. A URL tab's toolbar renders no run, stop, restart, or console-drawer control, and renders the address
+   bar, reload, open-in-browser, clear-cache, device-toggle, inspect, and region-capture controls in an
+   enabled state once the page is loaded.
+6. Committing input that does not normalize to an `http`/`https` URL — empty, `not a url`,
+   `file:///etc/passwd`, `javascript://x` — leaves the entry in the address bar's invalid treatment and
+   mounts no webview. A unit test covers each of these inputs against the normalizer.
+7. On a remote daemon, committing a loopback URL on an eligible port produces a tab showing a pending state
+   that names the port, then loads the tunnel origin with the original path, query, and fragment preserved.
+   The only tunnel calls made are the existing per-port start/stop endpoints; the diff adds no route and
+   changes no file under `packages/core-rs`.
+8. A tunnel that reports an error, or that produces no ready-and-resolvable URL within 60 s, leaves the tab
+   in a failure state containing the daemon's error text (or a stated timeout) plus a Retry control; the
+   webview area is never left blank without a state.
+9. On a remote daemon, a loopback URL on a port below 1024 or on the daemon's own port shows that specific
+   rejection text in the tab body and issues no tunnel start request.
+10. Inspect and region capture succeed on a non-localhost, non-tunnel `https` origin: an inspect click
+    delivers an element result to chat and a region drag delivers a capture. A Rust unit test asserts the
+    four bridge commands stay reachable and that the external-open scheme guard still rejects `file:`,
+    `javascript:`, and `ssh:`.
+11. Closing a URL tab whose tunnel it exclusively started stops that tunnel (the port disappears from the
+    tunnel list). Closing one of two tabs sharing a port, or a tab that adopted a tunnel started by the chat
+    chip, leaves the tunnel running.
+12. A URL tab created in one project or worktree does not appear in a session belonging to another, and is
+    removed when its launch scope is released — the same assertions the existing scope tests make for
+    preview tabs.
+13. After a restart, a URL tab is present with its URL and title intact and loads on first activation; a
+    persisted URL tab on a remote daemon returns to the pending state and re-requests its tunnel rather than
+    loading a stored tunnel URL. A sanitizer test asserts the URL kind survives serialization while preview,
+    console, and terminal are still stripped.
+14. Every interactive element added carries a `data-testid` in `<surface>-<element>` kebab-case, keyed by tab
+    id: `run-tab-url-<tabId>`, `run-tab-url-entry`, `run-tab-url-entry-input`, `run-picker-open-url`, plus
+    the chip's menu rows. No testid is keyed by array index.
+15. No webview label or tab id contains characters outside `[A-Za-z0-9_-]`; a test asserts a URL committed
+    with a path and query produces a conforming tab id.
+16. URL normalization and validation, duplicate detection, tunnel-state resolution (including the
+    port-rejection and DNS-pending cases), tab-model transitions, and persistence sanitization are unit
+    tested outside React. No file exceeds 300 lines and no function exceeds 50.
+17. `pnpm --filter @qlan-ro/mainframe-ui typecheck` and the UI test suite pass; `cargo check` in
+    `packages/app-tauri/src-tauri` passes; a changeset is present.
+
+## Decisions
+
+**Hard to reverse**
+
+- **D1. Widen the preview bridge's remote-origin allowlist to all `http`/`https` origins.** `hard-to-reverse`
+  — ruled at the design gate on 2026-07-28, superseding the brief's "do not widen" recommendation. Every
+  child webview is already built with an injected bridge and no URL check; only the capability's `remote.urls`
+  list decides which origins may call back. One allowlist keeps every control identical on every URL and
+  removes a degraded state that would have to be designed, explained, and tested. Accepted and recorded so it
+  is not rediscovered as a bug: a hostile page can fabricate an inspect payload that reaches the agent's
+  context, and can raise OS-browser windows limited to `http`/`https` by the unchanged scheme guard. The
+  capability's description must be rewritten — its current text justifies the narrow scope.
+- **D2. Restrict URL normalization to `http` and `https`.** `hard-to-reverse` in the sense that it removes
+  capability users may have relied on: the shared normalizer accepts any parseable scheme today, so the
+  existing preview address bar can point a child webview at `file://`. Both the new entry and the existing
+  address bar reject non-http(s) input from now on. Fixed in the same pass rather than deferred, because the
+  new entry point would otherwise widen the reach of the same hole.
+
+**Reversible**
+
+- **D3. A URL tab is its own tab kind, not a preview tab with a URL.** `reversible` — the preview kind's
+  identity, per-config dedup, process controls, and console drawer are all launch-config semantics;
+  overloading it makes every one of them conditional. Adopted from the brief.
+- **D4. URL tabs persist across restarts.** `reversible` — the sanitizer strips preview, console, and
+  terminal because they hold live process handles. A URL tab's whole identity is a string, so it joins the
+  file-backed kinds in the persist-safe set. Adopted from the brief.
+- **D5. Remote-daemon tunnelling ships in v1, strictly as a consumer.** `reversible` — it is the stated
+  motivation and the service exists end to end. If integration turns out to need a daemon change, that
+  change splits into its own todo rather than expanding this one. Adopted from the brief.
+- **D6. Two entry points, one creation path: the tab strip's `+` (and the empty-state picker) and the chat
+  chip.** `reversible` — the strip is where tabs already come from; the chip is where a URL the user wants
+  already is. Adopted from the design direction, extended to the empty-state picker because an empty Run
+  surface has no `+`.
+- **D7. The chip's open control becomes a menu with "Open in Mainframe" above "Open in browser".**
+  `reversible` — the design direction specifies that order and that stacking. It costs the existing
+  browser-open flow one extra click; a second icon button would avoid that but contradicts the approved
+  layout. Revisit if the click proves annoying.
+- **D8. Dedup by normalized URL within a launch scope; opening a duplicate focuses the existing tab.**
+  `reversible` — mirrors preview's per-config singleton. Adopted from the brief.
+- **D9. The tab's address bar persists its typed URL.** `reversible` — for a URL tab the typed URL is the
+  tab's identity, unlike a preview tab where it is a transient override of a derived URL. Adopted from the
+  brief.
+- **D10. Stop a tunnel on close only when this tab started it and no other URL tab uses that port.**
+  `reversible` — the chat chip has no ownership registry, so a tunnel that already existed when the tab
+  asked for one is treated as adopted and never stopped by the tab. Errs toward leaving a tunnel up, which
+  matches the chip's existing rule against optimistic teardown.
+- **D11. Hold the pending state until the tunnel's hostname is verified as resolvable, with a 60 s
+  watchdog.** `reversible` — the daemon publishes a usable URL on connect and verifies DNS 20–30 s later.
+  The chat chip hands the pre-DNS URL to the OS browser, where a reload costs nothing; an embedded webview
+  would show a hard resolution error for half a minute instead. The preview tab's 20 s watchdog is too short
+  for this path, hence 60 s. The client currently discards the daemon's DNS flag, so the port-tunnel store
+  must start carrying it — a renderer-side change with no effect on the chip.
+- **D12. Carry the original path, query, and fragment onto the tunnel origin.** `reversible` — a tunnel maps
+  a port, not a page; loading only the origin would silently drop the part of the URL the user cared about.
+- **D13. Reload reloads the currently displayed URL rather than re-deriving it from a port.** `reversible` —
+  a URL tab has no port to derive from, and for a preview tab that has not been navigated away the behavior
+  is identical. It also removes the preview tab's surprising snap-back to `localhost:<port>` after the user
+  navigates elsewhere.
+- **D14. An externally stopped tunnel puts the tab in a stopped state with Retry; it never auto-restarts.**
+  `reversible` — auto-restarting would fight a user who just pressed "Stop tunnel" on the chip.
+- **D15. The tab title is the URL's host and port, not the page's `<title>`.** `reversible` — the webview
+  handle exposes navigation URLs, not document titles; deriving the title from the URL needs no new host
+  contract.
+- **D16. Check port eligibility on the client before requesting a tunnel.** `reversible` — the rejection
+  rule is already shared pure logic, so the tab can name the reason immediately instead of round-tripping to
+  learn it. A rejection that still comes back from the daemon replaces the local text verbatim.

--- a/docs/specs/2026-07-28-todo-281-preview-open-urls.md
+++ b/docs/specs/2026-07-28-todo-281-preview-open-urls.md
@@ -64,14 +64,26 @@ tunnel, scoped to the active chat:
 
 1. If the port is one the tunnel service refuses — below 1024, or the daemon's own port — the tab shows
    that specific reason and stops. No request is made.
-2. Otherwise the tab adopts an existing tunnel for that port, or requests one, and shows a pending state
-   naming the port and saying a tunnel is coming up. It never shows a blank webview while waiting.
-3. Pending ends when the tunnel is ready **and its hostname has been verified as resolvable**. The tab then
-   loads the tunnel origin carrying over the original URL's path, query, and fragment.
-4. A tunnel that reports an error, or that produces nothing within 60 seconds, puts the tab into a failure
-   state that shows the daemon's own error text and a **Retry**. The address bar stays live, so the user can
-   type a different URL out of the failure state.
-5. If the tunnel is stopped from somewhere else (the chat chip, settings) while a tab is using it, the tab
+2. Otherwise the tab adopts the tunnel that port already has, or requests one. Until it has a URL it shows a
+   pending state naming the port and saying a tunnel is coming up; it never shows a blank webview while
+   waiting.
+3. Pending ends at the first of these to arrive: the port already has a ready tunnel URL when the tab asks
+   for one — from the boot snapshot, the chat chip, or another tab; the tab's own start request returns a
+   URL; or the daemon reports that the tunnel's DNS check has finished. The tab then loads the tunnel origin
+   carrying over the original URL's path, query, and fragment.
+4. Adopting a tunnel never waits for an event. A tunnel the daemon already lists as ready has finished its
+   DNS check, so a second tab on the same port, a tab adopting the chip's tunnel, and a rehydrated tab after
+   a restart all load immediately. Only a tab that watched a tunnel come up from scratch waits, and it waits
+   for the DNS check to finish — which the daemon reports whether or not the name resolved, treating the URL
+   as usable either way.
+5. A tunnel that connected but whose DNS check has not finished still publishes a URL. A tab that loaded
+   such a URL early reloads once when the check finishes, so a resolution error clears without the user
+   acting.
+6. A tunnel that reports an error, or that produces no URL within 120 seconds, puts the tab into a failure
+   state that shows the daemon's own error text (or the stated timeout) and a **Retry**. The address bar
+   stays live, so the user can type a different URL out of the failure state. The failure is not terminal: a
+   URL that arrives afterwards loads and replaces the failure body.
+7. If the tunnel is stopped from somewhere else (the chat chip, settings) while a tab is using it, the tab
    says the tunnel was stopped and offers Retry. It does not silently re-request.
 
 A remote-daemon URL that is not loopback (a public site, a LAN host) loads directly, with no tunnel.
@@ -90,7 +102,9 @@ is still using that port, the tunnel is stopped; a tunnel the tab merely adopted
 needs, stays up.
 
 URL tabs survive an app restart. They rehydrate unmounted and load on first activation. A rehydrated tab
-resolves its tunnel from scratch — the stored value is the URL the user typed, never a tunnel URL.
+re-resolves its tunnel — the stored value is the URL the user typed, never a tunnel URL. When the daemon
+still holds a tunnel for that port, the tab adopts it and loads without a pending state; when the tunnel is
+gone, the tab requests one and shows pending like a fresh tab.
 
 ## Not Included
 
@@ -102,6 +116,8 @@ resolves its tunnel from scratch — the stored value is the URL the user typed,
   the user committed, not the last page it was on.
 - `deferred` — Refactoring the chat chip's browser opener to carry the original path onto the tunnel origin;
   the tab does this, the chip keeps its current behavior.
+- `deferred` — Wiring the Run surface's four file-backed guest kinds (code, diff, skill, viewer). They keep
+  rendering the `<kind>: <title>` placeholder they render today.
 - `declined` — Any daemon change. The tunnel start/stop/list endpoints, their validation, and their status
   events are consumed as they stand. No new route, no Rust daemon type, no envelope work.
 - `declined` — Changing how launch-config preview tabs derive their URL, or their run/stop/restart/console
@@ -125,9 +141,12 @@ resolves its tunnel from scratch — the stored value is the URL the user typed,
 - **Port the service refuses** — `http://localhost:22` on a remote daemon shows "Port must be 1024 or
   higher"-class text, not a generic failure. The check runs before any request; a rejection that still
   arrives from the daemon replaces it verbatim.
-- **Tunnel ready but DNS not yet propagated** — the daemon reports a usable URL up to ~30 s before its
-  hostname resolves. The tab stays pending through that window rather than loading a page that cannot
-  resolve.
+- **Tunnel ready but DNS not yet propagated** — the daemon publishes a usable URL on connect and finishes
+  its DNS check up to 45 s later. A tab that started the tunnel waits out that window in the pending state
+  rather than loading a name that cannot resolve; a tab that adopted an already-ready tunnel does not wait
+  at all; a tab that loaded a pre-check URL reloads once when the check finishes.
+- **Tunnel adopted mid-start** — a tab opened while another consumer's tunnel is connecting joins that
+  start rather than issuing a second one, and leaves pending on the same signal the first consumer does.
 - **Daemon switch with URL tabs open** — layout and tunnels are scoped per daemon; tabs re-resolve locality
   against the daemon that is now active.
 - **Scope released while a tunnel is up** — the tab is removed like any other; its exclusively-owned tunnel
@@ -144,8 +163,9 @@ resolves its tunnel from scratch — the stored value is the URL the user typed,
    input in the Run tab strip; committing `localhost:5173` creates a tab whose webview displays that page.
 2. With the Run surface empty, the Run picker offers **Open URL…**, and it produces the same inline input and
    the same tab.
-3. Selecting the URL kind never reaches the Run surface's fallback placeholder — the tab renders the real
-   view, and no rendered Run tab shows a `<kind>: <title>` placeholder for any kind in the union.
+3. A tab of the URL kind renders the real URL view; it never shows the Run surface's `<kind>: <title>`
+   fallback placeholder. The placeholder stays for the four file-backed guest kinds, which this work does
+   not wire.
 4. The chat localhost chip's open control shows a menu with **Open in Mainframe** listed above **Open in
    browser**. Choosing "Open in Mainframe" twice for the same URL yields exactly one Run tab, focused both
    times, and reveals the Run surface if it was hidden.
@@ -155,38 +175,44 @@ resolves its tunnel from scratch — the stored value is the URL the user typed,
 6. Committing input that does not normalize to an `http`/`https` URL — empty, `not a url`,
    `file:///etc/passwd`, `javascript://x` — leaves the entry in the address bar's invalid treatment and
    mounts no webview. A unit test covers each of these inputs against the normalizer.
-7. On a remote daemon, committing a loopback URL on an eligible port produces a tab showing a pending state
-   that names the port, then loads the tunnel origin with the original path, query, and fragment preserved.
-   The only tunnel calls made are the existing per-port start/stop endpoints; the diff adds no route and
-   changes no file under `packages/core-rs`.
-8. A tunnel that reports an error, or that produces no ready-and-resolvable URL within 60 s, leaves the tab
-   in a failure state containing the daemon's error text (or a stated timeout) plus a Retry control; the
-   webview area is never left blank without a state.
-9. On a remote daemon, a loopback URL on a port below 1024 or on the daemon's own port shows that specific
-   rejection text in the tab body and issues no tunnel start request.
-10. Inspect and region capture succeed on a non-localhost, non-tunnel `https` origin: an inspect click
+7. On a remote daemon, committing a loopback URL on an eligible port with no tunnel yet running produces a
+   tab showing a pending state that names the port, then loads the tunnel origin with the original path,
+   query, and fragment preserved. The only tunnel calls made are the existing per-port start/stop endpoints;
+   the diff adds no route and changes no file under `packages/core-rs`.
+8. A tab opened for a port the daemon already lists as ready — a second tab on that port, or one adopting
+   the chat chip's tunnel — loads without entering the pending state and without waiting for any tunnel
+   event.
+9. A tunnel that reports an error, or that produces no URL within 120 s, leaves the tab in a failure state
+   containing the daemon's error text (or a stated timeout) plus a Retry control; the webview area is never
+   left blank without a state. A URL that arrives after the failure body replaces it with the loaded page,
+   with no user action.
+10. On a remote daemon, a loopback URL on a port below 1024 or on the daemon's own port shows that specific
+    rejection text in the tab body and issues no tunnel start request.
+11. Inspect and region capture succeed on a non-localhost, non-tunnel `https` origin: an inspect click
     delivers an element result to chat and a region drag delivers a capture. A Rust unit test asserts the
     four bridge commands stay reachable and that the external-open scheme guard still rejects `file:`,
     `javascript:`, and `ssh:`.
-11. Closing a URL tab whose tunnel it exclusively started stops that tunnel (the port disappears from the
+12. Closing a URL tab whose tunnel it exclusively started stops that tunnel (the port disappears from the
     tunnel list). Closing one of two tabs sharing a port, or a tab that adopted a tunnel started by the chat
     chip, leaves the tunnel running.
-12. A URL tab created in one project or worktree does not appear in a session belonging to another, and is
+13. A URL tab created in one project or worktree does not appear in a session belonging to another, and is
     removed when its launch scope is released — the same assertions the existing scope tests make for
     preview tabs.
-13. After a restart, a URL tab is present with its URL and title intact and loads on first activation; a
-    persisted URL tab on a remote daemon returns to the pending state and re-requests its tunnel rather than
-    loading a stored tunnel URL. A sanitizer test asserts the URL kind survives serialization while preview,
-    console, and terminal are still stripped.
-14. Every interactive element added carries a `data-testid` in `<surface>-<element>` kebab-case, keyed by tab
+14. After a restart, a URL tab is present with its URL and title intact and loads on first activation, and
+    never loads a stored tunnel URL. On a remote daemon it re-resolves: with the tunnel still running it
+    adopts it from the daemon's tunnel list and loads with no pending state; with the tunnel gone it shows
+    pending and requests a new one. A sanitizer test asserts the URL kind survives serialization while
+    preview, console, and terminal are still stripped.
+15. Every interactive element added carries a `data-testid` in `<surface>-<element>` kebab-case, keyed by tab
     id: `run-tab-url-<tabId>`, `run-tab-url-entry`, `run-tab-url-entry-input`, `run-picker-open-url`, plus
     the chip's menu rows. No testid is keyed by array index.
-15. No webview label or tab id contains characters outside `[A-Za-z0-9_-]`; a test asserts a URL committed
+16. No webview label or tab id contains characters outside `[A-Za-z0-9_-]`; a test asserts a URL committed
     with a path and query produces a conforming tab id.
-16. URL normalization and validation, duplicate detection, tunnel-state resolution (including the
-    port-rejection and DNS-pending cases), tab-model transitions, and persistence sanitization are unit
-    tested outside React. No file exceeds 300 lines and no function exceeds 50.
-17. `pnpm --filter @qlan-ro/mainframe-ui typecheck` and the UI test suite pass; `cargo check` in
+17. URL normalization and validation, duplicate detection, tunnel-state resolution (including port
+    rejection, an already-ready tunnel, a pre-DNS-check URL, and the timeout), tab-model transitions, and
+    persistence sanitization are unit tested outside React. No file exceeds 300 lines and no function
+    exceeds 50.
+18. `pnpm --filter @qlan-ro/mainframe-ui typecheck` and the UI test suite pass; `cargo check` in
     `packages/app-tauri/src-tauri` passes; a changeset is present.
 
 ## Decisions
@@ -235,12 +261,20 @@ resolves its tunnel from scratch — the stored value is the URL the user typed,
   `reversible` — the chat chip has no ownership registry, so a tunnel that already existed when the tab
   asked for one is treated as adopted and never stopped by the tab. Errs toward leaving a tunnel up, which
   matches the chip's existing rule against optimistic teardown.
-- **D11. Hold the pending state until the tunnel's hostname is verified as resolvable, with a 60 s
-  watchdog.** `reversible` — the daemon publishes a usable URL on connect and verifies DNS 20–30 s later.
-  The chat chip hands the pre-DNS URL to the OS browser, where a reload costs nothing; an embedded webview
-  would show a hard resolution error for half a minute instead. The preview tab's 20 s watchdog is too short
-  for this path, hence 60 s. The client currently discards the daemon's DNS flag, so the port-tunnel store
-  must start carrying it — a renderer-side change with no effect on the chip.
+- **D11. Any ready tunnel ends pending; only a tab watching a start waits for the DNS check, under a 120 s
+  non-terminal watchdog.** `reversible` — the daemon publishes a usable URL on connect and finishes its DNS
+  check up to 45 s later, so an embedded webview that loads immediately can show a resolution error for half
+  a minute; the chat chip gets away with it because the OS browser makes a reload free. Waiting is therefore
+  right for a tab that started the tunnel and wrong for every other path: the registry returns an existing
+  tunnel with no status broadcast at all, and the REST snapshot the store seeds from carries no DNS field,
+  so a rule that waited for a DNS event would hang a second tab on the same port, a tab adopting the chip's
+  tunnel, and every rehydrated tab. A tunnel the daemon reports ready has already passed the DNS step, which
+  makes "ready" a sufficient exit. The one gap left — adopting a tunnel that connected seconds ago, before
+  its check finished — is covered by a single automatic reload when the check lands, so the store does start
+  carrying the daemon's DNS flag, now as a reload trigger rather than a gate. The watchdog is 120 s because
+  the daemon's own budget is 45 s to connect plus 45 s for DNS, and it is non-terminal: a late URL replaces
+  the failure body, matching the launch preview's watchdog, which renders a failure body but still mounts on
+  a late URL.
 - **D12. Carry the original path, query, and fragment onto the tunnel origin.** `reversible` — a tunnel maps
   a port, not a page; loading only the origin would silently drop the part of the URL the user cared about.
 - **D13. Reload reloads the currently displayed URL rather than re-deriving it from a port.** `reversible` —

--- a/docs/specs/2026-07-28-todo-281-preview-open-urls.md
+++ b/docs/specs/2026-07-28-todo-281-preview-open-urls.md
@@ -188,10 +188,13 @@ gone, the tab requests one and shows pending like a fresh tab.
    with no user action.
 10. On a remote daemon, a loopback URL on a port below 1024 or on the daemon's own port shows that specific
     rejection text in the tab body and issues no tunnel start request.
-11. Inspect and region capture succeed on a non-localhost, non-tunnel `https` origin: an inspect click
-    delivers an element result to chat and a region drag delivers a capture. A Rust unit test asserts the
-    four bridge commands stay reachable and that the external-open scheme guard still rejects `file:`,
-    `javascript:`, and `ssh:`.
+11. Inspect and region capture succeed on both origins the old allowlist excluded: a loopback origin on a
+    non-default port (`http://localhost:5173/`) and a non-localhost, non-tunnel `https` origin. On each, an
+    inspect click delivers an element result to chat and a region drag delivers a capture. A Rust unit test
+    asserts that the capability's remote-origin patterns match `http://localhost:5173/path`,
+    `http://192.168.1.5:3000/a?b=1`, `https://example.com:8443/a`, and `https://example.com/x`, that they
+    match neither `file:///etc/passwd` nor `ssh://host`, that the four bridge commands stay granted, and that
+    the external-open scheme guard still rejects `file:`, `javascript:`, and `ssh:`.
 12. Closing a URL tab whose tunnel it exclusively started stops that tunnel (the port disappears from the
     tunnel list). Closing one of two tabs sharing a port, or a tab that adopted a tunnel started by the chat
     chip, leaves the tunnel running.
@@ -219,14 +222,24 @@ gone, the tab requests one and shows pending like a fresh tab.
 
 **Hard to reverse**
 
-- **D1. Widen the preview bridge's remote-origin allowlist to all `http`/`https` origins.** `hard-to-reverse`
-  — ruled at the design gate on 2026-07-28, superseding the brief's "do not widen" recommendation. Every
-  child webview is already built with an injected bridge and no URL check; only the capability's `remote.urls`
-  list decides which origins may call back. One allowlist keeps every control identical on every URL and
-  removes a degraded state that would have to be designed, explained, and tested. Accepted and recorded so it
-  is not rediscovered as a bug: a hostile page can fabricate an inspect payload that reaches the agent's
-  context, and can raise OS-browser windows limited to `http`/`https` by the unchanged scheme guard. The
-  capability's description must be rewritten — its current text justifies the narrow scope.
+- **D1. Widen the preview bridge's remote-origin allowlist to every `http`/`https` origin on every port —
+  the pattern form is `http://*:*` and `https://*:*`, not `http://*` and `https://*`.** `hard-to-reverse` —
+  the widening was ruled at the design gate on 2026-07-28, superseding the brief's "do not widen"
+  recommendation; the pattern form is this spec's ruling, made under the verification that direction asked
+  for. Every child webview is already built with an injected bridge and no URL check; only the capability's
+  remote-origin list decides which origins may call back. One allowlist keeps every control identical on
+  every URL and removes a degraded state that would have to be designed, explained, and tested. The port
+  wildcard is not cosmetic: Tauri's matcher fills in a missing search, hash, and path with `*` but leaves the
+  port component empty, and an empty port matches only the scheme's default port. `http://*` therefore
+  matches `http://example.com/x` but not `http://localhost:5173/` or `http://192.168.1.5:3000/a?b=1`, and
+  `https://*` does not match `https://example.com:8443/a` — shipping those patterns would take inspect,
+  region capture, and navigation tracking away from every ported dev server, including the launch-config
+  preview tabs that have them today. `http://*:*` and `https://*:*` match all of those and still leave
+  `file://`, `ssh://`, and every other scheme unmatched, because the scheme component stays literal.
+  Accepted and recorded so it is not rediscovered as a bug: a hostile page can fabricate an inspect payload
+  that reaches the agent's context, and can raise OS-browser windows limited to `http`/`https` by the
+  unchanged scheme guard. The capability's description must be rewritten — its current text justifies the
+  narrow scope.
 - **D2. Restrict URL normalization to `http` and `https`.** `hard-to-reverse` in the sense that it removes
   capability users may have relied on: the shared normalizer accepts any parseable scheme today, so the
   existing preview address bar can point a child webview at `file://`. Both the new entry and the existing

--- a/packages/app-tauri/src-tauri/capabilities/preview.json
+++ b/packages/app-tauri/src-tauri/capabilities/preview.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "preview-bridge-capability",
-  "description": "Preview child webviews load remote origins (the user's dev server or tunnel), so their IPC is denied by default. Grant exactly the four preview-bridge callbacks — picker/navigation results and the scheme-allowlisted external opener — and nothing else.",
+  "description": "Preview and URL tabs load arbitrary user-named http/https origins in remote child webviews, so their IPC is denied by default unless granted here. Every http(s) origin may call the four preview-bridge callbacks — picker/navigation results and the scheme-allowlisted external opener. No other scheme matches, since the scheme component of each pattern is literal. Accepted risk: a hostile page can fabricate an inspect-result payload that reaches the agent's context.",
   "webviews": ["preview-*"],
   "remote": {
-    "urls": ["http://localhost:*", "http://127.0.0.1:*", "https://*.trycloudflare.com"]
+    "urls": ["http://*:*", "https://*:*"]
   },
   "permissions": [
     "preview-bridge:allow-inspect-result",

--- a/packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs
+++ b/packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs
@@ -78,6 +78,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
 #[cfg(test)]
 mod tests {
     use super::super::bridge::BRIDGE_JS;
+    use super::is_allowed_external_scheme;
 
     /// BRIDGE_JS runs in remote-origin child webviews, where Tauri's ACL only
     /// allows the plugin-prefixed commands granted by capabilities/preview.json.
@@ -123,13 +124,14 @@ mod tests {
             .iter()
             .filter_map(|u| u.as_str())
             .collect();
+        assert_eq!(urls.len(), 2, "remote.urls must carry exactly two patterns");
         assert!(
-            urls.contains(&"http://localhost:*"),
-            "localhost missing from remote urls"
+            urls.contains(&"http://*:*"),
+            "http://*:* missing from remote urls"
         );
         assert!(
-            urls.contains(&"http://127.0.0.1:*"),
-            "127.0.0.1 missing from remote urls"
+            urls.contains(&"https://*:*"),
+            "https://*:* missing from remote urls"
         );
         let perms: Vec<&str> = cap["permissions"]
             .as_array()
@@ -144,6 +146,54 @@ mod tests {
             "preview-bridge:allow-open-external",
         ] {
             assert!(perms.contains(&p), "missing permission {p}");
+        }
+    }
+
+    /// The widened patterns must actually span every http(s) host, port, and
+    /// path — not just the default port a bare `http://*` would silently
+    /// restrict to (spec D1).
+    #[test]
+    fn preview_capability_patterns_match_every_http_origin() {
+        use tauri::utils::acl::RemoteUrlPattern;
+        use tauri::Url;
+
+        let patterns: Vec<RemoteUrlPattern> = ["http://*:*", "https://*:*"]
+            .iter()
+            .map(|p| p.parse().expect("pattern must parse"))
+            .collect();
+        let matches = |raw: &str| {
+            let url = Url::parse(raw).expect("test URL must parse");
+            patterns.iter().any(|p| p.test(&url))
+        };
+
+        for allowed in [
+            "http://localhost:5173/path",
+            "http://192.168.1.5:3000/a?b=1",
+            "https://example.com:8443/a",
+            "https://example.com/x",
+        ] {
+            assert!(matches(allowed), "expected a pattern to match {allowed}");
+        }
+        for disallowed in ["file:///etc/passwd", "ssh://host"] {
+            assert!(
+                !matches(disallowed),
+                "no pattern should match {disallowed}"
+            );
+        }
+    }
+
+    /// The widened remote allowlist must not be mistaken for a widened
+    /// opener: `open_external` keeps rejecting non-http(s) schemes.
+    #[test]
+    fn external_open_scheme_guard_still_rejects_dangerous_schemes() {
+        for dangerous in ["file:///etc/passwd", "javascript:alert(1)", "ssh://host"] {
+            assert!(
+                !is_allowed_external_scheme(dangerous),
+                "expected rejected: {dangerous}"
+            );
+        }
+        for safe in ["http://x", "https://x"] {
+            assert!(is_allowed_external_scheme(safe), "expected allowed: {safe}");
         }
     }
 }

--- a/packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs
+++ b/packages/app-tauri/src-tauri/src/preview/bridge_plugin.rs
@@ -186,7 +186,14 @@ mod tests {
     /// opener: `open_external` keeps rejecting non-http(s) schemes.
     #[test]
     fn external_open_scheme_guard_still_rejects_dangerous_schemes() {
-        for dangerous in ["file:///etc/passwd", "javascript:alert(1)", "ssh://host"] {
+        for dangerous in [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "ssh://host",
+            "vscode://open",
+            "slack://chan",
+            "jetbrains://x",
+        ] {
             assert!(
                 !is_allowed_external_scheme(dangerous),
                 "expected rejected: {dangerous}"

--- a/packages/app-tauri/src-tauri/src/preview/mod.rs
+++ b/packages/app-tauri/src-tauri/src/preview/mod.rs
@@ -68,15 +68,16 @@ pub struct NavigateResult {
 
 // ── URL scheme allowlist ───────────────────────────────────────────────────────
 
-/// Canonical allowlist — mirrors @qlan-ro/mainframe-types ALLOWED_EXTERNAL_SCHEMES
-/// (source of truth: packages/types/src/host/external-schemes.ts). Both hosts behave 1:1.
-const ALLOWED_EXTERNAL_SCHEMES: &[&str] = &[
-    "http", "https", "mailto", "slack", "vscode", "vscode-insiders", "cursor",
-    "jetbrains", "idea", "zed", "figma", "linear", "notion", "discord", "tel",
-];
+/// Deliberately narrower than `@qlan-ro/mainframe-types` `ALLOWED_EXTERNAL_SCHEMES`
+/// (packages/types/src/host/external-schemes.ts, the main window's own
+/// link-opening allowlist): `capabilities/preview.json` grants this bridge
+/// command to every http(s) origin a preview/URL tab loads, so a deep-link
+/// scheme here would let any previewed page launch a local app. Widening past
+/// http/https is a design-gate decision, not one this guard should inherit.
+const ALLOWED_EXTERNAL_SCHEMES: &[&str] = &["http", "https"];
 
-/// Returns `true` only for schemes safe to forward to the OS opener.
-/// Rejects `file://`, `javascript:`, `ssh://`, `data:` and any unknown scheme.
+/// Returns `true` only for schemes safe to forward to the OS opener from a
+/// remote-origin preview page. Rejects everything but http/https.
 pub(crate) fn is_allowed_external_scheme(url: &str) -> bool {
     let lower = url.to_ascii_lowercase();
     ALLOWED_EXTERNAL_SCHEMES
@@ -394,14 +395,18 @@ mod tests {
         assert!(is_allowed_external_scheme("HTTP://example.com"));
     }
 
+    /// Deep-link/IDE/app schemes are safe for the main window's own opener
+    /// (`ALLOWED_EXTERNAL_SCHEMES` in `@qlan-ro/mainframe-types`), but every
+    /// http(s) origin loaded in a preview/URL tab can reach this bridge
+    /// command — so it must reject all of them, not mirror that wider list.
     #[test]
-    fn ide_and_app_schemes_pass() {
+    fn ide_and_app_schemes_are_rejected() {
         for s in [
             "vscode://open", "vscode-insiders://open", "cursor://x", "jetbrains://x",
             "idea://x", "zed://x", "slack://chan", "linear://x", "notion://x",
             "figma://x", "discord://x", "mailto:a@b.com", "tel:+15551234",
         ] {
-            assert!(is_allowed_external_scheme(s), "expected allowed: {s}");
+            assert!(!is_allowed_external_scheme(s), "expected rejected: {s}");
         }
     }
 

--- a/packages/ui/src/features/chat/smart-actions/UrlChip.tsx
+++ b/packages/ui/src/features/chat/smart-actions/UrlChip.tsx
@@ -7,7 +7,14 @@
  * On a local daemon the chip is a plain opener and the word "tunnel" appears
  * nowhere — same port, different machine, different meaning.
  */
-import { ExternalLink, Globe, Unplug } from 'lucide-react';
+import { AppWindow, ExternalLink, Globe, Unplug } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { emitSurfaceIntent } from '@/store/surface-intents';
 import { useUrlTunnel } from './use-url-tunnel';
 import type { PortTunnelEntry } from '@/store/port-tunnels';
 
@@ -54,17 +61,34 @@ export function UrlChip({ href, port }: UrlChipProps) {
     <span className={CHIP_CLASS} data-smart-action-port={port}>
       <span className="font-mono text-caption text-primary">{href}</span>
       {badge && <span className={`${BADGE_CLASS} ${badge.className}`}>{badge.label}</span>}
-      <button
-        type="button"
-        data-testid="smart-action-url-open"
-        title={openLabel}
-        aria-label={openLabel}
-        disabled={busy}
-        className={ICON_BUTTON_CLASS}
-        onClick={open}
-      >
-        <OpenIcon className="size-3.5" />
-      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            data-testid="smart-action-url-open"
+            title={openLabel}
+            aria-label={openLabel}
+            disabled={busy}
+            className={ICON_BUTTON_CLASS}
+          >
+            <OpenIcon className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {/* The tab owns tunnelling — this path must not start one. */}
+          <DropdownMenuItem
+            data-testid="smart-action-url-open-in-app"
+            onSelect={() => emitSurfaceIntent({ type: 'open-url-tab', url: href })}
+          >
+            <AppWindow />
+            Open in Mainframe
+          </DropdownMenuItem>
+          <DropdownMenuItem data-testid="smart-action-url-open-browser" onSelect={open}>
+            <ExternalLink />
+            Open in browser
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       {canStop && (
         <button
           type="button"

--- a/packages/ui/src/features/chat/smart-actions/__tests__/url-chip-menu.test.tsx
+++ b/packages/ui/src/features/chat/smart-actions/__tests__/url-chip-menu.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * UrlChip's open menu — row order and the "Open in Mainframe" action (#281,
+ * AC4, D7). `url-chip.test.tsx` covers the tunnelling behaviour behind the
+ * "Open in browser" row; this file stays about the menu itself.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const openExternal = vi.fn(() => Promise.resolve());
+vi.mock('@/lib/host', () => ({ useHost: () => ({ shell: { openExternal } }) }));
+
+vi.mock('@/lib/toast', () => ({ mfToast: { success: vi.fn(), error: vi.fn() } }));
+
+const startPortTunnel = vi.fn<(port: number, body: unknown) => Promise<{ url: string }>>();
+const stopPortTunnel = vi.fn<(port: number, portNum: number) => Promise<void>>();
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: (port: number, body: unknown) => startPortTunnel(port, body),
+  stopPortTunnel: (port: number, portNum: number) => stopPortTunnel(port, portNum),
+  listPortTunnels: vi.fn(),
+}));
+
+vi.mock('@/lib/daemon/ws-client', () => ({ daemonWs: { onEvent: () => () => {} } }));
+
+const emitSurfaceIntent = vi.fn();
+vi.mock('@/store/surface-intents', () => ({ emitSurfaceIntent: (intent: unknown) => emitSurfaceIntent(intent) }));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({ useDaemonPort: () => 31415 }));
+vi.mock('@/lib/daemon/use-daemon-is-local', () => ({ useDaemonIsLocal: () => true }));
+vi.mock('@/features/chat/tools/chat-tool-context', () => ({ useChatId: () => 'chat-1' }));
+
+import { UrlChip } from '../UrlChip';
+import { resetPortTunnels } from '@/store/port-tunnels';
+
+const HREF = 'http://localhost:5173/app';
+const PORT = 5173;
+
+function renderChip() {
+  return render(
+    <TooltipProvider>
+      <UrlChip href={HREF} port={PORT} />
+    </TooltipProvider>,
+  );
+}
+
+async function openMenu(): Promise<void> {
+  await userEvent.click(screen.getByTestId('smart-action-url-open'));
+}
+
+beforeEach(() => {
+  emitSurfaceIntent.mockReset();
+  startPortTunnel.mockReset();
+  stopPortTunnel.mockReset();
+  openExternal.mockClear();
+});
+
+afterEach(() => {
+  resetPortTunnels();
+});
+
+describe('UrlChip — open menu', () => {
+  it('lists Open in Mainframe above Open in browser', async () => {
+    renderChip();
+    await openMenu();
+
+    const inApp = await screen.findByTestId('smart-action-url-open-in-app');
+    const browser = await screen.findByTestId('smart-action-url-open-browser');
+
+    expect(inApp.compareDocumentPosition(browser) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(inApp).toHaveTextContent('Open in Mainframe');
+    expect(browser).toHaveTextContent('Open in browser');
+  });
+
+  it('the in-app row emits one open-url-tab intent with the chip href and starts no tunnel or OS opener', async () => {
+    renderChip();
+    await openMenu();
+    await userEvent.click(await screen.findByTestId('smart-action-url-open-in-app'));
+
+    expect(emitSurfaceIntent).toHaveBeenCalledTimes(1);
+    expect(emitSurfaceIntent).toHaveBeenCalledWith({ type: 'open-url-tab', url: HREF });
+    expect(startPortTunnel).not.toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('the browser row still calls the pre-existing opener', async () => {
+    renderChip();
+    await openMenu();
+    await userEvent.click(await screen.findByTestId('smart-action-url-open-browser'));
+
+    expect(openExternal).toHaveBeenCalledWith(HREF);
+    expect(emitSurfaceIntent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/chat/smart-actions/__tests__/url-chip.test.tsx
+++ b/packages/ui/src/features/chat/smart-actions/__tests__/url-chip.test.tsx
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { DaemonEvent } from '@qlan-ro/mainframe-types';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -78,6 +79,16 @@ function openButton(): HTMLElement {
   return screen.getByTestId('smart-action-url-open');
 }
 
+/**
+ * The open control is a menu since #281 — every browser-open assertion below
+ * goes through it. This file stays about tunnelling; the menu itself (row order,
+ * the in-app row) is covered separately.
+ */
+async function openInBrowser(trigger: HTMLElement = openButton()): Promise<void> {
+  await userEvent.click(trigger);
+  await userEvent.click(await screen.findByTestId('smart-action-url-open-browser'));
+}
+
 /** A start POST that never settles — the daemon answers over WS long before it resolves. */
 function pendingStart(): void {
   startPortTunnel.mockReturnValue(new Promise<{ url: string }>(() => {}));
@@ -101,7 +112,7 @@ describe('UrlChip — local daemon', () => {
     daemonIsLocal = true;
   });
 
-  it('opens the localhost URL directly and never mentions tunnelling', () => {
+  it('opens the localhost URL directly and never mentions tunnelling', async () => {
     const { container } = renderChip();
 
     expect(openButton()).toHaveAttribute('title', 'Open');
@@ -110,7 +121,7 @@ describe('UrlChip — local daemon', () => {
     expect(screen.queryByTestId('smart-action-url-stop-tunnel')).toBeNull();
     expect(container.textContent).toBe('http://localhost:5173/app');
 
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     expect(openExternal).toHaveBeenCalledWith(HREF);
     expect(startPortTunnel).not.toHaveBeenCalled();
@@ -132,12 +143,12 @@ describe('UrlChip — local daemon', () => {
 });
 
 describe('UrlChip — remote daemon, first open', () => {
-  it('asks the daemon to tunnel the port for the active chat', () => {
+  it('asks the daemon to tunnel the port for the active chat', async () => {
     pendingStart();
     renderChip();
 
     expect(openButton()).toHaveAttribute('title', 'Tunnel and open');
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     expect(startPortTunnel).toHaveBeenCalledTimes(1);
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
@@ -146,10 +157,10 @@ describe('UrlChip — remote daemon, first open', () => {
     expect(screen.getByText('tunnelling…')).toBeInTheDocument();
   });
 
-  it('reaches tunnelled and opens the event URL while the start POST is still pending', () => {
+  it('reaches tunnelled and opens the event URL while the start POST is still pending', async () => {
     pendingStart();
     renderChip();
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     emit({ state: 'starting', label: 'port:5173' });
     expect(screen.getByText('tunnelling…')).toBeInTheDocument();
@@ -164,10 +175,10 @@ describe('UrlChip — remote daemon, first open', () => {
     expect(openButton()).toHaveAttribute('title', 'Reopen tunnel URL');
   });
 
-  it('warns that the link is public exactly once', () => {
+  it('warns that the link is public exactly once', async () => {
     pendingStart();
     renderChip();
-    fireEvent.click(openButton());
+    await openInBrowser();
     emit({ state: 'ready', label: 'port:5173', url: TUNNEL_URL });
 
     expect(toastSuccess).toHaveBeenCalledTimes(1);
@@ -176,10 +187,10 @@ describe('UrlChip — remote daemon, first open', () => {
     );
   });
 
-  it('does not reopen on the dns_verified event that follows ready', () => {
+  it('does not reopen on the dns_verified event that follows ready', async () => {
     pendingStart();
     renderChip();
-    fireEvent.click(openButton());
+    await openInBrowser();
     emit({ state: 'ready', label: 'port:5173', url: TUNNEL_URL });
     emit({ state: 'dns_verified', label: 'port:5173', url: TUNNEL_URL, dnsVerified: true });
 
@@ -188,12 +199,12 @@ describe('UrlChip — remote daemon, first open', () => {
     expect(screen.getByText('tunnelled')).toBeInTheDocument();
   });
 
-  it('does nothing without a chat in scope', () => {
+  it('does nothing without a chat in scope', async () => {
     chatId = undefined;
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     renderChip();
 
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     expect(startPortTunnel).not.toHaveBeenCalled();
     expect(openExternal).not.toHaveBeenCalled();
@@ -203,7 +214,7 @@ describe('UrlChip — remote daemon, first open', () => {
 });
 
 describe('UrlChip — a second chip on the same port', () => {
-  it('shares the tunnel state but only the clicked chip opens a window', () => {
+  it('shares the tunnel state but only the clicked chip opens a window', async () => {
     pendingStart();
     render(
       <TooltipProvider>
@@ -212,7 +223,7 @@ describe('UrlChip — a second chip on the same port', () => {
       </TooltipProvider>,
     );
 
-    fireEvent.click(screen.getAllByTestId('smart-action-url-open')[0]!);
+    await openInBrowser(screen.getAllByTestId('smart-action-url-open')[0]!);
     emit({ state: 'ready', label: 'port:5173', url: TUNNEL_URL });
 
     expect(screen.getAllByText('tunnelled')).toHaveLength(2);
@@ -223,11 +234,11 @@ describe('UrlChip — a second chip on the same port', () => {
 });
 
 describe('UrlChip — reopen', () => {
-  it('opens the known tunnel URL without starting a second tunnel', () => {
+  it('opens the known tunnel URL without starting a second tunnel', async () => {
     renderChip();
     emit({ state: 'ready', label: 'port:5173', url: TUNNEL_URL });
 
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     expect(openExternal).toHaveBeenCalledWith(TUNNEL_URL);
     expect(startPortTunnel).not.toHaveBeenCalled();
@@ -292,7 +303,7 @@ describe('UrlChip — failed start', () => {
     startPortTunnel.mockRejectedValue(new Error('cloudflared is not installed'));
     renderChip();
 
-    fireEvent.click(openButton());
+    await openInBrowser();
     await vi.waitFor(() => expect(screen.getByText('tunnel failed')).toBeInTheDocument());
 
     expect(toastError).toHaveBeenCalledTimes(1);
@@ -308,10 +319,10 @@ describe('UrlChip — failed start', () => {
     expect(toastError).toHaveBeenCalledTimes(1);
   });
 
-  it('re-enables the button on a daemon error event while the POST hangs', () => {
+  it('re-enables the button on a daemon error event while the POST hangs', async () => {
     pendingStart();
     renderChip();
-    fireEvent.click(openButton());
+    await openInBrowser();
     emit({ state: 'starting', label: 'port:5173' });
     expect(openButton()).toBeDisabled();
 
@@ -321,10 +332,10 @@ describe('UrlChip — failed start', () => {
     expect(openButton()).toBeEnabled();
   });
 
-  it('does not open a window when a later ready arrives after the failure', () => {
+  it('does not open a window when a later ready arrives after the failure', async () => {
     pendingStart();
     renderChip();
-    fireEvent.click(openButton());
+    await openInBrowser();
     emit({ state: 'error', label: 'port:5173', error: 'tunnel died' });
     emit({ state: 'ready', label: 'port:5173', url: TUNNEL_URL });
 
@@ -342,12 +353,12 @@ describe('UrlChip — reload seed', () => {
     expect(openButton()).toBeDisabled();
   });
 
-  it('shows a seeded ready tunnel as tunnelled and reopens it without a POST', () => {
+  it('shows a seeded ready tunnel as tunnelled and reopens it without a POST', async () => {
     act(() => applyPortTunnelSnapshot([{ port: PORT, state: 'ready', url: TUNNEL_URL }]));
     renderChip();
 
     expect(screen.getByText('tunnelled')).toBeInTheDocument();
-    fireEvent.click(openButton());
+    await openInBrowser();
 
     expect(openExternal).toHaveBeenCalledWith(TUNNEL_URL);
     expect(startPortTunnel).not.toHaveBeenCalled();

--- a/packages/ui/src/features/chat/smart-actions/use-url-tunnel.ts
+++ b/packages/ui/src/features/chat/smart-actions/use-url-tunnel.ts
@@ -82,7 +82,9 @@ export function useUrlTunnel(href: string, port: number): UrlTunnelController {
     startPortTunnel(daemonPort, { port, chatId }).catch((err: unknown) => {
       pendingOpenRef.current = false;
       setStarting(false);
-      reportPortTunnelError(port, message(err));
+      // This chip's start failed; the daemon said nothing. Marking the entry
+      // client-written keeps it out of a URL tab's claim evidence (#281 D10).
+      reportPortTunnelError(port, message(err), 'client');
     });
   }, [chatId, daemonPort, entry, href, isLocal, openExternal, port]);
 

--- a/packages/ui/src/features/preview/PreviewInstance.tsx
+++ b/packages/ui/src/features/preview/PreviewInstance.tsx
@@ -70,7 +70,7 @@ export function PreviewInstance({ tabId, config, visible, scopeKey, port: portPr
     projectId: effectiveProjectId,
     device,
   });
-  usePreviewGeometry({ handle, anchorRef, containerRef, active: visible, status });
+  usePreviewGeometry({ handle, anchorRef, containerRef, active: visible, mounted: handle !== null });
   // Hide the native webview only while a DOM overlay actually overlaps it (it
   // composites above the DOM, so popovers/dialogs/CMD-F would be clipped behind
   // it otherwise). Electron's <webview> stacks in the DOM so no hiding is needed

--- a/packages/ui/src/features/preview/PreviewInstance.tsx
+++ b/packages/ui/src/features/preview/PreviewInstance.tsx
@@ -136,11 +136,7 @@ export function PreviewInstance({ tabId, config, visible, scopeKey, port: portPr
       style={{ visibility: visible ? 'visible' : 'hidden' }}
     >
       <PreviewToolbar
-        tabId={tabId}
-        port={port}
-        configName={config}
-        projectId={projectId}
-        daemonPort={daemonPort}
+        seedUrl={port !== null ? `http://localhost:${port}` : null}
         status={status}
         device={device}
         onDeviceChange={setDevice}

--- a/packages/ui/src/features/preview/PreviewToolbar.tsx
+++ b/packages/ui/src/features/preview/PreviewToolbar.tsx
@@ -5,11 +5,8 @@ import { PreviewDeviceToggle } from './PreviewDeviceToggle';
 import { PreviewCaptureCluster } from './PreviewCaptureCluster';
 
 interface PreviewToolbarProps {
-  tabId: string;
-  port: number | null;
-  configName: string | undefined;
-  projectId: string | undefined;
-  daemonPort: number;
+  /** The address the URL bar shows until the webview navigates elsewhere. */
+  seedUrl: string | null;
   status: LaunchProcessStatus | null;
   device: 'desktop' | 'mobile';
   onDeviceChange: (d: 'desktop' | 'mobile') => void;
@@ -25,8 +22,7 @@ interface PreviewToolbarProps {
 }
 
 export function PreviewToolbar({
-  tabId: _tabId,
-  port,
+  seedUrl,
   status,
   device,
   onDeviceChange,
@@ -48,7 +44,7 @@ export function PreviewToolbar({
       className="flex h-[38px] flex-shrink-0 items-center gap-[8px] [border-bottom:0.5px_solid_var(--border)] bg-background px-[8px]"
     >
       <PreviewRunControl status={status} onRun={onRun} onStop={onStop} onRestart={onRestart} />
-      <PreviewUrlBar handle={handle} port={port} isRunning={isRunning} />
+      <PreviewUrlBar handle={handle} seedUrl={seedUrl} enabled={isRunning} />
       <PreviewDeviceToggle device={device} onChange={onDeviceChange} />
       <PreviewCaptureCluster
         isRunning={isRunning}

--- a/packages/ui/src/features/preview/PreviewUrlBar.tsx
+++ b/packages/ui/src/features/preview/PreviewUrlBar.tsx
@@ -2,32 +2,55 @@ import { useEffect, useState } from 'react';
 import { RotateCw, ExternalLink, Eraser } from 'lucide-react';
 import { PreviewIconButton } from './PreviewIconButton';
 import { usePreviewAddress } from './use-preview-address';
+import { normalizePreviewUrl } from './normalize-url';
 import { useHost } from '@/lib/host';
 import type { PreviewHandle } from '@qlan-ro/mainframe-types';
 
 interface PreviewUrlBarProps {
   handle: PreviewHandle | null;
-  port: number | null;
-  isRunning: boolean;
+  /** The address to show until the webview navigates somewhere else. */
+  seedUrl: string | null;
+  /** Whether the bar accepts typing — the URL tab keeps it live with no webview. */
+  enabled: boolean;
+  /**
+   * When supplied, Enter hands the normalized URL to the owner instead of
+   * navigating: the owner re-drives the mount, so there is one navigation and
+   * no race between an optimistic navigate and a changed `seedUrl`.
+   */
+  onCommitUrl?: (url: string) => void;
 }
 
-export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
+export function PreviewUrlBar({ handle, seedUrl, enabled, onCommitUrl }: PreviewUrlBarProps) {
   const host = useHost();
-  const { currentUrl, navigateTo } = usePreviewAddress(handle, port);
+  const { currentUrl, navigateTo } = usePreviewAddress(handle, seedUrl);
   const [draft, setDraft] = useState(currentUrl);
   const [invalid, setInvalid] = useState(false);
+  const canAct = enabled && handle !== null;
 
-  // Keep the editable draft in sync when the current URL changes (port re-seed
-  // or an in-webview navigation). Overwrites an in-progress edit by design —
-  // the bar always shows the live URL, matching a browser address bar.
+  // Keep the editable draft in sync when the current URL changes (re-seed or an
+  // in-webview navigation). Overwrites an in-progress edit by design — the bar
+  // always shows the live URL, matching a browser address bar.
   useEffect(() => {
     setDraft(currentUrl);
     setInvalid(false);
   }, [currentUrl]);
 
+  function commit() {
+    if (!onCommitUrl) {
+      if (!navigateTo(draft)) setInvalid(true);
+      return;
+    }
+    const normalized = normalizePreviewUrl(draft);
+    if (!normalized) {
+      setInvalid(true);
+      return;
+    }
+    onCommitUrl(normalized);
+  }
+
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
-      if (!navigateTo(draft)) setInvalid(true);
+      commit();
     } else if (e.key === 'Escape') {
       setDraft(currentUrl);
       setInvalid(false);
@@ -35,14 +58,13 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
   }
 
   function handleReload() {
-    if (!port) return;
-    handle?.navigate(`http://localhost:${port}`).catch((e: unknown) => console.warn('[preview] url-bar reload', e));
+    if (!currentUrl) return;
+    handle?.navigate(currentUrl).catch((e: unknown) => console.warn('[preview] url-bar reload', e));
   }
 
   function handleOpenBrowser() {
-    const url = currentUrl || (port ? `http://localhost:${port}` : '');
-    if (!url) return;
-    host.shell.openExternal(url).catch((e: unknown) => console.warn('[preview] url-bar open-browser', e));
+    if (!currentUrl) return;
+    host.shell.openExternal(currentUrl).catch((e: unknown) => console.warn('[preview] url-bar open-browser', e));
   }
 
   function handleClearCache() {
@@ -51,25 +73,20 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
 
   return (
     <div className="min-w-0 flex-1 flex items-center gap-0.5 h-[26px] rounded-md border-[0.5px] border-border bg-card pl-0.5 pr-[4px]">
-      <PreviewIconButton
-        testId="preview-url-reload"
-        title="Reload preview"
-        onClick={handleReload}
-        disabled={!isRunning}
-      >
+      <PreviewIconButton testId="preview-url-reload" title="Reload preview" onClick={handleReload} disabled={!canAct}>
         <RotateCw size={14} />
       </PreviewIconButton>
 
       <span
         className={`w-1.5 h-1.5 rounded-full flex-shrink-0 mx-0.5 ${
-          isRunning ? 'bg-mf-success animate-pulse' : 'bg-mf-text-4'
+          enabled ? 'bg-mf-success animate-pulse' : 'bg-mf-text-4'
         }`}
       />
 
       <input
         data-testid="preview-url-input"
         value={draft}
-        disabled={!isRunning}
+        disabled={!enabled}
         spellCheck={false}
         autoComplete="off"
         placeholder="localhost:…"
@@ -81,7 +98,7 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         className={`flex-1 min-w-0 bg-transparent outline-none font-mono text-body px-[4px] ${
           invalid
             ? 'text-destructive ring-1 ring-destructive rounded-sm'
-            : isRunning
+            : enabled
               ? 'text-foreground'
               : 'text-muted-foreground'
         }`}
@@ -91,7 +108,7 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         testId="preview-url-open-browser"
         title="Open in browser"
         onClick={handleOpenBrowser}
-        disabled={!isRunning}
+        disabled={!canAct}
       >
         <ExternalLink size={14} />
       </PreviewIconButton>
@@ -100,7 +117,7 @@ export function PreviewUrlBar({ handle, port, isRunning }: PreviewUrlBarProps) {
         testId="preview-url-clear-cache"
         title="Clear cache"
         onClick={handleClearCache}
-        disabled={!isRunning}
+        disabled={!canAct}
       >
         <Eraser size={14} />
       </PreviewIconButton>

--- a/packages/ui/src/features/preview/__tests__/PreviewToolbar.test.tsx
+++ b/packages/ui/src/features/preview/__tests__/PreviewToolbar.test.tsx
@@ -28,11 +28,7 @@ async function renderToolbar(status: LaunchProcessStatus | null) {
   const { PreviewToolbar } = await import('../PreviewToolbar');
   render(
     <PreviewToolbar
-      tabId="t1"
-      port={3000}
-      configName="dev"
-      projectId="p1"
-      daemonPort={31415}
+      seedUrl="http://localhost:3000"
       status={status}
       device="desktop"
       onDeviceChange={onDeviceChange}

--- a/packages/ui/src/features/preview/__tests__/PreviewUrlBar.test.tsx
+++ b/packages/ui/src/features/preview/__tests__/PreviewUrlBar.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import type { PreviewHandle } from '@qlan-ro/mainframe-types';
 import { PreviewUrlBar } from '../PreviewUrlBar';
 
-function makeHandle(): PreviewHandle {
+function makeHandle(over: Partial<PreviewHandle> = {}): PreviewHandle {
   return {
     setVisible: vi.fn(),
     compositesAboveDom: true,
@@ -18,6 +18,7 @@ function makeHandle(): PreviewHandle {
     setDevice: vi.fn(),
     destroy: vi.fn(),
     clearCache: vi.fn().mockResolvedValue(undefined),
+    ...over,
   };
 }
 
@@ -27,13 +28,13 @@ describe('PreviewUrlBar', () => {
     handle = makeHandle();
   });
 
-  it('shows localhost:{port} as the input value when running', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+  it('shows the seed URL as the input value when enabled', () => {
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     expect(screen.getByTestId('preview-url-input')).toHaveValue('http://localhost:3000');
   });
 
   it('Enter navigates to the normalized typed URL', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     const input = screen.getByTestId('preview-url-input');
     fireEvent.change(input, { target: { value: 'localhost:3000/dashboard' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -41,7 +42,7 @@ describe('PreviewUrlBar', () => {
   });
 
   it('Escape reverts the draft to the current URL', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     const input = screen.getByTestId('preview-url-input') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'garbage' } });
     fireEvent.keyDown(input, { key: 'Escape' });
@@ -49,7 +50,7 @@ describe('PreviewUrlBar', () => {
   });
 
   it('invalid input on Enter does not navigate', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     const input = screen.getByTestId('preview-url-input');
     fireEvent.change(input, { target: { value: '   ' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -57,21 +58,29 @@ describe('PreviewUrlBar', () => {
   });
 
   it('applies the invalid (ring-destructive) state on invalid Enter', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     const input = screen.getByTestId('preview-url-input');
     fireEvent.change(input, { target: { value: '   ' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(input).toHaveClass('ring-destructive');
   });
 
-  it('disables the input when not running', () => {
-    render(<PreviewUrlBar handle={null} port={null} isRunning={false} />);
+  it('disables the input when not enabled', () => {
+    render(<PreviewUrlBar handle={null} seedUrl={null} enabled={false} />);
     expect(screen.getByTestId('preview-url-input')).toBeDisabled();
+  });
+
+  it('keeps the input live but dims the actions when enabled with no handle', () => {
+    render(<PreviewUrlBar handle={null} seedUrl="http://localhost:3000" enabled />);
+    expect(screen.getByTestId('preview-url-input')).not.toBeDisabled();
+    expect(screen.getByTestId('preview-url-reload')).toBeDisabled();
+    expect(screen.getByTestId('preview-url-open-browser')).toBeDisabled();
+    expect(screen.getByTestId('preview-url-clear-cache')).toBeDisabled();
   });
 
   it('Open in browser opens the current URL externally (not an in-webview navigate)', () => {
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     fireEvent.click(screen.getByTestId('preview-url-open-browser'));
     expect(openSpy).toHaveBeenCalledWith('http://localhost:3000', '_blank', 'noopener,noreferrer');
     expect(handle.navigate).not.toHaveBeenCalled();
@@ -79,9 +88,44 @@ describe('PreviewUrlBar', () => {
   });
 
   it('Clear cache clears the webview caches instead of navigating', () => {
-    render(<PreviewUrlBar handle={handle} port={3000} isRunning />);
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
     fireEvent.click(screen.getByTestId('preview-url-clear-cache'));
     expect(handle.clearCache).toHaveBeenCalledTimes(1);
     expect(handle.navigate).not.toHaveBeenCalled();
+  });
+
+  it('Reload reloads the URL the webview navigated to, not the seed', () => {
+    let emit: ((url: string) => void) | null = null;
+    handle = makeHandle({
+      onNavigate: (cb: (url: string) => void) => {
+        emit = cb;
+        return () => {};
+      },
+    });
+    render(<PreviewUrlBar handle={handle} seedUrl="http://localhost:3000" enabled />);
+    act(() => emit!('http://localhost:3000/deep/page'));
+    fireEvent.click(screen.getByTestId('preview-url-reload'));
+    expect(handle.navigate).toHaveBeenCalledWith('http://localhost:3000/deep/page');
+  });
+
+  it('Enter hands a valid URL to onCommitUrl instead of navigating', () => {
+    const onCommitUrl = vi.fn();
+    render(<PreviewUrlBar handle={null} seedUrl="https://example.com/" enabled onCommitUrl={onCommitUrl} />);
+    const input = screen.getByTestId('preview-url-input');
+    fireEvent.change(input, { target: { value: 'example.com/docs' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommitUrl).toHaveBeenCalledTimes(1);
+    expect(onCommitUrl).toHaveBeenCalledWith('http://example.com/docs');
+  });
+
+  it('Enter on an unsupported scheme neither commits nor navigates', () => {
+    const onCommitUrl = vi.fn();
+    render(<PreviewUrlBar handle={handle} seedUrl="https://example.com/" enabled onCommitUrl={onCommitUrl} />);
+    const input = screen.getByTestId('preview-url-input');
+    fireEvent.change(input, { target: { value: 'file:///etc/passwd' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onCommitUrl).not.toHaveBeenCalled();
+    expect(handle.navigate).not.toHaveBeenCalled();
+    expect(input).toHaveClass('ring-destructive');
   });
 });

--- a/packages/ui/src/features/preview/__tests__/normalize-url.test.ts
+++ b/packages/ui/src/features/preview/__tests__/normalize-url.test.ts
@@ -31,4 +31,24 @@ describe('normalizePreviewUrl', () => {
     expect(normalizePreviewUrl('http://')).toBeNull();
     expect(normalizePreviewUrl('::::')).toBeNull();
   });
+
+  it('normalizes the scheme to lowercase', () => {
+    expect(normalizePreviewUrl('HTTP://Example.com')).toBe('http://example.com/');
+  });
+
+  it('rejects a file: URL', () => {
+    expect(normalizePreviewUrl('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects a javascript: URL', () => {
+    expect(normalizePreviewUrl('javascript://x')).toBeNull();
+  });
+
+  it('rejects an ssh: URL', () => {
+    expect(normalizePreviewUrl('ssh://host')).toBeNull();
+  });
+
+  it('rejects a data: URL', () => {
+    expect(normalizePreviewUrl('data:text/html,x')).toBeNull();
+  });
 });

--- a/packages/ui/src/features/preview/__tests__/use-preview-address.test.ts
+++ b/packages/ui/src/features/preview/__tests__/use-preview-address.test.ts
@@ -23,24 +23,32 @@ function makeHandle(over: Partial<PreviewHandle> = {}): PreviewHandle {
 }
 
 describe('usePreviewAddress', () => {
-  it('seeds currentUrl from the port', () => {
-    const { result } = renderHook(({ h, p }) => usePreviewAddress(h, p), {
-      initialProps: { h: makeHandle(), p: 3000 as number | null },
+  it('seeds currentUrl from the seed URL', () => {
+    const { result } = renderHook(({ h, u }) => usePreviewAddress(h, u), {
+      initialProps: { h: makeHandle(), u: 'http://localhost:3000' as string | null },
     });
     expect(result.current.currentUrl).toBe('http://localhost:3000');
   });
 
-  it('re-seeds when the port changes', () => {
-    const { result, rerender } = renderHook(({ h, p }) => usePreviewAddress(h, p), {
-      initialProps: { h: makeHandle(), p: 3000 as number | null },
+  it('re-seeds when the seed URL changes', () => {
+    const { result, rerender } = renderHook(({ h, u }) => usePreviewAddress(h, u), {
+      initialProps: { h: makeHandle(), u: 'http://localhost:3000' as string | null },
     });
-    rerender({ h: makeHandle(), p: 4000 });
-    expect(result.current.currentUrl).toBe('http://localhost:4000');
+    rerender({ h: makeHandle(), u: 'https://example.com/docs' });
+    expect(result.current.currentUrl).toBe('https://example.com/docs');
+  });
+
+  it('keeps the current URL when the seed goes null', () => {
+    const { result, rerender } = renderHook(({ h, u }) => usePreviewAddress(h, u), {
+      initialProps: { h: makeHandle(), u: 'http://localhost:3000' as string | null },
+    });
+    rerender({ h: makeHandle(), u: null });
+    expect(result.current.currentUrl).toBe('http://localhost:3000');
   });
 
   it('navigateTo normalizes + calls handle.navigate and updates currentUrl', () => {
     const handle = makeHandle();
-    const { result } = renderHook(() => usePreviewAddress(handle, 3000));
+    const { result } = renderHook(() => usePreviewAddress(handle, 'http://localhost:3000'));
     let ok = false;
     act(() => {
       ok = result.current.navigateTo('localhost:3000/dashboard');
@@ -52,7 +60,7 @@ describe('usePreviewAddress', () => {
 
   it('navigateTo returns false and does not navigate on invalid input', () => {
     const handle = makeHandle();
-    const { result } = renderHook(() => usePreviewAddress(handle, 3000));
+    const { result } = renderHook(() => usePreviewAddress(handle, 'http://localhost:3000'));
     let ok = true;
     act(() => {
       ok = result.current.navigateTo('   ');
@@ -69,7 +77,7 @@ describe('usePreviewAddress', () => {
         return () => {};
       },
     });
-    const { result } = renderHook(() => usePreviewAddress(handle, 3000));
+    const { result } = renderHook(() => usePreviewAddress(handle, 'http://localhost:3000'));
     act(() => emit!('http://localhost:3000/from-page'));
     expect(result.current.currentUrl).toBe('http://localhost:3000/from-page');
   });

--- a/packages/ui/src/features/preview/__tests__/use-preview-geometry.test.ts
+++ b/packages/ui/src/features/preview/__tests__/use-preview-geometry.test.ts
@@ -39,7 +39,7 @@ function refs() {
 
 it('refits on window resize (position-only shifts never fire the ResizeObserver)', async () => {
   const { anchorRef, containerRef } = refs();
-  renderHook(() => usePreviewGeometry({ handle, anchorRef, containerRef, active: true, status: 'running' }));
+  renderHook(() => usePreviewGeometry({ handle, anchorRef, containerRef, active: true, mounted: true }));
   await act(async () => {
     await nextFrame();
   });
@@ -55,7 +55,7 @@ it('refits on window resize (position-only shifts never fire the ResizeObserver)
 it('removes the resize listener on unmount', async () => {
   const { anchorRef, containerRef } = refs();
   const { unmount } = renderHook(() =>
-    usePreviewGeometry({ handle, anchorRef, containerRef, active: true, status: 'running' }),
+    usePreviewGeometry({ handle, anchorRef, containerRef, active: true, mounted: true }),
   );
   await act(async () => {
     await nextFrame();

--- a/packages/ui/src/features/preview/__tests__/use-webview-mount.test.ts
+++ b/packages/ui/src/features/preview/__tests__/use-webview-mount.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+/**
+ * useWebviewMount — the URL-driven mount lifecycle extracted out of
+ * usePreviewLifecycle (#281 Task 16). Both the launch-config preview tab and
+ * the URL tab drive this one handle contract, so its five transitions are
+ * asserted here rather than through either caller.
+ */
+import { it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+
+import { useWebviewMount } from '../use-webview-mount';
+
+let fakeHost: FakeHostBridge;
+let fakeHandle: PreviewHandle;
+
+beforeEach(() => {
+  fakeHandle = {
+    setVisible: vi.fn(),
+    compositesAboveDom: true,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    capture: vi.fn().mockResolvedValue(new Uint8Array()),
+    startInspect: vi.fn().mockResolvedValue(undefined),
+    onInspect: vi.fn().mockReturnValue(() => {}),
+    startRegionSelect: vi.fn().mockResolvedValue(undefined),
+    onRegionSelect: vi.fn().mockReturnValue(() => {}),
+    onNavigate: vi.fn().mockReturnValue(() => {}),
+    refit: vi.fn(),
+    reanchor: vi.fn(),
+    setDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+  fakeHost = new FakeHostBridge();
+  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
+  setHostForTesting(fakeHost);
+});
+
+afterEach(() => {
+  resetHostForTesting();
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(HostProvider, { host: fakeHost, children });
+}
+
+function renderMount(
+  initialUrl: string | null,
+  refs: {
+    anchorRef: { current: HTMLDivElement | null };
+    containerRef: { current: HTMLDivElement | null };
+  },
+) {
+  return renderHook(
+    (props: { url: string | null; device: 'desktop' | 'mobile' }) =>
+      useWebviewMount({
+        url: props.url,
+        anchorRef: refs.anchorRef,
+        containerRef: refs.containerRef,
+        projectId: 'p1',
+        device: props.device,
+      }),
+    { initialProps: { url: initialUrl, device: 'desktop' as 'desktop' | 'mobile' }, wrapper },
+  );
+}
+
+function refs(anchor: HTMLDivElement | null = null) {
+  return {
+    anchorRef: { current: anchor },
+    containerRef: { current: document.createElement('div') as HTMLDivElement | null },
+  };
+}
+
+it('does not mount while the url is null', async () => {
+  renderMount(null, refs());
+  await act(async () => {});
+  expect(fakeHost.preview.mount).not.toHaveBeenCalled();
+});
+
+it('mounts on the first non-null url and returns the handle', async () => {
+  const r = refs();
+  const { result, rerender } = renderMount(null, r);
+  await act(async () => {
+    rerender({ url: 'http://localhost:3000', device: 'desktop' });
+  });
+  expect(fakeHost.preview.mount).toHaveBeenCalledWith(
+    r.containerRef.current,
+    'http://localhost:3000',
+    expect.objectContaining({ projectId: 'p1', device: 'desktop' }),
+  );
+  expect(result.current).toBe(fakeHandle);
+});
+
+it('prefers the anchor element over the container as the mount target', async () => {
+  const anchor = document.createElement('div');
+  const r = refs(anchor);
+  renderMount('http://localhost:3000', r);
+  await act(async () => {});
+  expect(fakeHost.preview.mount).toHaveBeenCalledWith(anchor, 'http://localhost:3000', expect.anything());
+});
+
+it('navigates (never remounts) when the url changes', async () => {
+  const r = refs();
+  const { rerender } = renderMount('http://localhost:3000', r);
+  await act(async () => {});
+  await act(async () => {
+    rerender({ url: 'https://example.com/docs', device: 'desktop' });
+  });
+  expect(fakeHandle.navigate).toHaveBeenCalledWith('https://example.com/docs');
+  expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
+});
+
+it('reanchors when the mount element is replaced', async () => {
+  const anchorA = document.createElement('div');
+  const r = refs(anchorA);
+  const { rerender } = renderMount('http://localhost:3000', r);
+  await act(async () => {});
+
+  const anchorB = document.createElement('div');
+  r.anchorRef.current = anchorB;
+  await act(async () => {
+    rerender({ url: 'http://localhost:3000', device: 'mobile' });
+  });
+  expect(fakeHandle.reanchor).toHaveBeenCalledWith(anchorB);
+  expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
+});
+
+it('destroys the handle when the url goes back to null', async () => {
+  const r = refs();
+  const { result, rerender } = renderMount('http://localhost:3000', r);
+  await act(async () => {});
+  vi.mocked(fakeHandle.destroy).mockClear();
+
+  await act(async () => {
+    rerender({ url: null, device: 'desktop' });
+  });
+  // Without this the native webview stays composited over the app.
+  expect(fakeHandle.destroy).toHaveBeenCalledTimes(1);
+  expect(result.current).toBeNull();
+});
+
+it('remounts after a destroy when a url returns', async () => {
+  const r = refs();
+  const { rerender } = renderMount('http://localhost:3000', r);
+  await act(async () => {});
+  await act(async () => {
+    rerender({ url: null, device: 'desktop' });
+  });
+  await act(async () => {
+    rerender({ url: 'http://localhost:4000', device: 'desktop' });
+  });
+  expect(fakeHost.preview.mount).toHaveBeenCalledTimes(2);
+  expect(fakeHost.preview.mount).toHaveBeenLastCalledWith(
+    r.containerRef.current,
+    'http://localhost:4000',
+    expect.anything(),
+  );
+});
+
+it('destroys on unmount', async () => {
+  const { unmount } = renderMount('http://localhost:3000', refs());
+  await act(async () => {});
+  unmount();
+  expect(fakeHandle.destroy).toHaveBeenCalled();
+});

--- a/packages/ui/src/features/preview/normalize-url.ts
+++ b/packages/ui/src/features/preview/normalize-url.ts
@@ -5,13 +5,17 @@
  * - Adds an `http://` scheme when none is present (dev servers are plain HTTP).
  * - Validates via `URL`; returns `null` when the result can't be parsed so the
  *   caller can show an invalid state instead of navigating to garbage.
+ * - Restricted to http/https: the address bar can point a child webview at
+ *   any scheme it's given, so `file:`/`javascript:`/etc. must be rejected here.
  */
 export function normalizePreviewUrl(input: string): string | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
   try {
-    return new URL(withScheme).toString();
+    const url = new URL(withScheme);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.toString();
   } catch {
     /* expected: invalid input — caller shows the invalid state */
     return null;

--- a/packages/ui/src/features/preview/use-preview-address.ts
+++ b/packages/ui/src/features/preview/use-preview-address.ts
@@ -3,23 +3,26 @@ import type { PreviewHandle } from '@qlan-ro/mainframe-types';
 import { normalizePreviewUrl } from './normalize-url';
 
 /**
- * Address-bar state for the preview tab.
+ * Address-bar state for a webview tab.
  *
- * - Seeds `currentUrl` to `http://localhost:{port}` and re-seeds on port change
- *   / server (re)start — the typed URL is intentionally NOT persisted.
+ * - Seeds `currentUrl` from `seedUrl` and re-seeds when it changes (a preview
+ *   tab passes `http://localhost:{port}`, a URL tab its committed address) —
+ *   the typed URL is intentionally NOT persisted.
  * - Reflects in-webview navigation via `handle.onNavigate` (two-way).
  * - `navigateTo` normalizes input, navigates the webview, and optimistically
  *   sets `currentUrl`. Returns false for invalid input (caller shows an error).
  */
 export function usePreviewAddress(
   handle: PreviewHandle | null,
-  port: number | null,
+  seedUrl: string | null,
 ): { currentUrl: string; navigateTo: (input: string) => boolean } {
   const [currentUrl, setCurrentUrl] = useState('');
 
+  // A null seed leaves the last address up: a stopped process or a torn-down
+  // tunnel should not blank the bar the user types their way out of.
   useEffect(() => {
-    if (port !== null) setCurrentUrl(`http://localhost:${port}`);
-  }, [port]);
+    if (seedUrl !== null) setCurrentUrl(seedUrl);
+  }, [seedUrl]);
 
   useEffect(() => {
     if (!handle) return;

--- a/packages/ui/src/features/preview/use-preview-geometry.ts
+++ b/packages/ui/src/features/preview/use-preview-geometry.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
-import type { LaunchProcessStatus, PreviewHandle } from '@qlan-ro/mainframe-types';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
 import { useLayoutStore } from '@/store/layout';
 import { useUiPrefs } from '@/store/ui-prefs';
 import { useTheme } from '@/store/theme';
@@ -17,11 +17,11 @@ interface PreviewGeometryProps {
    */
   containerRef: RefObject<HTMLDivElement | null>;
   active: boolean;
-  /** Re-attach the observer when the anchor (un)mounts on a status transition. */
-  status: LaunchProcessStatus | null;
+  /** Re-attach the observer when the anchor (un)mounts — i.e. when a webview is mounted. */
+  mounted: boolean;
 }
 
-export function usePreviewGeometry({ handle, anchorRef, containerRef, active, status }: PreviewGeometryProps): void {
+export function usePreviewGeometry({ handle, anchorRef, containerRef, active, mounted }: PreviewGeometryProps): void {
   const rafRef = useRef<number | null>(null);
 
   function scheduleRefit() {
@@ -64,5 +64,5 @@ export function usePreviewGeometry({ handle, anchorRef, containerRef, active, st
       window.removeEventListener('resize', onWindowResize);
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     };
-  }, [anchorRef, containerRef, status, handle]);
+  }, [anchorRef, containerRef, mounted, handle]);
 }

--- a/packages/ui/src/features/preview/use-preview-lifecycle.ts
+++ b/packages/ui/src/features/preview/use-preview-lifecycle.ts
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
-import { useHost } from '@/lib/host';
 import type { LaunchProcessStatus, PreviewHandle } from '@qlan-ro/mainframe-types';
+import { useWebviewMount } from './use-webview-mount';
 
 interface PreviewLifecycleProps {
   status: LaunchProcessStatus | null;
@@ -29,6 +28,11 @@ interface PreviewLifecycleProps {
   device: 'desktop' | 'mobile';
 }
 
+/**
+ * The launch-config preview tab's mount gate: a webview exists only while the
+ * process is running on a known port with a resolved URL. The handle lifecycle
+ * itself belongs to {@link useWebviewMount}, shared with the URL tab.
+ */
 export function usePreviewLifecycle({
   status,
   port,
@@ -38,72 +42,17 @@ export function usePreviewLifecycle({
   projectId,
   device,
 }: PreviewLifecycleProps): {
-  processStopped: boolean;
   handle: PreviewHandle | null;
   pendingTunnel: boolean;
 } {
-  const host = useHost();
-  const [handle, setHandle] = useState<PreviewHandle | null>(null);
-  const handleRef = useRef<PreviewHandle | null>(null);
-  const mountElRef = useRef<HTMLElement | null>(null);
-  const prevStatusRef = useRef<LaunchProcessStatus | null>(null);
-  const [processStopped, setProcessStopped] = useState(false);
-  const [pendingTunnel, setPendingTunnel] = useState(false);
+  const live = status === 'running' && port !== null;
+  const handle = useWebviewMount({
+    url: live ? resolvedUrl : null,
+    anchorRef,
+    containerRef,
+    projectId,
+    device,
+  });
 
-  useEffect(() => {
-    const prevStatus = prevStatusRef.current;
-    prevStatusRef.current = status ?? null;
-
-    // running → anything else: tear the webview down. This must cover null too
-    // (the scope entry can drop from the store, e.g. on a session-scope change);
-    // a status-list check would leak a live composited webview over the app.
-    if (handleRef.current && prevStatus === 'running' && status !== 'running') {
-      handleRef.current.destroy();
-      handleRef.current = null;
-      mountElRef.current = null;
-      setHandle(null);
-      if (status === 'stopped' || status === 'failed') setProcessStopped(true);
-      return;
-    }
-
-    if (status !== 'running' || port === null) return;
-    setProcessStopped(false);
-
-    // No resolved URL yet (remote tunnel still coming up) — do not mount; the
-    // body renders the pending state until the URL arrives (WS event or seed).
-    if (resolvedUrl === null) {
-      setPendingTunnel(true);
-      return;
-    }
-    setPendingTunnel(false);
-
-    // Prefer the anchor (phone-frame in mobile, inner overlay in desktop) so
-    // the native webview's initial rect and subsequent refit() calls track the
-    // precise frame — matching pre-Task-7 anchorRef ?? containerRef semantics.
-    const mountEl = anchorRef.current ?? containerRef.current;
-    if (!handleRef.current) {
-      if (!mountEl) return;
-      const h = host.preview.mount(mountEl, resolvedUrl, { projectId, device });
-      handleRef.current = h;
-      mountElRef.current = mountEl;
-      setHandle(h);
-    } else {
-      // The device toggle (and other layout swaps) can remount the anchor node;
-      // re-point the handle at the live element or its bounds reads go stale.
-      if (mountEl && mountEl !== mountElRef.current) {
-        handleRef.current.reanchor?.(mountEl);
-        mountElRef.current = mountEl;
-      }
-      void handleRef.current.navigate(resolvedUrl).catch((e) => console.warn('[preview] lifecycle navigate', e));
-    }
-  }, [status, port, resolvedUrl, anchorRef, containerRef, projectId, device, host]);
-
-  useEffect(() => {
-    return () => {
-      handleRef.current?.destroy();
-      handleRef.current = null;
-    };
-  }, []);
-
-  return { processStopped, handle, pendingTunnel };
+  return { handle, pendingTunnel: live && resolvedUrl === null };
 }

--- a/packages/ui/src/features/preview/use-webview-mount.ts
+++ b/packages/ui/src/features/preview/use-webview-mount.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { useHost } from '@/lib/host';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+
+interface WebviewMountProps {
+  /**
+   * The URL the webview should be showing, or `null` for "nothing should be
+   * mounted". This is the ONLY mount gate: a launch-config preview tab derives
+   * it from its process status and resolved tunnel, a URL tab from its own
+   * address — neither owns the handle lifecycle itself.
+   */
+  url: string | null;
+  /**
+   * The precise inner frame the webview should cover (the phone frame in MOBILE
+   * mode, the inner overlay div in DESKTOP mode). Preferred as the mount target
+   * so `refit()` reads its rect.
+   */
+  anchorRef: RefObject<HTMLDivElement | null>;
+  /** The always-present body wrapper — the mount target while the anchor is unmounted. */
+  containerRef: RefObject<HTMLDivElement | null>;
+  projectId?: string;
+  device: 'desktop' | 'mobile';
+}
+
+/**
+ * Owns one native webview handle: mount on the first URL, navigate on a change,
+ * re-anchor when the mount node is replaced, destroy when the URL goes away or
+ * the caller unmounts.
+ */
+export function useWebviewMount({
+  url,
+  anchorRef,
+  containerRef,
+  projectId,
+  device,
+}: WebviewMountProps): PreviewHandle | null {
+  const host = useHost();
+  const [handle, setHandle] = useState<PreviewHandle | null>(null);
+  const handleRef = useRef<PreviewHandle | null>(null);
+  const mountElRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // No URL: tear the webview down. Leaving it up would keep a native child
+    // webview composited over the app with nothing driving it.
+    if (url === null) {
+      if (!handleRef.current) return;
+      handleRef.current.destroy();
+      handleRef.current = null;
+      mountElRef.current = null;
+      setHandle(null);
+      return;
+    }
+
+    const mountEl = anchorRef.current ?? containerRef.current;
+    if (!handleRef.current) {
+      if (!mountEl) return;
+      const h = host.preview.mount(mountEl, url, { projectId, device });
+      handleRef.current = h;
+      mountElRef.current = mountEl;
+      setHandle(h);
+      return;
+    }
+
+    // The device toggle (and other layout swaps) can remount the anchor node;
+    // re-point the handle at the live element or its bounds reads go stale.
+    if (mountEl && mountEl !== mountElRef.current) {
+      handleRef.current.reanchor?.(mountEl);
+      mountElRef.current = mountEl;
+    }
+    void handleRef.current.navigate(url).catch((e) => console.warn('[preview] mount navigate', e));
+  }, [url, anchorRef, containerRef, projectId, device, host]);
+
+  useEffect(() => {
+    return () => {
+      handleRef.current?.destroy();
+      handleRef.current = null;
+    };
+  }, []);
+
+  return handle;
+}

--- a/packages/ui/src/features/url-tab/UrlTabBodyState.tsx
+++ b/packages/ui/src/features/url-tab/UrlTabBodyState.tsx
@@ -1,0 +1,135 @@
+/**
+ * The body of a `url` Run tab: the webview frame when there is something to
+ * show, and one explicit state for every other resolver outcome (#281, AC9).
+ * Mirrors `PreviewBodyState`'s frames so the two tab kinds read as one surface.
+ */
+import type { ReactNode, RefObject } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { UrlTabTarget } from './resolve-url-target';
+
+interface UrlTabBodyStateProps {
+  target: UrlTabTarget;
+  device: 'desktop' | 'mobile';
+  inspectActive: boolean;
+  anchorRef: RefObject<HTMLDivElement | null>;
+  onRetry: () => void;
+}
+
+function LoadedBody({
+  device,
+  inspectActive,
+  anchorRef,
+}: Pick<UrlTabBodyStateProps, 'device' | 'inspectActive' | 'anchorRef'>) {
+  const inspectFrame = inspectActive ? 'outline outline-[2px] outline-primary -outline-offset-2' : '';
+  const inspectBadge = inspectActive ? (
+    <div
+      data-testid="url-tab-inspect-active-indicator"
+      className="absolute top-[8px] left-[8px] z-10 rounded-[6px] bg-primary px-[7px] py-[2px] font-mono text-caption font-semibold text-primary-foreground"
+    >
+      Click an element
+    </div>
+  ) : null;
+
+  return (
+    <div data-testid="url-tab-body-loaded" className="absolute inset-0">
+      {device === 'desktop' ? (
+        <div
+          className={`absolute inset-0 overflow-hidden rounded-md [border:0.5px_solid_var(--border)] ${inspectFrame}`}
+        >
+          <div ref={anchorRef} className="absolute inset-0" />
+          {inspectBadge}
+        </div>
+      ) : (
+        <div className="flex items-center justify-center h-full">
+          <div
+            className={`relative w-[230px] h-[420px] overflow-hidden rounded-[22px] [border:0.5px_solid_var(--border)] [box-shadow:var(--mf-shadow-pop)] ${inspectFrame}`}
+          >
+            <div ref={anchorRef} className="w-full h-full" />
+            {inspectBadge}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MessageBody({ testId, children }: { testId: string; children: ReactNode }) {
+  return (
+    <div data-testid={testId} className="absolute inset-0 grid place-items-center bg-card">
+      <div className="flex max-w-[80%] flex-col items-center gap-2.5 text-center">{children}</div>
+    </div>
+  );
+}
+
+function FailureLine({ text }: { text: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-2 h-2 rounded-full bg-destructive" />
+      <span className="text-body text-muted-foreground">{text}</span>
+    </div>
+  );
+}
+
+function RetryButton({ onRetry }: { onRetry: () => void }) {
+  return (
+    <button
+      type="button"
+      data-testid="url-tab-retry"
+      onClick={onRetry}
+      className="rounded-md border border-border px-3 py-1.5 text-label text-foreground transition-colors hover:bg-accent"
+    >
+      Retry
+    </button>
+  );
+}
+
+export function UrlTabBodyState({ target, device, inspectActive, anchorRef, onRetry }: UrlTabBodyStateProps) {
+  if (target.kind === 'direct' || target.kind === 'tunnelled') {
+    return <LoadedBody device={device} inspectActive={inspectActive} anchorRef={anchorRef} />;
+  }
+
+  if (target.kind === 'pending') {
+    return (
+      <MessageBody testId="url-tab-body-pending">
+        <div className="flex items-center gap-[8px]">
+          <Loader2 size={12} className="animate-spin text-muted-foreground" />
+          <span className="text-label text-muted-foreground">Starting a tunnel for port {target.port}…</span>
+        </div>
+      </MessageBody>
+    );
+  }
+
+  if (target.kind === 'rejected') {
+    return (
+      <MessageBody testId="url-tab-body-rejected">
+        <FailureLine text={target.reason} />
+      </MessageBody>
+    );
+  }
+
+  if (target.kind === 'failed') {
+    return (
+      <MessageBody testId="url-tab-body-failed">
+        <FailureLine text={target.error} />
+        <RetryButton onRetry={onRetry} />
+      </MessageBody>
+    );
+  }
+
+  if (target.kind === 'stopped') {
+    return (
+      <MessageBody testId="url-tab-body-stopped">
+        <FailureLine text={`The tunnel for port ${target.port} was stopped`} />
+        <RetryButton onRetry={onRetry} />
+      </MessageBody>
+    );
+  }
+
+  // kind === 'invalid' — the address bar above is the only way out.
+  return (
+    <MessageBody testId="url-tab-body-invalid">
+      <FailureLine text="This tab’s saved address can’t be opened" />
+      {target.url !== '' && <span className="line-clamp-2 font-mono text-caption text-mf-text-3">{target.url}</span>}
+    </MessageBody>
+  );
+}

--- a/packages/ui/src/features/url-tab/UrlTabInstance.tsx
+++ b/packages/ui/src/features/url-tab/UrlTabInstance.tsx
@@ -36,8 +36,16 @@ export function UrlTabInstance({ tabId, url, visible, projectId }: UrlTabInstanc
   const effectiveProjectId = projectId ?? identity.projectId;
   const setUrlTabTarget = useLayoutStore((s) => s.setUrlTabTarget);
 
-  const { target, retry, reloadNonce } = useUrlTabTunnel({ tabId, url });
-  const loadUrl = target.kind === 'direct' || target.kind === 'tunnelled' ? target.url : null;
+  // A rehydrated tab must stay unmounted and tunnel-free until it is first shown
+  // (spec: "rehydrate unmounted and load on first activation") — latch true on
+  // first `visible` and never back, so switching away doesn't tear it down again.
+  const [hasBeenVisible, setHasBeenVisible] = useState(visible);
+  useEffect(() => {
+    if (visible) setHasBeenVisible(true);
+  }, [visible]);
+
+  const { target, retry, reloadNonce } = useUrlTabTunnel({ tabId, url, active: hasBeenVisible });
+  const loadUrl = hasBeenVisible && (target.kind === 'direct' || target.kind === 'tunnelled') ? target.url : null;
 
   const handle = useWebviewMount({
     url: loadUrl,

--- a/packages/ui/src/features/url-tab/UrlTabInstance.tsx
+++ b/packages/ui/src/features/url-tab/UrlTabInstance.tsx
@@ -1,0 +1,122 @@
+/**
+ * A `url` Run tab: the same native webview the preview tab drives, pointed at an
+ * arbitrary address instead of a launch config (#281). Everything process-shaped
+ * — run/stop, console, launch status — is absent by construction; the tunnel
+ * resolver in `useUrlTabTunnel` takes the place of the launch lifecycle.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useWebviewMount } from '@/features/preview/use-webview-mount';
+import { usePreviewGeometry } from '@/features/preview/use-preview-geometry';
+import { usePreviewVisibility } from '@/features/preview/use-preview-visibility';
+import { usePreviewOcclusion } from '@/features/preview/use-preview-occlusion';
+import { usePreviewCapture } from '@/features/preview/use-preview-capture';
+import { CaptureAnnotationPopover } from '@/features/preview/CaptureAnnotationPopover';
+import { useLayoutStore } from '@/store/layout';
+import { useActiveIdentity } from '@/features/sessions/use-active-identity';
+import { UrlTabToolbar } from './UrlTabToolbar';
+import { UrlTabBodyState } from './UrlTabBodyState';
+import { useUrlTabTunnel } from './use-url-tab-tunnel';
+import { urlTabTitle } from './url-tab-id';
+
+interface UrlTabInstanceProps {
+  tabId: string;
+  /** The tab's committed address — what the user typed, not what it resolves to. */
+  url: string;
+  visible: boolean;
+  /** Accepted for call-site parity with `PreviewInstance`; a URL tab has no launch scope to read. */
+  scopeKey?: string;
+  projectId?: string;
+}
+
+export function UrlTabInstance({ tabId, url, visible, projectId }: UrlTabInstanceProps) {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [device, setDevice] = useState<'desktop' | 'mobile'>('desktop');
+  const identity = useActiveIdentity();
+  const effectiveProjectId = projectId ?? identity.projectId;
+  const setUrlTabTarget = useLayoutStore((s) => s.setUrlTabTarget);
+
+  const { target, retry, reloadNonce } = useUrlTabTunnel({ tabId, url });
+  const loadUrl = target.kind === 'direct' || target.kind === 'tunnelled' ? target.url : null;
+
+  const handle = useWebviewMount({
+    url: loadUrl,
+    anchorRef,
+    containerRef,
+    projectId: effectiveProjectId,
+    device,
+  });
+  usePreviewGeometry({ handle, anchorRef, containerRef, active: visible, mounted: loadUrl !== null });
+  const occluded = usePreviewOcclusion(anchorRef, loadUrl !== null && (handle?.compositesAboveDom ?? false));
+  const [, setOverlayMounted] = usePreviewVisibility(handle, visible, occluded);
+
+  const {
+    pendingCaptures,
+    regionSelectActive,
+    annotationPopoverOpen,
+    annotationBackdrop,
+    inspectActive,
+    onCaptureClick,
+    onRegionClick,
+    onInspectClick,
+    onAnnotationChange,
+    onAnnotationSubmit,
+    onAnnotationCancel,
+  } = usePreviewCapture(handle, setOverlayMounted);
+
+  // The tunnel's edge DNS resolved after this tab already loaded, so what the
+  // webview is showing is a 404 until it navigates again (D11).
+  useEffect(() => {
+    if (reloadNonce === 0 || !handle || loadUrl === null) return;
+    void handle.navigate(loadUrl).catch((e: unknown) => {
+      console.warn('[url-tab] DNS reload navigate failed', e);
+    });
+  }, [reloadNonce, handle, loadUrl]);
+
+  return (
+    <div
+      data-testid={`url-tab-instance-${tabId}`}
+      className="absolute inset-0 flex flex-col"
+      style={{ visibility: visible ? 'visible' : 'hidden' }}
+    >
+      <UrlTabToolbar
+        url={url}
+        handle={handle}
+        device={device}
+        onDeviceChange={setDevice}
+        onCommitUrl={(next) => setUrlTabTarget(tabId, next, urlTabTitle(next))}
+        onCaptureClick={onCaptureClick}
+        onRegionClick={onRegionClick}
+        onInspectClick={onInspectClick}
+        inspectActive={inspectActive}
+        regionActive={regionSelectActive}
+      />
+      <div ref={containerRef} className="relative min-h-0 flex-1">
+        <UrlTabBodyState
+          target={target}
+          device={device}
+          inspectActive={inspectActive}
+          anchorRef={anchorRef}
+          onRetry={retry}
+        />
+        {annotationBackdrop && (
+          <img
+            data-testid="url-tab-annotation-backdrop"
+            src={annotationBackdrop}
+            alt=""
+            className="pointer-events-none absolute inset-0 z-40 h-full w-full object-contain"
+          />
+        )}
+      </div>
+
+      {annotationPopoverOpen && (
+        <CaptureAnnotationPopover
+          captures={pendingCaptures}
+          onAnnotationChange={onAnnotationChange}
+          onSubmit={onAnnotationSubmit}
+          onCancel={onAnnotationCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/features/url-tab/UrlTabToolbar.tsx
+++ b/packages/ui/src/features/url-tab/UrlTabToolbar.tsx
@@ -1,0 +1,56 @@
+/**
+ * The URL tab's toolbar. Same address bar, device toggle and capture cluster as
+ * the preview tab; the run/stop controls and the console drawer are absent
+ * rather than disabled — a URL tab has no process behind it (#281, AC5).
+ */
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+import { PreviewUrlBar } from '@/features/preview/PreviewUrlBar';
+import { PreviewDeviceToggle } from '@/features/preview/PreviewDeviceToggle';
+import { PreviewCaptureCluster } from '@/features/preview/PreviewCaptureCluster';
+
+interface UrlTabToolbarProps {
+  /** The tab's committed address — never the tunnel URL it resolves to. */
+  url: string;
+  handle: PreviewHandle | null;
+  device: 'desktop' | 'mobile';
+  onDeviceChange: (d: 'desktop' | 'mobile') => void;
+  onCommitUrl: (url: string) => void;
+  onCaptureClick: () => void;
+  onRegionClick: () => void;
+  onInspectClick: () => void;
+  inspectActive: boolean;
+  regionActive?: boolean;
+}
+
+export function UrlTabToolbar({
+  url,
+  handle,
+  device,
+  onDeviceChange,
+  onCommitUrl,
+  onCaptureClick,
+  onRegionClick,
+  onInspectClick,
+  inspectActive,
+  regionActive = false,
+}: UrlTabToolbarProps) {
+  return (
+    <div
+      data-testid="url-tab-toolbar"
+      className="flex h-[38px] flex-shrink-0 items-center gap-[8px] [border-bottom:0.5px_solid_var(--border)] bg-background px-[8px]"
+    >
+      {/* Always enabled: typing a new address is the only way out of the failed,
+          stopped and invalid states, and none of them has a webview mounted. */}
+      <PreviewUrlBar handle={handle} seedUrl={url} enabled onCommitUrl={onCommitUrl} />
+      <PreviewDeviceToggle device={device} onChange={onDeviceChange} />
+      <PreviewCaptureCluster
+        isRunning={handle !== null}
+        inspectActive={inspectActive}
+        regionActive={regionActive}
+        onCaptureClick={onCaptureClick}
+        onRegionClick={onRegionClick}
+        onInspectClick={onInspectClick}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabBodyState.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * UrlTabBodyState — one explicit body per resolved `UrlTabTarget` (#281, Task 1).
+ * Pure render tests: no store, no host, a bare `createRef` anchor.
+ */
+import { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UrlTabBodyState } from '../UrlTabBodyState';
+import type { UrlTabTarget } from '../resolve-url-target';
+
+function renderBody(target: UrlTabTarget, overrides: { device?: 'desktop' | 'mobile'; inspectActive?: boolean } = {}) {
+  const anchorRef = createRef<HTMLDivElement>();
+  const onRetry = vi.fn();
+  const { unmount } = render(
+    <UrlTabBodyState
+      target={target}
+      device={overrides.device ?? 'desktop'}
+      inspectActive={overrides.inspectActive ?? false}
+      anchorRef={anchorRef}
+      onRetry={onRetry}
+    />,
+  );
+  return { anchorRef, onRetry, unmount };
+}
+
+describe('UrlTabBodyState', () => {
+  it.each<[UrlTabTarget['kind'], UrlTabTarget]>([
+    ['direct', { kind: 'direct', url: 'http://localhost:5173/' }],
+    ['tunnelled', { kind: 'tunnelled', url: 'https://abc.trycloudflare.com/' }],
+  ])('renders url-tab-body-loaded for a %s target, desktop and mobile', (_kind, target) => {
+    const { unmount } = render(
+      <UrlTabBodyState
+        target={target}
+        device="desktop"
+        inspectActive={false}
+        anchorRef={createRef<HTMLDivElement>()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    unmount();
+
+    render(
+      <UrlTabBodyState
+        target={target}
+        device="mobile"
+        inspectActive={false}
+        anchorRef={createRef<HTMLDivElement>()}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+  });
+
+  it('shows the inspect-active indicator only when inspectActive is true on a loaded body', () => {
+    const target: UrlTabTarget = { kind: 'direct', url: 'http://localhost:5173/' };
+
+    const { unmount } = renderBody(target, { inspectActive: true });
+    expect(screen.getByTestId('url-tab-inspect-active-indicator')).toBeInTheDocument();
+    unmount();
+
+    renderBody(target, { inspectActive: false });
+    expect(screen.queryByTestId('url-tab-inspect-active-indicator')).toBeNull();
+  });
+
+  it('renders the pending body naming the port, with no retry', () => {
+    renderBody({ kind: 'pending', port: 5173 });
+
+    const body = screen.getByTestId('url-tab-body-pending');
+    expect(body.textContent).toContain('5173');
+    expect(screen.queryByTestId('url-tab-retry')).toBeNull();
+  });
+
+  it('renders the rejected body with the reason verbatim and no retry (AC10)', () => {
+    renderBody({ kind: 'rejected', port: 22, reason: 'Port must be 1024 or higher' });
+
+    const body = screen.getByTestId('url-tab-body-rejected');
+    expect(body.textContent).toContain('Port must be 1024 or higher');
+    expect(screen.queryByTestId('url-tab-retry')).toBeNull();
+  });
+
+  it('renders the failed body with the error text and a working retry (AC9)', () => {
+    const { onRetry } = renderBody({ kind: 'failed', error: 'cloudflared exited with code 1' });
+
+    const body = screen.getByTestId('url-tab-body-failed');
+    expect(body.textContent).toContain('cloudflared exited with code 1');
+
+    const retry = screen.getByTestId('url-tab-retry');
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the stopped body naming the port, with a working retry', () => {
+    const { onRetry } = renderBody({ kind: 'stopped', port: 5173 });
+
+    const body = screen.getByTestId('url-tab-body-stopped');
+    expect(body.textContent).toContain('5173');
+
+    fireEvent.click(screen.getByTestId('url-tab-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the invalid body with no mono URL line for an empty url, and no retry', () => {
+    renderBody({ kind: 'invalid', url: '' });
+
+    const body = screen.getByTestId('url-tab-body-invalid');
+    expect(body).toBeInTheDocument();
+    expect(body.querySelector('.font-mono')).toBeNull();
+    expect(screen.queryByTestId('url-tab-retry')).toBeNull();
+  });
+
+  it('renders the invalid body with the offending text for a non-empty url, and no retry', () => {
+    renderBody({ kind: 'invalid', url: 'not a url' });
+
+    expect(screen.getByTestId('url-tab-body-invalid')).toBeInTheDocument();
+    expect(screen.getByText('not a url')).toBeInTheDocument();
+    expect(screen.queryByTestId('url-tab-retry')).toBeNull();
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * UrlTabInstance — toolbar composition and the live address bar (#281, Task 2).
+ *
+ * Covers AC1 (mounts with no launch config), AC5 (the process-control pair and
+ * the preview tab's own toolbar are absent by construction), D9/spec §6 (the
+ * address bar stays live and commits even with nothing mounted), AC6 (invalid
+ * input never mounts a webview), and the device-toggle/unmount lifecycle.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
+import { useLayoutStore } from '@/store/layout';
+import { usePortTunnelsStore } from '@/store/port-tunnels';
+import { useSandboxStore } from '@/store/sandbox';
+
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31415,
+}));
+
+vi.mock('@/lib/daemon/use-daemon-is-local', () => ({
+  useDaemonIsLocal: vi.fn(),
+}));
+
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: vi.fn(),
+  stopPortTunnel: vi.fn(),
+}));
+
+import { UrlTabInstance } from '../UrlTabInstance';
+
+const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
+
+/** Seed a single-pane Run holding one `url` tab, so setUrlTabTarget has something to retarget. */
+function seedUrlTab(tabId: string, url: string) {
+  useLayoutStore.setState({
+    layout: { ...FRESH_LAYOUT },
+    run: {
+      dir: 'v',
+      flex: [1],
+      panes: [{ id: 'pane-1', active: tabId, tabs: [{ id: tabId, kind: 'url', title: url, url }] }],
+    },
+    sessions: new Map(),
+    activeSessionId: null,
+  });
+}
+
+let fakeHost: FakeHostBridge;
+let fakeHandle: PreviewHandle;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeHandle = {
+    setVisible: vi.fn(),
+    compositesAboveDom: false,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    capture: vi.fn().mockResolvedValue(new Uint8Array()),
+    startInspect: vi.fn().mockResolvedValue(undefined),
+    onInspect: vi.fn().mockReturnValue(() => {}),
+    startRegionSelect: vi.fn().mockResolvedValue(undefined),
+    onRegionSelect: vi.fn().mockReturnValue(() => {}),
+    onNavigate: vi.fn().mockReturnValue(() => {}),
+    refit: vi.fn(),
+    reanchor: vi.fn(),
+    setDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+  fakeHost = new FakeHostBridge();
+  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
+  setHostForTesting(fakeHost);
+
+  useSandboxStore.setState({
+    captures: [],
+    logsOutput: [],
+    selectedConfigByScope: {},
+    lastStartedProcess: null,
+    processStatuses: {},
+  });
+  usePortTunnelsStore.setState({ byPort: {}, daemonPort: null, generation: 0 });
+  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
+});
+
+afterEach(() => {
+  resetHostForTesting();
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <HostProvider host={fakeHost}>{children}</HostProvider>;
+}
+
+describe('UrlTabInstance — toolbar composition and the live address bar', () => {
+  it('mounts the webview for a local daemon with no launch config (AC1)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(true);
+
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, { wrapper });
+
+    expect(fakeHost.preview.mount).toHaveBeenCalledWith(expect.anything(), 'http://localhost:5173/', {
+      projectId: 'proj-A',
+      device: 'desktop',
+    });
+    expect(screen.getByTestId('url-tab-instance-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+  });
+
+  it('renders exactly the URL-tab control inventory, never the preview tab toolbar or process controls (AC5)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(true);
+
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, { wrapper });
+
+    const toolbar = screen.getByTestId('url-tab-toolbar');
+    expect(toolbar).toBeInTheDocument();
+    for (const id of [
+      'preview-url-input',
+      'preview-url-reload',
+      'preview-url-open-browser',
+      'preview-url-clear-cache',
+      'preview-toolbar-inspect',
+      'preview-toolbar-capture',
+      'preview-toolbar-region',
+    ]) {
+      expect(screen.getByTestId(id)).toBeInTheDocument();
+    }
+    expect(screen.queryByTestId('preview-run-start')).toBeNull();
+    expect(screen.queryByTestId('preview-run-stop')).toBeNull();
+    expect(screen.queryByTestId('preview-toolbar')).toBeNull();
+  });
+
+  it('keeps the address bar live and commits a new address with nothing mounted (spec §6, D9)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(false);
+    usePortTunnelsStore.setState({
+      byPort: { 9999: { state: 'error', error: 'boom' } },
+      daemonPort: 31415,
+      generation: 1,
+    });
+    seedUrlTab('t1', 'http://localhost:9999/');
+
+    render(<UrlTabInstance tabId="t1" url="http://localhost:9999/" visible />, { wrapper });
+
+    expect(screen.getByTestId('url-tab-body-failed')).toBeInTheDocument();
+    const input = screen.getByTestId('preview-url-input');
+    expect(input).not.toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'localhost:5173' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    const tab = useLayoutStore.getState().run?.panes[0]?.tabs[0];
+    expect(tab?.url).toBe('http://localhost:5173/');
+    expect(tab?.title).toBe('localhost:5173');
+    expect(fakeHost.preview.mount).not.toHaveBeenCalled();
+  });
+
+  it('renders the invalid body and never mounts, with the input still enabled (AC6)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(true);
+
+    render(<UrlTabInstance tabId="t1" url="" visible />, { wrapper });
+
+    expect(screen.getByTestId('url-tab-body-invalid')).toBeInTheDocument();
+    expect(fakeHost.preview.mount).not.toHaveBeenCalled();
+    expect(screen.getByTestId('preview-url-input')).not.toBeDisabled();
+  });
+
+  it('flips the device toggle without recreating the webview (reanchor, not remount)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(true);
+
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, { wrapper });
+    expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('preview-device-mobile'));
+
+    expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
+    expect(fakeHandle.reanchor).toHaveBeenCalled();
+  });
+
+  it('destroys the webview handle on unmount (AC12)', () => {
+    vi.mocked(useDaemonIsLocal).mockReturnValue(true);
+
+    const { unmount } = render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, { wrapper });
+    unmount();
+
+    expect(fakeHandle.destroy).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * UrlTabInstance — the round-5 tunnel-claim sequences the ownership rework
+ * exists to fix, plus the Retry-on-`ready` rule it must not break (#281, D10,
+ * AC12).
+ *
+ * Runs the REAL `tunnel-consumers` registry (only `startPortTunnel`/
+ * `stopPortTunnel` are mocked), same as
+ * `UrlTabInstance.tunnel-retarget-ownership.test.tsx`, so a wrongly-dropped or
+ * wrongly-kept claim shows up as a wrong `stopPortTunnel` call on release
+ * rather than as an internal state assertion.
+ */
+import { screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
+import { usePortTunnelsStore } from '@/store/port-tunnels';
+import { startPortTunnel, stopPortTunnel } from '@/lib/api/tunnel-ports';
+import { releaseUrlTunnelConsumers, clearUrlTunnelConsumers } from '@/features/url-tab/tunnel-consumers';
+import { URL_TAB_TUNNEL_TIMEOUT_MS } from '../resolve-url-target';
+import { installFakeHost, seedStores, setPortEntry, renderTab } from './url-tab-tunnel-harness';
+
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31415,
+}));
+
+vi.mock('@/lib/daemon/use-daemon-is-local', () => ({
+  useDaemonIsLocal: vi.fn(),
+}));
+
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: vi.fn(),
+  stopPortTunnel: vi.fn(),
+}));
+
+function deletePortEntry(port: number): void {
+  usePortTunnelsStore.setState((s) => {
+    const byPort = { ...s.byPort };
+    delete byPort[port];
+    return { byPort, generation: s.generation + 1 };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearUrlTunnelConsumers();
+  installFakeHost();
+  seedStores();
+
+  vi.mocked(useDaemonIsLocal).mockReturnValue(false);
+  vi.mocked(startPortTunnel).mockResolvedValue({ url: 'https://abc.trycloudflare.com' });
+  vi.mocked(stopPortTunnel).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('UrlTabInstance — a hung earlier attempt rejects after a successful retry (round-5 defect 1)', () => {
+  it('keeps the claim through the stale rejection and still stops the tunnel on release', async () => {
+    let rejectFirstAttempt!: (err: unknown) => void;
+    vi.mocked(startPortTunnel).mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirstAttempt = reject;
+        }),
+    );
+    vi.mocked(startPortTunnel).mockResolvedValue({ url: 'https://abc.trycloudflare.com' });
+
+    renderTab('http://localhost:5173/');
+
+    act(() => {
+      setPortEntry(5173, { state: 'error', error: 'boom' });
+    });
+    expect(screen.getByTestId('url-tab-body-failed')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('url-tab-retry'));
+    });
+    expect(startPortTunnel).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+
+    await act(async () => {
+      rejectFirstAttempt(new Error('transport died'));
+    });
+
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+});
+
+describe('UrlTabInstance — the non-terminal watchdog fires, then the tunnel becomes ready (round-5 defect 2)', () => {
+  it('keeps the claim through the watchdog and still stops the tunnel on release', async () => {
+    vi.useFakeTimers();
+    vi.mocked(startPortTunnel).mockImplementation(() => new Promise(() => {}));
+
+    renderTab('http://localhost:5173/');
+
+    act(() => {
+      setPortEntry(5173, { state: 'starting' });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(URL_TAB_TUNNEL_TIMEOUT_MS);
+    });
+    expect(screen.getByTestId('url-tab-body-failed')).toBeInTheDocument();
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+});
+
+describe('UrlTabInstance — Retry pressed while the entry is ready never re-adopts a later, foreign restart', () => {
+  it('does not stop a tunnel a different consumer starts after this tab’s own ready-but-unverified tunnel times out and Retry is pressed', async () => {
+    vi.useFakeTimers();
+    vi.mocked(startPortTunnel).mockImplementation(() => new Promise(() => {}));
+
+    renderTab('http://localhost:5173/');
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com' });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(URL_TAB_TUNNEL_TIMEOUT_MS);
+    });
+    expect(screen.getByTestId('url-tab-body-failed')).toBeInTheDocument();
+
+    // clearPortTunnelEntry no-ops on a `ready` entry, so this never fires a
+    // start POST for a new attempt — it only resets the per-attempt flags.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('url-tab-retry'));
+    });
+
+    // The daemon stops this tab's tunnel and a different consumer starts a
+    // brand-new, foreign one on the same port — one batch, so this tab's
+    // `entry` never renders an intermediate `undefined` that would make it
+    // look like a fresh port ready for this tab's own next attempt to adopt.
+    act(() => {
+      deletePortEntry(5173);
+      setPortEntry(5173, { state: 'ready', url: 'https://foreign.trycloudflare.com', dnsVerified: true });
+    });
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
@@ -180,3 +180,37 @@ describe('UrlTabInstance — a session-switch unmount does not lose this tab’s
     expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
   });
 });
+
+describe('UrlTabInstance — a revocation that happens entirely while unmounted is not missed (review-fix NEW finding)', () => {
+  it('does not stop a foreign tunnel a chip or settings restarted on the same port while this tab was unmounted', async () => {
+    const { unmount } = renderTab('http://localhost:5173/');
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+
+    // A session switch unmounts the tab without releasing it. While unmounted,
+    // the daemon drops this tab's tunnel and a foreign consumer (the chip, or
+    // the settings UI — neither registers in the URL-tab registry) starts a
+    // brand-new one on the same port. Neither write goes through this tab's
+    // own React effects, since none are mounted to run them.
+    unmount();
+    act(() => {
+      deletePortEntry(5173);
+    });
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://foreign.trycloudflare.com', dnsVerified: true });
+    });
+
+    // Remounting must not re-adopt the foreign tunnel as if this tab still
+    // owned it, and issues no new start against an already-`ready` port.
+    renderTab('http://localhost:5173/');
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-claim-lifecycle.test.tsx
@@ -157,3 +157,26 @@ describe('UrlTabInstance — Retry pressed while the entry is ready never re-ado
     expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
   });
 });
+
+describe('UrlTabInstance — a session-switch unmount does not lose this tab’s claim (review-fix finding 1/3)', () => {
+  it('remounts against an already-ready port, still owns the claim, and stops the tunnel on release', async () => {
+    const { unmount } = renderTab('http://localhost:5173/');
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+
+    // A session switch unmounts the tab without ever releasing it — the port
+    // entry stays `ready`, so no new start is issued on remount.
+    unmount();
+
+    renderTab('http://localhost:5173/');
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * UrlTabInstance — retargeting never falsely claims an already-tunnelled port
+ * (#281, review-fix findings 1+2, AC12/D10).
+ *
+ * Runs the REAL `tunnel-consumers` registry (only `startPortTunnel`/
+ * `stopPortTunnel` are mocked), so a stale-state write that the pure reducer
+ * tests can't see — the hook registering `started: true` for one render
+ * before correcting itself — shows up as a wrongful `stopPortTunnel` call
+ * once the tab is released.
+ */
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
+import { useLayoutStore } from '@/store/layout';
+import { usePortTunnelsStore } from '@/store/port-tunnels';
+import { useSandboxStore } from '@/store/sandbox';
+import { startPortTunnel, stopPortTunnel } from '@/lib/api/tunnel-ports';
+import { releaseUrlTunnelConsumers, clearUrlTunnelConsumers } from '@/features/url-tab/tunnel-consumers';
+
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31415,
+}));
+
+vi.mock('@/lib/daemon/use-daemon-is-local', () => ({
+  useDaemonIsLocal: vi.fn(),
+}));
+
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: vi.fn(),
+  stopPortTunnel: vi.fn(),
+}));
+
+import { UrlTabInstance } from '../UrlTabInstance';
+
+const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
+
+let fakeHost: FakeHostBridge;
+let fakeHandle: PreviewHandle;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearUrlTunnelConsumers();
+  fakeHandle = {
+    setVisible: vi.fn(),
+    compositesAboveDom: false,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    capture: vi.fn().mockResolvedValue(new Uint8Array()),
+    startInspect: vi.fn().mockResolvedValue(undefined),
+    onInspect: vi.fn().mockReturnValue(() => {}),
+    startRegionSelect: vi.fn().mockResolvedValue(undefined),
+    onRegionSelect: vi.fn().mockReturnValue(() => {}),
+    onNavigate: vi.fn().mockReturnValue(() => {}),
+    refit: vi.fn(),
+    reanchor: vi.fn(),
+    setDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+  fakeHost = new FakeHostBridge();
+  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
+  setHostForTesting(fakeHost);
+
+  vi.mocked(useDaemonIsLocal).mockReturnValue(false);
+  vi.mocked(startPortTunnel).mockResolvedValue({ url: 'https://abc.trycloudflare.com' });
+  vi.mocked(stopPortTunnel).mockResolvedValue(undefined);
+
+  useSandboxStore.setState({
+    captures: [],
+    logsOutput: [],
+    selectedConfigByScope: {},
+    lastStartedProcess: null,
+    processStatuses: {},
+  });
+  usePortTunnelsStore.setState({ byPort: {}, daemonPort: 31415, generation: 0 });
+  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
+});
+
+afterEach(() => {
+  resetHostForTesting();
+});
+
+describe('UrlTabInstance — retarget onto an already-tunnelled port never adopts as owner', () => {
+  it('does not stop the adopted port on release, and still stops the abandoned owned port', async () => {
+    const { rerender } = render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+
+    // Port 4000 already carries a ready tunnel started by someone else (e.g. a
+    // chat chip) before this tab ever retargets onto it.
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 4000: { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true } },
+        generation: s.generation + 1,
+      }));
+    });
+
+    await act(async () => {
+      rerender(<UrlTabInstance tabId="t1" url="http://localhost:4000/" visible />);
+    });
+
+    // The old owned port is abandoned and stopped (AC12/D10 still holds).
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+    vi.mocked(stopPortTunnel).mockClear();
+
+    // Releasing the tab must not stop port 4000 — this tab only adopted it.
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 4000);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
@@ -9,17 +9,14 @@
  * before correcting itself — shows up as a wrongful `stopPortTunnel` call
  * once the tab is released.
  */
-import { render, act } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { PreviewHandle } from '@qlan-ro/mainframe-types';
-import { FakeHostBridge } from '@/lib/host/fake-adapter';
-import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import { resetHostForTesting } from '@/lib/host';
 import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
-import { useLayoutStore } from '@/store/layout';
 import { usePortTunnelsStore } from '@/store/port-tunnels';
-import { useSandboxStore } from '@/store/sandbox';
 import { startPortTunnel, stopPortTunnel } from '@/lib/api/tunnel-ports';
 import { releaseUrlTunnelConsumers, clearUrlTunnelConsumers } from '@/features/url-tab/tunnel-consumers';
+import { installFakeHost, seedStores, setPortEntry, renderTab } from './url-tab-tunnel-harness';
 
 vi.mock('@/features/sessions/use-active-identity', () => ({
   useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
@@ -40,46 +37,23 @@ vi.mock('@/lib/api/tunnel-ports', () => ({
 
 import { UrlTabInstance } from '../UrlTabInstance';
 
-const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
-
-let fakeHost: FakeHostBridge;
-let fakeHandle: PreviewHandle;
+function deletePortEntry(port: number): void {
+  usePortTunnelsStore.setState((s) => {
+    const byPort = { ...s.byPort };
+    delete byPort[port];
+    return { byPort, generation: s.generation + 1 };
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
   clearUrlTunnelConsumers();
-  fakeHandle = {
-    setVisible: vi.fn(),
-    compositesAboveDom: false,
-    navigate: vi.fn().mockResolvedValue(undefined),
-    capture: vi.fn().mockResolvedValue(new Uint8Array()),
-    startInspect: vi.fn().mockResolvedValue(undefined),
-    onInspect: vi.fn().mockReturnValue(() => {}),
-    startRegionSelect: vi.fn().mockResolvedValue(undefined),
-    onRegionSelect: vi.fn().mockReturnValue(() => {}),
-    onNavigate: vi.fn().mockReturnValue(() => {}),
-    refit: vi.fn(),
-    reanchor: vi.fn(),
-    setDevice: vi.fn(),
-    destroy: vi.fn(),
-  };
-  fakeHost = new FakeHostBridge();
-  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
-  setHostForTesting(fakeHost);
+  installFakeHost();
+  seedStores();
 
   vi.mocked(useDaemonIsLocal).mockReturnValue(false);
   vi.mocked(startPortTunnel).mockResolvedValue({ url: 'https://abc.trycloudflare.com' });
   vi.mocked(stopPortTunnel).mockResolvedValue(undefined);
-
-  useSandboxStore.setState({
-    captures: [],
-    logsOutput: [],
-    selectedConfigByScope: {},
-    lastStartedProcess: null,
-    processStatuses: {},
-  });
-  usePortTunnelsStore.setState({ byPort: {}, daemonPort: 31415, generation: 0 });
-  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
 });
 
 afterEach(() => {
@@ -88,19 +62,14 @@ afterEach(() => {
 
 describe('UrlTabInstance — retarget onto an already-tunnelled port never adopts as owner', () => {
   it('does not stop the adopted port on release, and still stops the abandoned owned port', async () => {
-    const { rerender } = render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    const { rerender } = renderTab('http://localhost:5173/');
     await act(async () => {});
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
 
     // Port 4000 already carries a ready tunnel started by someone else (e.g. a
     // chat chip) before this tab ever retargets onto it.
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 4000: { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(4000, { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true });
     });
 
     await act(async () => {
@@ -119,38 +88,23 @@ describe('UrlTabInstance — retarget onto an already-tunnelled port never adopt
 
 describe('UrlTabInstance — an externally-restarted tunnel on the owned port is never this tab’s to stop', () => {
   it('drops ownership when the started tunnel disappears, so a later restart by someone else survives release', async () => {
-    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    renderTab('http://localhost:5173/');
     await act(async () => {});
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
 
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 5173: { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
     });
 
     // The chat chip's Stop tears the tunnel down — the store entry disappears.
     act(() => {
-      usePortTunnelsStore.setState((s) => {
-        const byPort = { ...s.byPort };
-        delete byPort[5173];
-        return { byPort, generation: s.generation + 1 };
-      });
+      deletePortEntry(5173);
     });
 
     // A different consumer starts a NEW tunnel on the same port; this tab
     // never asked for it and must not claim it.
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: {
-          ...s.byPort,
-          5173: { state: 'ready', url: 'https://new-owner.trycloudflare.com', dnsVerified: true },
-        },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'ready', url: 'https://new-owner.trycloudflare.com', dnsVerified: true });
     });
 
     releaseUrlTunnelConsumers(['t1']);
@@ -160,19 +114,14 @@ describe('UrlTabInstance — an externally-restarted tunnel on the owned port is
 
 describe('UrlTabInstance — a port abandoned via retarget is never re-adopted as owned on return', () => {
   it('does not stop a foreign tunnel that later appears on a previously-owned, since-abandoned port', async () => {
-    const { rerender } = render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    const { rerender } = renderTab('http://localhost:5173/');
     await act(async () => {});
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
 
     // Retarget onto a port someone else already tunnels, so this tab's own
     // start effect never fires for it — it only adopts.
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 4000: { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(4000, { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true });
     });
     await act(async () => {
       rerender(<UrlTabInstance tabId="t1" url="http://localhost:4000/" visible />);
@@ -182,10 +131,7 @@ describe('UrlTabInstance — a port abandoned via retarget is never re-adopted a
 
     // The abandoned port later gets a fresh, unrelated tunnel (e.g. the chat chip).
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 5173: { state: 'ready', url: 'https://foreign.trycloudflare.com', dnsVerified: true } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'ready', url: 'https://foreign.trycloudflare.com', dnsVerified: true });
     });
 
     await act(async () => {
@@ -201,27 +147,16 @@ describe('UrlTabInstance — a start POST that itself fails never leaves this ta
   it('does not stop a tunnel a different consumer later starts on the same port', async () => {
     vi.mocked(startPortTunnel).mockRejectedValueOnce(new Error('daemon says no'));
 
-    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    renderTab('http://localhost:5173/');
     await act(async () => {});
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
 
     // The chat chip starts its own tunnel on the same port after this tab's start failed.
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 5173: { state: 'starting' } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'starting' });
     });
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: {
-          ...s.byPort,
-          5173: { state: 'ready', url: 'https://chip-owned.trycloudflare.com', dnsVerified: true },
-        },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'ready', url: 'https://chip-owned.trycloudflare.com', dnsVerified: true });
     });
 
     releaseUrlTunnelConsumers(['t1']);
@@ -231,29 +166,18 @@ describe('UrlTabInstance — a start POST that itself fails never leaves this ta
 
 describe('UrlTabInstance — a live tunnel that dies with a daemon-side error is never this tab’s to stop once restarted', () => {
   it('does not stop a tunnel a different consumer restarts after this tab’s own tunnel errors out', async () => {
-    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    renderTab('http://localhost:5173/');
     await act(async () => {});
     expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
 
     // This tab's own tunnel dies with a daemon-side error entry (not a `stopped`).
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: { ...s.byPort, 5173: { state: 'error', error: 'cloudflared died' } },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'error', error: 'cloudflared died' });
     });
 
     // A different consumer restarts a NEW tunnel on the same port.
     act(() => {
-      usePortTunnelsStore.setState((s) => ({
-        byPort: {
-          ...s.byPort,
-          5173: { state: 'ready', url: 'https://restarted.trycloudflare.com', dnsVerified: true },
-        },
-        generation: s.generation + 1,
-      }));
+      setPortEntry(5173, { state: 'ready', url: 'https://restarted.trycloudflare.com', dnsVerified: true });
     });
 
     releaseUrlTunnelConsumers(['t1']);

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
@@ -1,6 +1,7 @@
 /**
- * UrlTabInstance — retargeting never falsely claims an already-tunnelled port
- * (#281, review-fix findings 1+2, AC12/D10).
+ * UrlTabInstance — retargeting and an externally-restarted tunnel never
+ * falsely claim a port this tab didn't (still) start (#281, review-fix
+ * findings 1+2, AC12/D10).
  *
  * Runs the REAL `tunnel-consumers` registry (only `startPortTunnel`/
  * `stopPortTunnel` are mocked), so a stale-state write that the pure reducer
@@ -113,5 +114,85 @@ describe('UrlTabInstance — retarget onto an already-tunnelled port never adopt
     // Releasing the tab must not stop port 4000 — this tab only adopted it.
     releaseUrlTunnelConsumers(['t1']);
     expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 4000);
+  });
+});
+
+describe('UrlTabInstance — an externally-restarted tunnel on the owned port is never this tab’s to stop', () => {
+  it('drops ownership when the started tunnel disappears, so a later restart by someone else survives release', async () => {
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 5173: { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true } },
+        generation: s.generation + 1,
+      }));
+    });
+
+    // The chat chip's Stop tears the tunnel down — the store entry disappears.
+    act(() => {
+      usePortTunnelsStore.setState((s) => {
+        const byPort = { ...s.byPort };
+        delete byPort[5173];
+        return { byPort, generation: s.generation + 1 };
+      });
+    });
+
+    // A different consumer starts a NEW tunnel on the same port; this tab
+    // never asked for it and must not claim it.
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: {
+          ...s.byPort,
+          5173: { state: 'ready', url: 'https://new-owner.trycloudflare.com', dnsVerified: true },
+        },
+        generation: s.generation + 1,
+      }));
+    });
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
+  });
+});
+
+describe('UrlTabInstance — a port abandoned via retarget is never re-adopted as owned on return', () => {
+  it('does not stop a foreign tunnel that later appears on a previously-owned, since-abandoned port', async () => {
+    const { rerender } = render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+
+    // Retarget onto a port someone else already tunnels, so this tab's own
+    // start effect never fires for it — it only adopts.
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 4000: { state: 'ready', url: 'https://xyz.trycloudflare.com', dnsVerified: true } },
+        generation: s.generation + 1,
+      }));
+    });
+    await act(async () => {
+      rerender(<UrlTabInstance tabId="t1" url="http://localhost:4000/" visible />);
+    });
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+    vi.mocked(stopPortTunnel).mockClear();
+
+    // The abandoned port later gets a fresh, unrelated tunnel (e.g. the chat chip).
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 5173: { state: 'ready', url: 'https://foreign.trycloudflare.com', dnsVerified: true } },
+        generation: s.generation + 1,
+      }));
+    });
+
+    await act(async () => {
+      rerender(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />);
+    });
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
   });
 });

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel-retarget-ownership.test.tsx
@@ -196,3 +196,67 @@ describe('UrlTabInstance — a port abandoned via retarget is never re-adopted a
     expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
   });
 });
+
+describe('UrlTabInstance — a start POST that itself fails never leaves this tab owning the port', () => {
+  it('does not stop a tunnel a different consumer later starts on the same port', async () => {
+    vi.mocked(startPortTunnel).mockRejectedValueOnce(new Error('daemon says no'));
+
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+
+    // The chat chip starts its own tunnel on the same port after this tab's start failed.
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 5173: { state: 'starting' } },
+        generation: s.generation + 1,
+      }));
+    });
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: {
+          ...s.byPort,
+          5173: { state: 'ready', url: 'https://chip-owned.trycloudflare.com', dnsVerified: true },
+        },
+        generation: s.generation + 1,
+      }));
+    });
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
+  });
+});
+
+describe('UrlTabInstance — a live tunnel that dies with a daemon-side error is never this tab’s to stop once restarted', () => {
+  it('does not stop a tunnel a different consumer restarts after this tab’s own tunnel errors out', async () => {
+    render(<UrlTabInstance tabId="t1" url="http://localhost:5173/" visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+
+    // This tab's own tunnel dies with a daemon-side error entry (not a `stopped`).
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: { ...s.byPort, 5173: { state: 'error', error: 'cloudflared died' } },
+        generation: s.generation + 1,
+      }));
+    });
+
+    // A different consumer restarts a NEW tunnel on the same port.
+    act(() => {
+      usePortTunnelsStore.setState((s) => ({
+        byPort: {
+          ...s.byPort,
+          5173: { state: 'ready', url: 'https://restarted.trycloudflare.com', dnsVerified: true },
+        },
+        generation: s.generation + 1,
+      }));
+    });
+
+    releaseUrlTunnelConsumers(['t1']);
+    expect(stopPortTunnel).not.toHaveBeenCalledWith(31415, 5173);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
@@ -14,6 +14,7 @@ import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
 import { usePortTunnelsStore } from '@/store/port-tunnels';
 import { startPortTunnel } from '@/lib/api/tunnel-ports';
 import { registerUrlTunnelConsumer } from '@/features/url-tab/tunnel-consumers';
+import { clearStoredClaims } from '@/features/url-tab/tunnel-claim-registry';
 import { installFakeHost, seedStores, setPortEntry, renderTab as renderUrlTab } from './url-tab-tunnel-harness';
 
 vi.mock('@/features/sessions/use-active-identity', () => ({
@@ -53,6 +54,10 @@ function renderTab(url = URL) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `tunnel-consumers` is mocked wholesale above, so its own `clearUrlTunnelConsumers`
+  // never reaches the real claim registry every case here re-seeds under 't1' —
+  // clear it directly or a claim a prior case earned leaks into the next one.
+  clearStoredClaims();
   ({ fakeHost, fakeHandle } = installFakeHost());
   seedStores();
 

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * UrlTabInstance — tunnel adoption, ownership, retry, DNS reload (#281, Task 3).
+ *
+ * Every case runs on a remote daemon against `http://localhost:5173/app?x=1`
+ * unless noted, exercising `useUrlTabTunnel` through the mounted component so
+ * the ownership registration and the mount seam are proven together.
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
+import { useLayoutStore } from '@/store/layout';
+import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
+import { useSandboxStore } from '@/store/sandbox';
+import { startPortTunnel } from '@/lib/api/tunnel-ports';
+import { registerUrlTunnelConsumer } from '@/features/url-tab/tunnel-consumers';
+
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31415,
+}));
+
+vi.mock('@/lib/daemon/use-daemon-is-local', () => ({
+  useDaemonIsLocal: vi.fn(),
+}));
+
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: vi.fn(),
+  stopPortTunnel: vi.fn(),
+}));
+
+vi.mock('@/features/url-tab/tunnel-consumers', () => ({
+  registerUrlTunnelConsumer: vi.fn(),
+  releaseUrlTunnelConsumers: vi.fn(),
+  clearUrlTunnelConsumers: vi.fn(),
+}));
+
+import { UrlTabInstance } from '../UrlTabInstance';
+
+const URL = 'http://localhost:5173/app?x=1';
+const TUNNEL_URL = 'https://abc.trycloudflare.com/app?x=1';
+const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
+
+let fakeHost: FakeHostBridge;
+let fakeHandle: PreviewHandle;
+
+function setPortEntry(port: number, entry: PortTunnelEntry) {
+  usePortTunnelsStore.setState((s) => ({ byPort: { ...s.byPort, [port]: entry }, generation: s.generation + 1 }));
+}
+
+function renderTab(url = URL) {
+  return render(<UrlTabInstance tabId="t1" url={url} visible />, {
+    wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fakeHandle = {
+    setVisible: vi.fn(),
+    compositesAboveDom: false,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    capture: vi.fn().mockResolvedValue(new Uint8Array()),
+    startInspect: vi.fn().mockResolvedValue(undefined),
+    onInspect: vi.fn().mockReturnValue(() => {}),
+    startRegionSelect: vi.fn().mockResolvedValue(undefined),
+    onRegionSelect: vi.fn().mockReturnValue(() => {}),
+    onNavigate: vi.fn().mockReturnValue(() => {}),
+    refit: vi.fn(),
+    reanchor: vi.fn(),
+    setDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+  fakeHost = new FakeHostBridge();
+  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
+  setHostForTesting(fakeHost);
+
+  vi.mocked(useDaemonIsLocal).mockReturnValue(false);
+  vi.mocked(startPortTunnel).mockResolvedValue({ url: TUNNEL_URL.replace('/app?x=1', '') });
+
+  useSandboxStore.setState({
+    captures: [],
+    logsOutput: [],
+    selectedConfigByScope: {},
+    lastStartedProcess: null,
+    processStatuses: {},
+  });
+  usePortTunnelsStore.setState({ byPort: {}, daemonPort: 31415, generation: 0 });
+  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
+});
+
+afterEach(() => {
+  resetHostForTesting();
+});
+
+describe('UrlTabInstance — tunnel adoption and ownership', () => {
+  it('a fresh start owns the tunnel (D10, AC12)', () => {
+    renderTab();
+
+    expect(screen.getByTestId('url-tab-body-pending')).toBeInTheDocument();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+    expect(startPortTunnel).toHaveBeenCalledWith(31415, { port: 5173, chatId: 'chat-1' });
+    expect(registerUrlTunnelConsumer).toHaveBeenLastCalledWith('t1', {
+      port: 5173,
+      started: true,
+      daemonHttpPort: 31415,
+    });
+  });
+
+  it('adopting a mid-start tunnel issues its own start but does not own it', () => {
+    setPortEntry(5173, { state: 'starting' });
+
+    renderTab();
+
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+    expect(registerUrlTunnelConsumer).toHaveBeenLastCalledWith('t1', {
+      port: 5173,
+      started: false,
+      daemonHttpPort: 31415,
+    });
+  });
+
+  it('a ready tunnel skips pending and carries the original path/query (D12, AC8)', () => {
+    setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+
+    renderTab();
+
+    expect(screen.queryByTestId('url-tab-body-pending')).toBeNull();
+    expect(fakeHost.preview.mount).toHaveBeenCalledWith(expect.anything(), TUNNEL_URL, expect.anything());
+  });
+
+  it('reloads exactly once when DNS verifies after the tab already loaded (D11)', () => {
+    setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: false });
+
+    renderTab();
+    expect(fakeHost.preview.mount).toHaveBeenCalledWith(expect.anything(), TUNNEL_URL, expect.anything());
+    expect(fakeHandle.navigate).not.toHaveBeenCalled();
+
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(fakeHandle.navigate).toHaveBeenCalledTimes(1);
+    expect(fakeHandle.navigate).toHaveBeenCalledWith(TUNNEL_URL);
+
+    // A later, unrelated re-set of the same ready+verified entry adds no further reload.
+    act(() => {
+      setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+    });
+    expect(fakeHandle.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('short-circuits a rejected port below 1024 without requesting a tunnel (AC10)', () => {
+    renderTab('http://localhost:22/');
+
+    const body = screen.getByTestId('url-tab-body-rejected');
+    expect(body.textContent).toContain('Port must be 1024 or higher');
+    expect(startPortTunnel).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits a rejected daemon's-own-port without requesting a tunnel (AC10)", () => {
+    renderTab('http://localhost:31415/');
+
+    const body = screen.getByTestId('url-tab-body-rejected');
+    expect(body.textContent).toContain("Cannot tunnel the daemon's own port");
+    expect(startPortTunnel).not.toHaveBeenCalled();
+  });
+
+  it('retry re-requests after clearing the stale error entry (PD1, AC9)', () => {
+    setPortEntry(5173, { state: 'error', error: 'boom' });
+
+    renderTab();
+    expect(screen.getByTestId('url-tab-body-failed')).toBeInTheDocument();
+    expect(startPortTunnel).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('url-tab-retry'));
+    });
+
+    expect(usePortTunnelsStore.getState().byPort[5173]).toBeUndefined();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+  });
+
+  it('a ready entry has no retry to click — it is never cleared (PD2)', () => {
+    setPortEntry(5173, { state: 'ready', url: 'https://abc.trycloudflare.com', dnsVerified: true });
+
+    renderTab();
+
+    expect(screen.getByTestId('url-tab-body-loaded')).toBeInTheDocument();
+    expect(screen.queryByTestId('url-tab-retry')).toBeNull();
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
@@ -8,14 +8,13 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PreviewHandle } from '@qlan-ro/mainframe-types';
-import { FakeHostBridge } from '@/lib/host/fake-adapter';
-import { HostProvider, setHostForTesting, resetHostForTesting } from '@/lib/host';
+import type { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, resetHostForTesting } from '@/lib/host';
 import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
-import { useLayoutStore } from '@/store/layout';
-import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
-import { useSandboxStore } from '@/store/sandbox';
+import { usePortTunnelsStore } from '@/store/port-tunnels';
 import { startPortTunnel } from '@/lib/api/tunnel-ports';
 import { registerUrlTunnelConsumer } from '@/features/url-tab/tunnel-consumers';
+import { installFakeHost, seedStores, setPortEntry, renderTab as renderUrlTab } from './url-tab-tunnel-harness';
 
 vi.mock('@/features/sessions/use-active-identity', () => ({
   useActiveIdentity: () => ({ projectId: 'proj-A', chatId: 'chat-1' }),
@@ -44,54 +43,21 @@ import { UrlTabInstance } from '../UrlTabInstance';
 
 const URL = 'http://localhost:5173/app?x=1';
 const TUNNEL_URL = 'https://abc.trycloudflare.com/app?x=1';
-const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
 
 let fakeHost: FakeHostBridge;
 let fakeHandle: PreviewHandle;
 
-function setPortEntry(port: number, entry: PortTunnelEntry) {
-  usePortTunnelsStore.setState((s) => ({ byPort: { ...s.byPort, [port]: entry }, generation: s.generation + 1 }));
-}
-
 function renderTab(url = URL) {
-  return render(<UrlTabInstance tabId="t1" url={url} visible />, {
-    wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-  });
+  return renderUrlTab(url);
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  fakeHandle = {
-    setVisible: vi.fn(),
-    compositesAboveDom: false,
-    navigate: vi.fn().mockResolvedValue(undefined),
-    capture: vi.fn().mockResolvedValue(new Uint8Array()),
-    startInspect: vi.fn().mockResolvedValue(undefined),
-    onInspect: vi.fn().mockReturnValue(() => {}),
-    startRegionSelect: vi.fn().mockResolvedValue(undefined),
-    onRegionSelect: vi.fn().mockReturnValue(() => {}),
-    onNavigate: vi.fn().mockReturnValue(() => {}),
-    refit: vi.fn(),
-    reanchor: vi.fn(),
-    setDevice: vi.fn(),
-    destroy: vi.fn(),
-  };
-  fakeHost = new FakeHostBridge();
-  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
-  setHostForTesting(fakeHost);
+  ({ fakeHost, fakeHandle } = installFakeHost());
+  seedStores();
 
   vi.mocked(useDaemonIsLocal).mockReturnValue(false);
   vi.mocked(startPortTunnel).mockResolvedValue({ url: TUNNEL_URL.replace('/app?x=1', '') });
-
-  useSandboxStore.setState({
-    captures: [],
-    logsOutput: [],
-    selectedConfigByScope: {},
-    lastStartedProcess: null,
-    processStatuses: {},
-  });
-  usePortTunnelsStore.setState({ byPort: {}, daemonPort: 31415, generation: 0 });
-  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
 });
 
 afterEach(() => {
@@ -118,9 +84,7 @@ describe('UrlTabInstance — rehydrated tabs stay unmounted until first activati
   });
 
   it('stays mounted once activated even after switching to another tab (visible false again)', async () => {
-    const { rerender } = render(<UrlTabInstance tabId="t1" url={URL} visible />, {
-      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
-    });
+    const { rerender } = renderTab();
     await act(async () => {});
     expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
 

--- a/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/UrlTabInstance.tunnel.test.tsx
@@ -98,6 +98,39 @@ afterEach(() => {
   resetHostForTesting();
 });
 
+describe('UrlTabInstance — rehydrated tabs stay unmounted until first activation', () => {
+  it('requests no tunnel and mounts no webview while never visible, then does both on first activation', async () => {
+    const { rerender } = render(<UrlTabInstance tabId="t1" url={URL} visible={false} />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+
+    expect(fakeHost.preview.mount).not.toHaveBeenCalled();
+    expect(startPortTunnel).not.toHaveBeenCalled();
+    expect(registerUrlTunnelConsumer).not.toHaveBeenCalled();
+
+    await act(async () => {
+      rerender(<UrlTabInstance tabId="t1" url={URL} visible />);
+    });
+
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+    expect(registerUrlTunnelConsumer).toHaveBeenCalled();
+    expect(fakeHost.preview.mount).toHaveBeenCalledWith(expect.anything(), TUNNEL_URL, expect.anything());
+  });
+
+  it('stays mounted once activated even after switching to another tab (visible false again)', async () => {
+    const { rerender } = render(<UrlTabInstance tabId="t1" url={URL} visible />, {
+      wrapper: ({ children }) => <HostProvider host={fakeHost}>{children}</HostProvider>,
+    });
+    await act(async () => {});
+    expect(fakeHost.preview.mount).toHaveBeenCalledTimes(1);
+
+    rerender(<UrlTabInstance tabId="t1" url={URL} visible={false} />);
+
+    expect(fakeHandle.destroy).not.toHaveBeenCalled();
+    expect(startPortTunnel).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('UrlTabInstance — tunnel adoption and ownership', () => {
   it('a fresh start owns the tunnel (D10, AC12)', () => {
     renderTab();

--- a/packages/ui/src/features/url-tab/__tests__/resolve-url-target.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/resolve-url-target.test.ts
@@ -1,0 +1,218 @@
+/**
+ * resolveUrlTabTarget / composeTunnelUrl — pure tunnel-state resolution for a
+ * `url` Run tab (#281, plan Task 11's priority-ordered contract).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveUrlTabTarget, composeTunnelUrl, type UrlTabTunnelInput } from '../resolve-url-target';
+import type { PortTunnelEntry } from '../../../store/port-tunnels';
+
+const LOOPBACK = 'http://localhost:5173/';
+
+const input = (overrides: Partial<UrlTabTunnelInput> = {}): UrlTabTunnelInput => ({
+  url: LOOPBACK,
+  isLocal: false,
+  daemonPort: 31415,
+  entry: undefined,
+  watching: false,
+  startUrl: null,
+  timedOut: false,
+  everHadEntry: false,
+  ...overrides,
+});
+
+describe('resolveUrlTabTarget — invalid input (fact 15)', () => {
+  it.each(['', '   ', 'not a url'])('%s is invalid on a local daemon', (url) => {
+    expect(resolveUrlTabTarget(input({ url, isLocal: true }))).toEqual({ kind: 'invalid', url });
+  });
+
+  it.each(['', '   ', 'not a url'])('%s is invalid on a remote daemon', (url) => {
+    expect(resolveUrlTabTarget(input({ url, isLocal: false }))).toEqual({ kind: 'invalid', url });
+  });
+});
+
+describe('resolveUrlTabTarget — direct (steps 1–2)', () => {
+  it('any URL on a local daemon is direct, including a loopback URL', () => {
+    expect(resolveUrlTabTarget(input({ url: LOOPBACK, isLocal: true }))).toEqual({
+      kind: 'direct',
+      url: LOOPBACK,
+    });
+    expect(resolveUrlTabTarget(input({ url: 'https://example.com/x', isLocal: true }))).toEqual({
+      kind: 'direct',
+      url: 'https://example.com/x',
+    });
+  });
+
+  it('a non-loopback URL on a remote daemon is direct', () => {
+    expect(resolveUrlTabTarget(input({ url: 'https://example.com/x' }))).toEqual({
+      kind: 'direct',
+      url: 'https://example.com/x',
+    });
+    expect(resolveUrlTabTarget(input({ url: 'http://192.168.1.5:3000/' }))).toEqual({
+      kind: 'direct',
+      url: 'http://192.168.1.5:3000/',
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — daemonPort not yet known (step 3)', () => {
+  it('a loopback URL with daemonPort null is pending', () => {
+    expect(resolveUrlTabTarget(input({ daemonPort: null }))).toEqual({ kind: 'pending', port: 5173 });
+  });
+});
+
+describe('resolveUrlTabTarget — rejected ports (step 4)', () => {
+  it('a port below 1024 is rejected', () => {
+    expect(resolveUrlTabTarget(input({ url: 'http://localhost:22/' }))).toEqual({
+      kind: 'rejected',
+      port: 22,
+      reason: 'Port must be 1024 or higher',
+    });
+  });
+
+  it("the daemon's own port is rejected", () => {
+    expect(resolveUrlTabTarget(input({ url: 'http://localhost:31415/', daemonPort: 31415 }))).toEqual({
+      kind: 'rejected',
+      port: 31415,
+      reason: "Cannot tunnel the daemon's own port",
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — entry undefined (step 5)', () => {
+  it('no entry yet and it never had one is pending, naming the port', () => {
+    expect(resolveUrlTabTarget(input())).toEqual({ kind: 'pending', port: 5173 });
+  });
+
+  it("no entry, never had one, but this tab's own POST answered is tunnelled from startUrl", () => {
+    expect(resolveUrlTabTarget(input({ startUrl: 'https://a.trycloudflare.com' }))).toEqual({
+      kind: 'tunnelled',
+      url: 'https://a.trycloudflare.com/',
+    });
+  });
+
+  it('no entry but everHadEntry is stopped even with a startUrl on file', () => {
+    expect(resolveUrlTabTarget(input({ everHadEntry: true, startUrl: null }))).toEqual({
+      kind: 'stopped',
+      port: 5173,
+    });
+    expect(resolveUrlTabTarget(input({ everHadEntry: true, startUrl: 'https://a.trycloudflare.com' }))).toEqual({
+      kind: 'stopped',
+      port: 5173,
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — starting entry (step 8)', () => {
+  it('a starting entry is pending', () => {
+    expect(resolveUrlTabTarget(input({ entry: { state: 'starting' } }))).toEqual({
+      kind: 'pending',
+      port: 5173,
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — ready entry, adopting (step 7, AC8)', () => {
+  it('adopting a ready tunnel is tunnelled regardless of dnsVerified', () => {
+    const entry: PortTunnelEntry = { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false };
+    expect(resolveUrlTabTarget(input({ entry, watching: false }))).toEqual({
+      kind: 'tunnelled',
+      url: 'https://a.trycloudflare.com/',
+    });
+  });
+});
+
+describe("resolveUrlTabTarget — ready entry, watching this tab's own start (step 7)", () => {
+  it('not yet dns-verified and no startUrl is pending', () => {
+    const entry: PortTunnelEntry = { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false };
+    expect(resolveUrlTabTarget(input({ entry, watching: true, startUrl: null }))).toEqual({
+      kind: 'pending',
+      port: 5173,
+    });
+  });
+
+  it('dns-verified opens the gate to tunnelled', () => {
+    const entry: PortTunnelEntry = { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true };
+    expect(resolveUrlTabTarget(input({ entry, watching: true, startUrl: null }))).toEqual({
+      kind: 'tunnelled',
+      url: 'https://a.trycloudflare.com/',
+    });
+  });
+
+  it("this tab's own POST answering opens the gate to tunnelled", () => {
+    const entry: PortTunnelEntry = { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false };
+    expect(resolveUrlTabTarget(input({ entry, watching: true, startUrl: 'https://a.trycloudflare.com' }))).toEqual({
+      kind: 'tunnelled',
+      url: 'https://a.trycloudflare.com/',
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — error entry (step 6)', () => {
+  it('an error entry with a message is failed', () => {
+    expect(resolveUrlTabTarget(input({ entry: { state: 'error', error: 'boom' } }))).toEqual({
+      kind: 'failed',
+      error: 'boom',
+    });
+  });
+
+  it('an error entry with no message falls back to a default', () => {
+    expect(resolveUrlTabTarget(input({ entry: { state: 'error' } }))).toEqual({
+      kind: 'failed',
+      error: 'Tunnel failed to start',
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — timeout (step 8, AC9)', () => {
+  it('a timeout while still pending on a non-error, non-ready entry is failed', () => {
+    expect(resolveUrlTabTarget(input({ entry: { state: 'starting' }, timedOut: true }))).toEqual({
+      kind: 'failed',
+      error: 'The tunnel did not produce a URL within 120 seconds',
+    });
+  });
+
+  it('a URL that arrives after the timeout is non-terminal: the ready entry still wins', () => {
+    const entry: PortTunnelEntry = { state: 'ready', url: 'https://a.trycloudflare.com' };
+    expect(resolveUrlTabTarget(input({ entry, watching: false, timedOut: true }))).toEqual({
+      kind: 'tunnelled',
+      url: 'https://a.trycloudflare.com/',
+    });
+  });
+});
+
+describe('resolveUrlTabTarget — post-Retry inputs are all pending (PD1)', () => {
+  const resetInput = input({ entry: undefined, everHadEntry: false, startUrl: null, timedOut: false });
+
+  it('after a rejected start', () => {
+    expect(resolveUrlTabTarget(resetInput)).toEqual({ kind: 'pending', port: 5173 });
+  });
+
+  it('after an externally stopped tunnel', () => {
+    expect(resolveUrlTabTarget(resetInput)).toEqual({ kind: 'pending', port: 5173 });
+  });
+
+  it('after a 120s timeout whose starting entry was cleared', () => {
+    expect(resolveUrlTabTarget(resetInput)).toEqual({ kind: 'pending', port: 5173 });
+  });
+
+  it('after a timeout that never had an entry', () => {
+    expect(resolveUrlTabTarget(input({ entry: undefined, everHadEntry: false, timedOut: false }))).toEqual({
+      kind: 'pending',
+      port: 5173,
+    });
+  });
+});
+
+describe('composeTunnelUrl (D12)', () => {
+  it('appends the path, query, and hash of the original URL to the tunnel origin', () => {
+    expect(composeTunnelUrl('https://x.trycloudflare.com', 'http://localhost:5173/a/b?q=1#f')).toBe(
+      'https://x.trycloudflare.com/a/b?q=1#f',
+    );
+  });
+
+  it('an origin-only original URL composes to the bare tunnel origin', () => {
+    expect(composeTunnelUrl('https://x.trycloudflare.com', 'http://localhost:5173/')).toBe(
+      'https://x.trycloudflare.com/',
+    );
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/tunnel-claim.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/tunnel-claim.test.ts
@@ -1,0 +1,245 @@
+/**
+ * tunnel-claim — the URL tab's ownership state machine (#281, D10/AC12).
+ *
+ * A claim is this tab's evidence that the daemon currently holds a tunnel, on
+ * this daemon, on this port, that this tab caused to exist. It is the only
+ * input to `started` in the consumer registry, and `started` is the only thing
+ * that lets a release stop a tunnel — so every row below is a rule about when
+ * closing a tab may kill cloudflared.
+ *
+ * There is deliberately **no watchdog case**: `ClaimSignal` carries no timeout
+ * member, which is how the 120 s watchdog (a client timer the spec calls
+ * non-terminal, D11/AC9) is kept from revoking a live claim. Do not add one.
+ */
+import { describe, it, expect } from 'vitest';
+import { claimOwns, claimReducer, entryDaemonState, type ClaimSignal, type TunnelClaim } from '../tunnel-claim';
+import type { PortTunnelEntry } from '../../../store/port-tunnels';
+
+const HTTP = 31415;
+const PORT = 5173;
+
+const claim = (overrides: Partial<TunnelClaim> = {}): TunnelClaim => ({
+  httpPort: HTTP,
+  port: PORT,
+  attempt: 0,
+  sawEntry: false,
+  ...overrides,
+});
+
+const issued = (overrides: Partial<Extract<ClaimSignal, { type: 'start-issued' }>> = {}): ClaimSignal => ({
+  type: 'start-issued',
+  httpPort: HTTP,
+  port: PORT,
+  attempt: 0,
+  entryExisted: false,
+  ...overrides,
+});
+
+const daemonState = (state: ReturnType<typeof entryDaemonState>, port = PORT, httpPort = HTTP): ClaimSignal => ({
+  type: 'daemon-state',
+  httpPort,
+  port,
+  state,
+});
+
+describe('entryDaemonState', () => {
+  it('reads no entry as an absent tunnel', () => {
+    expect(entryDaemonState(undefined)).toBe('absent');
+  });
+
+  it('reads a live entry as its own state', () => {
+    expect(entryDaemonState({ state: 'starting' })).toBe('starting');
+    expect(entryDaemonState({ state: 'ready', url: 'https://a.trycloudflare.com' })).toBe('ready');
+  });
+
+  it('reads an unmarked error as daemon truth: the daemon holds nothing', () => {
+    expect(entryDaemonState({ state: 'error', error: 'cloudflared exited' })).toBe('error');
+  });
+
+  it('reads a client-written error as unknown — a chip’s rejected start POST is not daemon truth', () => {
+    const entry: PortTunnelEntry = { state: 'error', error: 'fetch failed', errorOrigin: 'client' };
+    expect(entryDaemonState(entry)).toBe('unknown');
+  });
+});
+
+describe('claimReducer — rebind', () => {
+  const rebind = (port: number | null, httpPort = HTTP): ClaimSignal => ({ type: 'rebind', httpPort, port });
+
+  it('keeps a claim rebound to the same daemon and port', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, rebind(PORT))).toBe(c);
+  });
+
+  it('drops a claim when the tab retargets to another port', () => {
+    expect(claimReducer(claim({ sawEntry: true }), rebind(4000))).toBeNull();
+  });
+
+  it('drops a claim when the tab stops classifying as tunnellable at all', () => {
+    expect(claimReducer(claim(), rebind(null))).toBeNull();
+  });
+
+  it('drops a claim made against another daemon', () => {
+    expect(claimReducer(claim(), rebind(PORT, 31500))).toBeNull();
+  });
+
+  it('is a no-op with no claim', () => {
+    expect(claimReducer(null, rebind(PORT))).toBeNull();
+  });
+});
+
+describe('claimReducer — start-issued', () => {
+  it('claims the port when the store showed no entry as the POST went out', () => {
+    expect(claimReducer(null, issued())).toEqual(claim());
+  });
+
+  it('claims nothing when an entry already existed — this tab joined, it did not create', () => {
+    expect(claimReducer(null, issued({ entryExisted: true }))).toBeNull();
+  });
+
+  it('keeps an owner across Retry and rebinds the attempt (D10)', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, issued({ attempt: 1, entryExisted: true }))).toEqual({ ...c, attempt: 1 });
+  });
+
+  it('an owner retrying against an empty store keeps the claim with sawEntry reset', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, issued({ attempt: 1 }))).toEqual({ ...c, attempt: 1, sawEntry: false });
+  });
+
+  it.each([false, true])(
+    'never transfers a stale other-port claim onto the new port (entryExisted: %s)',
+    (entryExisted) => {
+      expect(claimReducer(claim(), issued({ port: 4000, entryExisted }))).toBeNull();
+    },
+  );
+
+  it('never transfers a claim made against another daemon', () => {
+    expect(claimReducer(claim(), issued({ httpPort: 31500 }))).toBeNull();
+  });
+});
+
+describe('claimReducer — start-rejected', () => {
+  const rejected = (attempt: number, port = PORT, httpPort = HTTP): ClaimSignal => ({
+    type: 'start-rejected',
+    httpPort,
+    port,
+    attempt,
+  });
+
+  it('revokes the claim its own attempt made', () => {
+    expect(claimReducer(claim({ sawEntry: true }), rejected(0))).toBeNull();
+  });
+
+  it('leaves a later attempt’s claim alone', () => {
+    const c = claim({ attempt: 1, sawEntry: true });
+    expect(claimReducer(c, rejected(0))).toBe(c);
+  });
+
+  it('a hung attempt-0 POST that rejects after attempt 1 succeeded never revokes attempt 1', () => {
+    let c = claimReducer(null, issued({ attempt: 0 }));
+    c = claimReducer(c, { type: 'local-clear', httpPort: HTTP, port: PORT });
+    c = claimReducer(c, issued({ attempt: 1 }));
+    c = claimReducer(c, daemonState('ready'));
+    expect(claimReducer(c, rejected(0))).toEqual(claim({ attempt: 1, sawEntry: true }));
+  });
+
+  it('ignores a rejection for another port or another daemon', () => {
+    const c = claim();
+    expect(claimReducer(c, rejected(0, 4000))).toBe(c);
+    expect(claimReducer(c, rejected(0, PORT, 31500))).toBe(c);
+  });
+});
+
+describe('claimReducer — daemon-state', () => {
+  it.each(['starting', 'ready'] as const)('records that the daemon holds a tunnel (%s)', (state) => {
+    expect(claimReducer(claim(), daemonState(state))).toEqual(claim({ sawEntry: true }));
+  });
+
+  it('does not churn the claim once the entry has been seen', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, daemonState('ready'))).toBe(c);
+  });
+
+  it('revokes on a daemon-sourced error — the daemon holds no live tunnel', () => {
+    expect(claimReducer(claim({ sawEntry: true }), daemonState('error'))).toBeNull();
+  });
+
+  it('revokes when a tunnel this claim watched disappears', () => {
+    expect(claimReducer(claim({ sawEntry: true }), daemonState('absent'))).toBeNull();
+  });
+
+  it('keeps a claim whose start is still in flight — no entry yet is not a gone entry', () => {
+    const c = claim();
+    expect(claimReducer(c, daemonState('absent'))).toBe(c);
+  });
+
+  it.each([true, false])('an unknown entry moves nothing (sawEntry: %s)', (sawEntry) => {
+    const c = claim({ sawEntry });
+    expect(claimReducer(c, daemonState('unknown'))).toBe(c);
+  });
+
+  it('ignores state on another port or another daemon', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, daemonState('error', 4000))).toBe(c);
+    expect(claimReducer(c, daemonState('error', PORT, 31500))).toBe(c);
+  });
+
+  it('is a no-op with no claim', () => {
+    expect(claimReducer(null, daemonState('ready'))).toBeNull();
+  });
+});
+
+describe('claimReducer — local-clear', () => {
+  const localClear = (port = PORT, httpPort = HTTP): ClaimSignal => ({ type: 'local-clear', httpPort, port });
+
+  it('keeps the claim but forgets the entry a Retry just cleared', () => {
+    expect(claimReducer(claim({ sawEntry: true }), localClear())).toEqual(claim({ sawEntry: false }));
+  });
+
+  it('so the absent entry that follows a Retry does not revoke the claim', () => {
+    const cleared = claimReducer(claim({ sawEntry: true }), localClear());
+    expect(claimReducer(cleared, daemonState('absent'))).toEqual(claim({ sawEntry: false }));
+  });
+
+  it('does not churn a claim that has seen no entry', () => {
+    const c = claim();
+    expect(claimReducer(c, localClear())).toBe(c);
+  });
+
+  it('ignores a clear on another port or another daemon', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimReducer(c, localClear(4000))).toBe(c);
+    expect(claimReducer(c, localClear(PORT, 31500))).toBe(c);
+  });
+});
+
+describe('claimReducer — signals for a port this claim does not name', () => {
+  const foreign: ClaimSignal[] = [
+    issued({ port: 4000, entryExisted: true }),
+    { type: 'start-rejected', httpPort: HTTP, port: 4000, attempt: 0 },
+    daemonState('error', 4000),
+    daemonState('absent', 4000),
+    { type: 'local-clear', httpPort: HTTP, port: 4000 },
+  ];
+
+  it.each(foreign.map((s) => [s.type, s] as const))('%s leaves the claim untouched by reference', (_type, signal) => {
+    const c = claim({ sawEntry: true });
+    // start-issued is the one signal that reacts to a mismatch, by dropping.
+    const expected = signal.type === 'start-issued' ? null : c;
+    expect(claimReducer(c, signal)).toBe(expected);
+  });
+});
+
+describe('claimOwns', () => {
+  it('owns nothing without a claim', () => {
+    expect(claimOwns(null, HTTP, PORT)).toBe(false);
+  });
+
+  it('owns only the exact daemon-and-port pair it named', () => {
+    const c = claim({ sawEntry: true });
+    expect(claimOwns(c, HTTP, PORT)).toBe(true);
+    expect(claimOwns(c, HTTP, 4000)).toBe(false);
+    expect(claimOwns(c, 31500, PORT)).toBe(false);
+    expect(claimOwns(c, HTTP, null)).toBe(false);
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/url-tab-id.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/url-tab-id.test.ts
@@ -1,0 +1,31 @@
+/**
+ * urlTabId / urlTabTitle — pure identity helpers for a `url` Run tab (#281).
+ *
+ * The id must be a valid webview-label fragment ([A-Za-z0-9_-] only, per the
+ * plan's AC16) and unique per call so two tabs on the same URL never collide.
+ * The title is the host the user sees in the tab strip.
+ */
+import { describe, it, expect } from 'vitest';
+import { urlTabId, urlTabTitle } from '../url-tab-id';
+
+describe('urlTabId', () => {
+  it('matches the sanitized id charset', () => {
+    expect(urlTabId('http://localhost:5173/a/b?q=1#frag')).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('produces a different id on each call for the same URL', () => {
+    const first = urlTabId('http://localhost:5173/');
+    const second = urlTabId('http://localhost:5173/');
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('urlTabTitle', () => {
+  it('is the host and port for a non-default port', () => {
+    expect(urlTabTitle('http://localhost:5173/a?q=1')).toBe('localhost:5173');
+  });
+
+  it('omits the port when it is the scheme default', () => {
+    expect(urlTabTitle('https://example.com/x')).toBe('example.com');
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/url-tab-tunnel-harness.tsx
+++ b/packages/ui/src/features/url-tab/__tests__/url-tab-tunnel-harness.tsx
@@ -1,0 +1,78 @@
+/**
+ * Shared scaffolding for `UrlTabInstance` tunnel tests (#281). Extracted once a
+ * third file needed the same fake handle/host, store seeding, and render
+ * wrapper as `UrlTabInstance.tunnel.test.tsx` and
+ * `UrlTabInstance.tunnel-retarget-ownership.test.tsx` (project rule: extract at
+ * 3+ duplications).
+ *
+ * No `vi.mock(...)` here — those calls are hoisted per module and cannot move
+ * out of the test files that need them. This file is not itself collected as a
+ * test (`vitest.config.ts` only picks up `*.test.tsx`/`*.test.ts`).
+ */
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { PreviewHandle } from '@qlan-ro/mainframe-types';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { HostProvider, setHostForTesting } from '@/lib/host';
+import { useLayoutStore } from '@/store/layout';
+import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
+import { useSandboxStore } from '@/store/sandbox';
+import { UrlTabInstance } from '../UrlTabInstance';
+
+const FRESH_LAYOUT = { top: ['run' as const], bottom: null as null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
+
+export function makeFakeHandle(): PreviewHandle {
+  return {
+    setVisible: vi.fn(),
+    compositesAboveDom: false,
+    navigate: vi.fn().mockResolvedValue(undefined),
+    capture: vi.fn().mockResolvedValue(new Uint8Array()),
+    startInspect: vi.fn().mockResolvedValue(undefined),
+    onInspect: vi.fn().mockReturnValue(() => {}),
+    startRegionSelect: vi.fn().mockResolvedValue(undefined),
+    onRegionSelect: vi.fn().mockReturnValue(() => {}),
+    onNavigate: vi.fn().mockReturnValue(() => {}),
+    refit: vi.fn(),
+    reanchor: vi.fn(),
+    setDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+}
+
+let installedHost: FakeHostBridge | null = null;
+
+/** Installs a fresh fake host + webview handle and points `setHostForTesting` at it. */
+export function installFakeHost(): { fakeHost: FakeHostBridge; fakeHandle: PreviewHandle } {
+  const fakeHandle = makeFakeHandle();
+  const fakeHost = new FakeHostBridge();
+  fakeHost.preview.mount = vi.fn().mockReturnValue(fakeHandle);
+  setHostForTesting(fakeHost);
+  installedHost = fakeHost;
+  return { fakeHost, fakeHandle };
+}
+
+/** Resets the sandbox, port-tunnels, and layout stores to a fresh, empty baseline. */
+export function seedStores(): void {
+  useSandboxStore.setState({
+    captures: [],
+    logsOutput: [],
+    selectedConfigByScope: {},
+    lastStartedProcess: null,
+    processStatuses: {},
+  });
+  usePortTunnelsStore.setState({ byPort: {}, daemonPort: 31415, generation: 0 });
+  useLayoutStore.setState({ layout: { ...FRESH_LAYOUT }, run: null, sessions: new Map(), activeSessionId: null });
+}
+
+export function setPortEntry(port: number, entry: PortTunnelEntry): void {
+  usePortTunnelsStore.setState((s) => ({ byPort: { ...s.byPort, [port]: entry }, generation: s.generation + 1 }));
+}
+
+/** Renders `UrlTabInstance`, visible, wrapped in the host installed by `installFakeHost`. */
+export function renderTab(url: string, { tabId = 't1' }: { tabId?: string } = {}) {
+  if (installedHost === null) throw new Error('renderTab() called before installFakeHost()');
+  const host = installedHost;
+  return render(<UrlTabInstance tabId={tabId} url={url} visible />, {
+    wrapper: ({ children }) => <HostProvider host={host}>{children}</HostProvider>,
+  });
+}

--- a/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure reducers over the URL-tab tunnel-ownership registry (#281, D10, AC12).
+ *
+ * `started: true` means this tab's own POST started the tunnel; `started: false`
+ * means it merely adopted one another tab already owns. Only an owner's release
+ * should ever stop a tunnel, and only when no other consumer remains on the port.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  addConsumer,
+  clearConsumers,
+  releaseConsumers,
+  emptyConsumerState,
+  type ConsumerRecord,
+} from '../url-tunnel-ownership';
+
+const rec = (port: number, started: boolean): ConsumerRecord => ({ port, started, daemonHttpPort: 31415 });
+
+describe('releaseConsumers', () => {
+  it('stops the port when the released tab started it and is the only consumer', () => {
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    const { next, stop } = releaseConsumers(state, ['tab-1']);
+    expect(stop).toEqual([{ port: 5173, daemonHttpPort: 31415 }]);
+    expect(next.byTab).toEqual({});
+  });
+
+  it('does not stop when the released tab only adopted the tunnel and is the only consumer', () => {
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false));
+    const { next, stop } = releaseConsumers(state, ['tab-1']);
+    expect(stop).toEqual([]);
+    expect(next.byTab).toEqual({});
+  });
+
+  it('does not stop while another consumer remains on the port', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    state = addConsumer(state, 'tab-2', rec(5173, false));
+    const { next, stop } = releaseConsumers(state, ['tab-1']);
+    expect(stop).toEqual([]);
+    expect(next.byTab).toEqual({ 'tab-2': rec(5173, false) });
+  });
+
+  it('stops the port once, not twice, when both consumers are released together', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    state = addConsumer(state, 'tab-2', rec(5173, false));
+    const { next, stop } = releaseConsumers(state, ['tab-1', 'tab-2']);
+    expect(stop).toEqual([{ port: 5173, daemonHttpPort: 31415 }]);
+    expect(next.byTab).toEqual({});
+  });
+
+  it('releasing an unknown tab id is a no-op and returns the same state reference', () => {
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    const { next, stop } = releaseConsumers(state, ['nope']);
+    expect(stop).toEqual([]);
+    expect(next).toBe(state);
+  });
+});
+
+describe('clearConsumers', () => {
+  it('empties the registry without producing any stops', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    state = addConsumer(state, 'tab-2', rec(8080, false));
+    const cleared = clearConsumers(state);
+    expect(cleared.byTab).toEqual({});
+  });
+});
+
+describe('addConsumer — ownership persistence (D10, AC12)', () => {
+  it('re-registering on the same port with started: false keeps started: true', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    state = addConsumer(state, 'tab-1', rec(5173, false));
+    expect(state.byTab['tab-1']).toEqual(rec(5173, true));
+  });
+
+  it('re-registering on a different port takes the new started verbatim: true to false', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    state = addConsumer(state, 'tab-1', rec(8080, false));
+    expect(state.byTab['tab-1']).toEqual(rec(8080, false));
+  });
+
+  it('re-registering on a different port takes the new started verbatim: false to true', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false));
+    state = addConsumer(state, 'tab-1', rec(8080, true));
+    expect(state.byTab['tab-1']).toEqual(rec(8080, true));
+  });
+});

--- a/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
@@ -18,37 +18,37 @@ const rec = (port: number, started: boolean): ConsumerRecord => ({ port, started
 
 describe('releaseConsumers', () => {
   it('stops the port when the released tab started it and is the only consumer', () => {
-    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
     const { next, stop } = releaseConsumers(state, ['tab-1']);
     expect(stop).toEqual([{ port: 5173, daemonHttpPort: 31415 }]);
     expect(next.byTab).toEqual({});
   });
 
   it('does not stop when the released tab only adopted the tunnel and is the only consumer', () => {
-    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false));
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false)).next;
     const { next, stop } = releaseConsumers(state, ['tab-1']);
     expect(stop).toEqual([]);
     expect(next.byTab).toEqual({});
   });
 
   it('does not stop while another consumer remains on the port', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
-    state = addConsumer(state, 'tab-2', rec(5173, false));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-2', rec(5173, false)).next;
     const { next, stop } = releaseConsumers(state, ['tab-1']);
     expect(stop).toEqual([]);
     expect(next.byTab).toEqual({ 'tab-2': rec(5173, false) });
   });
 
   it('stops the port once, not twice, when both consumers are released together', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
-    state = addConsumer(state, 'tab-2', rec(5173, false));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-2', rec(5173, false)).next;
     const { next, stop } = releaseConsumers(state, ['tab-1', 'tab-2']);
     expect(stop).toEqual([{ port: 5173, daemonHttpPort: 31415 }]);
     expect(next.byTab).toEqual({});
   });
 
   it('releasing an unknown tab id is a no-op and returns the same state reference', () => {
-    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
     const { next, stop } = releaseConsumers(state, ['nope']);
     expect(stop).toEqual([]);
     expect(next).toBe(state);
@@ -57,8 +57,8 @@ describe('releaseConsumers', () => {
 
 describe('clearConsumers', () => {
   it('empties the registry without producing any stops', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
-    state = addConsumer(state, 'tab-2', rec(8080, false));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-2', rec(8080, false)).next;
     const cleared = clearConsumers(state);
     expect(cleared.byTab).toEqual({});
   });
@@ -66,20 +66,44 @@ describe('clearConsumers', () => {
 
 describe('addConsumer — ownership persistence (D10, AC12)', () => {
   it('re-registering on the same port with started: false keeps started: true', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
-    state = addConsumer(state, 'tab-1', rec(5173, false));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-1', rec(5173, false)).next;
     expect(state.byTab['tab-1']).toEqual(rec(5173, true));
   });
 
   it('re-registering on a different port takes the new started verbatim: true to false', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true));
-    state = addConsumer(state, 'tab-1', rec(8080, false));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-1', rec(8080, false)).next;
     expect(state.byTab['tab-1']).toEqual(rec(8080, false));
   });
 
   it('re-registering on a different port takes the new started verbatim: false to true', () => {
-    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false));
-    state = addConsumer(state, 'tab-1', rec(8080, true));
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false)).next;
+    state = addConsumer(state, 'tab-1', rec(8080, true)).next;
     expect(state.byTab['tab-1']).toEqual(rec(8080, true));
+  });
+});
+
+describe('addConsumer — retarget releases the abandoned port (AC12/D10)', () => {
+  it('an owned port stops when its sole tab retargets to a different port', () => {
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    const { next, stop } = addConsumer(state, 'tab-1', rec(8080, false));
+    expect(stop).toEqual([{ port: 5173, daemonHttpPort: 31415 }]);
+    expect(next.byTab).toEqual({ 'tab-1': rec(8080, false) });
+  });
+
+  it('an owned port shared with another tab does not stop on retarget', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
+    state = addConsumer(state, 'tab-2', rec(5173, false)).next;
+    const { next, stop } = addConsumer(state, 'tab-1', rec(8080, true));
+    expect(stop).toEqual([]);
+    expect(next.byTab).toEqual({ 'tab-1': rec(8080, true), 'tab-2': rec(5173, false) });
+  });
+
+  it('an adopted (not owned) port never stops on retarget', () => {
+    const state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false)).next;
+    const { next, stop } = addConsumer(state, 'tab-1', rec(8080, false));
+    expect(stop).toEqual([]);
+    expect(next.byTab).toEqual({ 'tab-1': rec(8080, false) });
   });
 });

--- a/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
@@ -66,9 +66,9 @@ describe('clearConsumers', () => {
 
 describe('addConsumer — ownership persistence (D10, AC12)', () => {
   // Retry's D10 guarantee ("stays owner across retries") is enforced by the
-  // hook's `ownedPort` state, not here: a same-port re-register takes
-  // `started` verbatim so an explicit disown (review-fix findings 1+2) is
-  // never swallowed by a stale prior `true`.
+  // claim reducer, not here: a same-port re-register takes `started` verbatim
+  // so an explicit disown (review-fix findings 1+2) is never swallowed by a
+  // stale prior `true`.
   it('re-registering on the same port takes the new started verbatim: true to false', () => {
     let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
     state = addConsumer(state, 'tab-1', rec(5173, false)).next;

--- a/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
+++ b/packages/ui/src/features/url-tab/__tests__/url-tunnel-ownership.test.ts
@@ -65,9 +65,19 @@ describe('clearConsumers', () => {
 });
 
 describe('addConsumer — ownership persistence (D10, AC12)', () => {
-  it('re-registering on the same port with started: false keeps started: true', () => {
+  // Retry's D10 guarantee ("stays owner across retries") is enforced by the
+  // hook's `ownedPort` state, not here: a same-port re-register takes
+  // `started` verbatim so an explicit disown (review-fix findings 1+2) is
+  // never swallowed by a stale prior `true`.
+  it('re-registering on the same port takes the new started verbatim: true to false', () => {
     let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, true)).next;
     state = addConsumer(state, 'tab-1', rec(5173, false)).next;
+    expect(state.byTab['tab-1']).toEqual(rec(5173, false));
+  });
+
+  it('re-registering on the same port takes the new started verbatim: false to true', () => {
+    let state = addConsumer(emptyConsumerState, 'tab-1', rec(5173, false)).next;
+    state = addConsumer(state, 'tab-1', rec(5173, true)).next;
     expect(state.byTab['tab-1']).toEqual(rec(5173, true));
   });
 

--- a/packages/ui/src/features/url-tab/resolve-url-target.ts
+++ b/packages/ui/src/features/url-tab/resolve-url-target.ts
@@ -1,0 +1,91 @@
+/**
+ * resolveUrlTabTarget / composeTunnelUrl — pure tunnel-state resolution for a
+ * `url` Run tab (#281). Table-drives the priority-ordered contract below over
+ * a snapshot of the port-tunnels store, this tab's own start attempt, and its
+ * watchdog — never touches the store directly, so every case is a pure input.
+ */
+import { classifyLocalhostUrl, isTunnelEligiblePort } from '@qlan-ro/mainframe-types';
+import { normalizePreviewUrl } from '../preview/normalize-url';
+import type { PortTunnelEntry } from '../../store/port-tunnels';
+
+export type UrlTabTarget =
+  | { kind: 'direct'; url: string }
+  | { kind: 'tunnelled'; url: string }
+  | { kind: 'pending'; port: number }
+  | { kind: 'rejected'; port: number; reason: string }
+  | { kind: 'failed'; error: string }
+  | { kind: 'stopped'; port: number }
+  | { kind: 'invalid'; url: string };
+
+export interface UrlTabTunnelInput {
+  /** Normalized, user-committed address. */
+  url: string;
+  isLocal: boolean;
+  /** The daemon's own port from the tunnel snapshot — not the HTTP client port. */
+  daemonPort: number | null;
+  entry: PortTunnelEntry | undefined;
+  /** This tab attached while the tunnel was absent or starting (it owns the in-flight start). */
+  watching: boolean;
+  /** The URL this tab's own POST /tunnel/ports/start returned. */
+  startUrl: string | null;
+  /** The 120s watchdog fired. */
+  timedOut: boolean;
+  /** An entry existed for this port during this attempt and then disappeared. */
+  everHadEntry: boolean;
+}
+
+export const URL_TAB_TUNNEL_TIMEOUT_MS = 120_000;
+
+/** The daemon's own rejection strings, verbatim — `null` when the port is tunnel-eligible. */
+export function portRejectionReason(port: number, daemonPort: number): string | null {
+  if (port < 1024) return 'Port must be 1024 or higher';
+  if (port === daemonPort) return "Cannot tunnel the daemon's own port";
+  if (!isTunnelEligiblePort(port, daemonPort)) return `Port ${port} cannot be tunnelled`;
+  return null;
+}
+
+/** Steps 5–8: what to show once the URL is loopback, has a daemon port, and is tunnel-eligible. */
+function resolveEntryTarget(input: UrlTabTunnelInput, port: number): UrlTabTarget {
+  const { entry, watching, startUrl, timedOut, everHadEntry, url } = input;
+
+  if (entry === undefined) {
+    if (everHadEntry) return { kind: 'stopped', port };
+    return startUrl !== null ? { kind: 'tunnelled', url: composeTunnelUrl(startUrl, url) } : { kind: 'pending', port };
+  }
+
+  if (entry.state === 'error') return { kind: 'failed', error: entry.error ?? 'Tunnel failed to start' };
+
+  const tunnelOrigin = entry.state === 'ready' ? (entry.url ?? startUrl) : undefined;
+  const gateOpen = !watching || startUrl !== null || entry.dnsVerified === true;
+  if (tunnelOrigin && gateOpen) return { kind: 'tunnelled', url: composeTunnelUrl(tunnelOrigin, url) };
+
+  if (timedOut) return { kind: 'failed', error: 'The tunnel did not produce a URL within 120 seconds' };
+  return { kind: 'pending', port };
+}
+
+export function resolveUrlTabTarget(input: UrlTabTunnelInput): UrlTabTarget {
+  const { url, isLocal, daemonPort } = input;
+  if (normalizePreviewUrl(url) === null) return { kind: 'invalid', url };
+  if (isLocal) return { kind: 'direct', url };
+
+  const local = classifyLocalhostUrl(url);
+  if (local === null) return { kind: 'direct', url };
+  if (daemonPort === null) return { kind: 'pending', port: local.port };
+
+  const reason = portRejectionReason(local.port, daemonPort);
+  if (reason !== null) return { kind: 'rejected', port: local.port, reason };
+
+  return resolveEntryTarget(input, local.port);
+}
+
+/** Append the path/query/hash of `originalUrl` onto `tunnelOrigin`; unparsable input passes through unchanged. */
+export function composeTunnelUrl(tunnelOrigin: string, originalUrl: string): string {
+  try {
+    const tunnel = new URL(tunnelOrigin);
+    const original = new URL(originalUrl);
+    return `${tunnel.origin}${original.pathname}${original.search}${original.hash}`;
+  } catch {
+    /* expected: defensive only — both inputs come from already-validated sources */
+    return tunnelOrigin;
+  }
+}

--- a/packages/ui/src/features/url-tab/tunnel-claim-registry.ts
+++ b/packages/ui/src/features/url-tab/tunnel-claim-registry.ts
@@ -1,0 +1,44 @@
+/**
+ * Module-level home for each URL tab's tunnel claim, keyed by `tabId`
+ * (#281, D10, AC12, review-fix findings 1+3).
+ *
+ * A `TunnelClaim` used to live in `useTunnelClaim`'s component-local
+ * `useReducer` state, so it reset to `null` on every mount. The consumer
+ * registry it feeds (`tunnel-consumers.ts`) is module-level and survives a
+ * session-switch unmount — so a remount against an already-`ready` port never
+ * re-issues a start (nothing is pending), the claim came back empty, and the
+ * next registration silently downgraded a real `started: true` to `false`,
+ * leaking the tunnel it exclusively started.
+ *
+ * Storing the claim here, alongside the tab id the consumer registry already
+ * uses, lets a remount rehydrate its own prior evidence instead of losing it.
+ * Dropped only where a tab's consumer record is dropped — `tunnel-consumers.ts`
+ * — never on unmount, since unmounting (a session switch) is not closing.
+ */
+import type { TunnelClaim } from './tunnel-claim';
+
+let claims: Record<string, TunnelClaim | null> = {};
+
+/** Seeds `useTunnelClaim`'s reducer on (re)mount. */
+export function getStoredClaim(tabId: string): TunnelClaim | null {
+  return claims[tabId] ?? null;
+}
+
+/** Written back whenever the claim reducer produces a new value. */
+export function setStoredClaim(tabId: string, claim: TunnelClaim | null): void {
+  if (claims[tabId] === claim) return;
+  claims = { ...claims, [tabId]: claim };
+}
+
+/** Companion to `releaseConsumers`: drop the claims for tabs whose consumer record just left. */
+export function dropStoredClaims(tabIds: string[]): void {
+  if (tabIds.length === 0) return;
+  const next = { ...claims };
+  for (const id of tabIds) delete next[id];
+  claims = next;
+}
+
+/** Companion to `clearConsumers`: daemon-switch cleanup. */
+export function clearStoredClaims(): void {
+  claims = {};
+}

--- a/packages/ui/src/features/url-tab/tunnel-claim-registry.ts
+++ b/packages/ui/src/features/url-tab/tunnel-claim-registry.ts
@@ -1,6 +1,6 @@
 /**
  * Module-level home for each URL tab's tunnel claim, keyed by `tabId`
- * (#281, D10, AC12, review-fix findings 1+3).
+ * (#281, D10, AC12, review-fix findings 1+3+NEW).
  *
  * A `TunnelClaim` used to live in `useTunnelClaim`'s component-local
  * `useReducer` state, so it reset to `null` on every mount. The consumer
@@ -14,20 +14,59 @@
  * uses, lets a remount rehydrate its own prior evidence instead of losing it.
  * Dropped only where a tab's consumer record is dropped — `tunnel-consumers.ts`
  * — never on unmount, since unmounting (a session switch) is not closing.
+ *
+ * The `daemon-state` signal — the one that can *revoke* a claim — used to be
+ * dispatched from a `useEffect` in `useTunnelClaim`, so it died with the same
+ * unmount this module was built to survive: the daemon could drop the tunnel
+ * and hand the port to a foreign consumer while the tab was unmounted, the
+ * claim would never observe either, and a remount would rehydrate as owner and
+ * later stop a tunnel it doesn't own. This module now applies `daemon-state`
+ * to every stored claim itself, from a subscription to the port-tunnels store
+ * that is installed once at import time and outlives any component. Only the
+ * action-scoped signals (`rebind`/`start-issued`/`start-rejected`/
+ * `local-clear`) still come from the acting component; `useTunnelClaim` is a
+ * reader of whatever this module has already decided.
  */
-import type { TunnelClaim } from './tunnel-claim';
+import { usePortTunnelsStore } from '@/store/port-tunnels';
+import { claimReducer, entryDaemonState, type ClaimSignal, type TunnelClaim } from './tunnel-claim';
 
 let claims: Record<string, TunnelClaim | null> = {};
+const listeners = new Map<string, Set<() => void>>();
 
-/** Seeds `useTunnelClaim`'s reducer on (re)mount. */
+function notify(tabId: string): void {
+  const set = listeners.get(tabId);
+  if (set === undefined) return;
+  for (const listener of set) listener();
+}
+
+/** Current claim for a tab, read fresh on every render — this module is the source of truth. */
 export function getStoredClaim(tabId: string): TunnelClaim | null {
   return claims[tabId] ?? null;
 }
 
-/** Written back whenever the claim reducer produces a new value. */
-export function setStoredClaim(tabId: string, claim: TunnelClaim | null): void {
+/** `useSyncExternalStore` subscription so a mounted tab re-renders when its claim changes. */
+export function subscribeClaim(tabId: string, listener: () => void): () => void {
+  let set = listeners.get(tabId);
+  if (set === undefined) {
+    set = new Set();
+    listeners.set(tabId, set);
+  }
+  set.add(listener);
+  return () => {
+    set.delete(listener);
+    if (set.size === 0) listeners.delete(tabId);
+  };
+}
+
+function setStoredClaim(tabId: string, claim: TunnelClaim | null): void {
   if (claims[tabId] === claim) return;
   claims = { ...claims, [tabId]: claim };
+  notify(tabId);
+}
+
+/** Runs one `ClaimSignal` through the reducer for `tabId` and stores the result. */
+export function noteClaim(tabId: string, signal: ClaimSignal): void {
+  setStoredClaim(tabId, claimReducer(getStoredClaim(tabId), signal));
 }
 
 /** Companion to `releaseConsumers`: drop the claims for tabs whose consumer record just left. */
@@ -36,9 +75,29 @@ export function dropStoredClaims(tabIds: string[]): void {
   const next = { ...claims };
   for (const id of tabIds) delete next[id];
   claims = next;
+  for (const id of tabIds) notify(id);
 }
 
 /** Companion to `clearConsumers`: daemon-switch cleanup. */
 export function clearStoredClaims(): void {
+  const ids = Object.keys(claims);
   claims = {};
+  for (const id of ids) notify(id);
 }
+
+// Mount-independent revocation (review-fix NEW finding): mirrors every write
+// the port-tunnels store makes, not just the ones a mounted tab's own effect
+// happens to observe, so a claim is revoked even while its tab is unmounted.
+usePortTunnelsStore.subscribe((state, prev) => {
+  for (const [tabId, claim] of Object.entries(claims)) {
+    if (claim === null) continue;
+    const entry = state.byPort[claim.port];
+    if (entry === prev.byPort[claim.port]) continue;
+    noteClaim(tabId, {
+      type: 'daemon-state',
+      httpPort: claim.httpPort,
+      port: claim.port,
+      state: entryDaemonState(entry),
+    });
+  }
+});

--- a/packages/ui/src/features/url-tab/tunnel-claim.ts
+++ b/packages/ui/src/features/url-tab/tunnel-claim.ts
@@ -1,0 +1,117 @@
+/**
+ * tunnel-claim — when a URL tab may stop the port tunnel it is looking at
+ * (#281, D10/AC12).
+ *
+ * A **claim** is this tab's evidence that the daemon currently holds a tunnel,
+ * on this daemon, on this port, that this tab caused to exist. It is the only
+ * input to `started` in the consumer registry, and `started` is the only thing
+ * that lets a release stop a tunnel — so a claim that outlives its evidence
+ * kills someone else's tunnel, and one that dies too early leaks cloudflared.
+ *
+ * Creation evidence is a client inference: `POST /api/tunnel/ports/start`
+ * answers identically whether it created the tunnel or joined one, so "this tab
+ * created it" means the store held no entry for the port as the POST went out.
+ *
+ * Three facts a reader must not undo:
+ *
+ * 1. **The signal union carries no timeout member.** The 120 s watchdog is a
+ *    client timer the spec calls non-terminal (D11), and AC9 requires a tunnel
+ *    that arrives late to still load — so it says nothing about what the daemon
+ *    holds and must never revoke a claim. The fix is the absent case.
+ * 2. **`start-rejected` is attempt-scoped.** A hung attempt's POST can reject
+ *    long after a later attempt succeeded; only its own attempt's claim dies.
+ * 3. **A client-written error entry is `'unknown'`, not `'error'`.** Three
+ *    producers write `error` entries and only `applyPortTunnelEvent` speaks for
+ *    the daemon; a chip's rejected start POST on this port must not revoke a
+ *    live claim (`errorOrigin`, `store/port-tunnels.ts`).
+ *
+ * Pure and React-free: `PortTunnelEntry` arrives as a type only, so a node-env
+ * test can import this module without dragging zustand or the WS client in.
+ */
+import type { PortTunnelEntry } from '../../store/port-tunnels';
+
+/** What the store's entry for a port says about the daemon — `'unknown'` when it says nothing. */
+export type DaemonPortState = 'absent' | 'starting' | 'ready' | 'error' | 'unknown';
+
+export interface TunnelClaim {
+  httpPort: number;
+  port: number;
+  /** The start attempt that last renewed this claim; a rejection from an older one is stale. */
+  attempt: number;
+  /** The daemon has been observed holding a tunnel on the port since this claim was made. */
+  sawEntry: boolean;
+}
+
+export type ClaimSignal =
+  | { type: 'rebind'; httpPort: number; port: number | null }
+  | { type: 'start-issued'; httpPort: number; port: number; attempt: number; entryExisted: boolean }
+  | { type: 'start-rejected'; httpPort: number; port: number; attempt: number }
+  | { type: 'daemon-state'; httpPort: number; port: number; state: DaemonPortState }
+  | { type: 'local-clear'; httpPort: number; port: number };
+
+export function entryDaemonState(entry: PortTunnelEntry | undefined): DaemonPortState {
+  if (entry === undefined) return 'absent';
+  if (entry.state !== 'error') return entry.state;
+  return entry.errorOrigin === 'client' ? 'unknown' : 'error';
+}
+
+function owns(claim: TunnelClaim | null, httpPort: number, port: number | null): claim is TunnelClaim {
+  return claim !== null && claim.httpPort === httpPort && claim.port === port;
+}
+
+/** Keeps the reference when nothing moved, so an idempotent signal re-renders nothing. */
+function update(claim: TunnelClaim, changes: Partial<Pick<TunnelClaim, 'attempt' | 'sawEntry'>>): TunnelClaim {
+  const next = { ...claim, ...changes };
+  return next.attempt === claim.attempt && next.sawEntry === claim.sawEntry ? claim : next;
+}
+
+export function claimReducer(claim: TunnelClaim | null, signal: ClaimSignal): TunnelClaim | null {
+  switch (signal.type) {
+    case 'rebind':
+      return owns(claim, signal.httpPort, signal.port) ? claim : null;
+
+    case 'start-issued': {
+      // An owner survives Retry (D10); `sawEntry` re-states what the store showed
+      // as this attempt's POST went out.
+      if (owns(claim, signal.httpPort, signal.port)) {
+        return update(claim, { attempt: signal.attempt, sawEntry: signal.entryExisted });
+      }
+      // A claim naming another port or daemon is stale — drop it rather than
+      // move it, so ownership is never transferred by a signal that only
+      // reports a start.
+      if (claim !== null) return null;
+      return signal.entryExisted
+        ? null
+        : { httpPort: signal.httpPort, port: signal.port, attempt: signal.attempt, sawEntry: false };
+    }
+
+    case 'start-rejected':
+      if (!owns(claim, signal.httpPort, signal.port)) return claim;
+      return claim.attempt === signal.attempt ? null : claim;
+
+    case 'daemon-state': {
+      if (!owns(claim, signal.httpPort, signal.port)) return claim;
+      switch (signal.state) {
+        case 'starting':
+        case 'ready':
+          return update(claim, { sawEntry: true });
+        case 'error':
+          return null;
+        case 'absent':
+          // Absent before any entry means the start is still in flight, not gone.
+          return claim.sawEntry ? null : claim;
+        case 'unknown':
+          return claim;
+      }
+    }
+
+    case 'local-clear':
+      // Retry cleared the entry locally; the daemon was told nothing, so the
+      // claim stands but has no observation behind it any more.
+      return owns(claim, signal.httpPort, signal.port) ? update(claim, { sawEntry: false }) : claim;
+  }
+}
+
+export function claimOwns(claim: TunnelClaim | null, httpPort: number, port: number | null): boolean {
+  return owns(claim, httpPort, port);
+}

--- a/packages/ui/src/features/url-tab/tunnel-consumers.ts
+++ b/packages/ui/src/features/url-tab/tunnel-consumers.ts
@@ -1,0 +1,41 @@
+/**
+ * Module-level tunnel-ownership registry for URL tabs (#281, D10, AC12).
+ *
+ * Wraps the pure `url-tunnel-ownership` reducers with the one side effect
+ * releasing an owner actually needs: stopping the tunnel on the daemon.
+ */
+import { stopPortTunnel } from '@/lib/api/tunnel-ports';
+import {
+  addConsumer,
+  clearConsumers,
+  emptyConsumerState,
+  releaseConsumers,
+  type ConsumerRecord,
+} from './url-tunnel-ownership';
+
+let state = emptyConsumerState;
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Register (or re-register) a URL tab's claim on a tunnelled port. Idempotent per tab id. */
+export function registerUrlTunnelConsumer(tabId: string, rec: ConsumerRecord): void {
+  state = addConsumer(state, tabId, rec);
+}
+
+/** Release the given tabs' claims, stopping any port whose last owner just left. */
+export function releaseUrlTunnelConsumers(tabIds: string[]): void {
+  const { next, stop } = releaseConsumers(state, tabIds);
+  state = next;
+  for (const { port, daemonHttpPort } of stop) {
+    stopPortTunnel(daemonHttpPort, port).catch((err: unknown) => {
+      console.warn(`[url-tab] failed to stop the tunnel on port ${port}`, message(err));
+    });
+  }
+}
+
+/** Daemon-switch cleanup: drop the registry without stopping anything (wrong-daemon risk). */
+export function clearUrlTunnelConsumers(): void {
+  state = clearConsumers(state);
+}

--- a/packages/ui/src/features/url-tab/tunnel-consumers.ts
+++ b/packages/ui/src/features/url-tab/tunnel-consumers.ts
@@ -5,6 +5,7 @@
  * releasing an owner actually needs: stopping the tunnel on the daemon.
  */
 import { stopPortTunnel } from '@/lib/api/tunnel-ports';
+import { clearStoredClaims, dropStoredClaims } from './tunnel-claim-registry';
 import {
   addConsumer,
   clearConsumers,
@@ -42,10 +43,12 @@ export function registerUrlTunnelConsumer(tabId: string, rec: ConsumerRecord): v
 export function releaseUrlTunnelConsumers(tabIds: string[]): void {
   const { next, stop } = releaseConsumers(state, tabIds);
   state = next;
+  dropStoredClaims(tabIds);
   stopTunnels(stop);
 }
 
 /** Daemon-switch cleanup: drop the registry without stopping anything (wrong-daemon risk). */
 export function clearUrlTunnelConsumers(): void {
   state = clearConsumers(state);
+  clearStoredClaims();
 }

--- a/packages/ui/src/features/url-tab/tunnel-consumers.ts
+++ b/packages/ui/src/features/url-tab/tunnel-consumers.ts
@@ -19,20 +19,30 @@ function message(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** Register (or re-register) a URL tab's claim on a tunnelled port. Idempotent per tab id. */
+function stopTunnels(stop: Array<{ port: number; daemonHttpPort: number }>): void {
+  for (const { port, daemonHttpPort } of stop) {
+    stopPortTunnel(daemonHttpPort, port).catch((err: unknown) => {
+      console.warn(`[url-tab] failed to stop the tunnel on port ${port}`, message(err));
+    });
+  }
+}
+
+/**
+ * Register (or re-register) a URL tab's claim on a tunnelled port. Idempotent
+ * per tab id. Retargeting to a different port releases the old one first
+ * (stopping it if this tab owned it and no other consumer remains).
+ */
 export function registerUrlTunnelConsumer(tabId: string, rec: ConsumerRecord): void {
-  state = addConsumer(state, tabId, rec);
+  const { next, stop } = addConsumer(state, tabId, rec);
+  state = next;
+  stopTunnels(stop);
 }
 
 /** Release the given tabs' claims, stopping any port whose last owner just left. */
 export function releaseUrlTunnelConsumers(tabIds: string[]): void {
   const { next, stop } = releaseConsumers(state, tabIds);
   state = next;
-  for (const { port, daemonHttpPort } of stop) {
-    stopPortTunnel(daemonHttpPort, port).catch((err: unknown) => {
-      console.warn(`[url-tab] failed to stop the tunnel on port ${port}`, message(err));
-    });
-  }
+  stopTunnels(stop);
 }
 
 /** Daemon-switch cleanup: drop the registry without stopping anything (wrong-daemon risk). */

--- a/packages/ui/src/features/url-tab/url-tab-id.ts
+++ b/packages/ui/src/features/url-tab/url-tab-id.ts
@@ -1,0 +1,32 @@
+/**
+ * urlTabId / urlTabTitle — pure identity helpers for a `url` Run tab (#281).
+ *
+ * The id doubles as the child webview's label, so it must stay inside Tauri's
+ * label charset — the URL itself must never leak into it.
+ */
+
+const DEFAULT_PORTS: Record<string, string> = { 'http:': '80', 'https:': '443' };
+
+/** A fresh id for a `url` tab — unique per call so two tabs on the same URL never collide. */
+export function urlTabId(url: string): string {
+  const uuid = crypto.randomUUID().slice(0, 8);
+  try {
+    const host = new URL(url).host.replace(/[^A-Za-z0-9_-]/g, '_');
+    return `url-${host}-${uuid}`;
+  } catch {
+    /* expected: defensive only — callers normalize the URL before creating a tab */
+    return `url-${uuid}`;
+  }
+}
+
+/** The tab-strip label: the host, plus `:port` when the port isn't the scheme default. */
+export function urlTabTitle(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const isDefaultPort = parsed.port === '' || parsed.port === DEFAULT_PORTS[parsed.protocol];
+    return isDefaultPort ? parsed.hostname : `${parsed.hostname}:${parsed.port}`;
+  } catch {
+    /* expected: defensive only — callers normalize the URL before creating a tab */
+    return url;
+  }
+}

--- a/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
+++ b/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure reducers over the URL-tab tunnel-ownership registry (#281, D10, AC12).
+ *
+ * `started: true` means this tab's own POST started the tunnel; `started: false`
+ * means it merely adopted one another tab already owns. Only an owner's release
+ * should ever stop a tunnel, and only when no other consumer remains on the port.
+ */
+
+export interface ConsumerRecord {
+  port: number;
+  started: boolean;
+  daemonHttpPort: number;
+}
+
+export interface ConsumerState {
+  byTab: Record<string, ConsumerRecord>;
+}
+
+export const emptyConsumerState: ConsumerState = { byTab: {} };
+
+export function addConsumer(state: ConsumerState, tabId: string, rec: ConsumerRecord): ConsumerState {
+  const existing = state.byTab[tabId];
+  // An owner (started: true) stays an owner across a same-port re-register (Retry);
+  // a port change takes the new value verbatim — the old port's ownership doesn't apply to the new one.
+  const started = existing && existing.port === rec.port ? existing.started || rec.started : rec.started;
+  return { byTab: { ...state.byTab, [tabId]: { ...rec, started } } };
+}
+
+export function releaseConsumers(
+  state: ConsumerState,
+  tabIds: string[],
+): {
+  next: ConsumerState;
+  stop: Array<{ port: number; daemonHttpPort: number }>;
+} {
+  const removed = tabIds.map((id) => state.byTab[id]).filter((rec): rec is ConsumerRecord => rec !== undefined);
+  if (removed.length === 0) return { next: state, stop: [] };
+
+  const byTab = { ...state.byTab };
+  for (const id of tabIds) delete byTab[id];
+
+  const remainingPorts = new Set(Object.values(byTab).map((rec) => rec.port));
+  const stopPorts = new Set<number>();
+  const stop: Array<{ port: number; daemonHttpPort: number }> = [];
+  for (const rec of removed) {
+    if (rec.started && !remainingPorts.has(rec.port) && !stopPorts.has(rec.port)) {
+      stopPorts.add(rec.port);
+      stop.push({ port: rec.port, daemonHttpPort: rec.daemonHttpPort });
+    }
+  }
+
+  return { next: { byTab }, stop };
+}
+
+export function clearConsumers(state: ConsumerState): ConsumerState {
+  if (Object.keys(state.byTab).length === 0) return state;
+  return emptyConsumerState;
+}

--- a/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
+++ b/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
@@ -18,10 +18,28 @@ export interface ConsumerState {
 
 export const emptyConsumerState: ConsumerState = { byTab: {} };
 
-export function addConsumer(state: ConsumerState, tabId: string, rec: ConsumerRecord): ConsumerState {
+export function addConsumer(
+  state: ConsumerState,
+  tabId: string,
+  rec: ConsumerRecord,
+): {
+  next: ConsumerState;
+  stop: Array<{ port: number; daemonHttpPort: number }>;
+} {
   const existing = state.byTab[tabId];
-  // An owner (started: true) stays an owner across a same-port re-register (Retry);
-  // a port change takes the new value verbatim — the old port's ownership doesn't apply to the new one.
+  // A retarget to a different port abandons this tab's claim on the old one —
+  // release it through the same owner-and-last-consumer rule a close uses, so
+  // an owned tunnel never survives orphaned (AC12/D10).
+  if (existing !== undefined && existing.port !== rec.port) {
+    const released = releaseConsumers(state, [tabId]);
+    return { next: writeConsumer(released.next, tabId, rec), stop: released.stop };
+  }
+  return { next: writeConsumer(state, tabId, rec), stop: [] };
+}
+
+function writeConsumer(state: ConsumerState, tabId: string, rec: ConsumerRecord): ConsumerState {
+  const existing = state.byTab[tabId];
+  // An owner (started: true) stays an owner across a same-port re-register (Retry).
   const started = existing && existing.port === rec.port ? existing.started || rec.started : rec.started;
   return { byTab: { ...state.byTab, [tabId]: { ...rec, started } } };
 }

--- a/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
+++ b/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
@@ -4,6 +4,12 @@
  * `started: true` means this tab's own POST started the tunnel; `started: false`
  * means it merely adopted one another tab already owns. Only an owner's release
  * should ever stop a tunnel, and only when no other consumer remains on the port.
+ *
+ * A same-port re-register takes `started` verbatim, no OR-merge with the prior
+ * value: the hook is the one source of truth for whether *this* tab currently
+ * owns the port (`ownedPort`, cleared on retarget and on an observed stop), so
+ * a stale `true` here would out-live the state that justified it — exactly the
+ * bug this file exists to prevent (review-fix findings 1+2).
  */
 
 export interface ConsumerRecord {
@@ -30,18 +36,9 @@ export function addConsumer(
   // A retarget to a different port abandons this tab's claim on the old one —
   // release it through the same owner-and-last-consumer rule a close uses, so
   // an owned tunnel never survives orphaned (AC12/D10).
-  if (existing !== undefined && existing.port !== rec.port) {
-    const released = releaseConsumers(state, [tabId]);
-    return { next: writeConsumer(released.next, tabId, rec), stop: released.stop };
-  }
-  return { next: writeConsumer(state, tabId, rec), stop: [] };
-}
-
-function writeConsumer(state: ConsumerState, tabId: string, rec: ConsumerRecord): ConsumerState {
-  const existing = state.byTab[tabId];
-  // An owner (started: true) stays an owner across a same-port re-register (Retry).
-  const started = existing && existing.port === rec.port ? existing.started || rec.started : rec.started;
-  return { byTab: { ...state.byTab, [tabId]: { ...rec, started } } };
+  const base =
+    existing !== undefined && existing.port !== rec.port ? releaseConsumers(state, [tabId]) : { next: state, stop: [] };
+  return { next: { byTab: { ...base.next.byTab, [tabId]: rec } }, stop: base.stop };
 }
 
 export function releaseConsumers(

--- a/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
+++ b/packages/ui/src/features/url-tab/url-tunnel-ownership.ts
@@ -6,10 +6,10 @@
  * should ever stop a tunnel, and only when no other consumer remains on the port.
  *
  * A same-port re-register takes `started` verbatim, no OR-merge with the prior
- * value: the hook is the one source of truth for whether *this* tab currently
- * owns the port (`ownedPort`, cleared on retarget and on an observed stop), so
- * a stale `true` here would out-live the state that justified it — exactly the
- * bug this file exists to prevent (review-fix findings 1+2).
+ * value: the claim reducer in `tunnel-claim.ts` is the one source of truth for
+ * whether *this* tab currently owns the port, so a stale `true` here would
+ * out-live the evidence that justified it — exactly the bug this file exists to
+ * prevent (review-fix findings 1+2).
  */
 
 export interface ConsumerRecord {

--- a/packages/ui/src/features/url-tab/use-dns-reload.ts
+++ b/packages/ui/src/features/url-tab/use-dns-reload.ts
@@ -1,0 +1,35 @@
+/**
+ * useDnsReload — cloudflared answers with a URL before its edge DNS resolves,
+ * so a URL tab that loaded early is showing a 404 until it reloads. Bump the
+ * nonce exactly once, when DNS verifies after the tab already loaded (#281 D11).
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { UrlTabTarget } from './resolve-url-target';
+
+export function useDnsReload({
+  targetKind,
+  dnsVerified,
+}: {
+  targetKind: UrlTabTarget['kind'];
+  dnsVerified: boolean;
+}): number {
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const loadedBeforeDnsRef = useRef(false);
+
+  useEffect(() => {
+    if (targetKind !== 'tunnelled') {
+      loadedBeforeDnsRef.current = false;
+      return;
+    }
+    if (!dnsVerified) {
+      loadedBeforeDnsRef.current = true;
+      return;
+    }
+    if (loadedBeforeDnsRef.current) {
+      loadedBeforeDnsRef.current = false;
+      setReloadNonce((n) => n + 1);
+    }
+  }, [targetKind, dnsVerified]);
+
+  return reloadNonce;
+}

--- a/packages/ui/src/features/url-tab/use-tunnel-attempt.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-attempt.ts
@@ -1,0 +1,163 @@
+/**
+ * useTunnelAttempt — the per-attempt lifecycle of a URL tab's tunnel (#281):
+ * the attempt counter, the flags that feed `resolveUrlTabTarget`, the 120 s
+ * watchdog, the start POST, and Retry.
+ *
+ * Every flag here is per *attempt* — a Retry bumps the counter and resets them
+ * wholesale, which is what makes Retry work from `failed` and `stopped` alike.
+ * Ownership is NOT here: it is per claim, lives in `tunnel-claim.ts`, and this
+ * hook only reports the two things that move it (a start going out, and that
+ * start being refused). `flags.everHadEntry` looks like `claim.sawEntry` and is
+ * not: it is per attempt and drives the `stopped` body (D14), while `sawEntry`
+ * is per claim and survives Retry.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { startPortTunnel } from '@/lib/api/tunnel-ports';
+import { clearPortTunnelEntry, reportPortTunnelError, type PortTunnelEntry } from '@/store/port-tunnels';
+import { resolveUrlTabTarget, URL_TAB_TUNNEL_TIMEOUT_MS, type UrlTabTarget } from './resolve-url-target';
+import type { ClaimSignal } from './tunnel-claim';
+
+interface AttemptFlags {
+  watching: boolean;
+  startUrl: string | null;
+  everHadEntry: boolean;
+  timedOut: boolean;
+}
+
+/** A stable identity so the reset is a no-op re-render when nothing has changed. */
+const FRESH: AttemptFlags = { watching: false, startUrl: null, everHadEntry: false, timedOut: false };
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface TunnelAttempt {
+  target: UrlTabTarget;
+  /** The only way out of `failed` and `stopped`; never fires on its own (D14). */
+  retry: () => void;
+}
+
+export interface TunnelAttemptArgs {
+  url: string;
+  isLocal: boolean;
+  daemonPort: number | null;
+  httpPort: number;
+  chatId: string | undefined;
+  port: number | null;
+  entry: PortTunnelEntry | undefined;
+  /** A never-activated rehydrated tab must start no tunnel and no watchdog. */
+  active: boolean;
+  note: (signal: ClaimSignal) => void;
+}
+
+export function useTunnelAttempt(args: TunnelAttemptArgs): TunnelAttempt {
+  const { url, isLocal, daemonPort, httpPort, chatId, port, entry, active, note } = args;
+  const [attempt, setAttempt] = useState(0);
+  const [flags, setFlags] = useState<AttemptFlags>(FRESH);
+
+  // Declared first so a Retry's or a retarget's reset lands before the effects
+  // that read the flags.
+  useEffect(() => {
+    setFlags(FRESH);
+  }, [attempt, port]);
+
+  const target = useMemo(
+    () => resolveUrlTabTarget({ url, isLocal, daemonPort, entry, ...flags }),
+    [url, isLocal, daemonPort, entry, flags],
+  );
+
+  useEffect(() => {
+    if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
+  }, [entry]);
+
+  const isPending = active && target.kind === 'pending';
+
+  useEffect(() => {
+    if (!isPending) return;
+    const timer = setTimeout(() => setFlags((f) => ({ ...f, timedOut: true })), URL_TAB_TUNNEL_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isPending, attempt]);
+
+  const onIssued = useCallback(() => setFlags((f) => (f.watching ? f : { ...f, watching: true })), []);
+  const onStartUrl = useCallback((startUrl: string) => setFlags((f) => ({ ...f, startUrl })), []);
+
+  useStartRequest({
+    enabled: isPending,
+    port,
+    httpPort,
+    daemonPort,
+    chatId,
+    entry,
+    attempt,
+    note,
+    onIssued,
+    onStartUrl,
+  });
+
+  const retry = useCallback(() => {
+    // Only a clear that actually happened is a local reset: `clearPortTunnelEntry`
+    // no-ops on a `ready` entry, and claiming otherwise would zero the claim's
+    // observation while the daemon still holds the tunnel.
+    if (port !== null && clearPortTunnelEntry(port)) note({ type: 'local-clear', httpPort, port });
+    setAttempt((n) => n + 1);
+  }, [port, httpPort, note]);
+
+  return { target, retry };
+}
+
+interface StartRequestArgs {
+  enabled: boolean;
+  port: number | null;
+  httpPort: number;
+  daemonPort: number | null;
+  chatId: string | undefined;
+  entry: PortTunnelEntry | undefined;
+  attempt: number;
+  note: (signal: ClaimSignal) => void;
+  onIssued: () => void;
+  onStartUrl: (startUrl: string) => void;
+}
+
+/**
+ * The start POST for the current attempt, issued at most once per (port,
+ * attempt) pair. Nothing but values and callbacks crosses this seam: a
+ * resolution or rejection that lands after its attempt is gone reaches the
+ * caller through neither, so ownership cannot leak back in through a stale ref.
+ */
+function useStartRequest(args: StartRequestArgs): void {
+  const { enabled, port, httpPort, daemonPort, chatId, entry, attempt, note, onIssued, onStartUrl } = args;
+  const issuedRef = useRef<{ port: number; attempt: number } | null>(null);
+  const liveRef = useRef({ port, attempt });
+
+  useEffect(() => {
+    liveRef.current = { port, attempt };
+  }, [port, attempt]);
+
+  useEffect(() => {
+    if (!enabled || port === null || daemonPort === null || !chatId) return;
+    const issued = issuedRef.current;
+    if (issued !== null && issued.port === port && issued.attempt === attempt) return;
+    issuedRef.current = { port, attempt };
+
+    // Observed as the POST goes out, not a gate on sending it: the daemon's
+    // registry is the single-flight point, so a start that joins another
+    // consumer's in-flight start spawns no second cloudflared — but this tab
+    // only owns the tunnel it saw come into existence (AC12).
+    note({ type: 'start-issued', httpPort, port, attempt, entryExisted: entry !== undefined });
+    onIssued();
+
+    const isLive = (): boolean => liveRef.current.port === port && liveRef.current.attempt === attempt;
+    startPortTunnel(httpPort, { port, chatId })
+      .then(({ url: startUrl }) => {
+        if (isLive()) onStartUrl(startUrl);
+      })
+      .catch((err: unknown) => {
+        // A superseded attempt says nothing about the live one: its rejection
+        // must neither revoke the current claim nor overwrite the store entry
+        // the live attempt is driving.
+        if (!isLive()) return;
+        note({ type: 'start-rejected', httpPort, port, attempt });
+        reportPortTunnelError(port, message(err), 'client');
+      });
+  }, [enabled, port, daemonPort, chatId, httpPort, attempt, entry, note, onIssued, onStartUrl]);
+}

--- a/packages/ui/src/features/url-tab/use-tunnel-attempt.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-attempt.ts
@@ -53,33 +53,14 @@ export interface TunnelAttemptArgs {
 export function useTunnelAttempt(args: TunnelAttemptArgs): TunnelAttempt {
   const { url, isLocal, daemonPort, httpPort, chatId, port, entry, active, note } = args;
   const [attempt, setAttempt] = useState(0);
-  const [flags, setFlags] = useState<AttemptFlags>(FRESH);
-
-  // Declared first so a Retry's or a retarget's reset lands before the effects
-  // that read the flags.
-  useEffect(() => {
-    setFlags(FRESH);
-  }, [attempt, port]);
+  const { flags, onIssued, onStartUrl, onTimedOut } = useAttemptFlags(attempt, port, entry);
 
   const target = useMemo(
     () => resolveUrlTabTarget({ url, isLocal, daemonPort, entry, ...flags }),
     [url, isLocal, daemonPort, entry, flags],
   );
-
-  useEffect(() => {
-    if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
-  }, [entry]);
-
   const isPending = active && target.kind === 'pending';
-
-  useEffect(() => {
-    if (!isPending) return;
-    const timer = setTimeout(() => setFlags((f) => ({ ...f, timedOut: true })), URL_TAB_TUNNEL_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, [isPending, attempt]);
-
-  const onIssued = useCallback(() => setFlags((f) => (f.watching ? f : { ...f, watching: true })), []);
-  const onStartUrl = useCallback((startUrl: string) => setFlags((f) => ({ ...f, startUrl })), []);
+  useTunnelWatchdog(isPending, attempt, onTimedOut);
 
   useStartRequest({
     enabled: isPending,
@@ -103,6 +84,47 @@ export function useTunnelAttempt(args: TunnelAttemptArgs): TunnelAttempt {
   }, [port, httpPort, note]);
 
   return { target, retry };
+}
+
+interface AttemptFlagsBinding {
+  flags: AttemptFlags;
+  onIssued: () => void;
+  onStartUrl: (startUrl: string) => void;
+  onTimedOut: () => void;
+}
+
+/** Owns the per-attempt flags and the two resets that keep them attached to the right attempt. */
+function useAttemptFlags(
+  attempt: number,
+  port: number | null,
+  entry: PortTunnelEntry | undefined,
+): AttemptFlagsBinding {
+  const [flags, setFlags] = useState<AttemptFlags>(FRESH);
+
+  // Declared first so a Retry's or a retarget's reset lands before the effects
+  // that read the flags.
+  useEffect(() => {
+    setFlags(FRESH);
+  }, [attempt, port]);
+
+  useEffect(() => {
+    if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
+  }, [entry]);
+
+  const onIssued = useCallback(() => setFlags((f) => (f.watching ? f : { ...f, watching: true })), []);
+  const onStartUrl = useCallback((startUrl: string) => setFlags((f) => ({ ...f, startUrl })), []);
+  const onTimedOut = useCallback(() => setFlags((f) => ({ ...f, timedOut: true })), []);
+
+  return { flags, onIssued, onStartUrl, onTimedOut };
+}
+
+/** The 120s watchdog (D11): fires once per attempt while the tunnel is pending. */
+function useTunnelWatchdog(active: boolean, attempt: number, onTimeout: () => void): void {
+  useEffect(() => {
+    if (!active) return;
+    const timer = setTimeout(onTimeout, URL_TAB_TUNNEL_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [active, attempt, onTimeout]);
 }
 
 interface StartRequestArgs {

--- a/packages/ui/src/features/url-tab/use-tunnel-claim.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-claim.ts
@@ -1,0 +1,43 @@
+/**
+ * useTunnelClaim — the React binding for the pure claim reducer in
+ * `tunnel-claim.ts` (#281, D10/AC12). It owns the two signals that come from
+ * render inputs rather than from an action: a `rebind` whenever this tab's
+ * (daemon, port) pair moves, and the daemon's own view of the port.
+ *
+ * `note` is the raw dispatch on purpose. Every caller stamps the `httpPort`,
+ * `port` and `attempt` it is *acting on*, so a promise callback that lands late
+ * carries its issue-time identity instead of the current render's — which is
+ * what makes a stale attempt's rejection harmless.
+ */
+import { useEffect, useReducer } from 'react';
+import type { PortTunnelEntry } from '@/store/port-tunnels';
+import { claimOwns, claimReducer, entryDaemonState, type ClaimSignal } from './tunnel-claim';
+
+export interface TunnelClaimBinding {
+  /** This tab may stop the tunnel currently on `port`. */
+  owns: boolean;
+  note: (signal: ClaimSignal) => void;
+}
+
+export function useTunnelClaim({
+  httpPort,
+  port,
+  entry,
+}: {
+  httpPort: number;
+  port: number | null;
+  entry: PortTunnelEntry | undefined;
+}): TunnelClaimBinding {
+  const [claim, note] = useReducer(claimReducer, null);
+
+  useEffect(() => {
+    note({ type: 'rebind', httpPort, port });
+  }, [httpPort, port]);
+
+  useEffect(() => {
+    if (port === null) return;
+    note({ type: 'daemon-state', httpPort, port, state: entryDaemonState(entry) });
+  }, [httpPort, port, entry]);
+
+  return { owns: claimOwns(claim, httpPort, port), note };
+}

--- a/packages/ui/src/features/url-tab/use-tunnel-claim.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-claim.ts
@@ -1,34 +1,27 @@
 /**
  * useTunnelClaim — the React binding for the pure claim reducer in
- * `tunnel-claim.ts` (#281, D10/AC12). It owns the two signals that come from
- * observation rather than from an action: a `rebind` whenever this tab's
- * (daemon, port) pair moves, and the daemon's own view of the port.
+ * `tunnel-claim.ts` (#281, D10/AC12). It owns none of the claim's state: that
+ * lives in the module-level `tunnel-claim-registry`, keyed by `tabId`
+ * (review-fix findings 1+3), so a session-switch unmount never forgets a
+ * claim the way a plain `useReducer(claimReducer, null)` would.
  *
- * The port is observed through the store's **writes**, not through the entry as
- * a render value. Two writes inside one React batch — the daemon's `stopped`
- * followed by a foreign consumer's `ready` on the same port — collapse into a
- * single rendered value, and the `absent` that revokes this tab's claim would
- * never be seen; the tab would then stop a tunnel it never started. A
- * subscription sees both, in order, and the reducer folds them the same way it
- * folds two separate ticks.
+ * `daemon-state` — the signal that can *revoke* a claim — is applied by the
+ * registry itself, from its own subscription to the port-tunnels store
+ * (review-fix NEW finding). That subscription outlives this component, so a
+ * revocation that happens while the tab is unmounted is not missed. This hook
+ * is therefore just a **reader** of the registry (`useSyncExternalStore`) plus
+ * a dispatcher for the signals that only an acting component can know about:
+ * `rebind` (this tab's own port changed) and, via `note`, `start-issued` /
+ * `start-rejected` / `local-clear`.
  *
  * `note` is the raw dispatch on purpose. Every caller stamps the `httpPort`,
  * `port` and `attempt` it is *acting on*, so a promise callback that lands late
  * carries its issue-time identity instead of the current render's — which is
  * what makes a stale attempt's rejection harmless.
- *
- * The reducer's state is seeded from — and written back to — the module-level
- * `tunnel-claim-registry` keyed by `tabId` (review-fix findings 1+3): a plain
- * `useReducer(claimReducer, null)` forgets the claim on every unmount, while the
- * consumer registry it feeds survives one, so a session-switch remount against
- * an already-`ready` port (nothing pending, no new `start-issued`) would
- * rehydrate to "owns nothing" and downgrade a real `started: true` to `false`,
- * leaking the tunnel this tab exclusively started.
  */
-import { useEffect, useReducer } from 'react';
-import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
-import { claimOwns, claimReducer, entryDaemonState, type ClaimSignal } from './tunnel-claim';
-import { getStoredClaim, setStoredClaim } from './tunnel-claim-registry';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { claimOwns, type ClaimSignal } from './tunnel-claim';
+import { getStoredClaim, noteClaim, subscribeClaim } from './tunnel-claim-registry';
 
 export interface TunnelClaimBinding {
   /** This tab may stop the tunnel currently on `port`. */
@@ -45,26 +38,15 @@ export function useTunnelClaim({
   httpPort: number;
   port: number | null;
 }): TunnelClaimBinding {
-  const [claim, note] = useReducer(claimReducer, tabId, getStoredClaim);
+  const subscribe = useCallback((onChange: () => void) => subscribeClaim(tabId, onChange), [tabId]);
+  const getSnapshot = useCallback(() => getStoredClaim(tabId), [tabId]);
+  const claim = useSyncExternalStore(subscribe, getSnapshot);
 
-  useEffect(() => {
-    setStoredClaim(tabId, claim);
-  }, [tabId, claim]);
+  const note = useCallback((signal: ClaimSignal) => noteClaim(tabId, signal), [tabId]);
 
   useEffect(() => {
     note({ type: 'rebind', httpPort, port });
-  }, [httpPort, port]);
-
-  useEffect(() => {
-    if (port === null) return;
-    const observe = (entry: PortTunnelEntry | undefined): void => {
-      note({ type: 'daemon-state', httpPort, port, state: entryDaemonState(entry) });
-    };
-    observe(usePortTunnelsStore.getState().byPort[port]);
-    return usePortTunnelsStore.subscribe((state, prev) => {
-      if (state.byPort[port] !== prev.byPort[port]) observe(state.byPort[port]);
-    });
-  }, [httpPort, port]);
+  }, [note, httpPort, port]);
 
   return { owns: claimOwns(claim, httpPort, port), note };
 }

--- a/packages/ui/src/features/url-tab/use-tunnel-claim.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-claim.ts
@@ -16,10 +16,19 @@
  * `port` and `attempt` it is *acting on*, so a promise callback that lands late
  * carries its issue-time identity instead of the current render's — which is
  * what makes a stale attempt's rejection harmless.
+ *
+ * The reducer's state is seeded from — and written back to — the module-level
+ * `tunnel-claim-registry` keyed by `tabId` (review-fix findings 1+3): a plain
+ * `useReducer(claimReducer, null)` forgets the claim on every unmount, while the
+ * consumer registry it feeds survives one, so a session-switch remount against
+ * an already-`ready` port (nothing pending, no new `start-issued`) would
+ * rehydrate to "owns nothing" and downgrade a real `started: true` to `false`,
+ * leaking the tunnel this tab exclusively started.
  */
 import { useEffect, useReducer } from 'react';
 import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
 import { claimOwns, claimReducer, entryDaemonState, type ClaimSignal } from './tunnel-claim';
+import { getStoredClaim, setStoredClaim } from './tunnel-claim-registry';
 
 export interface TunnelClaimBinding {
   /** This tab may stop the tunnel currently on `port`. */
@@ -27,8 +36,20 @@ export interface TunnelClaimBinding {
   note: (signal: ClaimSignal) => void;
 }
 
-export function useTunnelClaim({ httpPort, port }: { httpPort: number; port: number | null }): TunnelClaimBinding {
-  const [claim, note] = useReducer(claimReducer, null);
+export function useTunnelClaim({
+  tabId,
+  httpPort,
+  port,
+}: {
+  tabId: string;
+  httpPort: number;
+  port: number | null;
+}): TunnelClaimBinding {
+  const [claim, note] = useReducer(claimReducer, tabId, getStoredClaim);
+
+  useEffect(() => {
+    setStoredClaim(tabId, claim);
+  }, [tabId, claim]);
 
   useEffect(() => {
     note({ type: 'rebind', httpPort, port });

--- a/packages/ui/src/features/url-tab/use-tunnel-claim.ts
+++ b/packages/ui/src/features/url-tab/use-tunnel-claim.ts
@@ -1,8 +1,16 @@
 /**
  * useTunnelClaim — the React binding for the pure claim reducer in
  * `tunnel-claim.ts` (#281, D10/AC12). It owns the two signals that come from
- * render inputs rather than from an action: a `rebind` whenever this tab's
+ * observation rather than from an action: a `rebind` whenever this tab's
  * (daemon, port) pair moves, and the daemon's own view of the port.
+ *
+ * The port is observed through the store's **writes**, not through the entry as
+ * a render value. Two writes inside one React batch — the daemon's `stopped`
+ * followed by a foreign consumer's `ready` on the same port — collapse into a
+ * single rendered value, and the `absent` that revokes this tab's claim would
+ * never be seen; the tab would then stop a tunnel it never started. A
+ * subscription sees both, in order, and the reducer folds them the same way it
+ * folds two separate ticks.
  *
  * `note` is the raw dispatch on purpose. Every caller stamps the `httpPort`,
  * `port` and `attempt` it is *acting on*, so a promise callback that lands late
@@ -10,7 +18,7 @@
  * what makes a stale attempt's rejection harmless.
  */
 import { useEffect, useReducer } from 'react';
-import type { PortTunnelEntry } from '@/store/port-tunnels';
+import { usePortTunnelsStore, type PortTunnelEntry } from '@/store/port-tunnels';
 import { claimOwns, claimReducer, entryDaemonState, type ClaimSignal } from './tunnel-claim';
 
 export interface TunnelClaimBinding {
@@ -19,15 +27,7 @@ export interface TunnelClaimBinding {
   note: (signal: ClaimSignal) => void;
 }
 
-export function useTunnelClaim({
-  httpPort,
-  port,
-  entry,
-}: {
-  httpPort: number;
-  port: number | null;
-  entry: PortTunnelEntry | undefined;
-}): TunnelClaimBinding {
+export function useTunnelClaim({ httpPort, port }: { httpPort: number; port: number | null }): TunnelClaimBinding {
   const [claim, note] = useReducer(claimReducer, null);
 
   useEffect(() => {
@@ -36,8 +36,14 @@ export function useTunnelClaim({
 
   useEffect(() => {
     if (port === null) return;
-    note({ type: 'daemon-state', httpPort, port, state: entryDaemonState(entry) });
-  }, [httpPort, port, entry]);
+    const observe = (entry: PortTunnelEntry | undefined): void => {
+      note({ type: 'daemon-state', httpPort, port, state: entryDaemonState(entry) });
+    };
+    observe(usePortTunnelsStore.getState().byPort[port]);
+    return usePortTunnelsStore.subscribe((state, prev) => {
+      if (state.byPort[port] !== prev.byPort[port]) observe(state.byPort[port]);
+    });
+  }, [httpPort, port]);
 
   return { owns: claimOwns(claim, httpPort, port), note };
 }

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -127,15 +127,22 @@ export function useUrlTabTunnel({
       .then(({ url: startUrl }) => {
         if (attemptRef.current === at) setFlags((f) => ({ ...f, startUrl }));
       })
-      .catch((err: unknown) => reportPortTunnelError(port, message(err)));
+      .catch((err: unknown) => {
+        // A rejected start created nothing on the daemon to own — revoke the
+        // optimistic claim so a later `ready` entry (someone else's tunnel)
+        // is never mistaken for this tab's to stop (AC12/D10).
+        setOwnedPort((p) => (p === port ? null : p));
+        reportPortTunnelError(port, message(err));
+      });
   }, [isPending, port, daemonPort, chatId, httpPort, attempt, entry]);
 
   // The tunnel this tab started can be stopped out from under it (the chat
-  // chip's Stop, or the daemon reaping it) — a later `ready` entry on the
-  // same port belongs to whoever restarted it, never to this tab, so the
-  // claim is dropped the moment the store reports the owned tunnel gone.
+  // chip's Stop, or the daemon reaping it) or die with a daemon-side `error`
+  // entry (cloudflared crash) — either way the daemon holds no live tunnel of
+  // this tab's on the port, so a later `ready` entry belongs to whoever
+  // restarted it, never to this tab, and the claim is dropped.
   useEffect(() => {
-    if (target.kind === 'stopped' && ownedPort === port) setOwnedPort(null);
+    if ((target.kind === 'stopped' || target.kind === 'failed') && ownedPort === port) setOwnedPort(null);
   }, [target.kind, ownedPort, port]);
 
   useEffect(() => {

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -68,20 +68,27 @@ export function useUrlTabTunnel({
 
   const [attempt, setAttempt] = useState(0);
   const [flags, setFlags] = useState<AttemptFlags>(FRESH);
-  // The port this tab owns, or null. Keyed by port rather than a plain boolean
-  // so a retarget is correct on the very first render after `port` changes:
-  // `ownedPort === port` reads as false against the *new* port before any
-  // effect runs, with no reset effect needed and no window for a stale
-  // `started: true` write to land on the port being adopted (D10, AC12).
+  // The port this tab owns, or null. Cleared whenever the tab stops being the
+  // live starter of a port — on a retarget away from it (below) and when the
+  // store reports the owned tunnel gone (the `stopped`-transition effect
+  // below) — so a later return to that same port never re-adopts a tunnel
+  // this tab didn't start (D10, AC12; review-fix findings 1+2).
   const [ownedPort, setOwnedPort] = useState<number | null>(null);
   const attemptRef = useRef(0);
   const startedForAttemptRef = useRef<number | null>(null);
+  const prevPortRef = useRef(port);
 
   // Declared first so a Retry's reset lands before the effects that read it.
   useEffect(() => {
     attemptRef.current = attempt;
     startedForAttemptRef.current = null;
     setFlags(FRESH);
+    // Retry bumps `attempt` on the same port and must keep the owner (D10);
+    // only an actual retarget abandons the claim.
+    if (prevPortRef.current !== port) {
+      prevPortRef.current = port;
+      setOwnedPort(null);
+    }
   }, [attempt, port]);
 
   const target = useMemo(
@@ -122,6 +129,14 @@ export function useUrlTabTunnel({
       })
       .catch((err: unknown) => reportPortTunnelError(port, message(err)));
   }, [isPending, port, daemonPort, chatId, httpPort, attempt, entry]);
+
+  // The tunnel this tab started can be stopped out from under it (the chat
+  // chip's Stop, or the daemon reaping it) — a later `ready` entry on the
+  // same port belongs to whoever restarted it, never to this tab, so the
+  // claim is dropped the moment the store reports the owned tunnel gone.
+  useEffect(() => {
+    if (target.kind === 'stopped' && ownedPort === port) setOwnedPort(null);
+  }, [target.kind, ownedPort, port]);
 
   useEffect(() => {
     if (!active || port === null) return;

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -1,0 +1,151 @@
+/**
+ * useUrlTabTunnel — the React binding between a `url` Run tab and the per-port
+ * tunnel machinery (#281). All classification is pure and lives in
+ * `resolveUrlTabTarget`; this hook only owns the attempt-scoped state that
+ * feeds it, the start request, and the ownership registration.
+ *
+ * Every flag below is per *attempt* — a Retry bumps the counter and resets them
+ * wholesale, which is what makes Retry work from `failed` and `stopped` alike.
+ * The one exception is ownership, which is per *port*: a tab that was ever seen
+ * creating a port's tunnel stays its owner across retries (D10).
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { classifyLocalhostUrl } from '@qlan-ro/mainframe-types';
+import { startPortTunnel } from '@/lib/api/tunnel-ports';
+import {
+  usePortTunnelsStore,
+  useTunnelDaemonPort,
+  clearPortTunnelEntry,
+  reportPortTunnelError,
+} from '@/store/port-tunnels';
+import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
+import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
+import { useActiveIdentity } from '@/features/sessions/use-active-identity';
+import { registerUrlTunnelConsumer } from './tunnel-consumers';
+import { resolveUrlTabTarget, URL_TAB_TUNNEL_TIMEOUT_MS, type UrlTabTarget } from './resolve-url-target';
+
+interface AttemptFlags {
+  watching: boolean;
+  startUrl: string | null;
+  everHadEntry: boolean;
+  timedOut: boolean;
+}
+
+/** A stable identity so the reset is a no-op re-render when nothing has changed. */
+const FRESH: AttemptFlags = { watching: false, startUrl: null, everHadEntry: false, timedOut: false };
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface UrlTabTunnel {
+  target: UrlTabTarget;
+  /** The only way out of `failed` and `stopped`; never fires on its own (D14). */
+  retry: () => void;
+  /** Bumped once when the tunnel's DNS verifies after the tab already loaded. */
+  reloadNonce: number;
+}
+
+export function useUrlTabTunnel({ tabId, url }: { tabId: string; url: string }): UrlTabTunnel {
+  const isLocal = useDaemonIsLocal();
+  const httpPort = useDaemonPort();
+  const daemonPort = useTunnelDaemonPort();
+  const chatId = useActiveIdentity().chatId;
+
+  // A local daemon or a non-loopback address needs no tunnel at all, so it
+  // subscribes to no port and issues no start.
+  const port = useMemo(() => (isLocal ? null : (classifyLocalhostUrl(url)?.port ?? null)), [isLocal, url]);
+  const entry = usePortTunnelsStore((s) => (port === null ? undefined : s.byPort[port]));
+
+  const [attempt, setAttempt] = useState(0);
+  const [flags, setFlags] = useState<AttemptFlags>(FRESH);
+  const [owned, setOwned] = useState(false);
+  const attemptRef = useRef(0);
+  const startedForAttemptRef = useRef<number | null>(null);
+  const ownedRef = useRef(false);
+
+  // Declared first so a Retry's reset lands before the effects that read it.
+  useEffect(() => {
+    attemptRef.current = attempt;
+    startedForAttemptRef.current = null;
+    setFlags(FRESH);
+  }, [attempt, port]);
+
+  // Ownership is per port, not per attempt: a Retry must not demote an owner.
+  useEffect(() => {
+    ownedRef.current = false;
+    setOwned(false);
+  }, [port]);
+
+  const target = useMemo(
+    () => resolveUrlTabTarget({ url, isLocal, daemonPort, entry, ...flags }),
+    [url, isLocal, daemonPort, entry, flags],
+  );
+
+  useEffect(() => {
+    if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
+  }, [entry]);
+
+  const isPending = target.kind === 'pending';
+
+  useEffect(() => {
+    if (!isPending) return;
+    const timer = setTimeout(() => setFlags((f) => ({ ...f, timedOut: true })), URL_TAB_TUNNEL_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isPending, attempt]);
+
+  useEffect(() => {
+    if (!isPending || port === null || daemonPort === null || !chatId) return;
+    if (startedForAttemptRef.current === attempt) return;
+    startedForAttemptRef.current = attempt;
+    // Observed as the POST goes out, not a gate on sending it: the daemon's
+    // registry is the single-flight point, so a start that joins another
+    // consumer's in-flight start spawns no second cloudflared — but this tab
+    // only owns the tunnel it saw come into existence (AC12).
+    if (entry === undefined) {
+      ownedRef.current = true;
+      setOwned(true);
+    }
+    setFlags((f) => ({ ...f, watching: true }));
+
+    const at = attempt;
+    startPortTunnel(httpPort, { port, chatId })
+      .then(({ url: startUrl }) => {
+        if (attemptRef.current === at) setFlags((f) => ({ ...f, startUrl }));
+      })
+      .catch((err: unknown) => reportPortTunnelError(port, message(err)));
+  }, [isPending, port, daemonPort, chatId, httpPort, attempt, entry]);
+
+  useEffect(() => {
+    if (port === null) return;
+    registerUrlTunnelConsumer(tabId, { port, started: owned, daemonHttpPort: httpPort });
+  }, [tabId, port, owned, httpPort]);
+
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const loadedBeforeDnsRef = useRef(false);
+  const dnsVerified = entry?.dnsVerified === true;
+
+  // cloudflared answers with a URL before its edge DNS resolves, so a tab that
+  // loaded early is showing a 404 until it reloads — exactly once (D11).
+  useEffect(() => {
+    if (target.kind !== 'tunnelled') {
+      loadedBeforeDnsRef.current = false;
+      return;
+    }
+    if (!dnsVerified) {
+      loadedBeforeDnsRef.current = true;
+      return;
+    }
+    if (loadedBeforeDnsRef.current) {
+      loadedBeforeDnsRef.current = false;
+      setReloadNonce((n) => n + 1);
+    }
+  }, [target.kind, dnsVerified]);
+
+  const retry = useCallback(() => {
+    if (port !== null) clearPortTunnelEntry(port);
+    setAttempt((n) => n + 1);
+  }, [port]);
+
+  return { target, retry, reloadNonce };
+}

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -51,7 +51,7 @@ export function useUrlTabTunnel({ tabId, url, active }: UrlTabTunnelArgs): UrlTa
 
   // Declared before the attempt so its `rebind` and `daemon-state` effects are
   // registered — and so run — ahead of the same commit's `start-issued`.
-  const { owns, note } = useTunnelClaim({ httpPort, port });
+  const { owns, note } = useTunnelClaim({ tabId, httpPort, port });
   const { target, retry } = useTunnelAttempt({
     url,
     isLocal,

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -46,7 +46,16 @@ export interface UrlTabTunnel {
   reloadNonce: number;
 }
 
-export function useUrlTabTunnel({ tabId, url }: { tabId: string; url: string }): UrlTabTunnel {
+export function useUrlTabTunnel({
+  tabId,
+  url,
+  active,
+}: {
+  tabId: string;
+  url: string;
+  /** Gates the tunnel start + ownership claim — a never-activated rehydrated tab must request neither (spec §"rehydrate unmounted and load on first activation"). */
+  active: boolean;
+}): UrlTabTunnel {
   const isLocal = useDaemonIsLocal();
   const httpPort = useDaemonPort();
   const daemonPort = useTunnelDaemonPort();
@@ -86,7 +95,10 @@ export function useUrlTabTunnel({ tabId, url }: { tabId: string; url: string }):
     if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
   }, [entry]);
 
-  const isPending = target.kind === 'pending';
+  // Nothing below this point is real until the tab has been activated at least
+  // once — a rehydrated-but-unmounted tab must request no tunnel and start no
+  // watchdog (spec: URL tabs "rehydrate unmounted and load on first activation").
+  const isPending = active && target.kind === 'pending';
 
   useEffect(() => {
     if (!isPending) return;
@@ -117,9 +129,9 @@ export function useUrlTabTunnel({ tabId, url }: { tabId: string; url: string }):
   }, [isPending, port, daemonPort, chatId, httpPort, attempt, entry]);
 
   useEffect(() => {
-    if (port === null) return;
+    if (!active || port === null) return;
     registerUrlTunnelConsumer(tabId, { port, started: owned, daemonHttpPort: httpPort });
-  }, [tabId, port, owned, httpPort]);
+  }, [active, tabId, port, owned, httpPort]);
 
   const [reloadNonce, setReloadNonce] = useState(0);
   const loadedBeforeDnsRef = useRef(false);

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -1,42 +1,27 @@
 /**
  * useUrlTabTunnel — the React binding between a `url` Run tab and the per-port
- * tunnel machinery (#281). All classification is pure and lives in
- * `resolveUrlTabTarget`; this hook only owns the attempt-scoped state that
- * feeds it, the start request, and the ownership registration.
+ * tunnel machinery (#281). It composes three pieces and owns none of them:
  *
- * Every flag below is per *attempt* — a Retry bumps the counter and resets them
- * wholesale, which is what makes Retry work from `failed` and `stopped` alike.
- * The one exception is ownership, which is per *port*: a tab that was ever seen
- * creating a port's tunnel stays its owner across retries (D10).
+ * - `tunnel-claim.ts` (via `useTunnelClaim`) decides whether this tab may stop
+ *   the tunnel it is looking at (D10/AC12);
+ * - `use-tunnel-attempt.ts` runs the attempt lifecycle — the start POST, the
+ *   flags, the watchdog, Retry — and reports the two signals that move a claim;
+ * - `resolve-url-target.ts` classifies what to render, purely.
+ *
+ * What is left here is the tab's inputs, the composition order, and the
+ * ownership registration.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { classifyLocalhostUrl } from '@qlan-ro/mainframe-types';
-import { startPortTunnel } from '@/lib/api/tunnel-ports';
-import {
-  usePortTunnelsStore,
-  useTunnelDaemonPort,
-  clearPortTunnelEntry,
-  reportPortTunnelError,
-} from '@/store/port-tunnels';
+import { usePortTunnelsStore, useTunnelDaemonPort } from '@/store/port-tunnels';
 import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
 import { useDaemonIsLocal } from '@/lib/daemon/use-daemon-is-local';
 import { useActiveIdentity } from '@/features/sessions/use-active-identity';
-import { registerUrlTunnelConsumer } from './tunnel-consumers';
-import { resolveUrlTabTarget, URL_TAB_TUNNEL_TIMEOUT_MS, type UrlTabTarget } from './resolve-url-target';
-
-interface AttemptFlags {
-  watching: boolean;
-  startUrl: string | null;
-  everHadEntry: boolean;
-  timedOut: boolean;
-}
-
-/** A stable identity so the reset is a no-op re-render when nothing has changed. */
-const FRESH: AttemptFlags = { watching: false, startUrl: null, everHadEntry: false, timedOut: false };
-
-function message(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
+import { registerUrlTunnelConsumer, releaseUrlTunnelConsumers } from './tunnel-consumers';
+import { useTunnelClaim } from './use-tunnel-claim';
+import { useTunnelAttempt } from './use-tunnel-attempt';
+import { useDnsReload } from './use-dns-reload';
+import type { UrlTabTarget } from './resolve-url-target';
 
 export interface UrlTabTunnel {
   target: UrlTabTarget;
@@ -46,16 +31,14 @@ export interface UrlTabTunnel {
   reloadNonce: number;
 }
 
-export function useUrlTabTunnel({
-  tabId,
-  url,
-  active,
-}: {
+export interface UrlTabTunnelArgs {
   tabId: string;
   url: string;
   /** Gates the tunnel start + ownership claim — a never-activated rehydrated tab must request neither (spec §"rehydrate unmounted and load on first activation"). */
   active: boolean;
-}): UrlTabTunnel {
+}
+
+export function useUrlTabTunnel({ tabId, url, active }: UrlTabTunnelArgs): UrlTabTunnel {
   const isLocal = useDaemonIsLocal();
   const httpPort = useDaemonPort();
   const daemonPort = useTunnelDaemonPort();
@@ -66,115 +49,35 @@ export function useUrlTabTunnel({
   const port = useMemo(() => (isLocal ? null : (classifyLocalhostUrl(url)?.port ?? null)), [isLocal, url]);
   const entry = usePortTunnelsStore((s) => (port === null ? undefined : s.byPort[port]));
 
-  const [attempt, setAttempt] = useState(0);
-  const [flags, setFlags] = useState<AttemptFlags>(FRESH);
-  // The port this tab owns, or null. Cleared whenever the tab stops being the
-  // live starter of a port — on a retarget away from it (below) and when the
-  // store reports the owned tunnel gone (the `stopped`-transition effect
-  // below) — so a later return to that same port never re-adopts a tunnel
-  // this tab didn't start (D10, AC12; review-fix findings 1+2).
-  const [ownedPort, setOwnedPort] = useState<number | null>(null);
-  const attemptRef = useRef(0);
-  const startedForAttemptRef = useRef<number | null>(null);
-  const prevPortRef = useRef(port);
+  // Declared before the attempt so its `rebind` and `daemon-state` effects are
+  // registered — and so run — ahead of the same commit's `start-issued`.
+  const { owns, note } = useTunnelClaim({ httpPort, port });
+  const { target, retry } = useTunnelAttempt({
+    url,
+    isLocal,
+    daemonPort,
+    httpPort,
+    chatId,
+    port,
+    entry,
+    active,
+    note,
+  });
+  const reloadNonce = useDnsReload({ targetKind: target.kind, dnsVerified: entry?.dnsVerified === true });
 
-  // Declared first so a Retry's reset lands before the effects that read it.
+  // Registration reads the claim against *this* render's port: on the render
+  // where `port` flips, the claim still names the old one, so `started` is
+  // false until the new port is claimed on its own evidence.
   useEffect(() => {
-    attemptRef.current = attempt;
-    startedForAttemptRef.current = null;
-    setFlags(FRESH);
-    // Retry bumps `attempt` on the same port and must keep the owner (D10);
-    // only an actual retarget abandons the claim.
-    if (prevPortRef.current !== port) {
-      prevPortRef.current = port;
-      setOwnedPort(null);
-    }
-  }, [attempt, port]);
-
-  const target = useMemo(
-    () => resolveUrlTabTarget({ url, isLocal, daemonPort, entry, ...flags }),
-    [url, isLocal, daemonPort, entry, flags],
-  );
-
-  useEffect(() => {
-    if (entry !== undefined) setFlags((f) => (f.everHadEntry ? f : { ...f, everHadEntry: true }));
-  }, [entry]);
-
-  // Nothing below this point is real until the tab has been activated at least
-  // once — a rehydrated-but-unmounted tab must request no tunnel and start no
-  // watchdog (spec: URL tabs "rehydrate unmounted and load on first activation").
-  const isPending = active && target.kind === 'pending';
-
-  useEffect(() => {
-    if (!isPending) return;
-    const timer = setTimeout(() => setFlags((f) => ({ ...f, timedOut: true })), URL_TAB_TUNNEL_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, [isPending, attempt]);
-
-  useEffect(() => {
-    if (!isPending || port === null || daemonPort === null || !chatId) return;
-    if (startedForAttemptRef.current === attempt) return;
-    startedForAttemptRef.current = attempt;
-    // Observed as the POST goes out, not a gate on sending it: the daemon's
-    // registry is the single-flight point, so a start that joins another
-    // consumer's in-flight start spawns no second cloudflared — but this tab
-    // only owns the tunnel it saw come into existence (AC12).
-    if (entry === undefined) setOwnedPort(port);
-    setFlags((f) => ({ ...f, watching: true }));
-
-    const at = attempt;
-    startPortTunnel(httpPort, { port, chatId })
-      .then(({ url: startUrl }) => {
-        if (attemptRef.current === at) setFlags((f) => ({ ...f, startUrl }));
-      })
-      .catch((err: unknown) => {
-        // A rejected start created nothing on the daemon to own — revoke the
-        // optimistic claim so a later `ready` entry (someone else's tunnel)
-        // is never mistaken for this tab's to stop (AC12/D10).
-        setOwnedPort((p) => (p === port ? null : p));
-        reportPortTunnelError(port, message(err));
-      });
-  }, [isPending, port, daemonPort, chatId, httpPort, attempt, entry]);
-
-  // The tunnel this tab started can be stopped out from under it (the chat
-  // chip's Stop, or the daemon reaping it) or die with a daemon-side `error`
-  // entry (cloudflared crash) — either way the daemon holds no live tunnel of
-  // this tab's on the port, so a later `ready` entry belongs to whoever
-  // restarted it, never to this tab, and the claim is dropped.
-  useEffect(() => {
-    if ((target.kind === 'stopped' || target.kind === 'failed') && ownedPort === port) setOwnedPort(null);
-  }, [target.kind, ownedPort, port]);
-
-  useEffect(() => {
-    if (!active || port === null) return;
-    registerUrlTunnelConsumer(tabId, { port, started: ownedPort === port, daemonHttpPort: httpPort });
-  }, [active, tabId, port, ownedPort, httpPort]);
-
-  const [reloadNonce, setReloadNonce] = useState(0);
-  const loadedBeforeDnsRef = useRef(false);
-  const dnsVerified = entry?.dnsVerified === true;
-
-  // cloudflared answers with a URL before its edge DNS resolves, so a tab that
-  // loaded early is showing a 404 until it reloads — exactly once (D11).
-  useEffect(() => {
-    if (target.kind !== 'tunnelled') {
-      loadedBeforeDnsRef.current = false;
+    if (!active) return;
+    // A retarget onto an address that needs no tunnel leaves the old port with
+    // no consumer at all — releasing is what stops it (AC12).
+    if (port === null) {
+      releaseUrlTunnelConsumers([tabId]);
       return;
     }
-    if (!dnsVerified) {
-      loadedBeforeDnsRef.current = true;
-      return;
-    }
-    if (loadedBeforeDnsRef.current) {
-      loadedBeforeDnsRef.current = false;
-      setReloadNonce((n) => n + 1);
-    }
-  }, [target.kind, dnsVerified]);
-
-  const retry = useCallback(() => {
-    if (port !== null) clearPortTunnelEntry(port);
-    setAttempt((n) => n + 1);
-  }, [port]);
+    registerUrlTunnelConsumer(tabId, { port, started: owns, daemonHttpPort: httpPort });
+  }, [active, tabId, port, owns, httpPort]);
 
   return { target, retry, reloadNonce };
 }

--- a/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
+++ b/packages/ui/src/features/url-tab/use-url-tab-tunnel.ts
@@ -68,10 +68,14 @@ export function useUrlTabTunnel({
 
   const [attempt, setAttempt] = useState(0);
   const [flags, setFlags] = useState<AttemptFlags>(FRESH);
-  const [owned, setOwned] = useState(false);
+  // The port this tab owns, or null. Keyed by port rather than a plain boolean
+  // so a retarget is correct on the very first render after `port` changes:
+  // `ownedPort === port` reads as false against the *new* port before any
+  // effect runs, with no reset effect needed and no window for a stale
+  // `started: true` write to land on the port being adopted (D10, AC12).
+  const [ownedPort, setOwnedPort] = useState<number | null>(null);
   const attemptRef = useRef(0);
   const startedForAttemptRef = useRef<number | null>(null);
-  const ownedRef = useRef(false);
 
   // Declared first so a Retry's reset lands before the effects that read it.
   useEffect(() => {
@@ -79,12 +83,6 @@ export function useUrlTabTunnel({
     startedForAttemptRef.current = null;
     setFlags(FRESH);
   }, [attempt, port]);
-
-  // Ownership is per port, not per attempt: a Retry must not demote an owner.
-  useEffect(() => {
-    ownedRef.current = false;
-    setOwned(false);
-  }, [port]);
 
   const target = useMemo(
     () => resolveUrlTabTarget({ url, isLocal, daemonPort, entry, ...flags }),
@@ -114,10 +112,7 @@ export function useUrlTabTunnel({
     // registry is the single-flight point, so a start that joins another
     // consumer's in-flight start spawns no second cloudflared — but this tab
     // only owns the tunnel it saw come into existence (AC12).
-    if (entry === undefined) {
-      ownedRef.current = true;
-      setOwned(true);
-    }
+    if (entry === undefined) setOwnedPort(port);
     setFlags((f) => ({ ...f, watching: true }));
 
     const at = attempt;
@@ -130,8 +125,8 @@ export function useUrlTabTunnel({
 
   useEffect(() => {
     if (!active || port === null) return;
-    registerUrlTunnelConsumer(tabId, { port, started: owned, daemonHttpPort: httpPort });
-  }, [active, tabId, port, owned, httpPort]);
+    registerUrlTunnelConsumer(tabId, { port, started: ownedPort === port, daemonHttpPort: httpPort });
+  }, [active, tabId, port, ownedPort, httpPort]);
 
   const [reloadNonce, setReloadNonce] = useState(0);
   const loadedBeforeDnsRef = useRef(false);

--- a/packages/ui/src/layout/RunTabPill.tsx
+++ b/packages/ui/src/layout/RunTabPill.tsx
@@ -2,8 +2,8 @@
  * RunTabPill — one tab in the Run surface strip: a STATIC type glyph, the tab
  * title, an optional Stop, and a hover close (×). The leading glyph identifies
  * the tab TYPE and never changes with the process's running/stopped state:
- * console (logs-only launch) = square-terminal (cli console), preview webview = eye, terminal =
- * terminal, Files guest = file. A launch-config tab (console/preview — the only
+ * console (logs-only launch) = square-terminal (cli console), preview webview = eye, url = globe,
+ * terminal = terminal, Files guest = file. A launch-config tab (console/preview — the only
  * tabs carrying `config`) whose process is live shows a red Stop as a SEPARATE
  * control between the title and the close, mirroring the toolbar's Stop (todo
  * #206); clicking it stops the config via the same daemon call the toolbar uses,
@@ -11,7 +11,7 @@
  *
  * data-testid: run-tab-<id> / run-tab-stop-<id> / run-tab-close-<id>.
  */
-import { Eye, FileText, Square, SquareTerminal, Terminal, X } from 'lucide-react';
+import { Eye, FileText, Globe, Square, SquareTerminal, Terminal, X } from 'lucide-react';
 import type { LaunchConfiguration, LaunchProcessStatus } from '@qlan-ro/mainframe-types';
 import { useLayoutStore } from '@/store/layout';
 import { isLaunchStatusLive } from '@/features/run/derive-launch-control';
@@ -24,11 +24,12 @@ function tabGlyph(tab: RunTab, isActive: boolean) {
     ? 'text-mf-text-3'
     : tab.kind === 'terminal'
       ? 'text-mf-term-cyan'
-      : tab.kind === 'preview' || tab.kind === 'console'
+      : tab.kind === 'preview' || tab.kind === 'console' || tab.kind === 'url'
         ? 'text-mf-surface-run'
         : 'text-foreground';
   const cls = `flex-shrink-0 ${color}`;
   if (tab.kind === 'preview') return <Eye size={12} className={cls} />;
+  if (tab.kind === 'url') return <Globe size={12} className={cls} />;
   if (tab.kind === 'console') return <SquareTerminal size={12} className={cls} />;
   if (tab.kind === 'terminal') return <Terminal size={12} className={cls} />;
   return <FileText size={12} className={cls} />;

--- a/packages/ui/src/layout/RunTabStrip.tsx
+++ b/packages/ui/src/layout/RunTabStrip.tsx
@@ -16,13 +16,14 @@
  *   run-surface-drag                      — surface drag grip (primary pane)
  *   run-tab-strip-add-<paneId>            — the + trigger
  *   run-pane-new-terminal-<paneId>        — "New terminal" menu row
+ *   run-pane-open-url-<paneId>            — "URL…" menu row (opens the inline entry)
  *   run-pane-launch-<config>-<paneId>     — a launch-config menu row
  *   run-tab-strip-split-right / -split-down — split actions (primary)
  *   run-surface-close                     — close the Run surface (primary)
  *   run-pane-close-<paneId>               — un-split (secondary pane)
  */
 import { useState } from 'react';
-import { Eye, GripVertical, LayoutPanelLeft, LayoutPanelTop, Play, Plus, Terminal, X } from 'lucide-react';
+import { Eye, Globe, GripVertical, LayoutPanelLeft, LayoutPanelTop, Play, Plus, Terminal, X } from 'lucide-react';
 import type { LaunchConfiguration } from '@qlan-ro/mainframe-types';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { MenuDivider, MenuEmpty, MenuLabel, MenuRow } from '@/components/ui/menu';
@@ -33,6 +34,7 @@ import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
 import { useLaunchActions } from '@/features/run/use-launch-actions';
 import { useSurfaceDragStore } from './use-surface-drag';
 import { RunTabPill } from './RunTabPill';
+import { RunUrlEntry } from './RunUrlEntry';
 import { Hint } from '@/components/ui/hint';
 import type { RunPane } from '@/store/run-pane';
 
@@ -43,14 +45,15 @@ interface RunAddMenuProps {
   paneId: string;
   configs: LaunchConfiguration[];
   onLaunch: (config: LaunchConfiguration) => void;
+  onOpenUrl: () => void;
 }
 
-function RunAddMenu({ paneId, configs, onLaunch }: RunAddMenuProps) {
+function RunAddMenu({ paneId, configs, onLaunch, onOpenUrl }: RunAddMenuProps) {
   const [open, setOpen] = useState(false);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <Hint label="New terminal / Open preview">
+      <Hint label="New terminal, URL, or preview">
         <PopoverTrigger asChild>
           <button
             data-testid={`run-tab-strip-add-${paneId}`}
@@ -62,7 +65,7 @@ function RunAddMenu({ paneId, configs, onLaunch }: RunAddMenuProps) {
         </PopoverTrigger>
       </Hint>
       <PopoverContent data-testid={`run-add-menu-${paneId}`} className="w-[214px] rounded-[8px] p-[4px]" align="start">
-        <MenuLabel>New terminal</MenuLabel>
+        <MenuLabel>New tab</MenuLabel>
         <MenuRow
           data-testid={`run-pane-new-terminal-${paneId}`}
           icon={<Terminal className="size-[13px] text-mf-term-cyan" />}
@@ -71,6 +74,15 @@ function RunAddMenu({ paneId, configs, onLaunch }: RunAddMenuProps) {
           onClick={() => {
             setOpen(false);
             emitSurfaceIntent({ type: 'new-terminal', paneId });
+          }}
+        />
+        <MenuRow
+          data-testid={`run-pane-open-url-${paneId}`}
+          icon={<Globe className="size-[13px] text-mf-surface-run" />}
+          label="URL…"
+          onClick={() => {
+            setOpen(false);
+            onOpenUrl();
           }}
         />
         <MenuDivider />
@@ -104,6 +116,7 @@ function RunAddMenu({ paneId, configs, onLaunch }: RunAddMenuProps) {
 }
 
 export function RunTabStrip({ pane, primary }: { pane: RunPane; primary: boolean }) {
+  const [urlEntryOpen, setUrlEntryOpen] = useState(false);
   const splitAvailable = useLayoutStore((s) => layoutCanSplit(s.layout));
   const splitSurface = useLayoutStore((s) => s.splitSurface);
   const toggleSurface = useLayoutStore((s) => s.toggleSurface);
@@ -138,22 +151,37 @@ export function RunTabStrip({ pane, primary }: { pane: RunPane; primary: boolean
         <Play size={12} className="text-mf-surface-run" fill="currentColor" />
       </div>
 
-      <div className="flex h-full min-w-0 flex-initial items-center gap-[2px] overflow-x-auto pr-[2px] [scrollbar-width:none]">
-        {pane.tabs.map((t) => (
-          <RunTabPill
-            key={t.id}
-            pane={pane}
-            tab={t}
+      {/* The entry replaces the pill row rather than floating over the tab body:
+          the native child webview composites above the DOM and would swallow it. */}
+      {urlEntryOpen ? (
+        <div className="flex min-w-0 flex-1 items-center pr-[6px]">
+          <RunUrlEntry paneId={pane.id} onDone={() => setUrlEntryOpen(false)} />
+        </div>
+      ) : (
+        <>
+          <div className="flex h-full min-w-0 flex-initial items-center gap-[2px] overflow-x-auto pr-[2px] [scrollbar-width:none]">
+            {pane.tabs.map((t) => (
+              <RunTabPill
+                key={t.id}
+                pane={pane}
+                tab={t}
+                configs={configs}
+                scopeStatuses={scopeStatuses}
+                onStop={handleStop}
+              />
+            ))}
+          </div>
+
+          <RunAddMenu
+            paneId={pane.id}
             configs={configs}
-            scopeStatuses={scopeStatuses}
-            onStop={handleStop}
+            onLaunch={handleLaunch}
+            onOpenUrl={() => setUrlEntryOpen(true)}
           />
-        ))}
-      </div>
+        </>
+      )}
 
-      <RunAddMenu paneId={pane.id} configs={configs} onLaunch={handleLaunch} />
-
-      <div className="flex-1" />
+      {!urlEntryOpen && <div className="flex-1" />}
 
       <div className="flex flex-shrink-0 items-center gap-px pl-[2px] pr-[6px]">
         {primary && splitAvailable && (

--- a/packages/ui/src/layout/RunUrlEntry.tsx
+++ b/packages/ui/src/layout/RunUrlEntry.tsx
@@ -1,0 +1,76 @@
+/**
+ * RunUrlEntry — the inline "open a URL" field (#281), shared by the Run tab
+ * strip's `+` menu and the empty-state picker.
+ *
+ * Inline rather than a dialog: the strip is already the anchor, and a modal for
+ * one text field is heavier than the action. It only emits an intent — the
+ * subscriber owns tab creation — so it reads no layout state.
+ *
+ * data-testid:
+ *   run-tab-url-entry        — the field wrapper
+ *   run-tab-url-entry-input  — the input
+ */
+import { useState } from 'react';
+import { Globe } from 'lucide-react';
+import { normalizePreviewUrl } from '@/features/preview/normalize-url';
+import { emitSurfaceIntent } from '@/store/surface-intents';
+
+interface RunUrlEntryProps {
+  /** Target pane; omitted from the empty-state picker, which has no pane yet. */
+  paneId?: string;
+  /** Called once the entry is finished with — on commit, Escape, or blur. */
+  onDone: () => void;
+}
+
+export function RunUrlEntry({ paneId, onDone }: RunUrlEntryProps) {
+  const [draft, setDraft] = useState('');
+  const [invalid, setInvalid] = useState(false);
+
+  function commit() {
+    const url = normalizePreviewUrl(draft);
+    if (!url) {
+      setInvalid(true);
+      return;
+    }
+    emitSurfaceIntent({ type: 'open-url-tab', url, paneId });
+    onDone();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onDone();
+    }
+  }
+
+  return (
+    <div
+      data-testid="run-tab-url-entry"
+      className="flex h-[24px] min-w-0 flex-1 items-center gap-1 rounded-md border-[0.5px] border-border bg-card pl-1.5 pr-1"
+    >
+      <Globe size={12} className="flex-shrink-0 text-mf-text-3" aria-hidden />
+      <input
+        data-testid="run-tab-url-entry-input"
+        autoFocus
+        value={draft}
+        spellCheck={false}
+        autoComplete="off"
+        aria-label="Open a URL"
+        aria-invalid={invalid}
+        placeholder="localhost:3000"
+        onChange={(e) => {
+          setDraft(e.target.value);
+          setInvalid(false);
+        }}
+        onKeyDown={handleKeyDown}
+        onBlur={onDone}
+        className={`min-w-0 flex-1 bg-transparent px-[4px] font-mono text-body outline-none placeholder:text-mf-text-4 ${
+          invalid ? 'rounded-sm text-destructive ring-1 ring-destructive' : 'text-foreground'
+        }`}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/layout/SurfaceHost.tsx
+++ b/packages/ui/src/layout/SurfaceHost.tsx
@@ -7,6 +7,7 @@ import { windowStyleGeometry } from '@/lib/appearance/window-style';
 import { onSurfaceIntent } from '@/store/surface-intents';
 import { subscribeToFileIntents } from '@/store/intent-subscriber';
 import { subscribeToTerminalIntents } from '@/store/terminal-intent-subscriber';
+import { subscribeToUrlTabIntents } from '@/store/url-tab-intent-subscriber';
 import { SurfaceDragLayer } from './SurfaceDragLayer';
 import { SurfDivider } from './SurfDivider';
 import { FilesSurface } from './surfaces/FilesSurface';
@@ -68,6 +69,11 @@ function SurfaceHostImpl({ port }: Props) {
     return subscribeToTerminalIntents();
   }, []);
 
+  // Subscribe to open-url-tab intents — normalizes the URL and adds the Run tab.
+  useEffect(() => {
+    return subscribeToUrlTabIntents();
+  }, []);
+
   // Cmd/Ctrl + 1/2/3 toggle Chat/Files/Run.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -120,13 +126,7 @@ function SurfaceHostImpl({ port }: Props) {
       {/* Vertical divider + bottom strip. */}
       {bottom && (
         <>
-          <SurfDivider
-            axis="y"
-            containerRef={outerRef}
-            onFrac={setVFrac}
-            lineClass={geo.divider}
-            gutter={geo.gutter}
-          />
+          <SurfDivider axis="y" containerRef={outerRef} onFrac={setVFrac} lineClass={geo.divider} gutter={geo.gutter} />
           <div style={{ flex: vFlex.bottom }} className="flex min-h-0 overflow-hidden">
             <div data-drop-surface={bottom} className={`min-w-0 flex-1 ${panelCls}`}>
               <SurfaceView name={bottom} port={port} />

--- a/packages/ui/src/layout/SurfacePicker.tsx
+++ b/packages/ui/src/layout/SurfacePicker.tsx
@@ -1,4 +1,5 @@
-import { ChevronRight, Code2, Eye, FileText, GitCompare, Terminal } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronRight, Code2, Eye, FileText, GitCompare, Globe, Terminal } from 'lucide-react';
 import type { SurfaceId } from '@/store/layout';
 import { emitSurfaceIntent } from '@/store/surface-intents';
 import { MenuDivider, MenuLabel } from '@/components/ui/menu';
@@ -6,6 +7,7 @@ import { useActiveIdentity } from '@/features/sessions/use-active-identity';
 import { useDaemonPort } from '@/features/sessions/runtime/daemon-port-context';
 import { useLaunchActions } from '@/features/run/use-launch-actions';
 import { useRecentFiles } from '@/features/files/use-recent-files';
+import { RunUrlEntry } from './RunUrlEntry';
 
 interface RowProps {
   testid: string;
@@ -76,13 +78,26 @@ function FilesPickerContent() {
   );
 }
 
-/** Run-surface picker content: a New-terminal row + the launch-config list. */
+/** Run-surface picker content: Open-URL + New-terminal rows, then the launch-config list. */
 function RunPickerContent() {
+  const [urlEntryOpen, setUrlEntryOpen] = useState(false);
   const { projectId, chatId } = useActiveIdentity();
   const port = useDaemonPort();
   const { configs, handleLaunch } = useLaunchActions(port, projectId ?? undefined, chatId ?? undefined);
   return (
     <>
+      {urlEntryOpen ? (
+        <div className="flex px-[12px] py-[8px]">
+          <RunUrlEntry onDone={() => setUrlEntryOpen(false)} />
+        </div>
+      ) : (
+        <PickerRow
+          testid="run-picker-open-url"
+          icon={<Globe size={14} className="flex-shrink-0 text-mf-surface-run" />}
+          label="Open URL…"
+          onClick={() => setUrlEntryOpen(true)}
+        />
+      )}
       <PickerRow
         testid="run-picker-new-terminal"
         icon={<Terminal size={14} className="flex-shrink-0 text-mf-term-cyan" />}

--- a/packages/ui/src/layout/__tests__/RunSurface.url-tab.test.tsx
+++ b/packages/ui/src/layout/__tests__/RunSurface.url-tab.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * RunSurface — the `url` tab kind (#281, AC3, AC13).
+ *
+ * Mirrors RunSurface.tab-scope.test.tsx's mock set and scope-filtering model,
+ * adding a stub for UrlTabInstance and proving two things that file doesn't
+ * cover: the `url` kind renders through a real view (never the `${kind}:
+ * ${title}` placeholder), and it obeys the same scope filter/release as every
+ * other Run tab.
+ */
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TAB_SCOPE = 'proj-A:/Users/me/.worktrees/feat-x';
+
+const urlTabProps: Record<string, unknown>[] = [];
+vi.mock('@/features/url-tab/UrlTabInstance', () => ({
+  UrlTabInstance: (props: Record<string, unknown>) => {
+    urlTabProps.push({ ...props });
+    return <div data-testid={`stub-url-tab-${props['tabId'] as string}`} />;
+  },
+}));
+
+vi.mock('@/features/preview/PreviewInstance', () => ({
+  PreviewInstance: (props: Record<string, unknown>) => <div data-testid={`stub-preview-${props['tabId'] as string}`} />,
+}));
+
+vi.mock('@/features/run/ConsolePane', () => ({
+  ConsolePane: () => <div data-testid="stub-console-pane" />,
+}));
+
+vi.mock('@/features/terminal/TerminalInstance', () => ({
+  TerminalInstance: ({ terminalId }: { terminalId: string }) => <div data-testid={`stub-terminal-${terminalId}`} />,
+}));
+
+vi.mock('@/store/surface-intents', () => ({ emitSurfaceIntent: vi.fn() }));
+
+vi.mock('@/features/sessions/use-active-identity', () => ({
+  useActiveIdentity: () => ({
+    projectId: 'proj-A',
+    worktreePath: '/Users/me/.worktrees/feat-x',
+    chatId: 'chat-1',
+  }),
+}));
+
+vi.mock('@/features/sessions/runtime/daemon-port-context', () => ({
+  useDaemonPort: () => 31500,
+}));
+
+vi.mock('@/features/run/use-launch-actions', () => ({
+  useLaunchActions: () => ({
+    configs: [],
+    scopeStatuses: {},
+    selectedConfigName: null,
+    handleSelect: vi.fn(),
+    handleLaunch: vi.fn(),
+    handleStop: vi.fn(),
+    refetch: vi.fn(),
+  }),
+}));
+
+import { useLayoutStore } from '@/store/layout';
+import { useSandboxStore } from '@/store/sandbox';
+import { RunSurface } from '../surfaces/RunSurface';
+
+const FRESH_LAYOUT = {
+  top: ['run' as const],
+  bottom: null as null,
+  topFlex: {} as Record<string, number>,
+  vFlex: { top: 1, bottom: 0.4 },
+};
+
+function seedRunTabs(tabs: { id: string; kind: 'url' | 'code'; title: string; url?: string; scopeKey?: string }[]) {
+  useLayoutStore.setState({
+    layout: { ...FRESH_LAYOUT },
+    run: {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [{ id: 'pane-1', active: tabs[0]!.id, tabs }],
+    },
+    sessions: new Map(),
+    activeSessionId: null,
+  });
+  useSandboxStore.setState({
+    captures: [],
+    logsOutput: [],
+    selectedConfigByScope: {},
+    lastStartedProcess: null,
+    processStatuses: { [TAB_SCOPE]: { dev: 'running' } },
+  });
+}
+
+describe('RunSurface — the url tab kind', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    urlTabProps.length = 0;
+  });
+
+  it('renders a url tab through UrlTabInstance, never the fallback placeholder', () => {
+    seedRunTabs([
+      { id: 'tab-1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/', scopeKey: TAB_SCOPE },
+    ]);
+    const { getByTestId, queryByText } = render(<RunSurface />);
+
+    expect(getByTestId('stub-url-tab-tab-1')).toBeTruthy();
+    expect(queryByText('url: localhost:5173')).toBeNull();
+  });
+
+  it('threads tabId, url, visible, scopeKey, and projectId from the tab and active identity', () => {
+    seedRunTabs([
+      { id: 'tab-1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/', scopeKey: TAB_SCOPE },
+    ]);
+    render(<RunSurface />);
+
+    expect(urlTabProps[0]).toMatchObject({
+      tabId: 'tab-1',
+      url: 'http://localhost:5173/',
+      visible: true,
+      scopeKey: TAB_SCOPE,
+      projectId: 'proj-A',
+    });
+  });
+
+  it('a code tab still renders the fallback placeholder — the assertion above is not vacuous', () => {
+    seedRunTabs([{ id: 'tab-code', kind: 'code', title: 'index.ts', scopeKey: TAB_SCOPE }]);
+    const { getByText } = render(<RunSurface />);
+
+    expect(getByText('code: index.ts')).toBeTruthy();
+    expect(urlTabProps).toHaveLength(0);
+  });
+
+  it('does not render a url tab whose scopeKey belongs to a different project/worktree', () => {
+    seedRunTabs([
+      {
+        id: 'leak-tab',
+        kind: 'url',
+        title: 'localhost:5173',
+        url: 'http://localhost:5173/',
+        scopeKey: 'proj-B:/other',
+      },
+    ]);
+    const { queryByTestId } = render(<RunSurface />);
+
+    expect(urlTabProps).toHaveLength(0);
+    expect(queryByTestId('stub-url-tab-leak-tab')).toBeNull();
+  });
+
+  it('renders a url tab stamped with the active scope alongside a hidden non-matching one', () => {
+    seedRunTabs([
+      { id: 'keep-1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/', scopeKey: TAB_SCOPE },
+      { id: 'leak-1', kind: 'url', title: 'localhost:6000', url: 'http://localhost:6000/', scopeKey: 'proj-B:/other' },
+    ]);
+    const { getByTestId, queryByTestId } = render(<RunSurface />);
+
+    expect(urlTabProps).toHaveLength(1);
+    expect(urlTabProps[0]!['scopeKey']).toBe(TAB_SCOPE);
+    expect(getByTestId('stub-url-tab-keep-1')).toBeTruthy();
+    expect(queryByTestId('stub-url-tab-leak-1')).toBeNull();
+  });
+
+  it('removes a url tab from the DOM after its scope is released', () => {
+    seedRunTabs([
+      { id: 'tab-1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/', scopeKey: TAB_SCOPE },
+    ]);
+    const { queryByTestId, rerender } = render(<RunSurface />);
+    expect(queryByTestId('stub-url-tab-tab-1')).toBeTruthy();
+
+    useLayoutStore.getState().releaseRunScope(TAB_SCOPE);
+    rerender(<RunSurface />);
+
+    expect(queryByTestId('stub-url-tab-tab-1')).toBeNull();
+  });
+});

--- a/packages/ui/src/layout/__tests__/RunUrlEntry.test.tsx
+++ b/packages/ui/src/layout/__tests__/RunUrlEntry.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * RunUrlEntry — the inline "open a URL" field shared by the tab strip's `+`
+ * menu and the empty-state picker (#281, AC6, D2).
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const emitSurfaceIntent = vi.fn();
+vi.mock('@/store/surface-intents', () => ({ emitSurfaceIntent: (intent: unknown) => emitSurfaceIntent(intent) }));
+
+import { RunUrlEntry } from '../RunUrlEntry';
+
+function input(): HTMLElement {
+  return screen.getByTestId('run-tab-url-entry-input');
+}
+
+beforeEach(() => {
+  emitSurfaceIntent.mockReset();
+});
+
+describe('RunUrlEntry — commit', () => {
+  it('emits one open-url-tab intent with the normalized URL and calls onDone', async () => {
+    const onDone = vi.fn();
+    render(<RunUrlEntry paneId="pane-1" onDone={onDone} />);
+
+    await userEvent.type(input(), 'localhost:5173');
+    await userEvent.keyboard('{Enter}');
+
+    expect(emitSurfaceIntent).toHaveBeenCalledTimes(1);
+    expect(emitSurfaceIntent).toHaveBeenCalledWith({
+      type: 'open-url-tab',
+      url: 'http://localhost:5173/',
+      paneId: 'pane-1',
+    });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits paneId when the caller supplies none — the empty-state picker case', async () => {
+    const onDone = vi.fn();
+    render(<RunUrlEntry onDone={onDone} />);
+
+    await userEvent.type(input(), 'localhost:5173');
+    await userEvent.keyboard('{Enter}');
+
+    expect(emitSurfaceIntent).toHaveBeenCalledWith({
+      type: 'open-url-tab',
+      url: 'http://localhost:5173/',
+      paneId: undefined,
+    });
+  });
+});
+
+describe('RunUrlEntry — invalid input', () => {
+  it.each(['', '   ', 'not a url', 'file:///etc/passwd', 'javascript:alert(1)'])(
+    'emits nothing and marks the field invalid for %j',
+    async (draft) => {
+      const onDone = vi.fn();
+      render(<RunUrlEntry paneId="pane-1" onDone={onDone} />);
+
+      if (draft) await userEvent.type(input(), draft);
+      await userEvent.keyboard('{Enter}');
+
+      expect(emitSurfaceIntent).not.toHaveBeenCalled();
+      expect(onDone).not.toHaveBeenCalled();
+      expect(input()).toHaveAttribute('aria-invalid', 'true');
+    },
+  );
+
+  it('clears the invalid state once the user types again', async () => {
+    render(<RunUrlEntry paneId="pane-1" onDone={vi.fn()} />);
+
+    await userEvent.keyboard('{Enter}');
+    expect(input()).toHaveAttribute('aria-invalid', 'true');
+
+    await userEvent.type(input(), 'l');
+    expect(input()).toHaveAttribute('aria-invalid', 'false');
+  });
+});
+
+describe('RunUrlEntry — Escape', () => {
+  it('emits nothing and calls onDone', async () => {
+    const onDone = vi.fn();
+    render(<RunUrlEntry paneId="pane-1" onDone={onDone} />);
+
+    await userEvent.type(input(), 'localhost:5173');
+    await userEvent.keyboard('{Escape}');
+
+    expect(emitSurfaceIntent).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/layout/surfaces/RunSurface.tsx
+++ b/packages/ui/src/layout/surfaces/RunSurface.tsx
@@ -3,12 +3,14 @@
  * 1 or 2 panes laid out along `run.dir`; each pane is a `RunTabStrip` + the
  * active body. A preview-config tab shows the webview (`PreviewInstance`); a
  * process-config tab shows a full-space console (`ConsolePane variant="full"`);
- * a terminal tab shows the PTY. The whole surface is a drop target for a
+ * a terminal tab shows the PTY; a `url` tab shows an arbitrary address in the
+ * same webview (`UrlTabInstance`). The whole surface is a drop target for a
  * Files-tab drag (`data-drop-surface="run"`).
  */
 import { GripVertical, LayoutPanelLeft, LayoutPanelTop, Play, X } from 'lucide-react';
 import { TerminalInstance } from '@/features/terminal/TerminalInstance';
 import { PreviewInstance } from '@/features/preview/PreviewInstance';
+import { UrlTabInstance } from '@/features/url-tab/UrlTabInstance';
 import { ConsolePane } from '@/features/run/ConsolePane';
 import { RunTabStrip } from '../RunTabStrip';
 import { isSurfaceFloor, layoutCanSplit, useLayoutStore } from '@/store/layout';
@@ -124,6 +126,19 @@ function RunTabBody({
         scopeKey={tabScope ?? undefined}
         projectId={projectId ?? undefined}
         port={tab.port ?? null}
+      />
+    );
+  }
+  if (tab.kind === 'url') {
+    // A corrupt persisted tab with no url resolves to the `invalid` body, which
+    // still carries a live address bar — never the placeholder below.
+    return (
+      <UrlTabInstance
+        tabId={tab.id}
+        url={tab.url ?? ''}
+        visible={active}
+        scopeKey={tabScope ?? undefined}
+        projectId={projectId ?? undefined}
       />
     );
   }

--- a/packages/ui/src/lib/daemon/__tests__/dispose-daemon-session.test.ts
+++ b/packages/ui/src/lib/daemon/__tests__/dispose-daemon-session.test.ts
@@ -7,7 +7,7 @@ vi.mock('../../../features/sessions/runtime/chat-controller-registry', () => ({
 }));
 vi.mock('../../../store/terminal-cleanup', () => ({ killAndDisposeCachedTerminals: vi.fn() }));
 vi.mock('../../../store/layout', () => ({ useLayoutStore: { getState: vi.fn(() => ({ run: null })) } }));
-vi.mock('../../../store/run-pane', () => ({ terminalIdsInRun: vi.fn(() => []) }));
+vi.mock('../../../store/run-pane', () => ({ tabIdsInRun: vi.fn(() => []) }));
 
 // adapters/adapters-seed are exercised for real (not mocked) so the store-state
 // and generation-guard assertions below pin actual behavior. Only their network

--- a/packages/ui/src/lib/daemon/dispose-daemon-session.ts
+++ b/packages/ui/src/lib/daemon/dispose-daemon-session.ts
@@ -2,7 +2,7 @@ import { daemonWs } from './ws-client';
 import { chatControllerRegistry } from '../../features/sessions/runtime/chat-controller-registry';
 import { killAndDisposeCachedTerminals } from '../../store/terminal-cleanup';
 import { useLayoutStore } from '../../store/layout';
-import { terminalIdsInRun } from '../../store/run-pane';
+import { tabIdsInRun } from '../../store/run-pane';
 import { resetAdapters } from '../../store/adapters';
 import { invalidateSeedFetches } from '../../store/adapters-seed';
 
@@ -28,7 +28,7 @@ export function disposeDaemonSession(): void {
 
   try {
     const { run } = useLayoutStore.getState();
-    killAndDisposeCachedTerminals(terminalIdsInRun(run));
+    killAndDisposeCachedTerminals(tabIdsInRun(run, 'terminal'));
   } catch (err) {
     console.warn('[disposeDaemonSession] killAndDisposeCachedTerminals failed', err);
   }

--- a/packages/ui/src/lib/daemon/dispose-daemon-session.ts
+++ b/packages/ui/src/lib/daemon/dispose-daemon-session.ts
@@ -1,6 +1,7 @@
 import { daemonWs } from './ws-client';
 import { chatControllerRegistry } from '../../features/sessions/runtime/chat-controller-registry';
 import { killAndDisposeCachedTerminals } from '../../store/terminal-cleanup';
+import { clearUrlTunnelConsumers } from '../../features/url-tab/tunnel-consumers';
 import { useLayoutStore } from '../../store/layout';
 import { tabIdsInRun } from '../../store/run-pane';
 import { resetAdapters } from '../../store/adapters';
@@ -38,5 +39,13 @@ export function disposeDaemonSession(): void {
     invalidateSeedFetches();
   } catch (err) {
     console.warn('[disposeDaemonSession] adapters reset failed', err);
+  }
+
+  try {
+    // Drop the registry only — never stop a tunnel here, or the stop would go
+    // to the daemon we're leaving, not the one it actually runs on.
+    clearUrlTunnelConsumers();
+  } catch (err) {
+    console.warn('[disposeDaemonSession] clearUrlTunnelConsumers failed', err);
   }
 }

--- a/packages/ui/src/store/__tests__/layout-persist.test.ts
+++ b/packages/ui/src/store/__tests__/layout-persist.test.ts
@@ -38,6 +38,41 @@ describe('layout-persist', () => {
     ).toBeNull();
   });
 
+  it('keeps a url tab with its url and title intact, while still dropping preview/console/terminal', () => {
+    const r = {
+      dir: 'v' as const,
+      flex: [1, 1],
+      panes: [
+        {
+          id: 'p1',
+          active: 'u1',
+          tabs: [
+            { id: 't1', kind: 'terminal', title: 'bash' },
+            { id: 'pv', kind: 'preview', title: 'web', config: 'dev' },
+            { id: 'cs', kind: 'console', title: 'proc', config: 'dev' },
+            { id: 'u1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/' },
+          ],
+        },
+      ],
+    } as unknown as RunState;
+    const out = sanitizeRun(r)!;
+    expect(out.panes[0]!.tabs).toEqual([
+      { id: 'u1', kind: 'url', title: 'localhost:5173', url: 'http://localhost:5173/' },
+    ]);
+  });
+
+  it('keeps a pane containing only a url tab, instead of dropping it', () => {
+    const r = {
+      dir: 'v' as const,
+      flex: [1, 1],
+      panes: [{ id: 'p1', active: 'u1', tabs: [{ id: 'u1', kind: 'url', title: 'x', url: 'http://x/' }] }],
+    } as unknown as RunState;
+    const out = sanitizeRun(r);
+    expect(out).not.toBeNull();
+    expect(out!.panes).toHaveLength(1);
+    expect(out!.panes[0]!.tabs[0]!.kind).toBe('url');
+  });
+
   it('serializeSessions sanitizes run and skips __LOCALID_ drafts', () => {
     const sessions = new Map<string, SessionWorkspace>([
       ['chat-1', { layout, run: run([{ id: 't1', kind: 'terminal', title: 'bash' }]) }],

--- a/packages/ui/src/store/__tests__/port-tunnels.test.ts
+++ b/packages/ui/src/store/__tests__/port-tunnels.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/api/tunnel-ports', () => ({ listPortTunnels: (port: number) => li
 import {
   applyPortTunnelEvent,
   applyPortTunnelSnapshot,
+  clearPortTunnelEntry,
   installPortTunnelSubscriber,
   portTunnelGeneration,
   reportPortTunnelError,
@@ -58,20 +59,20 @@ describe('applyPortTunnelEvent — state mapping', () => {
 
   it('records a ready tunnel with its url', () => {
     applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:5173', url: 'https://a.trycloudflare.com' }));
-    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com' } });
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false } });
   });
 
   it('treats dns_verified as ready', () => {
     applyPortTunnelEvent(
       tunnelEvent({ state: 'dns_verified', label: 'port:5173', url: 'https://a.trycloudflare.com', dnsVerified: true }),
     );
-    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com' } });
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true } });
   });
 
   it('keeps the known url when a dns_verified event carries none', () => {
     applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:5173', url: 'https://a.trycloudflare.com' }));
     applyPortTunnelEvent(tunnelEvent({ state: 'dns_verified', label: 'port:5173' }));
-    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com' } });
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true } });
   });
 
   it('records an error with the daemon’s message', () => {
@@ -95,8 +96,68 @@ describe('applyPortTunnelEvent — state mapping', () => {
     applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:8080', url: 'https://b.trycloudflare.com' }));
     expect(entries()).toEqual({
       5173: { state: 'starting' },
-      8080: { state: 'ready', url: 'https://b.trycloudflare.com' },
+      8080: { state: 'ready', url: 'https://b.trycloudflare.com', dnsVerified: false },
     });
+  });
+});
+
+describe('applyPortTunnelEvent — dnsVerified flag (D11)', () => {
+  it('a dns_verified event with no prior ready still yields dnsVerified: true', () => {
+    applyPortTunnelEvent(
+      tunnelEvent({ state: 'dns_verified', label: 'port:5173', url: 'https://a.trycloudflare.com' }),
+    );
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true } });
+  });
+
+  it('a late duplicate ready event cannot un-verify an already-verified tunnel', () => {
+    applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:5173', url: 'https://a.trycloudflare.com' }));
+    applyPortTunnelEvent(tunnelEvent({ state: 'dns_verified', label: 'port:5173' }));
+    applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:5173', url: 'https://a.trycloudflare.com' }));
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true } });
+  });
+});
+
+describe('applyPortTunnelSnapshot — dnsVerified flag (D11, fact 8)', () => {
+  it('marks a ready entry dnsVerified: true', () => {
+    applyPortTunnelSnapshot([{ port: 5173, state: 'ready', url: 'https://a.trycloudflare.com' }]);
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true } });
+  });
+
+  it('leaves a starting entry without the flag', () => {
+    applyPortTunnelSnapshot([{ port: 5173, state: 'starting' }]);
+    expect(entries()).toEqual({ 5173: { state: 'starting' } });
+  });
+});
+
+describe('clearPortTunnelEntry (PD2)', () => {
+  it('clears an error entry, bumps generation, and returns true', () => {
+    applyPortTunnelEvent(tunnelEvent({ state: 'error', label: 'port:5173', error: 'boom' }));
+    const before = portTunnelGeneration();
+    expect(clearPortTunnelEntry(5173)).toBe(true);
+    expect(entries()).toEqual({});
+    expect(portTunnelGeneration()).toBe(before + 1);
+  });
+
+  it('clears a starting entry, bumps generation, and returns true', () => {
+    applyPortTunnelEvent(tunnelEvent({ state: 'starting', label: 'port:5173' }));
+    const before = portTunnelGeneration();
+    expect(clearPortTunnelEntry(5173)).toBe(true);
+    expect(entries()).toEqual({});
+    expect(portTunnelGeneration()).toBe(before + 1);
+  });
+
+  it('is a no-op on a ready entry: state/url/dnsVerified survive, returns false, generation unchanged', () => {
+    applyPortTunnelEvent(tunnelEvent({ state: 'ready', label: 'port:5173', url: 'https://a.trycloudflare.com' }));
+    const before = portTunnelGeneration();
+    expect(clearPortTunnelEntry(5173)).toBe(false);
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false } });
+    expect(portTunnelGeneration()).toBe(before);
+  });
+
+  it('returns false and leaves the state reference untouched for a port with no entry', () => {
+    const before = usePortTunnelsStore.getState();
+    expect(clearPortTunnelEntry(5173)).toBe(false);
+    expect(usePortTunnelsStore.getState()).toBe(before);
   });
 });
 
@@ -162,7 +223,7 @@ describe('reportPortTunnelError', () => {
 
     reportPortTunnelError(5173, 'edge reconnect');
 
-    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com' } });
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false } });
     expect(toastError).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       '[port-tunnels] ignoring an error for the live tunnel on port 5173: edge reconnect',
@@ -176,7 +237,7 @@ describe('reportPortTunnelError', () => {
 
     applyPortTunnelEvent(tunnelEvent({ state: 'error', label: 'port:5173', error: 'edge reconnect' }));
 
-    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com' } });
+    expect(entries()).toEqual({ 5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: false } });
     expect(toastError).not.toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -203,7 +264,7 @@ describe('seedPortTunnels', () => {
 
     expect(listPortTunnels).toHaveBeenCalledWith(31415);
     expect(entries()).toEqual({
-      5173: { state: 'ready', url: 'https://a.trycloudflare.com' },
+      5173: { state: 'ready', url: 'https://a.trycloudflare.com', dnsVerified: true },
       8080: { state: 'starting' },
     });
   });
@@ -242,7 +303,7 @@ describe('seedPortTunnels', () => {
     await Promise.resolve();
 
     expect(usePortTunnelsStore.getState().daemonPort).toBe(31500);
-    expect(entries()).toEqual({ 8080: { state: 'ready', url: 'https://second.trycloudflare.com' } });
+    expect(entries()).toEqual({ 8080: { state: 'ready', url: 'https://second.trycloudflare.com', dnsVerified: true } });
   });
 
   it('warns and leaves the store alone when the fetch fails', async () => {

--- a/packages/ui/src/store/__tests__/port-tunnels.test.ts
+++ b/packages/ui/src/store/__tests__/port-tunnels.test.ts
@@ -249,6 +249,29 @@ describe('reportPortTunnelError', () => {
   });
 });
 
+describe('reportPortTunnelError — error provenance (#281 D10/AC12)', () => {
+  it('marks a client-written error so a reader can tell it apart from daemon truth', () => {
+    reportPortTunnelError(5173, 'fetch failed', 'client');
+    expect(entries()).toEqual({ 5173: { state: 'error', error: 'fetch failed', errorOrigin: 'client' } });
+  });
+
+  it('leaves a daemon-origin error unmarked — the absence of the key IS the daemon claim', () => {
+    reportPortTunnelError(5173, 'cloudflared exited', 'daemon');
+    expect(entries()).toEqual({ 5173: { state: 'error', error: 'cloudflared exited' } });
+  });
+
+  it('defaults to daemon origin, so an unmarked entry stays evidence about the daemon', () => {
+    applyPortTunnelEvent(tunnelEvent({ state: 'error', label: 'port:5173', error: 'cloudflared exited' }));
+    expect(entries()[5173]).not.toHaveProperty('errorOrigin');
+  });
+
+  it('drops the marker when a daemon error replaces a client one on the same port', () => {
+    reportPortTunnelError(5173, 'fetch failed', 'client');
+    reportPortTunnelError(5173, 'cloudflared exited');
+    expect(entries()).toEqual({ 5173: { state: 'error', error: 'cloudflared exited' } });
+  });
+});
+
 describe('seedPortTunnels', () => {
   it('applies the snapshot and the daemon’s own port', async () => {
     listPortTunnels.mockResolvedValue({

--- a/packages/ui/src/store/__tests__/run-pane-release-scope.test.ts
+++ b/packages/ui/src/store/__tests__/run-pane-release-scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { releaseRunScope, terminalIdsForScope, type RunState } from '../run-pane';
+import { releaseRunScope, tabIdsForScope, type RunState } from '../run-pane';
 
 const SCOPE = 'p:/a';
 const OTHER = 'p:/b';
@@ -27,12 +27,12 @@ function run(): RunState {
   };
 }
 
-describe('terminalIdsForScope', () => {
+describe('tabIdsForScope', () => {
   it('returns only terminal tab ids of the target scope', () => {
-    expect(terminalIdsForScope(run(), SCOPE)).toEqual(['t2', 't4']);
+    expect(tabIdsForScope(run(), SCOPE, 'terminal')).toEqual(['t2', 't4']);
   });
   it('returns [] for null run', () => {
-    expect(terminalIdsForScope(null, SCOPE)).toEqual([]);
+    expect(tabIdsForScope(null, SCOPE, 'terminal')).toEqual([]);
   });
 });
 

--- a/packages/ui/src/store/__tests__/run-pane-terminal.test.ts
+++ b/packages/ui/src/store/__tests__/run-pane-terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { addRunTab, moveTabToRun, terminalIdsInPane, terminalIdsInRun, type RunTab } from '../run-pane';
+import { addRunTab, moveTabToRun, tabIdsInPane, tabIdsInRun, type RunTab } from '../run-pane';
 import { useLayoutStore, type SurfaceId } from '../layout';
 
 const tab = (id: string): RunTab => ({ id, kind: 'terminal', title: id });
@@ -69,7 +69,7 @@ describe('terminal id collectors', () => {
   const term = (id: string): RunTab => ({ id, kind: 'terminal', title: id });
   const code = (id: string): RunTab => ({ id, kind: 'code', title: id });
 
-  it('terminalIdsInRun returns every terminal tab id across panes', () => {
+  it('tabIdsInRun returns every terminal tab id across panes', () => {
     const run = {
       dir: 'v' as const,
       flex: [1, 1],
@@ -78,10 +78,10 @@ describe('terminal id collectors', () => {
         { id: 'p2', tabs: [term('t2')], active: 't2' },
       ],
     };
-    expect(terminalIdsInRun(run).sort()).toEqual(['t1', 't2']);
+    expect(tabIdsInRun(run, 'terminal').sort()).toEqual(['t1', 't2']);
   });
 
-  it('terminalIdsInPane returns only that pane terminal ids', () => {
+  it('tabIdsInPane returns only that pane terminal ids', () => {
     const run = {
       dir: 'v' as const,
       flex: [1, 1],
@@ -90,12 +90,12 @@ describe('terminal id collectors', () => {
         { id: 'p2', tabs: [term('t2')], active: 't2' },
       ],
     };
-    expect(terminalIdsInPane(run, 'p1')).toEqual(['t1']);
-    expect(terminalIdsInPane(run, 'p2')).toEqual(['t2']);
-    expect(terminalIdsInPane(run, 'nope')).toEqual([]);
+    expect(tabIdsInPane(run, 'p1', 'terminal')).toEqual(['t1']);
+    expect(tabIdsInPane(run, 'p2', 'terminal')).toEqual(['t2']);
+    expect(tabIdsInPane(run, 'nope', 'terminal')).toEqual([]);
   });
 
-  it('terminalIdsInRun on null is empty', () => {
-    expect(terminalIdsInRun(null)).toEqual([]);
+  it('tabIdsInRun on null is empty', () => {
+    expect(tabIdsInRun(null, 'terminal')).toEqual([]);
   });
 });

--- a/packages/ui/src/store/__tests__/run-pane-url-tab.test.ts
+++ b/packages/ui/src/store/__tests__/run-pane-url-tab.test.ts
@@ -1,0 +1,180 @@
+/**
+ * URL tab model: dedup within addRunTab, scope release, kind-parameterized id
+ * collectors, and the retargetUrlTab reducer (#281, plan tasks 2 and 8).
+ *
+ * `tabIdsInRun` / `tabIdsInPane` / `tabIdsForScope` replace the terminal-only
+ * `terminalIds*` helpers with a `kind` parameter (task 8 item 4); this file
+ * exercises them for both `'url'` and `'terminal'` so the generalization is
+ * covered, not just the new kind.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  addRunTab,
+  releaseRunScope,
+  retargetUrlTab,
+  tabIdsForScope,
+  tabIdsInPane,
+  tabIdsInRun,
+  type RunState,
+  type RunTab,
+} from '../run-pane';
+
+const urlTab = (id: string, url: string, scopeKey = 'scope-a'): RunTab => ({
+  id,
+  kind: 'url',
+  title: url,
+  url,
+  scopeKey,
+});
+
+describe('addRunTab — url tab dedup', () => {
+  it('appends a new url tab and focuses it', () => {
+    const run = addRunTab(null, urlTab('u1', 'http://localhost:5173/'))!;
+    expect(run.panes[0]!.tabs.map((t) => t.id)).toEqual(['u1']);
+    expect(run.panes[0]!.active).toBe('u1');
+  });
+
+  it('same normalized URL in the same scope focuses the existing tab instead of duplicating', () => {
+    const first = addRunTab(null, urlTab('u1', 'http://localhost:5173/'))!;
+    const second = addRunTab(first, urlTab('u2', 'http://localhost:5173/'))!;
+    expect(second.panes[0]!.tabs.map((t) => t.id)).toEqual(['u1']);
+    expect(second.panes[0]!.active).toBe('u1');
+  });
+
+  it('dedups across panes, not just the target pane', () => {
+    const base = addRunTab(null, urlTab('u1', 'http://localhost:5173/'))!;
+    const split: RunState = {
+      ...base,
+      panes: [base.panes[0]!, { id: 'pane-2', tabs: [urlTab('other', 'http://localhost:9000/')], active: 'other' }],
+    };
+    const result = addRunTab(split, urlTab('u2', 'http://localhost:5173/'), 'pane-2')!;
+    expect(tabIdsInRun(result, 'url').sort()).toEqual(['other', 'u1']);
+    expect(result.panes[0]!.active).toBe('u1');
+  });
+
+  it('same URL with a different scopeKey creates a second tab', () => {
+    const first = addRunTab(null, urlTab('u1', 'http://localhost:5173/', 'scope-a'))!;
+    const second = addRunTab(first, urlTab('u2', 'http://localhost:5173/', 'scope-b'))!;
+    expect(tabIdsInRun(second, 'url').sort()).toEqual(['u1', 'u2']);
+    expect(second.panes[0]!.active).toBe('u2');
+  });
+
+  it('two URL tabs on the same port with different paths are two tabs', () => {
+    const first = addRunTab(null, urlTab('u1', 'http://localhost:5173/a'))!;
+    const second = addRunTab(first, urlTab('u2', 'http://localhost:5173/b'))!;
+    expect(tabIdsInRun(second, 'url').sort()).toEqual(['u1', 'u2']);
+  });
+});
+
+describe('releaseRunScope — url tabs', () => {
+  it('removes url tabs of the released scope and leaves the others', () => {
+    const run: RunState = {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [
+        {
+          id: 'p1',
+          active: 'u2',
+          tabs: [urlTab('u1', 'http://localhost:1/', 'scope-a'), urlTab('u2', 'http://localhost:2/', 'scope-b')],
+        },
+      ],
+    };
+    const result = releaseRunScope(run, 'scope-a')!;
+    expect(result.panes[0]!.tabs.map((t) => t.id)).toEqual(['u2']);
+  });
+});
+
+describe('kind-parameterized tab id collectors', () => {
+  const term = (id: string): RunTab => ({ id, kind: 'terminal', title: id });
+
+  function run(): RunState {
+    return {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [
+        { id: 'p1', active: 'u1', tabs: [urlTab('u1', 'http://localhost:1/', 'scope-a'), term('t1')] },
+        { id: 'p2', active: 't2', tabs: [term('t2'), urlTab('u2', 'http://localhost:2/', 'scope-a')] },
+      ],
+    };
+  }
+
+  it('tabIdsInRun returns only ids of the requested kind', () => {
+    expect(tabIdsInRun(run(), 'url').sort()).toEqual(['u1', 'u2']);
+    expect(tabIdsInRun(run(), 'terminal').sort()).toEqual(['t1', 't2']);
+  });
+
+  it("tabIdsInPane returns only that pane's ids of the requested kind", () => {
+    expect(tabIdsInPane(run(), 'p1', 'url')).toEqual(['u1']);
+    expect(tabIdsInPane(run(), 'p2', 'terminal')).toEqual(['t2']);
+  });
+
+  it('tabIdsForScope returns only ids of the requested kind in that scope', () => {
+    expect(tabIdsForScope(run(), 'scope-a', 'url').sort()).toEqual(['u1', 'u2']);
+  });
+});
+
+describe('retargetUrlTab', () => {
+  function run(): RunState {
+    return {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [{ id: 'p1', active: 'u1', tabs: [urlTab('u1', 'http://localhost:1/', 'scope-a')] }],
+    };
+  }
+
+  it('updates the url and title in place, keeping the id', () => {
+    const result = retargetUrlTab(run(), 'u1', 'http://localhost:2/', 'localhost:2');
+    const tab = result.panes[0]!.tabs[0]!;
+    expect(tab.id).toBe('u1');
+    expect(tab.url).toBe('http://localhost:2/');
+    expect(tab.title).toBe('localhost:2');
+  });
+
+  it('returns the same reference when retargeting to the URL it already holds', () => {
+    const start = run();
+    expect(retargetUrlTab(start, 'u1', 'http://localhost:1/', 'localhost:1')).toBe(start);
+  });
+
+  it('activates a sibling tab in the same scope that already holds the target URL, and leaves the source untouched', () => {
+    const start: RunState = {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [
+        { id: 'p1', active: 'u1', tabs: [urlTab('u1', 'http://localhost:1/', 'scope-a')] },
+        { id: 'p2', active: 'u2', tabs: [urlTab('u2', 'http://localhost:2/', 'scope-a')] },
+      ],
+    };
+    const result = retargetUrlTab(start, 'u1', 'http://localhost:2/', 'localhost:2');
+    // Source tab u1 unchanged.
+    expect(result.panes[0]!.tabs[0]).toEqual(start.panes[0]!.tabs[0]);
+    // The holder (u2) is activated in its own pane.
+    expect(result.panes[1]!.active).toBe('u2');
+  });
+
+  it('a tab in a DIFFERENT scope holding that URL does not block the retarget', () => {
+    const start: RunState = {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [
+        { id: 'p1', active: 'u1', tabs: [urlTab('u1', 'http://localhost:1/', 'scope-a')] },
+        { id: 'p2', active: 'u2', tabs: [urlTab('u2', 'http://localhost:2/', 'scope-b')] },
+      ],
+    };
+    const result = retargetUrlTab(start, 'u1', 'http://localhost:2/', 'localhost:2');
+    expect(result.panes[0]!.tabs[0]!.url).toBe('http://localhost:2/');
+  });
+
+  it('returns the same reference for an unknown tabId', () => {
+    const start = run();
+    expect(retargetUrlTab(start, 'nope', 'http://localhost:2/', 'localhost:2')).toBe(start);
+  });
+
+  it('returns the same reference for a tab whose kind is not url', () => {
+    const start: RunState = {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [{ id: 'p1', active: 't1', tabs: [{ id: 't1', kind: 'terminal', title: 'sh' }] }],
+    };
+    expect(retargetUrlTab(start, 't1', 'http://localhost:2/', 'localhost:2')).toBe(start);
+  });
+});

--- a/packages/ui/src/store/__tests__/url-tab-intent-subscriber.test.ts
+++ b/packages/ui/src/store/__tests__/url-tab-intent-subscriber.test.ts
@@ -1,0 +1,188 @@
+/**
+ * subscribeToUrlTabIntents — the sanctioned bridge for the `open-url-tab`
+ * surface intent (#281, AC4, AC13, AC16), plus the tunnel-release contract
+ * that fires from the four store-level tab-removal sites (D10, AC12).
+ *
+ * Real `useLayoutStore`, `useActiveBasesStore`, and the real `tunnel-consumers`
+ * ownership registry; only the daemon API is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const startPortTunnel = vi.fn();
+const stopPortTunnel = vi.fn<(port: number, portNum: number) => Promise<void>>();
+vi.mock('@/lib/api/tunnel-ports', () => ({
+  startPortTunnel: (...a: unknown[]) => startPortTunnel(...a),
+  stopPortTunnel: (...a: Parameters<typeof stopPortTunnel>) => stopPortTunnel(...a),
+  listPortTunnels: vi.fn(),
+}));
+
+import { emitSurfaceIntent } from '../surface-intents';
+import { useActiveBasesStore } from '../active-bases-store';
+import { useLayoutStore } from '../layout';
+import { subscribeToUrlTabIntents } from '../url-tab-intent-subscriber';
+import { clearUrlTunnelConsumers, registerUrlTunnelConsumer } from '@/features/url-tab/tunnel-consumers';
+import type { RunTab } from '../run-pane';
+
+const FRESH_LAYOUT = { top: ['chat', 'run'] as const, bottom: null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } };
+
+function resetLayout(): void {
+  useLayoutStore.setState({
+    layout: { ...FRESH_LAYOUT, top: [...FRESH_LAYOUT.top] },
+    run: null,
+    sessions: new Map(),
+    activeSessionId: null,
+  });
+}
+
+/** Seed Run directly with the given tabs, bypassing addRunTab (used for release scenarios). */
+function seedRun(tabs: RunTab[]): void {
+  useLayoutStore.setState({
+    layout: { ...FRESH_LAYOUT, top: [...FRESH_LAYOUT.top] },
+    run: { dir: 'v', flex: [1, 1], panes: [{ id: 'pane-1', active: tabs[0]!.id, tabs }] },
+    sessions: new Map(),
+    activeSessionId: null,
+  });
+}
+
+beforeEach(() => {
+  stopPortTunnel.mockReset();
+  stopPortTunnel.mockResolvedValue(undefined);
+  startPortTunnel.mockReset();
+  clearUrlTunnelConsumers();
+  useActiveBasesStore.setState({ bases: {}, scopeKey: null });
+  resetLayout();
+});
+
+describe('subscribeToUrlTabIntents — creation', () => {
+  it('creates one url tab whose id is a valid webview label and whose url is normalized', () => {
+    const unsub = subscribeToUrlTabIntents();
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+
+    const run = useLayoutStore.getState().run!;
+    expect(run.panes[0]!.tabs).toHaveLength(1);
+    const tab = run.panes[0]!.tabs[0]!;
+    expect(tab.id).toMatch(/^url-[A-Za-z0-9_-]+$/);
+    expect(tab.url).toBe('http://localhost:5173/');
+    unsub();
+  });
+
+  it('emitting the same URL twice yields one tab, active both times', () => {
+    const unsub = subscribeToUrlTabIntents();
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+    const firstId = useLayoutStore.getState().run!.panes[0]!.tabs[0]!.id;
+
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+    const run = useLayoutStore.getState().run!;
+
+    expect(run.panes[0]!.tabs.map((t) => t.id)).toEqual([firstId]);
+    expect(run.panes[0]!.active).toBe(firstId);
+    unsub();
+  });
+
+  it('a different active scope yields a second tab for the same URL', () => {
+    const unsub = subscribeToUrlTabIntents();
+    useActiveBasesStore.setState({ bases: {}, scopeKey: 'scope-a' });
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+
+    useActiveBasesStore.setState({ bases: {}, scopeKey: 'scope-b' });
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+
+    expect(useLayoutStore.getState().run!.panes[0]!.tabs).toHaveLength(2);
+    unsub();
+  });
+
+  it('places Run in the layout even when it was not visible before', () => {
+    useLayoutStore.setState({ layout: { top: ['chat'], bottom: null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } } });
+    const unsub = subscribeToUrlTabIntents();
+
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+
+    const { layout } = useLayoutStore.getState();
+    expect(layout.top.includes('run') || layout.bottom === 'run').toBe(true);
+    unsub();
+  });
+
+  it('creates no tab for an unnormalizable URL', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const unsub = subscribeToUrlTabIntents();
+
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'javascript:alert(1)' });
+
+    expect(useLayoutStore.getState().run).toBeNull();
+    warn.mockRestore();
+    unsub();
+  });
+
+  it('the returned unsubscribe stops further intents from creating tabs', () => {
+    const unsub = subscribeToUrlTabIntents();
+    unsub();
+
+    emitSurfaceIntent({ type: 'open-url-tab', url: 'http://localhost:5173/' });
+
+    expect(useLayoutStore.getState().run).toBeNull();
+  });
+});
+
+describe('URL tab tunnel release — the four store-level removal sites', () => {
+  it('closeRunTab stops a tunnel this tab exclusively started', () => {
+    seedRun([{ id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a' }]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: true, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().closeRunTab('pane-1', 'url-a');
+
+    expect(stopPortTunnel).toHaveBeenCalledTimes(1);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+
+  it('closeRunTab does not stop a port still held by another tab', () => {
+    seedRun([
+      { id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a' },
+      { id: 'url-b', kind: 'url', title: 'b', url: 'http://localhost:5173/b' },
+    ]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: true, daemonHttpPort: 31415 });
+    registerUrlTunnelConsumer('url-b', { port: 5173, started: false, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().closeRunTab('pane-1', 'url-a');
+
+    expect(stopPortTunnel).not.toHaveBeenCalled();
+  });
+
+  it('closeRunTab does not stop a tunnel this tab only adopted', () => {
+    seedRun([{ id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a' }]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: false, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().closeRunTab('pane-1', 'url-a');
+
+    expect(stopPortTunnel).not.toHaveBeenCalled();
+  });
+
+  it('releaseRunScope stops an exclusively-started tunnel held by that scope', () => {
+    seedRun([{ id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a', scopeKey: 'scope-a' }]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: true, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().releaseRunScope('scope-a');
+
+    expect(stopPortTunnel).toHaveBeenCalledTimes(1);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+
+  it('closePane stops an exclusively-started tunnel held by that pane', () => {
+    seedRun([{ id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a' }]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: true, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().closePane('pane-1');
+
+    expect(stopPortTunnel).toHaveBeenCalledTimes(1);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+
+  it("toggleSurface('run') while Run is lit stops an exclusively-started tunnel", () => {
+    seedRun([{ id: 'url-a', kind: 'url', title: 'a', url: 'http://localhost:5173/a' }]);
+    registerUrlTunnelConsumer('url-a', { port: 5173, started: true, daemonHttpPort: 31415 });
+
+    useLayoutStore.getState().toggleSurface('run');
+
+    expect(stopPortTunnel).toHaveBeenCalledTimes(1);
+    expect(stopPortTunnel).toHaveBeenCalledWith(31415, 5173);
+  });
+});

--- a/packages/ui/src/store/__tests__/url-tab-retarget.test.ts
+++ b/packages/ui/src/store/__tests__/url-tab-retarget.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLayoutStore } from '../layout';
+
+beforeEach(() => {
+  useLayoutStore.setState({
+    layout: { top: ['run'], bottom: null, topFlex: {}, vFlex: { top: 1, bottom: 0.4 } },
+    run: {
+      dir: 'v',
+      flex: [1, 1],
+      panes: [
+        {
+          id: 'pane-1',
+          active: 'url-a',
+          tabs: [
+            { id: 'url-a', kind: 'url', title: 'localhost', url: 'http://localhost:3000', scopeKey: 'p:/a' },
+            { id: 'url-b', kind: 'url', title: 'example', url: 'https://example.com', scopeKey: 'p:/a' },
+            { id: 'term-c', kind: 'terminal', title: 'sh', scopeKey: 'p:/a' },
+          ],
+        },
+      ],
+    },
+    sessions: new Map(),
+    activeSessionId: null,
+  });
+});
+
+describe('useLayoutStore.setUrlTabTarget', () => {
+  it('updates the tab in place when the target URL has no sibling holder', () => {
+    useLayoutStore.getState().setUrlTabTarget('url-a', 'http://localhost:4000', 'localhost:4000');
+    const run = useLayoutStore.getState().run!;
+    const tab = run.panes[0]!.tabs.find((t) => t.id === 'url-a')!;
+    expect(tab).toMatchObject({ id: 'url-a', url: 'http://localhost:4000', title: 'localhost:4000' });
+  });
+
+  it('activates a same-scope sibling already holding the target URL and leaves the source untouched', () => {
+    useLayoutStore.getState().setUrlTabTarget('url-a', 'https://example.com', 'example');
+    const run = useLayoutStore.getState().run!;
+    expect(run.panes[0]!.active).toBe('url-b');
+    const source = run.panes[0]!.tabs.find((t) => t.id === 'url-a')!;
+    expect(source.url).toBe('http://localhost:3000');
+  });
+
+  it('is a no-op when the target tab id is not a url tab', () => {
+    const before = useLayoutStore.getState().run;
+    useLayoutStore.getState().setUrlTabTarget('term-c', 'https://example.com', 'example');
+    expect(useLayoutStore.getState().run).toBe(before);
+  });
+});

--- a/packages/ui/src/store/layout-persist.ts
+++ b/packages/ui/src/store/layout-persist.ts
@@ -3,8 +3,11 @@ import { daemonScopedKey } from '@/lib/daemon/daemon-scoped-storage';
 import type { LayoutStore, SessionWorkspace } from './layout';
 import type { RunState, RunTab } from './run-pane';
 
-/** File-backed tab kinds that are safe to persist (no live PTY/webview ref). */
-export const SAFE_RUN_TAB_KINDS: ReadonlySet<RunTab['kind']> = new Set(['code', 'diff', 'skill', 'viewer']);
+/**
+ * Tab kinds safe to persist: no live PTY/webview ref. `url` qualifies too —
+ * its whole identity is a string, so rehydrating it just re-navigates.
+ */
+export const SAFE_RUN_TAB_KINDS: ReadonlySet<RunTab['kind']> = new Set(['code', 'diff', 'skill', 'viewer', 'url']);
 
 /**
  * Keep only file-backed tabs; drop empty panes; null the run if nothing

--- a/packages/ui/src/store/layout-placement.ts
+++ b/packages/ui/src/store/layout-placement.ts
@@ -1,0 +1,102 @@
+/**
+ * store/layout-placement.ts — pure workspace-layout types and placement
+ * helpers (mirrors 04-engine.jsx placeInLayout / removeSurface). Split out of
+ * `layout.ts` (#281 Task 32): these touch no store state, unlike the Run-tab
+ * mutators, which close over `get()`/`writeWorkspace` and would need an
+ * injection shape to extract for a much smaller line-count win.
+ */
+
+export type SurfaceId = 'chat' | 'files' | 'run';
+
+/** Where a dragged surface lands when repositioned. */
+export type RepositionTarget = 'top-left' | 'top-right' | 'bottom';
+
+export interface WorkspaceLayout {
+  /** 1 or 2 surfaces in the main horizontal row. Chat always lives here. */
+  top: SurfaceId[];
+  /** Optional single surface in a strip below the top row. */
+  bottom: SurfaceId | null;
+  /** Flex weights for the top-row surfaces (default 1 each, set by drag). */
+  topFlex: Partial<Record<SurfaceId, number>>;
+  /** Flex weights for top-row vs bottom-strip (set by drag). */
+  vFlex: { top: number; bottom: number };
+}
+
+export function insertTop(top: SurfaceId[], s: SurfaceId): SurfaceId[] {
+  if (s === 'chat') return ['chat', ...top.filter((x) => x !== 'chat')];
+  // Non-chat: keep chat leftmost, append new surface after existing ones.
+  return [...top, s];
+}
+
+export function placeInLayout(layout: WorkspaceLayout, s: SurfaceId): WorkspaceLayout {
+  const { top, bottom } = layout;
+  if (top.includes(s) || bottom === s) return layout;
+
+  const newTop = [...top];
+  let newBottom = bottom;
+
+  if (s === 'chat') {
+    // Demote the most-recent top surface to bottom if the row is full.
+    if (newTop.length >= 2 && !newBottom) newBottom = newTop.pop()!;
+    return { ...layout, top: insertTop(newTop, 'chat'), bottom: newBottom };
+  }
+
+  if (newTop.length < 2) return { ...layout, top: insertTop(newTop, s) };
+  if (!newBottom) return { ...layout, bottom: s };
+  return layout; // all 3 slots already filled
+}
+
+export function removeSurface(layout: WorkspaceLayout, s: SurfaceId): WorkspaceLayout {
+  let top = layout.top.filter((x) => x !== s);
+  let bottom = layout.bottom === s ? null : layout.bottom;
+
+  // Compact: never leave a lone bottom strip — promote it to the top row.
+  if (bottom && top.length < 2) {
+    top = insertTop(top, bottom);
+    bottom = null;
+  }
+
+  // Floor: never zero surfaces — restore chat.
+  if (top.length === 0) top = ['chat'];
+
+  return { ...layout, top, bottom };
+}
+
+/** Manual-drag reposition. Chat may be reordered within the top row but never sent to the strip. */
+export function repositionInLayout(layout: WorkspaceLayout, s: SurfaceId, target: RepositionTarget): WorkspaceLayout {
+  let top = layout.top.filter((x) => x !== s);
+  let bottom = layout.bottom === s ? null : layout.bottom;
+
+  if (target === 'bottom') {
+    if (s === 'chat') return layout; // chat never goes to the strip
+    if (bottom) top = insertTop(top, bottom);
+    bottom = s;
+  } else if (target === 'top-left') {
+    top = [s, ...top];
+  } else {
+    top = [...top, s];
+  }
+
+  if (top.length === 0) top = ['chat'];
+  return { ...layout, top, bottom };
+}
+
+/** True when at least one of files/run is not yet in the layout. */
+export function layoutCanSplit(layout: WorkspaceLayout): boolean {
+  return (['files', 'run'] as SurfaceId[]).some((s) => !layout.top.includes(s) && layout.bottom !== s);
+}
+
+/** Number of surfaces currently shown (top row + optional bottom strip). */
+export function litSurfaceCount(layout: WorkspaceLayout): number {
+  return layout.top.length + (layout.bottom ? 1 : 0);
+}
+
+/**
+ * The dynamic floor: a lit surface that is the ONLY one shown is non-dismissable
+ * (mirrors `04-engine.jsx` `isFloor = lit && litCount === 1`). Not a hardcoded
+ * chat floor — whichever surface is last-lit becomes the floor.
+ */
+export function isSurfaceFloor(layout: WorkspaceLayout, id: SurfaceId): boolean {
+  const lit = layout.top.includes(id) || layout.bottom === id;
+  return lit && litSurfaceCount(layout) === 1;
+}

--- a/packages/ui/src/store/layout.ts
+++ b/packages/ui/src/store/layout.ts
@@ -7,9 +7,9 @@ import {
   closeRunTab as closeRunTabReducer,
   moveTabToRun as moveTabToRunReducer,
   releaseRunScope as releaseRunScopeReducer,
-  terminalIdsForScope,
-  terminalIdsInPane,
-  terminalIdsInRun,
+  tabIdsForScope,
+  tabIdsInPane,
+  tabIdsInRun,
   type RunDropEdge,
   type RunState,
   type RunTab,
@@ -213,7 +213,7 @@ export const useLayoutStore = create<LayoutStore>()(
         const nextLayout = isActive ? removeSurface(layout, surface) : placeInLayout(layout, surface);
         // Toggling Run off kills any live PTYs before discarding the panes.
         if (surface === 'run' && isActive) {
-          killAndDisposeCachedTerminals(terminalIdsInRun(run));
+          killAndDisposeCachedTerminals(tabIdsInRun(run, 'terminal'));
         }
         writeWorkspace({ layout: nextLayout, run: surface === 'run' && isActive ? null : run });
       },
@@ -290,7 +290,7 @@ export const useLayoutStore = create<LayoutStore>()(
       closePane(paneId) {
         const { layout, run } = get();
         if (!run) return;
-        killAndDisposeCachedTerminals(terminalIdsInPane(run, paneId));
+        killAndDisposeCachedTerminals(tabIdsInPane(run, paneId, 'terminal'));
         // Preview destruction is handled by the PreviewInstance lifecycle hook's
         // cleanup effect when components unmount after the pane is removed.
         const nextRun = closePaneReducer(run, paneId);
@@ -300,7 +300,7 @@ export const useLayoutStore = create<LayoutStore>()(
       releaseRunScope(scopeKey) {
         const { layout, run } = get();
         if (!run) return;
-        killAndDisposeCachedTerminals(terminalIdsForScope(run, scopeKey));
+        killAndDisposeCachedTerminals(tabIdsForScope(run, scopeKey, 'terminal'));
         // Preview/console bodies tear down via their unmount cleanup once the
         // tabs are removed (PreviewInstance destroys its webview).
         const nextRun = releaseRunScopeReducer(run, scopeKey);

--- a/packages/ui/src/store/layout.ts
+++ b/packages/ui/src/store/layout.ts
@@ -7,6 +7,7 @@ import {
   closeRunTab as closeRunTabReducer,
   moveTabToRun as moveTabToRunReducer,
   releaseRunScope as releaseRunScopeReducer,
+  retargetUrlTab as retargetUrlTabReducer,
   tabIdsForScope,
   tabIdsInPane,
   tabIdsInRun,
@@ -84,6 +85,8 @@ export interface LayoutStore {
    */
   addRunTab: (tab: RunTab, paneId?: string) => boolean;
   activateRunTab: (paneId: string, tabId: string) => void;
+  /** Point a URL tab at a newly committed URL. The tab's id — and its webview — survive. */
+  setUrlTabTarget: (tabId: string, url: string, title: string) => void;
   closeRunTab: (paneId: string, tabId: string) => void;
   closePane: (paneId: string) => void;
   /** Release a launch scope: dispose its terminals and drop its Run tabs. */
@@ -191,6 +194,13 @@ export const useLayoutStore = create<LayoutStore>()(
         const { layout, run } = get();
         if (!run) return;
         writeWorkspace({ layout, run: activateRunTabReducer(run, paneId, tabId) });
+      },
+
+      setUrlTabTarget(tabId, url, title) {
+        const { layout, run } = get();
+        if (!run) return;
+        const nextRun = retargetUrlTabReducer(run, tabId, url, title);
+        if (nextRun !== run) writeWorkspace({ layout, run: nextRun });
       },
 
       closeRunTab(paneId, tabId) {

--- a/packages/ui/src/store/layout.ts
+++ b/packages/ui/src/store/layout.ts
@@ -17,6 +17,7 @@ import {
 import { useTabsStore } from './tabs';
 import { useActiveBasesStore } from './active-bases-store';
 import { killAndDisposeCachedTerminals } from './terminal-cleanup';
+import { releaseUrlTunnels } from './url-tunnel-cleanup';
 import { layoutPersistOptions, prunePersistedSessions } from './layout-persist';
 import {
   isSurfaceFloor,
@@ -126,9 +127,10 @@ export const useLayoutStore = create<LayoutStore>()(
         if (isSurfaceFloor(layout, surface)) return;
         const isActive = layout.top.includes(surface) || layout.bottom === surface;
         const nextLayout = isActive ? removeSurface(layout, surface) : placeInLayout(layout, surface);
-        // Toggling Run off kills any live PTYs before discarding the panes.
+        // Toggling Run off kills any live PTYs and releases URL tabs' tunnels before discarding the panes.
         if (surface === 'run' && isActive) {
           killAndDisposeCachedTerminals(tabIdsInRun(run, 'terminal'));
+          releaseUrlTunnels(tabIdsInRun(run, 'url'));
         }
         writeWorkspace({ layout: nextLayout, run: surface === 'run' && isActive ? null : run });
       },
@@ -196,6 +198,7 @@ export const useLayoutStore = create<LayoutStore>()(
         if (!run) return;
         const tab = run.panes.find((p) => p.id === paneId)?.tabs.find((t) => t.id === tabId);
         if (tab?.kind === 'terminal') killAndDisposeCachedTerminals([tabId]);
+        if (tab?.kind === 'url') releaseUrlTunnels([tabId]);
         // Preview destruction is handled by the PreviewInstance lifecycle hook's
         // cleanup effect when the component unmounts after the tab is removed.
         const nextRun = closeRunTabReducer(run, paneId, tabId);
@@ -206,6 +209,7 @@ export const useLayoutStore = create<LayoutStore>()(
         const { layout, run } = get();
         if (!run) return;
         killAndDisposeCachedTerminals(tabIdsInPane(run, paneId, 'terminal'));
+        releaseUrlTunnels(tabIdsInPane(run, paneId, 'url'));
         // Preview destruction is handled by the PreviewInstance lifecycle hook's
         // cleanup effect when components unmount after the pane is removed.
         const nextRun = closePaneReducer(run, paneId);
@@ -216,6 +220,7 @@ export const useLayoutStore = create<LayoutStore>()(
         const { layout, run } = get();
         if (!run) return;
         killAndDisposeCachedTerminals(tabIdsForScope(run, scopeKey, 'terminal'));
+        releaseUrlTunnels(tabIdsForScope(run, scopeKey, 'url'));
         // Preview/console bodies tear down via their unmount cleanup once the
         // tabs are removed (PreviewInstance destroys its webview).
         const nextRun = releaseRunScopeReducer(run, scopeKey);

--- a/packages/ui/src/store/layout.ts
+++ b/packages/ui/src/store/layout.ts
@@ -18,108 +18,23 @@ import { useTabsStore } from './tabs';
 import { useActiveBasesStore } from './active-bases-store';
 import { killAndDisposeCachedTerminals } from './terminal-cleanup';
 import { layoutPersistOptions, prunePersistedSessions } from './layout-persist';
+import {
+  isSurfaceFloor,
+  placeInLayout,
+  removeSurface,
+  repositionInLayout,
+  type RepositionTarget,
+  type SurfaceId,
+  type WorkspaceLayout,
+} from './layout-placement';
 
-export type SurfaceId = 'chat' | 'files' | 'run';
-
-/** Where a dragged surface lands when repositioned. */
-export type RepositionTarget = 'top-left' | 'top-right' | 'bottom';
-
-export interface WorkspaceLayout {
-  /** 1 or 2 surfaces in the main horizontal row. Chat always lives here. */
-  top: SurfaceId[];
-  /** Optional single surface in a strip below the top row. */
-  bottom: SurfaceId | null;
-  /** Flex weights for the top-row surfaces (default 1 each, set by drag). */
-  topFlex: Partial<Record<SurfaceId, number>>;
-  /** Flex weights for top-row vs bottom-strip (set by drag). */
-  vFlex: { top: number; bottom: number };
-}
+export type { RepositionTarget, SurfaceId, WorkspaceLayout } from './layout-placement';
+export { isSurfaceFloor, layoutCanSplit, litSurfaceCount } from './layout-placement';
 
 /** A single session's remembered workspace (surface placement + Run panes). */
 export interface SessionWorkspace {
   layout: WorkspaceLayout;
   run: RunState | null;
-}
-
-// ── placement helpers (mirror 04-engine.jsx placeInLayout / removeSurface) ──
-
-function insertTop(top: SurfaceId[], s: SurfaceId): SurfaceId[] {
-  if (s === 'chat') return ['chat', ...top.filter((x) => x !== 'chat')];
-  // Non-chat: keep chat leftmost, append new surface after existing ones.
-  return [...top, s];
-}
-
-function placeInLayout(layout: WorkspaceLayout, s: SurfaceId): WorkspaceLayout {
-  const { top, bottom } = layout;
-  if (top.includes(s) || bottom === s) return layout;
-
-  const newTop = [...top];
-  let newBottom = bottom;
-
-  if (s === 'chat') {
-    // Demote the most-recent top surface to bottom if the row is full.
-    if (newTop.length >= 2 && !newBottom) newBottom = newTop.pop()!;
-    return { ...layout, top: insertTop(newTop, 'chat'), bottom: newBottom };
-  }
-
-  if (newTop.length < 2) return { ...layout, top: insertTop(newTop, s) };
-  if (!newBottom) return { ...layout, bottom: s };
-  return layout; // all 3 slots already filled
-}
-
-function removeSurface(layout: WorkspaceLayout, s: SurfaceId): WorkspaceLayout {
-  let top = layout.top.filter((x) => x !== s);
-  let bottom = layout.bottom === s ? null : layout.bottom;
-
-  // Compact: never leave a lone bottom strip — promote it to the top row.
-  if (bottom && top.length < 2) {
-    top = insertTop(top, bottom);
-    bottom = null;
-  }
-
-  // Floor: never zero surfaces — restore chat.
-  if (top.length === 0) top = ['chat'];
-
-  return { ...layout, top, bottom };
-}
-
-/** Manual-drag reposition. Chat may be reordered within the top row but never sent to the strip. */
-function repositionInLayout(layout: WorkspaceLayout, s: SurfaceId, target: RepositionTarget): WorkspaceLayout {
-  let top = layout.top.filter((x) => x !== s);
-  let bottom = layout.bottom === s ? null : layout.bottom;
-
-  if (target === 'bottom') {
-    if (s === 'chat') return layout; // chat never goes to the strip
-    if (bottom) top = insertTop(top, bottom);
-    bottom = s;
-  } else if (target === 'top-left') {
-    top = [s, ...top];
-  } else {
-    top = [...top, s];
-  }
-
-  if (top.length === 0) top = ['chat'];
-  return { ...layout, top, bottom };
-}
-
-/** True when at least one of files/run is not yet in the layout. */
-export function layoutCanSplit(layout: WorkspaceLayout): boolean {
-  return (['files', 'run'] as SurfaceId[]).some((s) => !layout.top.includes(s) && layout.bottom !== s);
-}
-
-/** Number of surfaces currently shown (top row + optional bottom strip). */
-export function litSurfaceCount(layout: WorkspaceLayout): number {
-  return layout.top.length + (layout.bottom ? 1 : 0);
-}
-
-/**
- * The dynamic floor: a lit surface that is the ONLY one shown is non-dismissable
- * (mirrors `04-engine.jsx` `isFloor = lit && litCount === 1`). Not a hardcoded
- * chat floor — whichever surface is last-lit becomes the floor.
- */
-export function isSurfaceFloor(layout: WorkspaceLayout, id: SurfaceId): boolean {
-  const lit = layout.top.includes(id) || layout.bottom === id;
-  return lit && litSurfaceCount(layout) === 1;
 }
 
 /** Build a RunTab guest from a Files editor tab, stamped with the active scope. */

--- a/packages/ui/src/store/port-tunnels.ts
+++ b/packages/ui/src/store/port-tunnels.ts
@@ -24,6 +24,13 @@ export interface PortTunnelEntry {
   error?: string;
   /** True once cloudflared's edge DNS resolves the hostname — a `ready` tunnel can 404 until then. */
   dnsVerified?: boolean;
+  /**
+   * Set only when a client `.catch` wrote this `error`; its absence means the
+   * daemon did. Only a daemon-sourced error is evidence about what the daemon
+   * holds, so a URL tab's tunnel claim moves on an unmarked error and ignores a
+   * marked one (#281 D10/AC12).
+   */
+  errorOrigin?: 'client';
 }
 
 export interface PortTunnelListEntry extends PortTunnelEntry {
@@ -112,14 +119,23 @@ const lastToastAt = new Map<number, number>();
  * A tunnel that is already `ready` is never downgraded: cloudflared re-emits
  * errors for a live tunnel (a transient edge reconnect), and taking a working
  * URL away from the user over one is worse than saying nothing.
+ *
+ * `origin` defaults to `'daemon'`, so **any new client-side `.catch` caller must
+ * pass `'client'` explicitly**: a client error that silently claims daemon
+ * origin revokes a URL tab's live tunnel claim and leaks cloudflared (#281 D10).
  */
-export function reportPortTunnelError(port: number, message: string): void {
+export function reportPortTunnelError(port: number, message: string, origin: 'daemon' | 'client' = 'daemon'): void {
   if (usePortTunnelsStore.getState().byPort[port]?.state === 'ready') {
     console.warn(`[port-tunnels] ignoring an error for the live tunnel on port ${port}: ${message}`);
     return;
   }
 
-  setEntry(port, { state: 'error', error: message });
+  setEntry(
+    port,
+    origin === 'client'
+      ? { state: 'error', error: message, errorOrigin: 'client' }
+      : { state: 'error', error: message },
+  );
 
   const now = Date.now();
   const last = lastToastAt.get(port);

--- a/packages/ui/src/store/port-tunnels.ts
+++ b/packages/ui/src/store/port-tunnels.ts
@@ -22,6 +22,8 @@ export interface PortTunnelEntry {
   state: 'starting' | 'ready' | 'error';
   url?: string;
   error?: string;
+  /** True once cloudflared's edge DNS resolves the hostname — a `ready` tunnel can 404 until then. */
+  dnsVerified?: boolean;
 }
 
 export interface PortTunnelListEntry extends PortTunnelEntry {
@@ -86,6 +88,19 @@ function clearEntry(port: number): void {
   });
 }
 
+/**
+ * Clear a non-live entry so a Retry action starts from `pending` instead of
+ * replaying the same failure. Never touches a `ready` entry — a live tunnel
+ * only clears via the daemon's own `stopped` event. Returns whether it
+ * actually cleared anything.
+ */
+export function clearPortTunnelEntry(port: number): boolean {
+  const entry = usePortTunnelsStore.getState().byPort[port];
+  if (!entry || entry.state === 'ready') return false;
+  clearEntry(port);
+  return true;
+}
+
 const TOAST_DEDUPE_MS = 1000;
 const lastToastAt = new Map<number, number>();
 
@@ -123,10 +138,21 @@ export function applyPortTunnelEvent(event: DaemonEvent): void {
     case 'starting':
       setEntry(port, { state: 'starting' });
       break;
-    case 'ready':
+    case 'ready': {
+      const prior = usePortTunnelsStore.getState().byPort[port];
+      const url = event.url ?? prior?.url;
+      // Never downgrade: a late duplicate `ready` must not un-verify a tunnel
+      // a `dns_verified` event already confirmed.
+      const dnsVerified = prior?.dnsVerified ?? false;
+      setEntry(port, url !== undefined ? { state: 'ready', url, dnsVerified } : { state: 'ready', dnsVerified });
+      break;
+    }
     case 'dns_verified': {
       const url = event.url ?? usePortTunnelsStore.getState().byPort[port]?.url;
-      setEntry(port, url !== undefined ? { state: 'ready', url } : { state: 'ready' });
+      setEntry(
+        port,
+        url !== undefined ? { state: 'ready', url, dnsVerified: true } : { state: 'ready', dnsVerified: true },
+      );
       break;
     }
     case 'error':
@@ -138,11 +164,21 @@ export function applyPortTunnelEvent(event: DaemonEvent): void {
   }
 }
 
-/** Replace the live entries with a REST snapshot. Does not touch `generation`. */
+/**
+ * Replace the live entries with a REST snapshot. Does not touch `generation`.
+ * A snapshot only ever reports a tunnel already `ready`, so it's already past
+ * DNS verification — the seed can't observe the `starting`→`ready` transition
+ * the WS stream does.
+ */
 export function applyPortTunnelSnapshot(tunnels: PortTunnelInfo[]): void {
   const byPort: Record<number, PortTunnelEntry> = {};
   for (const t of tunnels) {
-    byPort[t.port] = t.url !== undefined ? { state: t.state, url: t.url } : { state: t.state };
+    if (t.state === 'ready') {
+      byPort[t.port] =
+        t.url !== undefined ? { state: 'ready', url: t.url, dnsVerified: true } : { state: 'ready', dnsVerified: true };
+    } else {
+      byPort[t.port] = t.url !== undefined ? { state: t.state, url: t.url } : { state: t.state };
+    }
   }
   usePortTunnelsStore.setState({ byPort });
 }

--- a/packages/ui/src/store/run-pane.ts
+++ b/packages/ui/src/store/run-pane.ts
@@ -8,19 +8,21 @@
  * (`layout.ts`) owns the wiring + side-effects.
  */
 
-export type RunTabKind = 'preview' | 'console' | 'terminal' | 'code' | 'diff' | 'skill' | 'viewer';
+export type RunTabKind = 'preview' | 'console' | 'terminal' | 'code' | 'diff' | 'skill' | 'viewer' | 'url';
 
-/** A tab inside a Run pane (a launched preview/console, a terminal, or a Files guest). */
+/** A tab inside a Run pane (a launched preview/console, a terminal, a Files guest, or a URL tab). */
 export interface RunTab {
   id: string;
   kind: RunTabKind;
   title: string;
-  /** File path for code/diff/skill/viewer guests; absent for preview/console/terminal. */
+  /** File path for code/diff/skill/viewer guests; absent for preview/console/terminal/url. */
   path?: string;
   /** Launch-config name for preview (webview) and console (process) tabs. */
   config?: string;
   /** Resolved dev-server port for a preview tab (the webview loads localhost:port). */
   port?: number;
+  /** Normalized address for a `url` tab (http/https only — see normalizePreviewUrl). */
+  url?: string;
   /**
    * Launch scope this tab belongs to (`buildLaunchScope(projectId,
    * effectivePath)`), captured at creation from the active session. Run tabs are
@@ -37,6 +39,22 @@ export interface RunTab {
 /** A launch-config tab — a `preview` webview or a `console` process. */
 function isLaunchTab(t: RunTab): boolean {
   return t.kind === 'preview' || t.kind === 'console';
+}
+
+/**
+ * A predicate matching the existing tab `addRunTab` should focus instead of
+ * duplicating, or `null` when `tab` has no dedup identity. Launch tabs dedup by
+ * `config` + `scopeKey`; `url` tabs dedup by exact (already-normalized) `url` +
+ * `scopeKey` — same shape, different identity field.
+ */
+function dedupMatcher(tab: RunTab): ((t: RunTab) => boolean) | null {
+  if (isLaunchTab(tab) && tab.config) {
+    return (t) => isLaunchTab(t) && t.config === tab.config && t.scopeKey === tab.scopeKey;
+  }
+  if (tab.kind === 'url' && tab.url) {
+    return (t) => t.kind === 'url' && t.url === tab.url && t.scopeKey === tab.scopeKey;
+  }
+  return null;
 }
 
 export interface RunPane {
@@ -78,17 +96,17 @@ export function emptyRun(): RunState {
  */
 export function addRunTab(run: RunState | null, tab: RunTab, paneId?: string): RunState | null {
   const base = run ?? emptyRun();
-  // Launch-config tabs (preview webview OR console process) are singletons per
-  // config WITHIN a launch scope: if one already exists for the same config AND
-  // scope (in any pane), focus it instead of stacking a duplicate — the run
-  // button re-launches the same config repeatedly. Different scopes (a same-named
-  // config in another project/worktree) get their own tab. This is the "or
-  // activates" half of addRunTab.
-  if (isLaunchTab(tab) && tab.config) {
-    const matches = (t: RunTab): boolean => isLaunchTab(t) && t.config === tab.config && t.scopeKey === tab.scopeKey;
-    const pane = base.panes.find((p) => p.tabs.some(matches));
+  // Launch-config tabs (preview webview OR console process) and url tabs are
+  // singletons per identity WITHIN a launch scope: if one already exists (in
+  // any pane), focus it instead of stacking a duplicate — the run button
+  // re-launches the same config repeatedly, and typing the same address twice
+  // shouldn't open a second webview. Different scopes get their own tab. This
+  // is the "or activates" half of addRunTab.
+  const matcher = dedupMatcher(tab);
+  if (matcher) {
+    const pane = base.panes.find((p) => p.tabs.some(matcher));
     if (pane) {
-      const existing = pane.tabs.find(matches)!;
+      const existing = pane.tabs.find(matcher)!;
       return activateRunTab(base, pane.id, existing.id);
     }
   }
@@ -140,26 +158,24 @@ export function closePane(run: RunState, paneId: string): RunState | null {
   return { ...run, panes, flex: [1, 1] };
 }
 
-/** Every terminal tab id in the run state (across all panes). */
-export function terminalIdsInRun(run: RunState | null): string[] {
+/** Every tab id of `kind` in the run state (across all panes). */
+export function tabIdsInRun(run: RunState | null, kind: RunTabKind): string[] {
   if (!run) return [];
-  return run.panes.flatMap((p) => p.tabs.filter((t) => t.kind === 'terminal').map((t) => t.id));
+  return run.panes.flatMap((p) => p.tabs.filter((t) => t.kind === kind).map((t) => t.id));
 }
 
-/** Terminal tab ids in a single pane. */
-export function terminalIdsInPane(run: RunState | null, paneId: string): string[] {
+/** Tab ids of `kind` in a single pane. */
+export function tabIdsInPane(run: RunState | null, paneId: string, kind: RunTabKind): string[] {
   if (!run) return [];
   const pane = run.panes.find((p) => p.id === paneId);
   if (!pane) return [];
-  return pane.tabs.filter((t) => t.kind === 'terminal').map((t) => t.id);
+  return pane.tabs.filter((t) => t.kind === kind).map((t) => t.id);
 }
 
-/** Terminal tab ids belonging to a launch scope (across all panes). */
-export function terminalIdsForScope(run: RunState | null, scopeKey: string): string[] {
+/** Tab ids of `kind` belonging to a launch scope (across all panes). */
+export function tabIdsForScope(run: RunState | null, scopeKey: string, kind: RunTabKind): string[] {
   if (!run) return [];
-  return run.panes.flatMap((p) =>
-    p.tabs.filter((t) => t.kind === 'terminal' && t.scopeKey === scopeKey).map((t) => t.id),
-  );
+  return run.panes.flatMap((p) => p.tabs.filter((t) => t.kind === kind && t.scopeKey === scopeKey).map((t) => t.id));
 }
 
 /**
@@ -178,6 +194,29 @@ export function releaseRunScope(run: RunState, scopeKey: string): RunState | nul
     .filter((p) => p.tabs.length > 0);
   if (panes.length === 0) return null;
   return { ...run, panes, flex: panes.length === 1 ? [1, 1] : run.flex };
+}
+
+/**
+ * Point a `url` tab at a new address (the address bar navigated in place). If a
+ * sibling tab in the same scope already holds the target URL, activate that
+ * sibling instead of creating a duplicate and leave the source tab untouched —
+ * mirrors addRunTab's dedup-or-activate rule for the in-place case. Returns the
+ * same `run` reference for a no-op: unknown `tabId`, a non-`url` tab, or
+ * retargeting to the URL the tab already holds.
+ */
+export function retargetUrlTab(run: RunState, tabId: string, url: string, title: string): RunState {
+  const sourcePane = run.panes.find((p) => p.tabs.some((t) => t.id === tabId));
+  const source = sourcePane?.tabs.find((t) => t.id === tabId);
+  if (!sourcePane || !source || source.kind !== 'url' || source.url === url) return run;
+
+  const holds = (t: RunTab): boolean => t.kind === 'url' && t.url === url && t.scopeKey === source.scopeKey;
+  const holderPane = run.panes.find((p) => p.tabs.some(holds));
+  if (holderPane) return activateRunTab(run, holderPane.id, holderPane.tabs.find(holds)!.id);
+
+  const panes = run.panes.map((p) =>
+    p.id === sourcePane.id ? { ...p, tabs: p.tabs.map((t) => (t.id === tabId ? { ...t, url, title } : t)) } : p,
+  );
+  return { ...run, panes };
 }
 
 /**

--- a/packages/ui/src/store/surface-intents.ts
+++ b/packages/ui/src/store/surface-intents.ts
@@ -9,6 +9,8 @@ export type SurfaceIntent =
   | { type: 'inspector-tab'; tab: 'files' | 'changes' }
   /** Spawn a new terminal in the Run surface (optionally targeting a pane). */
   | { type: 'new-terminal'; paneId?: string }
+  /** Open (or focus) a URL tab in the Run surface (optionally targeting a pane). */
+  | { type: 'open-url-tab'; url: string; paneId?: string }
   /** Open the global search / command palette overlay. */
   | { type: 'open-search-palette' }
   /** Open the find-in-path overlay scoped to a file or directory. */

--- a/packages/ui/src/store/url-tab-intent-subscriber.ts
+++ b/packages/ui/src/store/url-tab-intent-subscriber.ts
@@ -1,0 +1,44 @@
+/**
+ * store/url-tab-intent-subscriber.ts
+ *
+ * The sanctioned cross-store bridge for the `open-url-tab` surface intent
+ * (#281). Mounted once in SurfaceHost alongside subscribeToTerminalIntents.
+ * Both entry points — the Run tab strip and the chat URL chip — funnel through
+ * here; neither calls `addRunTab` itself, because features never import layout/.
+ *
+ * Unlike the terminal bridge this is fully synchronous: a URL tab owns nothing
+ * until the tab exists, so a rejected add has nothing to dispose.
+ */
+import { normalizePreviewUrl } from '@/features/preview/normalize-url';
+import { urlTabId, urlTabTitle } from '@/features/url-tab/url-tab-id';
+import { onSurfaceIntent } from './surface-intents';
+import { useActiveBasesStore } from './active-bases-store';
+import { useLayoutStore } from './layout';
+
+export function subscribeToUrlTabIntents(): () => void {
+  return onSurfaceIntent((intent) => {
+    if (intent.type !== 'open-url-tab') return;
+    openUrlTab(intent.url, intent.paneId);
+  });
+}
+
+function openUrlTab(raw: string, paneId: string | undefined): void {
+  // Second guard: both entry points normalize before emitting, so a null here
+  // means a caller skipped that step rather than a user typo.
+  const url = normalizePreviewUrl(raw);
+  if (!url) {
+    console.warn('[url-tab-intent] ignoring an unusable URL', raw);
+    return;
+  }
+
+  const { scopeKey } = useActiveBasesStore.getState();
+  // addRunTab dedups a `url` tab by normalized url + scope and places Run in
+  // the layout, so opening the same URL twice focuses the first tab.
+  const added = useLayoutStore
+    .getState()
+    .addRunTab(
+      { id: urlTabId(url), kind: 'url', title: urlTabTitle(url), url, scopeKey: scopeKey ?? undefined },
+      paneId,
+    );
+  if (!added) console.warn('[url-tab-intent] target pane closed before the URL tab was added', url);
+}

--- a/packages/ui/src/store/url-tunnel-cleanup.ts
+++ b/packages/ui/src/store/url-tunnel-cleanup.ts
@@ -1,0 +1,15 @@
+/**
+ * store/url-tunnel-cleanup.ts
+ *
+ * Release a set of URL tabs' tunnel-ownership claims, stopping any port whose
+ * last owner just left.
+ *
+ * This module imports ONLY the url-tab feature — never a store — so layout.ts
+ * can import it without creating a layout ↔ subscriber import cycle (mirrors
+ * `store/terminal-cleanup.ts`).
+ */
+import { releaseUrlTunnelConsumers } from '@/features/url-tab/tunnel-consumers';
+
+export function releaseUrlTunnels(tabIds: string[]): void {
+  releaseUrlTunnelConsumers(tabIds);
+}


### PR DESCRIPTION
Closes #281.

Adds a URL tab to the Preview/Run surface: a first-class tab kind that points the existing child-webview engine at an arbitrary http(s) URL, with no launch config behind it.

## What's in it

- **A new `url` tab kind** (not an overloaded preview tab), created from three entry points that funnel through one path: the tab strip's `+`, the empty-state Run picker, and an "Open in Mainframe" item on the chat localhost chip. URL tabs join the persist-safe set — they hold no process handle — and dedup by normalized URL within a launch scope.
- **Remote-daemon support** as a consumer of the existing per-port tunnel endpoints. No daemon-side changes.
- **Tunnel ownership modelled as one state machine.** A tab stops a tunnel on close only when it started that tunnel and no other tab uses the port; a pre-existing tunnel is adopted, never stopped.

## Two security fixes found along the way

Both predate this feature and are fixed here because it would otherwise widen their reach:

- `normalize-url.ts` accepted any scheme `new URL` could parse, so `file:///etc/passwd` typed into the **existing** preview address bar navigated a child webview to a local file. Normalization is now restricted to http/https, as is the preview shell's `open_external`.
- The preview bridge's remote-origin allowlist is deliberately widened to all http(s) origins, per the 2026-07-28 design-gate ruling that supersedes the brief. The accepted risk is recorded in the spec: a hostile page can fabricate an inspect payload that reaches the agent's context, and can raise OS-browser windows (still scheme-guarded).

## Why the diff is large

Tunnel ownership took two lanes and eight review rounds. Rounds 1–4 each landed a locally-correct point fix that opened an adjacent leak, because ownership was being derived from `UrlTabTarget.kind` — a presentation projection folding together locality, URL validity, port eligibility, per-attempt flags and a 120s client watchdog. A later pass found a third confound: `reportPortTunnelError` has three producers, two of them clients, so an `error` entry is not daemon truth either.

The rework replaces that with an explicit claim reducer over a signal union derived from daemon-authoritative state. Both classes of defect now close by construction rather than by a guard — the start rejection is attempt-scoped, and the signal union has no timeout member at all, so the watchdog cannot be evidence about what the daemon holds. The spec already said as much: D11 calls the watchdog non-terminal and AC9 requires a late URL to replace the failure body with no user action.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean; the URL-tab suites are 14 files / 203 tests green.
- `cargo test --lib preview::bridge_plugin` green.

## ⚠️ QA is partial — read before merging

The tauri-mcp automation bridge loses all window tracking (`Window 'main' not found`) the instant a URL tab mounts a native child webview. This is confirmed **not** a product crash — the app and daemon stay alive and the log shows no panic — and it is unrecoverable within an app instance. It generalizes a known project limitation to trigger on the first URL-tab mount.

Verified live: invalid-URL rejection (inline `aria-invalid`, no tab created) and the empty-picker "Open URL…" row. Tab creation triggered correctly but could not be DOM-verified afterward. The remaining scenarios fall back to automated coverage, re-run rather than cited.

**Never exercised live at all: the tunnel path.** The QA environment's daemon is local, so `isLocal` is true and AC4/5/6 are structurally unreachable without a second remote-mode daemon. The ownership state machine — the part that consumed eight review rounds — has good unit coverage but has never watched a real cloudflared start, leak, or stop. That gap is worth its own todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
