### PR TITLE
fix(automations): send a User-Agent on every connector request

### DIFF
--- a/.changeset/automations-http-user-agent.md
+++ b/.changeset/automations-http-user-agent.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-core': patch
+---
+
+Send a User-Agent on every automations connector request. GitHub rejects requests without one, so the `github.create_pr` and `github.list_prs` actions failed with 403 "Request forbidden by administrative rules" against the live API.

--- a/packages/core-rs/crates/mainframe-automations/src/actions/ado.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/ado.rs
@@ -58,7 +58,7 @@ impl AdoCreateItemAction {
     pub fn with_base_url(base: impl Into<String>) -> Self {
         Self {
             base: base.into(),
-            client: reqwest::Client::new(),
+            client: super::http_client(),
         }
     }
 }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/github.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/github.rs
@@ -82,7 +82,7 @@ impl GithubCreatePrAction {
     pub fn with_base_url(base: impl Into<String>) -> Self {
         Self {
             base: base.into(),
-            client: reqwest::Client::new(),
+            client: super::http_client(),
         }
     }
 }
@@ -195,7 +195,7 @@ impl GithubListPrsAction {
     pub fn with_base_url(base: impl Into<String>) -> Self {
         Self {
             base: base.into(),
-            client: reqwest::Client::new(),
+            client: super::http_client(),
         }
     }
 }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/http_action.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/http_action.rs
@@ -66,7 +66,7 @@ pub struct HttpRequestAction {
 impl HttpRequestAction {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: super::http_client(),
         }
     }
 }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/mod.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/mod.rs
@@ -63,6 +63,26 @@ pub trait Action: Send + Sync {
     ) -> BoxFuture<'a, Result<ActionOutputs, ActionError>>;
 }
 
+/// GitHub's REST API answers 403 "Request forbidden by administrative rules"
+/// to any request without a `User-Agent`, and reqwest sends none by default.
+/// No version suffix: the Rust crates are all pinned at the workspace's
+/// placeholder `0.0.0`, so one would advertise a number that never moves.
+pub(crate) const USER_AGENT: &str = "mainframe";
+
+/// The one client every connector builds from, so no future connector can
+/// reach an API with a bare `reqwest::Client::new()` again.
+pub(crate) fn http_client() -> reqwest::Client {
+    match reqwest::Client::builder().user_agent(USER_AGENT).build() {
+        Ok(client) => client,
+        Err(err) => {
+            // Only the TLS backend can fail here, and that fails every request
+            // anyway — so log and let the call site report the real failure.
+            tracing::error!(%err, "automations: HTTP client built without a User-Agent");
+            reqwest::Client::new()
+        }
+    }
+}
+
 const ERROR_BODY_SNIPPET_CHARS: usize = 500;
 
 /// Connector HTTP failure (Node's `<op> failed (<status>): <500-char body>`),
@@ -155,6 +175,9 @@ mod registry_tests;
 
 #[cfg(test)]
 mod run_command_tests;
+
+#[cfg(test)]
+mod user_agent_tests;
 
 // PORT STATUS: greenfield (docs/plans/2026-07-12-automations-v2-rust-engine.md T6.2-T7.3), not a TS port
 // confidence: high

--- a/packages/core-rs/crates/mainframe-automations/src/actions/notion.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/notion.rs
@@ -47,7 +47,7 @@ impl NotionAddRowAction {
     pub fn with_base_url(base: impl Into<String>) -> Self {
         Self {
             base: base.into(),
-            client: reqwest::Client::new(),
+            client: super::http_client(),
         }
     }
 }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/user_agent_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/user_agent_tests.rs
