### PR TITLE
fix(ui): stop rendering two working indicators at once

### DIFF
--- a/.changeset/tidy-dots-stop-doubling.md
+++ b/.changeset/tidy-dots-stop-doubling.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Stop showing two working indicators at once. While a tool call was the last part of a running turn, the message rendered a bare pulse dot on top of the thread's "Working… 12s" row, with the message timestamp between them. The per-message dot is now suppressed in the main thread and kept only in nested subagent transcripts, which have no thread-level indicator.

--- a/packages/ui/src/features/chat/messages/AssistantMessage.tsx
+++ b/packages/ui/src/features/chat/messages/AssistantMessage.tsx
@@ -27,6 +27,7 @@ import { AssistantErrorBlock } from './AssistantErrorBlock';
 import { MessagePathContextMenu } from './MessagePathContextMenu';
 import { useIsNestedTranscript } from './nested-transcript-context';
 
+/** Nested-only: the top-level thread has ChatThread's labelled indicator instead. */
 function RunningIndicator() {
   return (
     <span
@@ -60,7 +61,9 @@ export function AssistantMessage() {
   }
 
   const groupedParts = (
-    <MessagePrimitive.GroupedParts groupBy={groupBy}>
+    // `never` at the top level — ChatThread's GeneratingIndicator already carries
+    // the pulse dot; nested transcripts have no such row, so they keep the default.
+    <MessagePrimitive.GroupedParts groupBy={groupBy} indicator={isNested ? 'no-text' : 'never'}>
       {({ part, children }) => {
         // GroupPart nodes carry `indices`; leaf parts do not.
         if ('indices' in part) {

--- a/packages/ui/src/features/chat/messages/__tests__/AssistantMessage.test.tsx
+++ b/packages/ui/src/features/chat/messages/__tests__/AssistantMessage.test.tsx
@@ -1,10 +1,12 @@
 /**
- * AssistantMessage — MessagePathContextMenu mounting (274-A7).
+ * AssistantMessage — MessagePathContextMenu mounting (274-A7) and the
+ * GroupedParts indicator mode.
  *
  * Heavy assistant-ui/view-model deps are stubbed so only the wrapper
  * placement is under test: normal branch wraps GroupedParts in the menu
  * (skipped inside a nested/subagent transcript); the error branch never
- * wraps, in either context.
+ * wraps, in either context. The indicator mode follows the same nesting
+ * split — `never` at the top level, the default `no-text` when nested.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -15,8 +17,10 @@ let mockMeta: { errorText?: string; partGroups?: Record<string, string>; groupSu
 vi.mock('@assistant-ui/react', () => ({
   MessagePrimitive: {
     Root: ({ children, ...props }: { children?: ReactNode }) => <div {...props}>{children}</div>,
-    GroupedParts: ({ children }: { children: (arg: unknown) => ReactNode }) => (
-      <div data-testid="grouped-parts-stub">{children({ part: { type: 'text', text: 'hi' }, children: null })}</div>
+    GroupedParts: ({ children, indicator }: { children: (arg: unknown) => ReactNode; indicator?: string }) => (
+      <div data-testid="grouped-parts-stub" data-indicator={indicator}>
+        {children({ part: { type: 'text', text: 'hi' }, children: null })}
+      </div>
     ),
   },
   useAuiState: () => 'msg-1',
@@ -76,5 +80,23 @@ describe('AssistantMessage — MessagePathContextMenu mounting', () => {
     );
     expect(screen.queryByTestId('chat-message-menu-trigger')).toBeNull();
     expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});
+
+describe('AssistantMessage — running-indicator mode', () => {
+  it('suppresses the per-message indicator at the top level, where ChatThread renders its own', () => {
+    mockMeta = { partGroups: {}, groupSummaries: {} };
+    render(<AssistantMessage />);
+    expect(screen.getByTestId('grouped-parts-stub')).toHaveAttribute('data-indicator', 'never');
+  });
+
+  it('keeps the per-message indicator inside a nested transcript, which has no thread-level one', () => {
+    mockMeta = { partGroups: {}, groupSummaries: {} };
+    render(
+      <NestedTranscriptProvider>
+        <AssistantMessage />
+      </NestedTranscriptProvider>,
+    );
+    expect(screen.getByTestId('grouped-parts-stub')).toHaveAttribute('data-indicator', 'no-text');
   });
 });


### PR DESCRIPTION
## What

While a tool call was the tail part of a running turn, the chat showed **two** working indicators stacked: a bare pulse dot inside the message, then the message timestamp, then the thread's own dot + "Working…" + elapsed row.

Both were real. `MessagePrimitive.GroupedParts` defaults to `indicator="no-text"`, so assistant-ui emits a synthetic `indicator` part whenever the message is running and its last part isn't text or reasoning — which `AssistantMessage` rendered as `RunningIndicator`. `ChatThread`'s `GeneratingIndicator` lights on `thread.isRunning` independently. The thread-level row landed in #568; the older per-message dot from the #565 port was never removed.

## Change

`indicator="never"` at the top level, where `GeneratingIndicator` already carries the pulse dot plus the phrase and the elapsed readout.

Nested subagent transcripts keep the default `no-text`: no `GeneratingIndicator` renders inside a `TaskCard`, so the per-message dot is their only activity cue.

## Verification

- `AssistantMessage.test.tsx` — 6 passed, two new ones locking the top-level/nested split.
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean.
- No other consumer of `data-slot="message-indicator"`; the e2e specs key off `chat-thread-running`, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)