### PR TITLE
fix(ui): session panel invisible in packaged builds — cold-boot measure race

### DIFF
--- a/.changeset/session-panel-cold-boot-race.md
+++ b/.changeset/session-panel-cold-boot-race.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix the session panel never appearing in packaged builds: the panel's width measurement ran once before the chat surface's initializing branch gave way to the real layout row, so the observer never attached and the panel stayed permanently hidden. The host is now a state-backed callback ref that re-measures whenever the row mounts. Dev servers booted fast enough to always win that race, which is why it only ever reproduced in release builds.

--- a/packages/ui/src/features/session-panel/__tests__/use-session-panel-state.test.tsx
+++ b/packages/ui/src/features/session-panel/__tests__/use-session-panel-state.test.tsx
@@ -24,17 +24,19 @@ let host: HTMLDivElement;
 let root: HTMLDivElement;
 
 /**
- * The hook measures `hostRef` and light-dismisses against `rootRef`. renderHook
- * renders no elements, so both refs are seeded during render — a ref is just a
- * box, and this is exactly what React would have put there before the effects run.
+ * The hook measures the host through its state-backed callback ref and
+ * light-dismisses against `rootRef`. The host is attached AFTER mount — the
+ * same order a cold boot produces (initializing branch first, row later), which
+ * the old RefObject-seeded harness could not express and therefore never caught.
  */
 function renderPanelState() {
-  return renderHook(() => {
+  const rendered = renderHook(() => {
     const state = useSessionPanelState();
-    state.hostRef.current = host;
     state.rootRef.current = root;
     return state;
   });
+  act(() => rendered.result.current.hostRef(host));
+  return rendered;
 }
 
 function setWidth(width: number) {
@@ -60,6 +62,29 @@ describe('useSessionPanelState — mode', () => {
   it('observes the host row, not the panel root', () => {
     renderPanelState();
     expect(observed).toEqual([host]);
+  });
+
+  // Regression: the packaged app's cold boot renders the initializing branch
+  // first, so the host row mounts on a LATER commit than the hook. The old
+  // []-deps effect read a null RefObject once and never retried — the panel
+  // stayed permanently hidden in every release build.
+  it('attaches the observer when the host mounts after the hook (cold-boot race)', () => {
+    const rendered = renderHook(() => useSessionPanelState());
+    expect(observed).toEqual([]);
+    expect(rendered.result.current.mode).toBe('hidden');
+
+    act(() => rendered.result.current.hostRef(host));
+    expect(observed).toEqual([host]);
+    setWidth(1000);
+    expect(rendered.result.current.mode).toBe('rail');
+  });
+
+  it('re-attaches to a replacement host and disconnects from the old one', () => {
+    const rendered = renderPanelState();
+    const nextHost = document.createElement('div');
+    document.body.append(nextHost);
+    act(() => rendered.result.current.hostRef(nextHost));
+    expect(observed).toEqual([host, nextHost]);
   });
 
   it('starts in rail mode on a narrow surface', () => {

--- a/packages/ui/src/features/session-panel/use-session-panel-state.ts
+++ b/packages/ui/src/features/session-panel/use-session-panel-state.ts
@@ -27,8 +27,15 @@ export interface SessionPanelState {
   /** Goes on the chat surface's horizontal row — the FULL width, including the
    *  part the panel floats over, since the mode follows the gutter that width
    *  leaves beside the centred transcript. Explicit, rather than the panel
-   *  root's `parentElement`, so a split surface measures the row it shrinks. */
-  hostRef: RefObject<HTMLElement | null>;
+   *  root's `parentElement`, so a split surface measures the row it shrinks.
+   *
+   *  A CALLBACK ref backed by state, not a RefObject, and that is load-bearing:
+   *  on a cold boot the chat surface shows its initializing branch first, so the
+   *  row does not exist when this hook's effects first run. A `[]`-deps effect
+   *  reading a RefObject box measured `null` once and never retried — the panel
+   *  stayed `hidden` forever in the packaged app, where the daemon spawn always
+   *  loses that race (dev servers boot fast enough to always win it). */
+  hostRef: (el: HTMLElement | null) => void;
   /** Goes on the panel + rail root; light dismiss treats it as "inside". */
   rootRef: RefObject<HTMLDivElement | null>;
   surfaceWidth: number;
@@ -61,7 +68,7 @@ function hasOpenDialogOutside(root: HTMLElement | null): boolean {
 }
 
 export function useSessionPanelState(): SessionPanelState {
-  const hostRef = useRef<HTMLElement | null>(null);
+  const [hostEl, setHostEl] = useState<HTMLElement | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const sectionEls = useRef(new Map<SessionPanelSectionId, HTMLElement>());
   const [surfaceWidth, setSurfaceWidth] = useState(0);
@@ -74,17 +81,19 @@ export function useSessionPanelState(): SessionPanelState {
   const userCollapsed = useUiPrefs((s) => s.sessionPanelCollapsed);
   const setUserCollapsed = useUiPrefs((s) => s.setSessionPanelCollapsed);
 
+  // Keyed on the host ELEMENT, so the observer attaches whenever the row
+  // (re)mounts — including the cold-boot case where the initializing branch
+  // rendered first and the row only exists on a later commit.
   useEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    setSurfaceWidth(host.clientWidth);
+    if (!hostEl) return;
+    setSurfaceWidth(hostEl.clientWidth);
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (entry) setSurfaceWidth(entry.contentRect.width);
     });
-    observer.observe(host);
+    observer.observe(hostEl);
     return () => observer.disconnect();
-  }, []);
+  }, [hostEl]);
 
   const gutterFits = gutterFitsPanel(surfaceWidth);
   const railFits = gutterFitsRail(surfaceWidth);
@@ -167,7 +176,7 @@ export function useSessionPanelState(): SessionPanelState {
 
   return useMemo(
     () => ({
-      hostRef,
+      hostRef: setHostEl,
       rootRef,
       surfaceWidth,
       mode,

--- a/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
+++ b/packages/ui/src/features/sessions/new-thread/ChatSurface.tsx
@@ -32,7 +32,7 @@
  * which shrinks when the surface is split and which the panel measuring its own
  * box would never see.
  */
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAuiState } from '@assistant-ui/react';
 import { useSessionFilters } from '@/store/session-filters';
 import { SessionPanel } from '@/features/session-panel/SessionPanel';
@@ -81,15 +81,11 @@ export function ChatSurface() {
   useNewThreadAutoConfig();
 
   const panelState = useSessionPanelState();
-  const { hostRef } = panelState;
-  // A callback ref, because `hostRef` is typed to the generic HTMLElement the
-  // panel measures — a div's own ref prop would not accept it.
-  const setHostRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      hostRef.current = el;
-    },
-    [hostRef],
-  );
+  // `hostRef` is the hook's state-backed callback ref — passed straight through,
+  // so the hook re-measures whenever THIS row (re)mounts. On a cold boot the
+  // initializing branch renders first and the row arrives on a later commit;
+  // a RefObject here left the panel unmeasured (hidden) in the packaged app.
+  const setHostRef = panelState.hostRef;
 
   const mainThreadId = useAuiState((s) => s.threads.mainThreadId);
   // s.threadListItem is the native active ThreadListItemState; its `status`


### PR DESCRIPTION
## The bug

The session panel (PR #567) never appeared in packaged builds — at any window size — while every dev/e2e/browser environment rendered it correctly. Reported against the rc.20 DMG.

## Root cause

`useSessionPanelState` measured its host row in a `[]`-deps effect reading a `RefObject`. On a cold boot the chat surface renders its **initializing branch first** — the host row doesn't exist yet — so the effect read `null`, bailed, and never retried. `surfaceWidth` stayed 0, `derivePanelMode` returned `hidden`, and the panel rendered `null` forever.

**Release-only by timing, not by build**: dev servers and the e2e fast-boot render the normal branch on the first commit, so the ref was always populated before the effect ran. A real daemon spawn always loses that race.

## The hunt (for the record)

Eliminated in order, each with evidence: stale release (rc.20 verified installed) · WKWebView cache (cleared; WebsiteData clean) · supply chain (embedded asset hashes reproduced byte-identical from the release commit) · CSP (bug persists with `csp: null`) · engine (dev-Tauri WKWebView renders fine) · localStorage state (dumped from the WebKit sqlite, healthy) · `ResizeObserver` under `tauri://` (manual observer fires; the hook's provably dead — the differentiator). Verified live in an instrumented release build (`--features mcp-bridge`, embedded assets): DOM root absent before the fix, rail/inline present after, on a real cold boot.

## The fix

`hostRef` becomes a state-backed **callback ref** and the measure/observe effect is keyed on the element — the panel measures whenever the row (re)mounts. `ChatSurface` passes it straight through. The regression test pins the attach-after-mount order (the old harness seeded the ref during render, which is exactly why it couldn't catch this).

224 panel tests green · typecheck clean · fix verified in a release-profile build with embedded assets against a cold daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)