@@ -1,0 +1,133 @@
+//! Every connector must send a `User-Agent`. GitHub rejects requests without
+//! one (403 "Request forbidden by administrative rules"), and the wiremock
+//! suites elsewhere in this module never asserted the header, so a bare
+//! `reqwest::Client::new()` shipped undetected. One file covers all four
+//! connectors because the trap is per-client, not per-API.
+
+use std::collections::BTreeMap;
+
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::credentials::{CredentialKind, Credentials};
+
+use super::ado::AdoCreateItemAction;
+use super::github::{GithubCreatePrAction, GithubListPrsAction};
+use super::http_action::HttpRequestAction;
+use super::notion::NotionAddRowAction;
+use super::{Action, ActionCtx, USER_AGENT};
+
+fn ctx() -> ActionCtx {
+    ActionCtx {
+        creds: Some(Credentials {
+            kind: CredentialKind::Token,
+            token: "token".to_string(),
+            extra: None,
+        }),
+        credential_label: Some("label".to_string()),
+        idempotency_key: "run-1:step-1".to_string(),
+        project_root: "/tmp".to_string(),
+        worktree_path: None,
+    }
+}
+
+/// Mounts a catch-all that only matches when the User-Agent is ours, so a
+/// missing header fails the action rather than silently passing.
+async fn server_requiring_user_agent(status: u16, body: serde_json::Value) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(header("user-agent", USER_AGENT))
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+    server
+}
+
+#[tokio::test]
+async fn github_create_pr_sends_a_user_agent() {
+    let server = server_requiring_user_agent(
+        201,
+        json!({"html_url": "https://github.com/qlan/mainframe/pull/7", "number": 7}),
+    )
+    .await;
+
+    let result = GithubCreatePrAction::with_base_url(server.uri())
+        .execute(
+            &json!({
+                "repo": "qlan/mainframe",
+                "title": "feat: thing",
+                "head": "feat/thing",
+                "base": "main",
+            }),
+            &ctx(),
+        )
+        .await;
+
+    assert!(result.is_ok(), "create_pr without a User-Agent: {result:?}");
+}
+
+#[tokio::test]
+async fn github_list_prs_sends_a_user_agent() {
+    let server = server_requiring_user_agent(200, json!({"items": []})).await;
+
+    let result = GithubListPrsAction::with_base_url(server.uri())
+        .execute(&json!({}), &ctx())
+        .await;
+
+    assert!(result.is_ok(), "list_prs without a User-Agent: {result:?}");
+}
+
+#[tokio::test]
+async fn notion_add_row_sends_a_user_agent() {
+    let server = server_requiring_user_agent(200, json!({"url": "https://notion.so/page"})).await;
+
+    let result = NotionAddRowAction::with_base_url(server.uri())
+        .execute(&json!({"databaseId": "db-1", "Name": "row"}), &ctx())
+        .await;
+
+    assert!(result.is_ok(), "notion without a User-Agent: {result:?}");
+}
+
+#[tokio::test]
+async fn ado_create_item_sends_a_user_agent() {
+    let server =
+        server_requiring_user_agent(200, json!({"id": 42, "_links": {"html": {"href": "u"}}}))
+            .await;
+
+    let result = AdoCreateItemAction::with_base_url(server.uri())
+        .execute(
+            &json!({
+                "org": "org",
+                "project": "proj",
+                "type": "Bug",
+                "title": "it broke",
+            }),
+            &ctx(),
+        )
+        .await;
+
+    assert!(result.is_ok(), "ado without a User-Agent: {result:?}");
+}
+
+#[tokio::test]
+async fn http_request_sends_a_user_agent() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/thing"))
+        .and(header("user-agent", USER_AGENT))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let outputs = HttpRequestAction::new()
+        .execute(
+            &json!({"method": "GET", "url": format!("{}/thing", server.uri())}),
+            &ctx(),
+        )
+        .await;
+
+    assert!(outputs.is_ok(), "http without a User-Agent: {outputs:?}");
+    let _: BTreeMap<_, _> = outputs.unwrap();
+}


### PR DESCRIPTION
## What

GitHub's REST API answers `403 Request forbidden by administrative rules` to any request without a `User-Agent`, and reqwest sends none by default. Every automations connector built a bare `reqwest::Client::new()`, so `github.create_pr` and `github.list_prs` could never reach the live API.

Verified against the real API:

```
$ curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent:' https://api.github.com/repos/qlan-ro/mainframe
403
$ curl -s -o /dev/null -w '%{http_code}' -A mainframe   https://api.github.com/repos/qlan-ro/mainframe
200
```

## Why CI stayed green

The wiremock suites (`github_tests`, `notion_ado_tests`, `http_tests`) never assert request headers, so a missing `User-Agent` was invisible.

## Change

- One `actions::http_client()` builds the client with the header; all four connectors (github, notion, ado, http.request) construct from it, so a new connector can't reintroduce a bare client.
- `user_agent_tests.rs` mounts mocks that **only** match when the header is present, so a regression fails the action rather than passing silently.
- No version suffix in the UA: the Rust crates are pinned at the workspace placeholder `0.0.0`, so a version would advertise a number that never moves.

## Verification

- `cargo test -p mainframe-automations` — 306 passed, 17 passed (doc/integration), 0 failed
- `cargo fmt -p mainframe-automations -- --check` — clean
- `cargo clippy -p mainframe-automations --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)