### PR TITLE
chore(e2e): bound what a failing mock run can cost

### DIFF
--- a/.changeset/few-snails-give.md
+++ b/.changeset/few-snails-give.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: cap the mock-mode per-test timeout at 45s and declare the daemon-picker suite serial, so a failing run costs minutes instead of a quarter-hour. No shipped behavior changes.

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -5,7 +5,13 @@ export default defineConfig({
   // Builds the UI bundle once and starts the shared vite preview (a stateless static server) for
   // the whole run; returns a teardown that kills it. See fixtures/global-setup.ts.
   globalSetup: './fixtures/global-setup.ts',
-  timeout: 120_000, // 2 min per test — AI calls are slow
+  // 2 min per test for the real-adapter runs, where a live AI call sets the pace. Mock mode
+  // replays recorded NDJSON with every inter-event delay capped at 120ms, so its slowest
+  // PASSING test on CI is under 5s — a 2-min budget there only decides how long a hung test
+  // takes to be declared dead, and rc.22 spent 12 of its 27 test-minutes doing exactly that.
+  // 45s keeps ~9x headroom over the slowest observed test. A spec that genuinely needs more
+  // (stress-matrix) overrides per-test with `test.setTimeout`.
+  timeout: process.env['E2E_MODE'] === 'mock' ? 45_000 : 120_000,
   // 40 min total by default — the full AI suite (serial) exceeds 10 min end-to-end. Override via
   // MF_E2E_GLOBAL_TIMEOUT (ms) for targeted multi-file invocations where 40 min would starve later
   // files sharing this one process budget (e.g. running a handful of specs back-to-back).

--- a/packages/e2e/tests-tauri/daemon-picker.spec.ts
+++ b/packages/e2e/tests-tauri/daemon-picker.spec.ts
@@ -173,6 +173,15 @@ async function recoverToLocal(page: Page): Promise<void> {
   await expect(footerLabel(page)).toHaveText('This Mac');
 }
 
+// Serial in fact, so declared serial: every test here inherits the daemon the
+// previous one left active, the pairing tests hand a remote row to the manage
+// tests, and the last test asserts the suite ended back on local. Undeclared,
+// one broken test ran the remaining four against a wedged app for the full
+// per-test budget each — 14m31s in rc.22 for a file that takes 12s green. The
+// trade is real: a failure here now skips its followers instead of reporting
+// them, so a single red run says less than it used to.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('§daemon-picker', () => {
   let app: TauriAppFixture;
   let project: TauriProject;


### PR DESCRIPTION
Third of the e2e changes for the release gate. This one fixes no tests — it bounds what a red run costs.

## The measurement

rc.22's e2e job ran 32m19s against rc.16's 13m27s. None of it was a slower runner. The slowest **passing** test in that entire CI run was **4.8s**. The extra ~17 minutes were failing tests sitting out a 2-minute budget, twice each (`retries: 1`), plus four tests that only failed because a fifth had wedged the app they share:

| test | attempt 1 | retry |
|---|---|---|
| daemon-picker unreachable overlay | 2.0m | 2.0m |
| daemon-picker rename | 2.0m | 2.0m |
| daemon-picker remove | 2.0m | 2.0m |
| sessions-draft config selectors | 2.0m | 10s |

daemon-picker alone ran 14m31s for a file that takes 12s green.

## Two bounds

- **Mock mode gets a 45s per-test timeout** (~9× the slowest observed test). The 2-minute budget stays for real-adapter runs, where a live AI call sets the pace; `stress-matrix` keeps its own `test.setTimeout(240_000)` override, which wins over config either way.
- **`daemon-picker` is declared serial.** It already was in fact — each test inherits the daemon the previous one left active, the pairing tests hand a remote row to the manage tests, and the last test asserts the suite ended back on local. Declared, a failure skips its followers instead of running them against a wedged app.

## The trade, stated plainly

Neither change makes a red run green. And the serial declaration costs signal: the first failure in that file now hides whatever the rest of it would have said. That seemed right for a file whose tests genuinely cannot run independently, and wrong to apply suite-wide, so it is scoped to this one file.

Note the deeper lesson from the same data: the two daemon-picker tests with a bounded wait at the assertion (`toBeVisible({ timeout: 30_000 })`) died in 32s and named the missing element. The three without one burned the full budget and reported "target page has been closed", naming nothing. A shorter backstop makes bad waits cheaper; bounding the wait makes them diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)