### PR TITLE
test(e2e): background the attention-badge chat over a second connection

### DIFF
--- a/.changeset/frank-hairs-bathe.md
+++ b/.changeset/frank-hairs-bathe.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: background the attention-badge test's chat over a second daemon connection instead of racing the reply. No shipped behavior changes.

--- a/packages/e2e/helpers/tauri/background-client.ts
+++ b/packages/e2e/helpers/tauri/background-client.ts
@@ -1,0 +1,35 @@
+/**
+ * A second daemon WebSocket connection, for driving a chat the app is NOT showing.
+ *
+ * The app can only send from its active chat, so a test that needs a BACKGROUND
+ * chat to produce a response used to send from it and then race the reply to a
+ * row click. That race is unwinnable under load — the mock adapter caps every
+ * inter-event delay at 120ms, so a reply can land in well under a second — and it
+ * is what made the attention-badge test fail in rc.20 and rc.22.
+ *
+ * A second connection removes the race outright: the chat under test is never the
+ * active one, which is also the scenario the product code is about. `message.send`
+ * needs only `chatId` and `content` (mainframe-server/src/ws_schemas.rs), and the
+ * daemon trusts loopback callers, so no token is involved.
+ */
+import { DAEMON_BASE } from '../../fixtures/daemon.js';
+
+export interface BackgroundClient {
+  /** Fire-and-forget: the daemon runs the chat and broadcasts to every client. */
+  send(chatId: string, content: string): void;
+  close(): void;
+}
+
+export async function openBackgroundClient(): Promise<BackgroundClient> {
+  const ws = new WebSocket(DAEMON_BASE.replace(/^http/, 'ws'));
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(), { once: true });
+    ws.addEventListener('error', () => reject(new Error('background client could not reach the daemon')), {
+      once: true,
+    });
+  });
+  return {
+    send: (chatId, content) => ws.send(JSON.stringify({ type: 'message.send', chatId, content })),
+    close: () => ws.close(),
+  };
+}

--- a/packages/e2e/tests-tauri/sessions-filters.spec.ts
+++ b/packages/e2e/tests-tauri/sessions-filters.spec.ts
@@ -73,7 +73,8 @@ import { createTauriProject, createTauriChat, cleanupTauriProject, type TauriPro
 import { closeMenus } from '../helpers/tauri/menus.js';
 import { sessionsSidebar } from '../helpers/tauri/page-objects.js';
 import { TOAST } from '../helpers/tauri/testids.js';
-import { sendMessage, waitConnected } from '../helpers/tauri/wait.js';
+import { waitConnected } from '../helpers/tauri/wait.js';
+import { openBackgroundClient } from '../helpers/tauri/background-client.js';
 
 const TAG_NAME = 'e2e-filter';
 
@@ -364,38 +365,37 @@ test.describe('§sessions-filters Project + tag filter bar', () => {
     );
   });
 
-  // KNOWN LOAD-SENSITIVE FLAKE (measured 2026-08-06): under full-suite
-  // parallel load the session hover card can wedge open and eat the row
-  // click (fails both attempts); isolated it passes 5/5 in ~3s. Not a UI
-  // regression — no sidebar/hover-card code changed in the failing range.
-  // Root-cause investigation (why the switch stalls mid-stream under load)
-  // is tracked separately; do not delete this test to silence it.
-  //
   // Attention badges are driven by useUnreadStore.markUnread, which is only
   // called by the session-list-router on a `chat.notification` /
   // `permission.requested{notify:true}` WS event. Previously that event never
   // reached the client for a BACKGROUND chat (see the sessions-rows.spec.ts
   // unread-dot test for the root cause); now that chat.notification is
   // connection-global, project A's badge lights up while B stays active.
+  //
+  // A was backgrounded by sending from it and switching away before the reply
+  // landed, which is a race the test lost whenever the machine was busy (rc.20,
+  // rc.22, and locally under full-suite load — previously annotated here as a
+  // hover-card flake). `openBackgroundClient` sends from a second daemon
+  // connection instead, so A is never the active chat and there is nothing to
+  // outrun.
   test('attention badges appear on non-filtered project rows', async () => {
     const { page } = app;
     const sidebar = sessionsSidebar(page);
+    await selectRow(page, sidebar.row(chatIdB));
 
-    const rowA = sidebar.row(chatIdA);
-    const rowB = sidebar.row(chatIdB);
-    await selectRow(page, rowA);
-
-    await sendMessage(page, 'What is 2 + 2? Reply with just the number.');
-    // Switch to B immediately — A is now the BACKGROUND chat while its
-    // response streams in.
-    await selectRow(page, rowB);
-
+    const background = await openBackgroundClient();
     const badgeA = page.getByTestId(`sidebar-project-badge-${projectA.projectId}`);
-    await expect(badgeA).toBeVisible({ timeout: 45_000 });
-    await expect(badgeA).toHaveText('1');
+    try {
+      background.send(chatIdA, 'What is 2 + 2? Reply with just the number.');
 
-    // Reselecting A's chat clears the unread flag, and with it the row badge.
-    await selectRow(page, rowA);
+      await expect(badgeA).toBeVisible({ timeout: 45_000 });
+      await expect(badgeA).toHaveText('1');
+    } finally {
+      background.close();
+    }
+
+    // Selecting A's chat clears the unread flag, and with it the row badge.
+    await selectRow(page, sidebar.row(chatIdA));
     await expect(badgeA).toHaveCount(0, { timeout: 10_000 });
   });
 


### PR DESCRIPTION
Fourth of the e2e fixes for the release gate. Failed **both attempts** on the Linux runner in the [#596 validation run](https://github.com/qlan-ro/mainframe/actions/runs/31390982055), flaky in rc.20 and rc.22, and flaky locally under full-suite load.

## Root cause

The test backgrounded chat A by sending from it and switching to B before the reply landed. The mock adapter caps every inter-event delay at 120ms, so that reply arrives in well under a second. On a busy machine the switch lost the race: `chat.notification` fired while A was still active, so no badge was ever going to appear and the test sat out its 45s budget.

The existing annotation blamed the hover card wedging open and ate the row click. That was a symptom of the same slowness, not the cause — and the retry loop written to survive it made the switch slower still, which is what turned a flake into a hard failure.

The race was structural: the app can only send from the chat it has active, so "make this chat a background chat" meant "send, then outrun the reply".

## Fix

`openBackgroundClient()` opens a second daemon WebSocket and sends `message.send` from there. Chat A is never the active chat, so there is nothing to outrun — and that is also the scenario the product code under test is about (a notification for a chat this client is not subscribed to). `message.send` needs only `chatId` and `content` per `ws_schemas.rs`, and the daemon trusts loopback callers, so no token is involved.

## Verification

Three consecutive green runs. The spec takes 7.2s instead of ~1m, since the time was the doomed 45s wait.

The same race shape is fixed differently in #597, where reordering the fixture was enough; here the sibling tests assert row order, so the ordering was not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)