### PR TITLE
test(e2e): unwedge the daemon picker suite after the paired-scheme fix

### DIFF
--- a/.changeset/violet-snakes-glow.md
+++ b/.changeset/violet-snakes-glow.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: realign the daemon-picker specs with the paired-scheme fix (todo #305) and make the draft specs retry-safe. No shipped behavior changes.

--- a/packages/e2e/tests-tauri/daemon-picker.spec.ts
+++ b/packages/e2e/tests-tauri/daemon-picker.spec.ts
@@ -47,11 +47,13 @@
  *      pairing flow, with `page.route()` mocking only the `/health` and
  *      `/api/auth/confirm` calls to the fake remote origin (network-level fault
  *      injection, not fabricated React/store state).
- *   2. The unreachable overlay then comes for free: `useConnectionState` polls the
+ *   2. The unreachable overlay is forced deliberately: `useConnectionState` polls the
  *      ACTIVE daemon's `/health` (`getActiveDaemon().baseUrl`, not a fixed local port),
- *      and a paired remote is stored as `https://<host>` — which no route in this file
- *      mocks — so the poll fails and `showUnreachableOverlay` raises through the app's
- *      real loop. Aborting the LOCAL health route reproduces it while local is active.
+ *      so the overlay test aborts the REMOTE origin's health route while that remote is
+ *      active. It used to come for free — a paired remote was stored as `https://<host>`,
+ *      which no route here mocks, so its poll could only fail. Todo #305 (the paired
+ *      scheme is persisted and honored) fixed exactly that: an http loopback remote now
+ *      answers the 200 `/health` mock this file installs, and reads Connected.
  * Every daemon switch in this suite is undone before the describe ends (CAUTION
  * in the dispatch); the final test re-asserts the app is back on the local daemon.
  *
@@ -78,13 +80,15 @@
  * post-dialog assertion below reopens the picker.)
  */
 
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Route } from '@playwright/test';
 import { launchTauriApp, closeTauriApp, type TauriAppFixture } from '../fixtures/app-tauri.js';
 import { createTauriProject, createTauriChat, cleanupTauriProject, type TauriProject } from '../helpers/tauri/setup.js';
 import { waitConnected } from '../helpers/tauri/wait.js';
-import { DAEMON_PORT } from '../fixtures/daemon.js';
 
-const LOCAL_HEALTH_URL = `http://127.0.0.1:${DAEMON_PORT}/health`;
+/** The fake remote this file pairs once and keeps for the rest of the describe.
+ *  Its label is derived from the host — "127.0.0.1:58202".split('.')[0] === "127". */
+const REMOTE_ORIGIN = 'http://127.0.0.1:58202';
+const REMOTE_HEALTH_URL = `${REMOTE_ORIGIN}/health`;
 
 /** Suffix-scoped locators — safe because at most one remote daemon exists at a
  *  time by the point these are used (the auto-switch test below adds and then
@@ -165,12 +169,21 @@ async function closePicker(page: Page): Promise<void> {
   await expect(page.getByTestId('daemon-picker')).toHaveCount(0, { timeout: 5_000 });
 }
 
-async function recoverToLocal(page: Page): Promise<void> {
-  await expect(page.getByTestId('daemon-unreachable')).toBeVisible({ timeout: 30_000 });
-  await page.getByTestId('daemon-unreachable-switchlocal').click();
-  await expect(page.getByTestId('daemon-unreachable')).toHaveCount(0, { timeout: 5_000 });
+/**
+ * Put the app back on the local daemon through the picker.
+ *
+ * This used to go through the unreachable overlay, which a paired remote raised on
+ * its own. Since todo #305 it cannot: the remotes paired here are loopback origins
+ * whose `/health` this file mocks 200, so they read Connected. The overlay is now
+ * something one test forces, not the way back from every pairing.
+ */
+async function switchToLocal(page: Page): Promise<void> {
+  await openPicker(page);
+  await page.getByTestId('daemon-row-local').click();
+  await expect(footerLabel(page)).toHaveText('This Mac', { timeout: 10_000 });
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('daemon-picker')).toHaveCount(0, { timeout: 5_000 });
   await waitConnected(page, 30_000);
