### PR TITLE
feat(ui): adopt aui elements — thinking indicator + activity working dot

### DIFF
--- a/.changeset/aui-elements-adoption.md
+++ b/.changeset/aui-elements-adoption.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Adopt two treatments from assistant-ui's element registry. A long run now shows how long it has been going: the chat thread's working indicator gains a pulse dot and a live elapsed readout beside the rotating phrase. The session panel's Background Activity rows take the same pulse dot in place of their spinner, so working reads identically wherever it appears.

--- a/packages/ui/src/features/chat/thread/ChatThread.tsx
+++ b/packages/ui/src/features/chat/thread/ChatThread.tsx
@@ -22,6 +22,7 @@ import { CompactingPill } from '../messages/SystemMessage';
 import { DegradedChatCard } from './DegradedChatCard';
 import { useChatExtras } from '../runtime/use-chat-thread-runtime';
 import { useRotatingPhrase } from './use-rotating-phrase';
+import { formatElapsedSeconds, useRunElapsed } from './use-run-elapsed';
 import { SkillsProvider } from '@/features/skills/use-chat-skills';
 import { FindBar } from '../find/FindBar';
 import { useFindHotkey } from '../find/use-find-hotkey';
@@ -54,12 +55,36 @@ function LoadErrorBanner() {
 const RUNNING_PHRASES = ['Thinking…', 'Working…', 'Reasoning…', 'Crunching…', 'Composing…'] as const;
 const PHRASE_INTERVAL_MS = 2600;
 
+/**
+ * Two treatments lifted from assistant-ui's `elements-thinking-indicator`
+ * (https://r.assistant-ui.com/elements-thinking-indicator.json, fetched
+ * 2026-08-07; sha256 of its `files[0].content`
+ * 974a60f431517c6c53273af3f8eef3f31dd37c00ca620b14b9297a91838f03d3 — the
+ * registry item carries no version, so re-pull and diff against that hash):
+ * the leading pulse dot and the trailing elapsed readout. An IDEA
+ * lift, not a fork — the component stays ours, so both are re-themed to house
+ * tokens: the dot is `primary`, not upstream's `blue-500` (v2's settled
+ * "working" signal — same call AssistantMessage's RunningIndicator took), and
+ * the readout takes `muted-foreground` rather than upstream's `text-foreground/30`
+ * ink tier, matching every other elapsed reading in the app.
+ *
+ * NOT taken: upstream's per-label entrance animation. It needs a second,
+ * absolutely-positioned copy of the label to carry the shimmer (`animate-in`
+ * and `shimmer` both write `animation`, so one element cannot do both), which
+ * would duplicate the phrase in the accessibility tree and in this row's
+ * textContent.
+ */
 function GeneratingIndicator() {
   const isRunning = useAuiState((s: { thread: { isRunning: boolean } }) => s.thread.isRunning);
   const phrase = useRotatingPhrase(isRunning, RUNNING_PHRASES, PHRASE_INTERVAL_MS);
+  const elapsed = useRunElapsed(isRunning);
   if (!isRunning) return null;
   return (
-    <div data-testid="chat-thread-running" className="px-1 pb-1.5">
+    <div data-testid="chat-thread-running" className="flex items-center gap-2 px-1 pb-1.5">
+      <span
+        aria-hidden
+        className="size-1.5 shrink-0 animate-pulse rounded-full bg-primary motion-reduce:animate-none"
+      />
       {/* Stock `shimmer` (from shadcn/tailwind.css, which the v2 sheet imports)
           replaces the bridge's hand-rolled `mf-text-shimmer`. It derives base and
           highlight from currentColor, so `text-muted-foreground` gives the same
@@ -69,6 +94,14 @@ function GeneratingIndicator() {
       <span data-testid="chat-thread-running-text" className="text-xs font-medium text-muted-foreground shimmer">
         {phrase}
       </span>
+      {elapsed !== undefined && (
+        <span
+          data-testid="chat-thread-running-elapsed"
+          className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground"
+        >
+          {formatElapsedSeconds(elapsed)}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/features/chat/thread/__tests__/ChatThread.test.tsx
+++ b/packages/ui/src/features/chat/thread/__tests__/ChatThread.test.tsx
@@ -6,8 +6,8 @@
  * composer (#214). We mock the assistant-ui primitives + heavy children down to
  * identifiable stubs so we can assert the DOM region the indicator lands in.
  */
-import { render, screen, within } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ReactNode } from 'react';
 
 // ── assistant-ui primitives → identifiable stub wrappers ─────────────────────
@@ -68,5 +68,31 @@ describe('ChatThread — thinking indicator placement (#214)', () => {
     // Same parent (the messages column) and the indicator follows the messages.
     expect(running.parentElement).toBe(messages.parentElement);
     expect(messages.compareDocumentPosition(running) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe('ChatThread — running indicator elapsed readout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows no elapsed readout during the first second of a run', () => {
+    render(<ChatThread />);
+    expect(screen.queryByTestId('chat-thread-running-elapsed')).toBeNull();
+  });
+
+  it('reveals the elapsed readout once the run passes a second, and keeps it ticking', () => {
+    render(<ChatThread />);
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(screen.getByTestId('chat-thread-running-elapsed')).toHaveTextContent('1s');
+
+    act(() => void vi.advanceTimersByTime(64_000));
+    expect(screen.getByTestId('chat-thread-running-elapsed')).toHaveTextContent('1m 05s');
   });
 });

--- a/packages/ui/src/features/chat/thread/__tests__/use-run-elapsed.test.ts
+++ b/packages/ui/src/features/chat/thread/__tests__/use-run-elapsed.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/**
+ * use-run-elapsed — unit tests for the running indicator's live elapsed timer.
+ *
+ * Every expectation is a hardcoded string/number, not a re-derivation of the
+ * formatter's own arithmetic.
+ *
+ * Behaviors covered:
+ *  - the formatter's three bands (seconds, minutes, hours) and their boundaries
+ *  - nothing is reported below 1s (a sub-second run must not flash "0s")
+ *  - the count ticks once per second while a run is active
+ *  - it clears when the run ends, and a second run restarts from zero
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { formatElapsedSeconds, useRunElapsed } from '../use-run-elapsed';
+
+describe('formatElapsedSeconds', () => {
+  it('reports whole seconds below a minute', () => {
+    expect(formatElapsedSeconds(0)).toBe('0s');
+    expect(formatElapsedSeconds(1)).toBe('1s');
+    expect(formatElapsedSeconds(9)).toBe('9s');
+    expect(formatElapsedSeconds(59)).toBe('59s');
+  });
+
+  it('switches to minutes at 60s, zero-padding the seconds so a ticking readout keeps its width', () => {
+    expect(formatElapsedSeconds(60)).toBe('1m 00s');
+    expect(formatElapsedSeconds(65)).toBe('1m 05s');
+    expect(formatElapsedSeconds(75)).toBe('1m 15s');
+    expect(formatElapsedSeconds(600)).toBe('10m 00s');
+    expect(formatElapsedSeconds(3599)).toBe('59m 59s');
+  });
+
+  it('drops seconds past an hour', () => {
+    expect(formatElapsedSeconds(3600)).toBe('1h 00m');
+    expect(formatElapsedSeconds(3725)).toBe('1h 02m');
+    expect(formatElapsedSeconds(7380)).toBe('2h 03m');
+  });
+
+  it('clamps a negative reading to zero', () => {
+    expect(formatElapsedSeconds(-5)).toBe('0s');
+  });
+});
+
+describe('useRunElapsed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports nothing while inactive', () => {
+    const { result } = renderHook(() => useRunElapsed(false));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('reports nothing for the first second of a run', () => {
+    const { result } = renderHook(() => useRunElapsed(true));
+    expect(result.current).toBeUndefined();
+
+    act(() => void vi.advanceTimersByTime(900));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('ticks once per second while the run is active', () => {
+    const { result } = renderHook(() => useRunElapsed(true));
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+
+    act(() => void vi.advanceTimersByTime(4000));
+    expect(result.current).toBe(5);
+  });
+
+  it('clears when the run ends', () => {
+    const { result, rerender } = renderHook(({ active }) => useRunElapsed(active), {
+      initialProps: { active: true },
+    });
+    act(() => void vi.advanceTimersByTime(3000));
+    expect(result.current).toBe(3);
+
+    rerender({ active: false });
+    expect(result.current).toBeUndefined();
+  });
+
+  it('restarts from zero on a second run rather than resuming the first', () => {
+    const { result, rerender } = renderHook(({ active }) => useRunElapsed(active), {
+      initialProps: { active: true },
+    });
+    act(() => void vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(30);
+
+    rerender({ active: false });
+    act(() => void vi.advanceTimersByTime(60_000));
+    rerender({ active: true });
+    expect(result.current).toBeUndefined();
+
+    act(() => void vi.advanceTimersByTime(2000));
+    expect(result.current).toBe(2);
+  });
+});

--- a/packages/ui/src/features/chat/thread/use-run-elapsed.ts
+++ b/packages/ui/src/features/chat/thread/use-run-elapsed.ts
@@ -1,0 +1,47 @@
+/**
+ * Live elapsed time for the thread's running indicator.
+ *
+ * Sibling of `useReasoningDuration` (ReasoningGroup.tsx), deliberately NOT a
+ * reuse of it: that hook reports a duration only once its window CLOSES, which
+ * is the opposite of what a running indicator needs. This one ticks while the
+ * run is open and reports nothing once it ends.
+ */
+import { useEffect, useState } from 'react';
+
+const TICK_MS = 1000;
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/**
+ * Whole seconds → "9s" / "1m 05s" / "1h 02m". The minute band zero-pads its
+ * seconds so a ticking readout keeps a constant width; the hour band drops
+ * seconds entirely (they are noise at that scale).
+ */
+export function formatElapsedSeconds(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  if (total < 60) return `${total}s`;
+  if (total < 3600) return `${Math.floor(total / 60)}m ${pad(total % 60)}s`;
+  return `${Math.floor(total / 3600)}h ${pad(Math.floor(total / 60) % 60)}m`;
+}
+
+/**
+ * Seconds elapsed since `active` last turned true, ticking every second.
+ * `undefined` while inactive and for the first second of a run — a turn that
+ * resolves in 300 ms must not flash "0s". Each run restarts the count.
+ */
+export function useRunElapsed(active: boolean): number | undefined {
+  const [seconds, setSeconds] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    setSeconds(undefined);
+    if (!active) return;
+    const startedAt = Date.now();
+    const id = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+      setSeconds(elapsed >= 1 ? elapsed : undefined);
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [active]);
+
+  return seconds;
+}

--- a/packages/ui/src/features/session-panel/ActivitySection.tsx
+++ b/packages/ui/src/features/session-panel/ActivitySection.tsx
@@ -3,9 +3,15 @@
  * background bash tasks, and workflow runs.
  *
  * The daemon ships only running work (there is no status field on
- * `BackgroundActivityTask`), so every row spins and the count IS the list
- * length. A workflow row drills in place into its run panel — the level swap
- * the composer's two-level popover used to do, minus the popover.
+ * `BackgroundActivityTask` — see background-task.ts), so every row reads as
+ * working and the count IS the list length. That is why `elements-agent-status`
+ * contributes only its working dot here: its `waiting` / `done` branches, and
+ * the `error` branch our workflow model would want, have no data to render, and
+ * its trailing pause/rerun button has no handler upstream. Its pill fill goes
+ * too — these rows are flat by design.
+ *
+ * A workflow row drills in place into its run panel — the level swap the
+ * composer's two-level popover used to do, minus the popover.
  *
  * The section stays mounted across a session switch, so the drill-in is reset
  * on `chatId` explicitly; the popover got that free from Radix unmounting.
@@ -15,7 +21,7 @@
  * worse than a placeholder.
  */
 import { useEffect, useMemo, useState } from 'react';
-import { Activity, ChevronLeft, ChevronRight, LoaderCircle } from 'lucide-react';
+import { Activity, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { BackgroundActivityTask, BackgroundWorkKind, ClaudeWorkflowRun } from '@qlan-ro/mainframe-types';
 import { cn } from '@v2/lib/utils';
 import { useChatExtras } from '@/features/chat/runtime/use-chat-thread-runtime';
@@ -37,10 +43,34 @@ const KIND_LABEL: Record<BackgroundWorkKind, string> = {
   other: 'Task',
 };
 
+/**
+ * Working dot, lifted from assistant-ui's `elements-agent-status`
+ * (https://r.assistant-ui.com/elements-agent-status.json, fetched 2026-08-07;
+ * sha256 of its `files[0].content`
+ * b2ab3bceee1da9fc28fb0243d38399ce67e08cb6e55c17d40efc72f8a1293227 — the
+ * registry item carries no version, so re-pull and diff against that hash),
+ * in place of the spinner. Re-themed to `primary` — upstream's `blue-500` is
+ * not a token here, and `primary` is the app's settled "working" signal
+ * (AssistantMessage's RunningIndicator, the thread's running indicator).
+ *
+ * The 6px dot sits in the 14px slot the spinner occupied so the title column
+ * does not shift.
+ */
+function WorkingDot() {
+  return (
+    <span aria-hidden className="flex size-3.5 shrink-0 items-center justify-center">
+      <span
+        data-testid="session-panel-working-dot"
+        className="size-1.5 rounded-full bg-primary animate-pulse motion-reduce:animate-none"
+      />
+    </span>
+  );
+}
+
 function RowBody({ title, detail, startedAt, now }: { title: string; detail: string; startedAt: number; now: number }) {
   return (
     <>
-      <LoaderCircle className="size-3.5 shrink-0 animate-spin text-primary" aria-hidden />
+      <WorkingDot />
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm">{title}</div>
         <div className="truncate text-xs text-muted-foreground">{detail}</div>

--- a/packages/ui/src/features/session-panel/__tests__/ActivitySection.test.tsx
+++ b/packages/ui/src/features/session-panel/__tests__/ActivitySection.test.tsx
@@ -9,7 +9,7 @@
  * Behaviors covered:
  *  - the empty state keeps the header and shows one muted placeholder row, with
  *    no count badge (D6)
- *  - one row per live task, with its description and elapsed time
+ *  - one row per live task, with its description, elapsed time and working dot
  *  - the count badge appears only while work is running
  *  - a live workflow row drills into its run panel; the breadcrumb comes back
  *  - agent/bash rows are inert
@@ -18,7 +18,7 @@
  * Mocked dependencies: `useChatExtras` (tasks + chat id) and `useWorkflowRun`.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent, within } from '@testing-library/react';
 import type { BackgroundActivityTask, ClaudeWorkflowRun } from '@qlan-ro/mainframe-types';
 import { TooltipProvider } from '@v2/components/ui/tooltip';
 
@@ -119,6 +119,16 @@ describe('ActivitySection — task rows', () => {
     mockTasks = { 'a-1': task('a-1', 'agent', 'reviewer'), 'b-1': task('b-1', 'bash', 'pnpm dev') };
     render(section());
     expect(screen.getByTestId('session-panel-section-toggle-activity')).toHaveTextContent('2');
+  });
+
+  it('marks every row as working with the pulse dot — the daemon ships no other status', () => {
+    mockTasks = { 'a-1': task('a-1', 'agent', 'reviewer'), 'b-1': task('b-1', 'bash', 'pnpm dev') };
+    render(section());
+
+    expect(within(screen.getByTestId('session-panel-task-a-1')).getByTestId('session-panel-working-dot')).toHaveClass(
+      'animate-pulse',
+    );
+    expect(within(screen.getByTestId('session-panel-task-b-1')).getByTestId('session-panel-working-dot')).toBeVisible();
   });
 
   it('leaves agent and bash rows inert — there is nothing to drill into', () => {


### PR DESCRIPTION
## What

Adopts the two shortlisted assistant-ui elements from the adoption audit (`docs/research/2026-08-06-aui-elements-adoption-audit.md`):

- **`thinking-indicator` → `GeneratingIndicator`**: leading pulse dot + live elapsed readout (`9s` / `1m 05s`, hidden under 1s), themed to house tokens. Upstream's double-rendered entrance animation deliberately skipped (duplicates the phrase in the a11y tree). New `use-run-elapsed` hook + 9 hardcoded-expectation tests.
- **`agent-status` → Activity rows**: the working-dot treatment replaces the spinner, sized into the settled panel row rhythm. Waiting/done/error branches deliberately NOT built — `BackgroundActivityTask` carries no status field (that's backend follow-up work); no dead pause buttons.

The audit's third item (tool-group `+N/−N` stats chips) was **rejected on evidence**: daemon-side grouping only ever groups explore tools (Read/Glob/Grep/LS; empty for Codex), so Edit/Write can never appear in a group — the chips would be dead code. Alternative placements (TaskCard subagent header / per-turn footer) are parked pending a product call.

## Verification

Typecheck clean · ChatThread 5 · use-run-elapsed 9 · ActivitySection 10 — all green on top of merged main. `chat-thread-running`'s textContent now includes the elapsed readout; the two e2e references are presence-only checks and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)