-  await expect(footerLabel(page)).toHaveText('This Mac');
 }
 
 test.describe('§daemon-picker', () => {
@@ -277,11 +290,10 @@ test.describe('§daemon-picker', () => {
 
   test('completing pairing adds a remote daemon row', async () => {
     const { page } = app;
-    const origin = 'http://127.0.0.1:58202';
-    await page.route(`${origin}/health`, async (route) => {
+    await page.route(REMOTE_HEALTH_URL, async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ version: '9.9.9' }) });
     });
-    await page.route(`${origin}/api/auth/confirm`, async (route) => {
+    await page.route(`${REMOTE_ORIGIN}/api/auth/confirm`, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -293,7 +305,7 @@ test.describe('§daemon-picker', () => {
     await page.getByTestId('daemon-picker-add').click();
     await expect(page.getByTestId('daemon-add-url')).toBeVisible();
 
-    await page.getByTestId('daemon-add-url').fill(origin);
+    await page.getByTestId('daemon-add-url').fill(REMOTE_ORIGIN);
     await page.getByTestId('daemon-add-verify').click();
     await expect(page.getByTestId('daemon-add-continue')).toBeVisible({ timeout: 10_000 });
     await page.getByTestId('daemon-add-continue').click();
@@ -315,10 +327,9 @@ test.describe('§daemon-picker', () => {
     await expect(page.getByTestId('daemon-pair-code')).toHaveCount(0, { timeout: 5_000 });
 
     await expect(footerLabel(page)).toHaveText('127', { timeout: 10_000 });
-    await recoverToLocal(page);
+    await switchToLocal(page);
 
-    // The row is added — label is derived from the host
-    // ("127.0.0.1:58202".split('.')[0] === "127").
+    // The row is added — label is derived from the host.
     await openPicker(page);
     await expect(remoteRow(page)).toBeVisible({ timeout: 10_000 });
     await expect(remoteRow(page)).toContainText('127');
@@ -339,11 +350,7 @@ test.describe('§daemon-picker', () => {
 
     // Establish a known starting state so this test's auto-switch assertion is
     // meaningful, not inherited ambient state.
-    await openPicker(page);
-    await page.getByTestId('daemon-row-local').click();
-    await expect(footerLabel(page)).toHaveText('This Mac', { timeout: 10_000 });
-    await page.keyboard.press('Escape');
-    await expect(page.getByTestId('daemon-picker')).toHaveCount(0, { timeout: 5_000 });
+    await switchToLocal(page);
 
     const origin = 'http://127.0.0.1:58203';
     await page.route(`${origin}/health`, async (route) => {
@@ -388,7 +395,7 @@ test.describe('§daemon-picker', () => {
     await expect(footerLabel(page)).not.toHaveText('This Mac', { timeout: 10_000 });
     await expect(footerLabel(page)).toHaveText('127', { timeout: 10_000 });
 
-    await recoverToLocal(page);
+    await switchToLocal(page);
 
     // Clean up this test's own second remote so the "exactly one remote"
     // invariant the rest of this suite relies on holds after.
@@ -416,11 +423,14 @@ test.describe('§daemon-picker', () => {
     await remoteRow(page).click();
     await expect(footerLabel(page)).toHaveText('127', { timeout: 10_000 });
 
-    // Force connState to 'disconnected' by failing the LOCAL daemon's health poll —
-    // the real signal DaemonFooterStatus/DaemonGatedShell react to (see file header).
-    await page.route(LOCAL_HEALTH_URL, async (route) => {
-      await route.abort();
-    });
+    // Force connState to 'disconnected' by failing the health poll — the real signal
+    // DaemonFooterStatus/DaemonGatedShell react to (see file header). `useConnectionState`
+    // polls the ACTIVE daemon, so with the remote active it is the REMOTE origin's health
+    // that has to fail; aborting the local one would poll nothing. The abort is registered
+    // after this file's 200 mock for the same URL and Playwright matches handlers
+    // most-recent-first, so it wins until the `finally` removes it by reference.
+    const killRemoteHealth = (route: Route) => route.abort();
+    await page.route(REMOTE_HEALTH_URL, killRemoteHealth);
 
     try {
       await expect(page.getByTestId('daemon-unreachable')).toBeVisible({ timeout: 30_000 });
@@ -431,7 +441,7 @@ test.describe('§daemon-picker', () => {
       // Active kind flips to local immediately on click, independent of the poll.
       await expect(page.getByTestId('daemon-unreachable')).toHaveCount(0, { timeout: 5_000 });
     } finally {
-      await page.unroute(LOCAL_HEALTH_URL);
+      await page.unroute(REMOTE_HEALTH_URL, killRemoteHealth);
     }
 
     await waitConnected(page, 30_000);

--- a/packages/e2e/tests-tauri/sessions-draft.spec.ts
+++ b/packages/e2e/tests-tauri/sessions-draft.spec.ts
@@ -84,6 +84,42 @@ async function pickProjectFromPicker(page: Page, projectId: string): Promise<voi
   await expect(page.getByTestId('sessions-new-picker')).toHaveCount(0, { timeout: 10_000 });
 }
 
+/**
+ * Close an open composer config menu and wait for its layer to retire.
+ *
+ * One blind `Escape` is not enough, for the same reason `pickProjectFromPicker`
+ * asserts on the menu's absence: while a Radix menu lives it owns `<html>`'s
+ * pointer events, so the NEXT trigger's click is swallowed and retried until the
+ * test budget runs out — which is how this read in CI, as `<html> intercepts
+ * pointer events` against a still-open model menu. Retry the Escape until the
+ * options are gone, so a menu that cannot be dismissed fails as itself.
+ */
+async function closeConfigMenu(page: Page, options: Locator): Promise<void> {
+  await expect(async () => {
+    await page.keyboard.press('Escape');
+    await expect(options).toHaveCount(0, { timeout: 1_000 });
+  }).toPass({ timeout: 15_000, intervals: [250, 500, 1_000] });
+}
+
+/**
+ * Make sure a draft row is active, creating one if this test did not inherit it.
+ *
+ * The draft tests below document that they continue from the previous test's
+ * draft. That holds on a clean pass and breaks on a RETRY: Playwright re-runs the
+ * failed test alone in a fresh worker, so `beforeAll` reseeds the app but the test
+ * that opened the draft never runs — turning any first failure in this describe
+ * into two.
+ */
+async function ensureDraftRow(page: Page, projectId: string): Promise<void> {
+  const draftRow = page.getByTestId('sessions-draft-row');
+  if ((await draftRow.count()) === 0) {
+    await sessionsSidebar(page).newButton().click();
+    await expect(page.getByTestId('sessions-new-picker')).toBeVisible({ timeout: 10_000 });
+    await pickProjectFromPicker(page, projectId);
+  }
+  await expect(draftRow).toBeVisible({ timeout: 10_000 });
+}
+
 interface SuggestionDto {
   title: string;
   meta: string;
@@ -208,37 +244,36 @@ test.describe('§sessions-draft — All view picker + draft row', () => {
     await expect(page.getByTestId('chat-header-project')).toContainText(baseName(project.projectPath));
   });
 
-  // Depends on the previous test's draft-row surviving — see the fix note
-  // documented on the test above.
+  // Continues from the previous test's draft-row — see the fix note documented on
+  // the test above; `ensureDraftRow` re-opens one when this runs as a lone retry.
   test('composer config selectors are usable on the unsent draft', async () => {
     const { page } = app;
-    // Continues from the previous test's active draft.
-    await expect(page.getByTestId('sessions-draft-row')).toBeVisible({ timeout: 10_000 });
+    await ensureDraftRow(page, project.projectId);
     await expect(composer(page).input()).toBeVisible({ timeout: 10_000 });
 
+    const modelOptions = page.locator('[data-testid^="composer-model-select-option-"]');
     const modelTrigger = page.getByTestId('composer-model-select');
     await expect(modelTrigger).toBeVisible({ timeout: 10_000 });
     await expect(modelTrigger).toBeEnabled();
     await modelTrigger.click();
-    await expect(page.locator('[data-testid^="composer-model-select-option-"]').first()).toBeVisible({
-      timeout: 5_000,
-    });
-    await page.keyboard.press('Escape');
+    await expect(modelOptions.first()).toBeVisible({ timeout: 5_000 });
+    await closeConfigMenu(page, modelOptions);
 
+    const permOption = page.getByTestId('composer-permission-mode-select-option-default');
     const permTrigger = page.getByTestId('composer-permission-mode-select');
     await expect(permTrigger).toBeVisible();
     await expect(permTrigger).toBeEnabled();
     await permTrigger.click();
-    await expect(page.getByTestId('composer-permission-mode-select-option-default')).toBeVisible({ timeout: 5_000 });
-    await page.keyboard.press('Escape');
+    await expect(permOption).toBeVisible({ timeout: 5_000 });
+    await closeConfigMenu(page, permOption);
   });
 
-  // Depends on a draft-row existing to discard — see the fix note documented
-  // on the first test in this describe block.
+  // Needs a draft-row to discard — see the fix note documented on the first test
+  // in this describe block.
   test('discarding the draft (✕) clears the row and returns to the previously active session', async () => {
     const { page } = app;
+    await ensureDraftRow(page, project.projectId);
     const draftRow = page.getByTestId('sessions-draft-row');
-    await expect(draftRow).toBeVisible({ timeout: 10_000 });
 
     await draftRow.hover();
     // The ✕ is a SidebarMenuAction — a sibling of the row button, so it is


### PR DESCRIPTION
The Release workflow's e2e job has been red since rc.20; rc.16 was the last green run. This fixes 7 of the 9 failures in [rc.22's run](https://github.com/qlan-ro/mainframe/actions/runs/31364585983/job/93380163571).

## daemon-picker (5 failures)

The spec returned to the local daemon through the unreachable overlay, which a paired remote used to raise on its own: the endpoint was rebuilt as `https://<host>`, which no route in the file mocks, so its health poll could only fail. Todo #305 (#583) made the paired scheme persist, so the loopback remote now answers the 200 `/health` the spec itself installs and reads Connected — the overlay never came. The failure screenshot shows the footer at `127.0.0.1:58202` with a green Connected dot.

The file is serial over one app, so the first pairing test stranded it on the fake remote and the four tests after it died, three at the 120 s timeout. That cascade is why the run took 26.9 min against rc.20's 10.1 min.

- Pairing tests return to local through the picker (`switchToLocal`).
- The overlay test forces the state it asserts, aborting the **active** daemon's health route — it aborted the local one, which `useConnectionState` stops polling the moment a remote goes active.
- Header docblock corrected; it still documented the pre-#305 `https://` behavior.

## sessions-draft (2 failures)

The permission trigger was clicked while the model menu was still open, so the Radix layer swallowed the click for the full test budget (`<html> intercepts pointer events`). Escape is now retried until the menu's options are gone — the same idiom `pickProjectFromPicker` already uses — so a menu that cannot be dismissed fails as itself.

The two continuation tests also open their own draft when they run as a lone retry, where `beforeAll` reseeds the app but the test that opened the draft never runs. That turned any first failure in the describe into two.

## Verification

`daemon-picker.spec.ts` + `sessions-draft.spec.ts`: 25/25 locally, run twice (before and after the lint hook). The 5 daemon-picker failures reproduce locally on `main`, so this is a confirmed fix rather than a CI-only guess.

## This does not turn the job green

Two transcript failures remain (`scroll-to-bottom`, `find-in-chat` counting `0/0`), plus `sessions-rows` #396. All three sit in the rc.16→rc.20 window (UI v2 port #565 / session panel #567 / pulse dot #568). The transcript pair fails deterministically on the Linux runner including retries but passes on macOS, both in isolation and in a full local suite run — root cause unconfirmed, and if `searchMessages` really returns 0 against the live DOM, ⌘F is broken for users rather than for the test. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)