### PR TITLE
fix(session-tabs): collapse the orphaned draft tab into its canonical session (#319)

### DIFF
--- a/.changeset/todo-319-session-tab-identity.md
+++ b/.changeset/todo-319-session-tab-identity.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Starting a session no longer leaves a second, unselectable tab behind — the draft tab becomes the session's tab in place.

--- a/docs/plans/2026-08-11-todo-319-session-tab-identity-plan.md
+++ b/docs/plans/2026-08-11-todo-319-session-tab-identity-plan.md
@@ -1,0 +1,393 @@
+# Session tabs: one tab per session across the local→remote handoff (todo #319)
+
+## Goal
+
+Starting a session leaves a second, dead tab behind. Pressing "+" makes a client-minted
+`__LOCALID_*` thread active, and the membership seam in `useSessionTabsSync` opens a tab for it. On
+first send the daemon chat is created, the `chat.created` reload adds a SECOND thread-list entry
+keyed by the new remote id, and the session-list router hands the active thread over to it — so the
+seam opens a second tab while nothing removes the first. The strip ends up with two pills for one
+session: the real one, and a placeholder-titled ghost that bounces straight back when clicked. This
+change teaches the tab strip that a session's pre-send and post-create identities are ONE member:
+`tabs-model.ts` gains a pure `canonicalTabId` + `reconcileTabIds` pass that collapses the local id
+onto its remote-keyed entry **in the slot the draft tab already held**, the store's prune operation
+becomes a resolver-based `reconcile`, and `SessionTabs` compares against the canonical active id so
+no pill can be dead. Persistence, the payload shape, the no-id-flip contract, the router's first-send
+handoff, and the sidebar are untouched.
+
+## Verified facts this plan rests on
+
+Read before planning; cite these instead of re-deriving them. assistant-ui pin: `react@0.15.13` /
+`core@0.3.12` (exact, per `packages/ui/CLAUDE.md`).
+
+- **Two entries for one session is real, and permanent for the run.**
+  `core/dist/runtimes/remote-thread-list/remote-thread-state.js`: `createThreadMappingId(id)` is the
+  identity function, and `classifyThreads` keys `threadData` by the *remote* id. `adapter.initialize`
+  (first send) writes `threadIdMap[remoteId] = <localMappingId>` onto the SAME local entry
+  (`RemoteThreadListThreadListRuntimeCore.js`, `initialize`), then the next `list()` merges
+  `threadIdMap: {...state.threadIdMap, ...fresh.threadIdMap}` and
+  `threadData: {...state.threadData, ...fresh.threadData}` (`getLoadThreadsPromise`). The fresh
+  remote-keyed mapping wins, a new `threadData['chat-x']` appears, and the local entry survives in
+  `threadData` untouched. Nothing but a delete removes it.
+- **`threads.threadItems` exposes BOTH.** `store/runtime-clients/thread-list-runtime-client.js` builds
+  the array from `Object.keys(runtimeState.threadItems)` — i.e. every `threadData` entry, not the
+  `threadIds` bucket. Insertion order puts the local entry first, so the ghost sorts ahead of its own
+  session.
+- **The orphan is shaped exactly as the brief says.** After the handoff the local entry is
+  `{ id: '__LOCALID_x', status: 'regular', remoteId: 'chat-x', title: undefined, custom: undefined }`
+  (`updateStatusReducer` flipped `new` → `regular`; `custom` only ever arrives under the remote-keyed
+  entry). The canonical entry carries `title`, `custom`, and `id === remoteId`.
+- **`switchToThread` accepts either id.** `_switchToThread` resolves through `getThreadData`, which
+  reads `threadIdMap`; both the local id and the remote id are keys. Canonicalising a tab to the
+  remote id therefore never breaks activation.
+- **The bounce-back is the router doing its job.** `use-session-list-router.ts:156-166`: an active
+  thread with no session metadata is treated as a stranded draft, and the remote item is adopted —
+  guarded by `items.some((t) => t.id === draftRemoteId)`, i.e. exactly the condition under which the
+  orphan exists. The fix is to stop exposing the orphan, not to touch this branch (brief: out of
+  scope).
+- **Nothing outside `features/session-tabs/` imports `useSessionTabsStore` or `validTabIds`**
+  (grepped across `packages/ui/src`). The open-set API and the prune rule can change shape freely.
+- **`s.threads.mainThreadId` is typed `string`** in `core/dist/store/scopes/threads.d.ts` (the hook's
+  existing `if (mainThreadId)` guard is a runtime belt, not a type requirement), and it is assignable
+  to the model's `activeId: string | null` parameters as they stand.
+- **#312 (`docs/plans/2026-08-11-session-tabs-reload-hydration-plan.md`) has already landed in this
+  branch's base** — `canRestoreTabs`, `list-load-state.ts` and `use-session-tabs-sync.test.tsx` are
+  present. The "whichever lands second rebases" obligation is discharged; this plan builds on that
+  code and keeps its tests green.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `packages/ui/src/features/session-tabs/tabs-model.ts` | add `canonicalTabId` + `reconcileTabIds`; make `validTabIds` module-private |
+| `packages/ui/src/features/session-tabs/store.ts` | replace `pruneTo(valid)` with `reconcile(resolve)`; update the docblock |
+| `packages/ui/src/features/session-tabs/use-session-tabs-sync.ts` | prune effect → reconcile effect (ungated); docblock |
+| `packages/ui/src/features/session-tabs/SessionTabs.tsx` | compare/act on the canonical active id |
+| `packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts` | `canonicalTabId` + `reconcileTabIds` describes; fold the `validTabIds` cases in |
+| `packages/ui/src/features/session-tabs/__tests__/store.test.ts` | `pruneTo` describe → `reconcile` describe |
+| `packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx` | add a handoff describe (ghost collapse, order, N sessions, persistence) |
+| `.changeset/<generated>.md` | patch bump for `@qlan-ro/mainframe-ui` |
+
+Constraints from `CLAUDE.md` / `packages/ui/CLAUDE.md`: max 300 lines per file (`tabs-model.ts` goes
+102 → ~140, every other file stays well under), max 50 lines per function, no `@ts-ignore`, comments
+state *why*, `data-testid` keyed by domain id (unchanged — pills stay keyed by tab id), pure logic
+lives in the model rather than in React, changeset required, and single-file vitest runs only
+(`pnpm --filter @qlan-ro/mainframe-ui exec vitest run <file>`) — never the full suite.
+
+## Design
+
+One rule, expressed once:
+
+```ts
+canonicalTabId(id, items)   // '__LOCALID_x' → 'chat-x' ONLY when a 'chat-x' entry also exists
+reconcileTabIds(tabIds, items, activeId)
+  // map every open id through canonicalTabId, keep the FIRST occurrence (in-place swap),
+  // then drop what the (now private) validTabIds rule rejects
+```
+
+`reconcileTabIds` subsumes the old prune: the sync hook's third effect calls
+`reconcile((ids) => reconcileTabIds(ids, items, mainThreadId))` and the store applies that resolver
+to its CURRENT `tabIds` inside `set`.
+
+Why first-wins dedupe is the whole fix: at the handoff the seam has appended the canonical id at the
+end, so the set reads `['chat-a', '__LOCALID_x', 'chat-x']`. Mapping gives
+`['chat-a', 'chat-x', 'chat-x']`; keeping the first occurrence yields `['chat-a', 'chat-x']` — the
+session stays in the draft tab's slot. "Remove the orphan and keep the appended tab" would move it to
+the end, which the user reads as a second bug (PM decision in the brief).
+
+## Decisions taken while planning
+
+1. **Canonicalise only when the remote-keyed entry exists.** `remoteId != null` alone is not an
+   orphan: between the first send and the `chat.created` reload (and forever, after a failed list
+   load) the local entry is the session's ONLY entry, and rewriting the tab to an id with no entry
+   would give the pill no title, no project colour, and — via `toTabEntry` — the literal label "New
+   Session". The existing #312 case that ends on `['chat-a', 'chat-b', '__LOCALID_1']` pins exactly
+   that state and must stay green.
+2. **The store operation takes a resolver, not a precomputed array.** `reconcileTabIds` needs `items`
+   and the active id, which only React has — but an array computed in the effect body is computed
+   from the render's `tabIds`, which is stale whenever `hydrate()` ran earlier in the same effect
+   flush (zustand `setState` is synchronous, React re-renders only after the flush). Writing that
+   stale array back would silently wipe a just-restored tab set. Passing
+   `(ids) => reconcileTabIds(ids, items, mainThreadId)` and applying it inside `set` reads the live
+   state, so no ordering assumption is needed. Do not "simplify" this to `reconcileTo(array)`.
+3. **The reconcile effect is NOT gated on `hydrated` (the prune effect was).** With the resolver, the
+   only reason for the gate is gone; pre-hydration the set holds nothing but ids the membership seam
+   added for an active thread, all valid by construction, so an early pass is a no-op. Keeping the
+   gate would cost a visible double-pill frame on a session-less install (where hydration first
+   latches in the same commit that lands the canonical entry) and would leave the ghost forever after
+   a failed list load. All five existing sync tests stay green (checked case by case).
+4. **The membership seam (`ensureTab`) is left exactly as it is.** Canonicalising there too looks
+   tidy but requires `items` in that effect's dependency array, and then any thread-list tick between
+   closing the ACTIVE tab and the resulting `switchToThread` landing would re-open the tab the user
+   just closed. Reconciliation collapses the transient duplicate in the same effect flush, before
+   paint, so nothing is gained by touching the seam.
+5. **`validTabIds` becomes module-private.** After this change its only caller is `reconcileTabIds`,
+   and nothing outside the feature imports it (grepped). Its four test cases move into the
+   `reconcileTabIds` describe unchanged in meaning — including the inactive-unsent-draft drop, which
+   is a listed acceptance criterion.
+6. **`SessionTabs` gets the canonical active id, and no new component test.** Between the reload and
+   the router's `switchToThread`, `mainThreadId` is still the local id while the tab is already
+   canonical; comparing raw ids would blank the active underline for a frame and would make
+   `nextActiveAfterClose` mis-resolve a close in that window. The component change is a one-line
+   substitution onto a unit-tested helper. The file has no test today (`MainToolbar.test.tsx` mocks
+   `SessionTabs` wholesale) and rendering it would need a Radix `TooltipProvider` harness; typecheck
+   plus the model tests are the gate. Stated here so the omission is a decision, not an oversight.
+7. **`restoreTabIds` / `persistTabIds` stay untouched.** Both already resolve through `remoteId`, and
+   the reconcile pass is the safety net if a restore ever matches the orphan entry first (it collapses
+   on the next pass). The persisted payload therefore keeps the `{ v: 1, ids }` shape and each stable
+   id appears exactly once, which is what the acceptance criteria ask for.
+
+## Tasks
+
+TDD order: tasks 1–4 are red-phase and must be **observed failing** before tasks 5–8 exist.
+
+### Task 1 — Red: `canonicalTabId` unit cases
+
+**File:** `packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts` (append a
+`describe('canonicalTabId')`; import the not-yet-existing `canonicalTabId` from `../tabs-model`).
+
+Reuse the file's existing `entry(id, over)` helper (`tabs-model.test.ts:15-17`), which builds
+`{ id, status: 'regular', ...over }`.
+
+Cases, each its own `it`:
+
+- collapses the local id onto the remote entry when both exist:
+  `items = [entry('__LOCALID_1', { remoteId: 'chat-a' }), entry('chat-a', { custom: {}, title: 'Fix the parser' })]`
+  → `canonicalTabId('__LOCALID_1', items) === 'chat-a'`.
+- returns the local id unchanged when the remote entry has not landed yet (the window between the
+  first send and the `chat.created` reload): `items = [entry('__LOCALID_1', { remoteId: 'chat-a' })]`
+  → `'__LOCALID_1'`.
+- returns an unsent draft unchanged: `items = [{ id: '__LOCALID_1', status: 'new' }]` → `'__LOCALID_1'`.
+- returns a canonical id unchanged: `items = [entry('chat-a', { remoteId: 'chat-a', custom: {} })]`
+  → `'chat-a'` (guards against a self-mapping loop, since listed entries carry `remoteId === id`).
+- returns an id with no entry at all unchanged: `canonicalTabId('chat-gone', []) === 'chat-gone'`.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/tabs-model.test.ts`
+fails to resolve `canonicalTabId`. Every pre-existing describe in the file must still pass.
+
+### Task 2 — Red: `reconcileTabIds` unit cases (absorbing the `validTabIds` block)
+
+**File:** `packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts`
+
+Add `describe('reconcileTabIds')` and **delete** `describe('validTabIds')` (`tabs-model.test.ts:89-117`),
+carrying its four cases over as reconcile cases — nothing is dropped, they are restated through the
+exported function. Import `reconcileTabIds`; remove `validTabIds` from the import list.
+
+The acceptance-criterion case, written literally:
+
+```ts
+it('collapses the orphaned draft identity onto the created session, in its original slot', () => {
+  const items = [
+    entry('chat-a', { custom: {}, title: 'Older session' }),
+    entry('__LOCALID_9', { remoteId: 'chat-new' }), // orphan: regular, remoteId, no custom/title
+    entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+  ];
+
+  expect(reconcileTabIds(['chat-a', '__LOCALID_9', 'chat-new'], items, 'chat-new')).toEqual([
+    'chat-a',
+    'chat-new',
+  ]);
+});
+```
+
+The remaining cases:
+
+- collapses in place even before the seam appends the canonical id (input
+  `['chat-a', '__LOCALID_9']`, same items → `['chat-a', 'chat-new']`) — the pass does not depend on
+  the seam having run.
+- keeps the pre-handoff draft as itself when only the local entry exists
+  (`items = [entry('chat-a', { custom: {} }), entry('__LOCALID_9', { remoteId: 'chat-new' })]`,
+  input `['chat-a', '__LOCALID_9']`, active `'__LOCALID_9'` → unchanged).
+- keeps the ACTIVE unsent draft (from `validTabIds`): `items = [entry('chat-a'), entry('__LOCALID_1', { status: 'new' })]`,
+  input `['chat-a', '__LOCALID_1']`, active `'__LOCALID_1'` → `['chat-a', '__LOCALID_1']`.
+- drops the INACTIVE unsent draft (from `validTabIds` — the boot-draft cleanup rule): same items,
+  input `['chat-a', '__LOCALID_1']`, active `'chat-a'` → `['chat-a']`.
+- drops archived entries (from `validTabIds`): `items = [entry('chat-a'), entry('chat-b', { status: 'archived' })]`,
+  input `['chat-a', 'chat-b']`, active `'chat-a'` → `['chat-a']`.
+- drops ids whose thread vanished (from `validTabIds`): input `['chat-a', 'chat-gone']`,
+  `items = [entry('chat-a')]`, active `'chat-a'` → `['chat-a']`.
+- keeps the active thread canonical when the active id is still the local one (the frame between the
+  reload and the router's handoff): same three-entry fixture as the criterion case, input
+  `['chat-a', '__LOCALID_9']`, active `'__LOCALID_9'` → `['chat-a', 'chat-new']`.
+- is a no-op on a set with nothing to collapse (`['chat-a', 'chat-b']`, two plain entries, active
+  `'chat-a'` → `['chat-a', 'chat-b']`).
+
+**Verify:** the same single-file vitest run fails on the new describe (unresolved `reconcileTabIds`);
+`restoreTabIds`, `persistTabIds`, `nextActiveAfterClose` and `canRestoreTabs` still pass.
+
+### Task 3 — Red: store `reconcile` cases
+
+**File:** `packages/ui/src/features/session-tabs/__tests__/store.test.ts`
+
+Replace `describe('pruneTo')` (`store.test.ts:80-107`) with `describe('reconcile')`. The store no
+longer knows the rule; it applies a resolver to the current ids.
+
+- applies the resolver to the live ids: `setState({ tabIds: ['a', 'gone', 'b'] })`, then
+  `reconcile((ids) => ids.filter((id) => id !== 'gone'))` → `['a', 'b']`.
+- swaps an id in place: `setState({ tabIds: ['a', 'local', 'b'] })`,
+  `reconcile((ids) => ids.map((id) => (id === 'local' ? 'remote' : id)))` → `['a', 'remote', 'b']`
+  (the tab keeps its slot — this is the store half of the in-place identity swap).
+- leaves the state object untouched when the resolver returns an EQUAL list — asserting on identity
+  (`expect(useSessionTabsStore.getState()).toBe(before)`) with a resolver that returns
+  `[...ids]`. Content equality, not reference equality, is the guard that matters:
+  `reconcileTabIds` allocates a fresh array on every pass and the effect runs on every thread-list
+  tick, so a reference check would re-render the whole strip while a chat streams.
+- empties the strip when the resolver returns `[]`.
+- reads the CURRENT ids, not a captured snapshot: `setState({ tabIds: ['a'] })`, then inside one test
+  call `useSessionTabsStore.getState().ensureTab('b')` before `reconcile((ids) => ids)` and assert
+  `['a', 'b']` survives — pins that the store passes `s.tabIds` into the resolver.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/store.test.ts`
+— the `reconcile` describe fails (no such action); `ensureTab`, `closeTab` and `hydrate` still pass.
+
+### Task 4 — Red: hook-level handoff regression tests
+
+**File:** `packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx` (append a
+`describe('first-send identity handoff')`; keep the file's existing mock harness — mutable
+`itemsValue` / `isLoadingValue` / `mainThreadIdValue` behind the mocked `useAuiState`, the
+`beforeEach` reset, and `listSucceeded()`).
+
+Cases:
+
+1. **The ghost never reaches the strip.** Start hydrated-by-play: `listSucceeded()`,
+   `items = [entry chat-a (custom), { id: '__LOCALID_9', status: 'new' }]`, `isLoading: false`,
+   `mainThreadId: '__LOCALID_9'`, render, assert `tabIds === ['chat-a', '__LOCALID_9']`
+   (`chat-a` arrives through the seam by activating it first, or by seeding
+   `useSessionTabsStore.setState({ tabIds: ['chat-a'] })` before the render — either is fine as long
+   as the draft tab lands second). Then simulate the first send + `chat.created` reload:
+   `items = [chat-a, { id: '__LOCALID_9', status: 'regular', remoteId: 'chat-new' }, { id: 'chat-new', status: 'regular', custom: {}, title: 'Fix the parser' }]`
+   with `mainThreadId` STILL `'__LOCALID_9'`; rerender. Assert `tabIds === ['chat-a', 'chat-new']` —
+   one tab, in the draft's slot, before the router even hands over.
+2. **The router's handover adds nothing.** From case 1's end state set
+   `mainThreadId = 'chat-new'` and rerender. Assert `tabIds` is still `['chat-a', 'chat-new']`
+   (the seam appends, the reconcile pass collapses in the same flush).
+3. **N sessions → N tabs.** Continue: `mainThreadId = '__LOCALID_10'` with a new draft entry appended
+   to `items`, rerender (→ three tabs), then land the second session the same way
+   (`__LOCALID_10` regular + `remoteId: 'chat-two'`, plus a `chat-two` entry with `custom`) and set
+   `mainThreadId = 'chat-two'`. Assert `tabIds === ['chat-a', 'chat-new', 'chat-two']` — three tabs
+   for three sessions, not five.
+4. **The persisted set holds each session once.** After case 3, assert the payload read back from
+   `localStorage['mf:session-tabs']` is `['chat-a', 'chat-new', 'chat-two']` (helper
+   `readPersistedIds()` already exists in the file).
+5. **Reconciliation does not wait for hydration.** Fresh state, `listSucceeded()` NOT called
+   (`hydrated` stays false), `items` = the orphan + its canonical entry, `mainThreadId` = the local
+   id, `tabIds` seeded `['__LOCALID_9']`. Assert `tabIds === ['chat-new']` and
+   `hydrated === false` — pins decision 3, and pins that a failed list load cannot strand a ghost.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx`
+— every new case fails on `main` (today the seam adds the canonical id and the prune rule keeps the
+orphan, so cases 1–3 see two ids per session and case 4 sees a doubled payload; case 5 sees the
+orphan survive because the prune effect is gated on `hydrated`). **The five pre-existing #312 cases
+must still pass** — record that in the red-phase output. Then run the two other suites unchanged as a
+baseline: `store.test.ts` (expected: task 3's describe red) and
+`src/features/sessions/ws/__tests__/use-session-list-router.test.tsx` (expected: green).
+
+### Task 5 — `canonicalTabId` + `reconcileTabIds` in the pure model
+
+**File:** `packages/ui/src/features/session-tabs/tabs-model.ts`
+
+- Add exported `canonicalTabId(id: string, items: readonly ThreadListEntry[]): string` — look up the
+  entry by `id`; return `id` unless its `remoteId` is set, differs from `id`, and `items` also holds
+  an entry keyed by that `remoteId`; then return the `remoteId`. Docblock: aui keeps BOTH identities
+  in its thread map for the run (the first send stamps `remoteId` on the local entry, the
+  `chat.created` reload adds a second remote-keyed entry), and `switchToThread` accepts either — cite
+  `RemoteThreadListThreadListRuntimeCore` / `classifyThreads`.
+- Add exported `reconcileTabIds(tabIds, items, activeId: string | null): string[]` — build the valid
+  set from `validTabIds(items, activeId === null ? null : canonicalTabId(activeId, items))` so the set
+  is expressed in canonical ids, then map each open id through `canonicalTabId`, keeping the FIRST
+  occurrence and dropping anything the valid set rejects. Docblock: first-wins dedupe is what makes
+  the handoff an in-place swap — the appended canonical tab merges into the draft tab's slot instead
+  of taking a new one at the end.
+- Drop the `export` from `validTabIds` (its rule is unchanged; its only caller is now
+  `reconcileTabIds`) and move its docblock's boot-draft paragraph with it.
+
+Both functions stay pure and allocation-only; no store, no aui imports. Keep the file under 300 lines
+and each function under 50.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/tabs-model.test.ts`
+— all green, including the pre-existing `restoreTabIds` / `persistTabIds` / `nextActiveAfterClose` /
+`canRestoreTabs` describes.
+
+### Task 6 — `reconcile` in the store
+
+**File:** `packages/ui/src/features/session-tabs/store.ts`
+
+- Replace `pruneTo: (valid: ReadonlySet<string>) => void` with
+  `reconcile: (resolve: (ids: readonly string[]) => string[]) => void`, implemented as
+  `set((s) => { const next = resolve(s.tabIds); return sameIds(next, s.tabIds) ? s : { tabIds: next }; })`
+  with a module-local `sameIds(a, b)` comparing length and every element in order.
+- Comment the two load-bearing properties in one line each: the resolver runs against the CURRENT
+  ids (a precomputed array would be stale after a same-flush `hydrate`), and the content check keeps
+  the state object identical when nothing moved (the caller allocates a fresh array on every
+  thread-list tick, and a new object would re-render the strip while a chat streams).
+- Update the interface docblock: the store no longer knows the prune rule; it applies whatever the
+  sync hook's pure resolver returns.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/store.test.ts` — green.
+
+### Task 7 — Reconcile at the sync seam
+
+**File:** `packages/ui/src/features/session-tabs/use-session-tabs-sync.ts`
+
+- Import `reconcileTabIds` instead of `validTabIds`; select `reconcile` instead of `pruneTo`.
+- Replace the prune effect with
+  `useEffect(() => { reconcile((ids) => reconcileTabIds(ids, items, mainThreadId)); }, [items, mainThreadId, reconcile]);`
+  — **without** the `hydrated` guard (decision 3), and leave `hydrated` out of its dependencies.
+- Leave the hydrate effect, the `ensureTab` effect (decision 4 — do NOT add `items` to its deps) and
+  the persist effect exactly as they are.
+- Update the module docblock: the third effect now reconciles identities as well as pruning — one
+  session's pre-send and post-create ids are one member, collapsed onto the remote-keyed entry in
+  place — and say why it runs before hydration (pre-hydration the set holds only seam-added active
+  ids, and a ghost must not outlive a failed list load).
+
+**Verify, in order:**
+1. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx` — green, new describe AND the five #312 cases.
+2. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/store.test.ts` — green.
+3. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/session-tabs/__tests__/tabs-model.test.ts` — green.
+4. `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/ws/__tests__/use-session-list-router.test.tsx` — green (the first-send handoff is untouched).
+
+### Task 8 — Canonical active id in the strip
+
+**File:** `packages/ui/src/features/session-tabs/SessionTabs.tsx`
+
+- Import `canonicalTabId` alongside `nextActiveAfterClose`.
+- Compute `const activeTabId = canonicalTabId(mainThreadId, items);` once in the component and use it
+  everywhere `mainThreadId` is compared against a TAB id: the `toTabEntry(id, items, activeTabId)`
+  call, the `handleActivate` early-return guard, and both `nextActiveAfterClose(...)` and the
+  post-close switch guard in `handleClose`.
+- Keep passing the id the user clicked to `aui.threads.switchToThread` — the ids in `tabIds` are
+  already canonical, and aui resolves either form.
+- One-line comment on `activeTabId`: between the `chat.created` reload and the router's handover the
+  active thread is still the local id while its tab is already canonical; comparing raw ids would
+  blank the active underline and mis-resolve a close in that window.
+
+Nothing else in the file changes — no markup, no testids, no styling (the brief puts the strip's
+visual design out of scope).
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes (it includes the test files), and
+`pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/layout/__tests__/MainToolbar.test.tsx` is
+green (it mocks `SessionTabs`, so this only proves nothing upstream moved).
+
+### Task 9 — Changeset
+
+Run `pnpm changeset`, select `@qlan-ro/mainframe-ui`, bump **patch**. One sentence, no marketing:
+starting a session no longer leaves a second, unselectable tab behind — the draft tab becomes the
+session's tab in place.
+
+**Verify:** the generated `.changeset/*.md` names `@qlan-ro/mainframe-ui` with `patch`.
+
+## Manual QA (post-merge, not a task gate)
+
+In the Tauri dev app with an isolated `MAINFRAME_DATA_DIR` and `DAEMON_PORT`: press "+", send a first
+message, and confirm the strip keeps ONE tab, in the slot the draft held, which takes the session's
+real title and project dot. Repeat twice more and confirm three tabs, not six. Click every tab and
+confirm each activates its own session with no bounce-back. Then `location.reload()` and confirm the
+same three tabs return (#312's behavior, unchanged).
+
+## Out of scope
+
+The no-id-flip contract and the per-chat controller's remote-id adoption; the session-list router's
+first-send handoff, boot auto-select, and archived-active fallback; assistant-ui internals and the
+exact `0.15.13` pin; the sidebar session list (it already hides the orphan); tab restore-on-reload
+timing (#312, already landed); any visual change to the strip — pill styling, overflow, the close
+affordance, and the new-session button all stay as they are.

--- a/packages/ui/src/features/session-tabs/SessionTabs.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabs.tsx
@@ -21,7 +21,7 @@ import { useNewChatHotkeyHandler } from '@/features/sessions/new-thread/use-new-
 import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
 import { SessionTabPill, type SessionTabEntry } from './SessionTabPill';
 import { useSessionTabsStore } from './store';
-import { nextActiveAfterClose } from './tabs-model';
+import { canonicalTabId, nextActiveAfterClose } from './tabs-model';
 import { useSessionTabsSync } from './use-session-tabs-sync';
 
 function toTabEntry(id: string, items: readonly ThreadListEntry[], activeId: string | null): SessionTabEntry {
@@ -44,17 +44,23 @@ export function SessionTabs() {
   const closeTab = useSessionTabsStore((s) => s.closeTab);
   const newSession = useNewChatHotkeyHandler(aui);
 
-  const tabs = tabIds.map((id) => toTabEntry(id, items, mainThreadId));
+  // Between the chat.created reload and the router's handover the active
+  // thread is still the draft's local id while its tab is already canonical;
+  // comparing raw ids would blank the active underline and mis-resolve a close
+  // in that window. aui switches on either id, so clicks pass the tab id.
+  const activeTabId = canonicalTabId(mainThreadId, items);
+
+  const tabs = tabIds.map((id) => toTabEntry(id, items, activeTabId));
 
   const handleActivate = (id: string) => {
-    if (id !== mainThreadId) aui.threads.switchToThread(id);
+    if (id !== activeTabId) aui.threads.switchToThread(id);
   };
 
   const handleClose = (id: string) => {
-    const next = nextActiveAfterClose(tabIds, id, mainThreadId);
+    const next = nextActiveAfterClose(tabIds, id, activeTabId);
     closeTab(id);
     if (next === null) newSession();
-    else if (next !== mainThreadId) aui.threads.switchToThread(next);
+    else if (next !== activeTabId) aui.threads.switchToThread(next);
   };
 
   return (

--- a/packages/ui/src/features/session-tabs/__tests__/store.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/store.test.ts
@@ -77,31 +77,52 @@ describe('hydrate', () => {
   });
 });
 
-describe('pruneTo', () => {
-  it('drops tabs whose thread vanished', () => {
+describe('reconcile', () => {
+  it('applies the resolver to the live ids', () => {
     useSessionTabsStore.setState({ tabIds: ['a', 'gone', 'b'] });
 
-    useSessionTabsStore.getState().pruneTo(new Set(['a', 'b']));
+    useSessionTabsStore.getState().reconcile((ids) => ids.filter((id) => id !== 'gone'));
 
     expect(read()).toEqual(['a', 'b']);
   });
 
-  it('leaves the state object untouched when every tab is still valid', () => {
-    // Identity matters, not just equality: the seam prunes on every thread-list
-    // change, and a fresh object each time would re-render the whole strip.
+  it('swaps an id in place — the tab keeps its slot', () => {
+    // This is the store half of the local→remote identity swap: the resolver
+    // maps one id to another without removing and re-appending it.
+    useSessionTabsStore.setState({ tabIds: ['a', 'local', 'b'] });
+
+    useSessionTabsStore.getState().reconcile((ids) => ids.map((id) => (id === 'local' ? 'remote' : id)));
+
+    expect(read()).toEqual(['a', 'remote', 'b']);
+  });
+
+  it('leaves the state object untouched when the resolver returns an equal list', () => {
+    // Identity matters, not just equality: the seam reconciles on every
+    // thread-list change, and a fresh object each time would re-render the
+    // whole strip while a chat streams — even though the resolver allocates a
+    // new array on every call.
     useSessionTabsStore.setState({ tabIds: ['a', 'b'] });
     const before = useSessionTabsStore.getState();
 
-    useSessionTabsStore.getState().pruneTo(new Set(['a', 'b', 'c']));
+    useSessionTabsStore.getState().reconcile((ids) => [...ids]);
 
     expect(useSessionTabsStore.getState()).toBe(before);
   });
 
-  it('empties the strip when nothing is valid', () => {
+  it('empties the strip when the resolver returns nothing', () => {
     useSessionTabsStore.setState({ tabIds: ['a'] });
 
-    useSessionTabsStore.getState().pruneTo(new Set<string>());
+    useSessionTabsStore.getState().reconcile(() => []);
 
     expect(read()).toEqual([]);
+  });
+
+  it('reads the current ids, not a snapshot captured before the call', () => {
+    useSessionTabsStore.setState({ tabIds: ['a'] });
+
+    useSessionTabsStore.getState().ensureTab('b');
+    useSessionTabsStore.getState().reconcile((ids) => ids);
+
+    expect(read()).toEqual(['a', 'b']);
   });
 });

--- a/packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts
@@ -9,7 +9,14 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
-import { canRestoreTabs, nextActiveAfterClose, persistTabIds, restoreTabIds, validTabIds } from '../tabs-model';
+import {
+  canRestoreTabs,
+  canonicalTabId,
+  nextActiveAfterClose,
+  persistTabIds,
+  restoreTabIds,
+  validTabIds,
+} from '../tabs-model';
 
 /** A real session row: a regular thread-list entry, optionally remoteId-stamped. */
 function entry(id: string, over: Partial<ThreadListEntry> = {}): ThreadListEntry {
@@ -83,6 +90,39 @@ describe('nextActiveAfterClose', () => {
     { name: 'the only tab leaves nothing active', tabs: ['a'], closed: 'a', active: 'a', expected: null },
   ])('closing $name', ({ tabs, closed, active, expected }) => {
     expect(nextActiveAfterClose(tabs, closed, active)).toBe(expected);
+  });
+});
+
+describe('canonicalTabId', () => {
+  it('collapses the local id onto the remote entry when both exist', () => {
+    const items = [
+      entry('__LOCALID_1', { remoteId: 'chat-a' }),
+      entry('chat-a', { custom: {}, title: 'Fix the parser' }),
+    ];
+
+    expect(canonicalTabId('__LOCALID_1', items)).toBe('chat-a');
+  });
+
+  it('returns the local id unchanged when the remote entry has not landed yet', () => {
+    const items = [entry('__LOCALID_1', { remoteId: 'chat-a' })];
+
+    expect(canonicalTabId('__LOCALID_1', items)).toBe('__LOCALID_1');
+  });
+
+  it('returns an unsent draft unchanged', () => {
+    const items: ThreadListEntry[] = [{ id: '__LOCALID_1', status: 'new' }];
+
+    expect(canonicalTabId('__LOCALID_1', items)).toBe('__LOCALID_1');
+  });
+
+  it('returns a canonical id unchanged (guards against a self-mapping loop)', () => {
+    const items = [entry('chat-a', { remoteId: 'chat-a', custom: {} })];
+
+    expect(canonicalTabId('chat-a', items)).toBe('chat-a');
+  });
+
+  it('returns an id with no entry at all unchanged', () => {
+    expect(canonicalTabId('chat-gone', [])).toBe('chat-gone');
   });
 });
 

--- a/packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/tabs-model.test.ts
@@ -14,8 +14,8 @@ import {
   canonicalTabId,
   nextActiveAfterClose,
   persistTabIds,
+  reconcileTabIds,
   restoreTabIds,
-  validTabIds,
 } from '../tabs-model';
 
 /** A real session row: a regular thread-list entry, optionally remoteId-stamped. */
@@ -126,33 +126,75 @@ describe('canonicalTabId', () => {
   });
 });
 
-describe('validTabIds', () => {
-  it('keeps regular entries', () => {
-    const items = [entry('chat-a'), entry('chat-b')];
+describe('reconcileTabIds', () => {
+  it('collapses the orphaned draft identity onto the created session, in its original slot', () => {
+    const items = [
+      entry('chat-a', { custom: {}, title: 'Older session' }),
+      entry('__LOCALID_9', { remoteId: 'chat-new' }), // orphan: regular, remoteId, no custom/title
+      entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+    ];
 
-    expect([...validTabIds(items, 'chat-a')].sort()).toEqual(['chat-a', 'chat-b']);
+    expect(reconcileTabIds(['chat-a', '__LOCALID_9', 'chat-new'], items, 'chat-new')).toEqual(['chat-a', 'chat-new']);
   });
 
-  it('keeps the ACTIVE draft even though it is not a regular entry', () => {
+  it('collapses in place even before the seam appends the canonical id', () => {
+    const items = [
+      entry('chat-a', { custom: {}, title: 'Older session' }),
+      entry('__LOCALID_9', { remoteId: 'chat-new' }),
+      entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+    ];
+
+    expect(reconcileTabIds(['chat-a', '__LOCALID_9'], items, 'chat-new')).toEqual(['chat-a', 'chat-new']);
+  });
+
+  it('keeps the pre-handoff draft as itself when only the local entry exists', () => {
+    const items = [entry('chat-a', { custom: {} }), entry('__LOCALID_9', { remoteId: 'chat-new' })];
+
+    expect(reconcileTabIds(['chat-a', '__LOCALID_9'], items, '__LOCALID_9')).toEqual(['chat-a', '__LOCALID_9']);
+  });
+
+  it('keeps the ACTIVE unsent draft even though it is not a regular entry', () => {
     // The unsent draft has status 'new' and no custom, so it is not a list row —
     // but it IS the focused tab while the user types into it.
     const items = [entry('chat-a'), entry('__LOCALID_1', { status: 'new' })];
 
-    expect([...validTabIds(items, '__LOCALID_1')].sort()).toEqual(['__LOCALID_1', 'chat-a']);
+    expect(reconcileTabIds(['chat-a', '__LOCALID_1'], items, '__LOCALID_1')).toEqual(['chat-a', '__LOCALID_1']);
   });
 
-  it('excludes an INACTIVE draft — the boot-draft cleanup rule', () => {
+  it('drops the INACTIVE unsent draft — the boot-draft cleanup rule', () => {
     // aui reuses one `__LOCALID_*` slot, so "+" reaches the same draft again;
     // a lingering "New Session" tab would survive every boot's auto-select redirect.
     const items = [entry('chat-a'), entry('__LOCALID_1', { status: 'new' })];
 
-    expect([...validTabIds(items, 'chat-a')]).toEqual(['chat-a']);
+    expect(reconcileTabIds(['chat-a', '__LOCALID_1'], items, 'chat-a')).toEqual(['chat-a']);
   });
 
-  it('excludes archived entries', () => {
+  it('drops archived entries', () => {
     const items = [entry('chat-a'), entry('chat-b', { status: 'archived' })];
 
-    expect([...validTabIds(items, null)]).toEqual(['chat-a']);
+    expect(reconcileTabIds(['chat-a', 'chat-b'], items, 'chat-a')).toEqual(['chat-a']);
+  });
+
+  it('drops ids whose thread vanished', () => {
+    const items = [entry('chat-a')];
+
+    expect(reconcileTabIds(['chat-a', 'chat-gone'], items, 'chat-a')).toEqual(['chat-a']);
+  });
+
+  it('keeps the active thread canonical when the active id is still the local one', () => {
+    const items = [
+      entry('chat-a', { custom: {}, title: 'Older session' }),
+      entry('__LOCALID_9', { remoteId: 'chat-new' }),
+      entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+    ];
+
+    expect(reconcileTabIds(['chat-a', '__LOCALID_9'], items, '__LOCALID_9')).toEqual(['chat-a', 'chat-new']);
+  });
+
+  it('is a no-op on a set with nothing to collapse', () => {
+    const items = [entry('chat-a'), entry('chat-b')];
+
+    expect(reconcileTabIds(['chat-a', 'chat-b'], items, 'chat-a')).toEqual(['chat-a', 'chat-b']);
   });
 });
 

--- a/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx
@@ -1,5 +1,6 @@
 /**
- * useSessionTabsSync — boot-race regression tests (TDD red phase, #312).
+ * useSessionTabsSync — boot-race regression tests (TDD red phase, #312), plus
+ * a first-send identity-handoff describe (TDD red phase, #319).
  *
  * The runtime seeds `threadItems` synchronously with the transient new-thread
  * draft before `adapter.list()` resolves. Hydration must wait for a list that
@@ -8,7 +9,7 @@
  * boot's runtime ids — otherwise it restores an empty set, latches, and the
  * persist effect overwrites `mf:session-tabs` with the survivors.
  */
-import { it, expect, vi, beforeEach } from 'vitest';
+import { it, expect, vi, beforeEach, describe } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { SESSION_TABS_STORAGE_KEY } from '../tabs-model';
 import { useSessionTabsStore } from '../store';
@@ -18,7 +19,7 @@ import { useSessionListLoadState } from '@/features/sessions/runtime/list-load-s
 // Mutable module-scope state the mocked @assistant-ui/react selector reads.
 // ---------------------------------------------------------------------------
 
-let itemsValue: Array<{ id: string; status?: string; custom?: unknown; remoteId?: string }>;
+let itemsValue: Array<{ id: string; status?: string; custom?: unknown; remoteId?: string; title?: string }>;
 let isLoadingValue: boolean;
 let mainThreadIdValue: string | null;
 
@@ -167,4 +168,85 @@ it('boots clean on a genuinely session-less install', () => {
   expect(state.tabIds).toEqual(['__LOCALID_1']);
   expect(state.hydrated).toBe(false);
   expect(localStorage.getItem(SESSION_TABS_STORAGE_KEY)).toBeNull();
+});
+
+/**
+ * first-send identity handoff — TDD red phase, #319.
+ *
+ * The seam opens a tab for whatever thread becomes active. On first send the
+ * local entry is remoteId-stamped and a SECOND, canonical entry appears; the
+ * router later hands the active thread to that canonical entry, so the seam
+ * would open a tab for it too unless something collapses the two identities
+ * into the slot the draft tab already held. These cases pin the collapse and
+ * are expected to fail until task 7 (the sync hook) reconciles instead of
+ * pruning — the pre-existing #312 cases above must stay green throughout.
+ */
+describe('first-send identity handoff', () => {
+  it('collapses the orphaned draft onto the canonical session, in place, across repeated sessions', () => {
+    useSessionTabsStore.setState({ tabIds: ['chat-a'] });
+    itemsValue = [
+      { id: 'chat-a', status: 'regular', custom: {} },
+      { id: '__LOCALID_9', status: 'new' },
+    ];
+    isLoadingValue = false;
+    mainThreadIdValue = '__LOCALID_9';
+    listSucceeded();
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', '__LOCALID_9']);
+
+    // First send + chat.created reload: the local entry is remoteId-stamped and
+    // a second, canonical entry lands — but the router has not handed the
+    // active thread over yet.
+    itemsValue = [
+      { id: 'chat-a', status: 'regular', custom: {} },
+      { id: '__LOCALID_9', status: 'regular', remoteId: 'chat-new' },
+      { id: 'chat-new', status: 'regular', custom: {}, title: 'Fix the parser' },
+    ];
+    rerender();
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new']);
+
+    // The router's handover lands; nothing changes — the seam appends the
+    // canonical id, and reconciliation collapses it in the same flush.
+    mainThreadIdValue = 'chat-new';
+    rerender();
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new']);
+
+    // A second session runs the same dance: N sessions leaves N tabs, not 2N.
+    itemsValue = [...itemsValue, { id: '__LOCALID_10', status: 'new' }];
+    mainThreadIdValue = '__LOCALID_10';
+    rerender();
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new', '__LOCALID_10']);
+
+    itemsValue = [
+      { id: 'chat-a', status: 'regular', custom: {} },
+      { id: '__LOCALID_9', status: 'regular', remoteId: 'chat-new' },
+      { id: 'chat-new', status: 'regular', custom: {}, title: 'Fix the parser' },
+      { id: '__LOCALID_10', status: 'regular', remoteId: 'chat-two' },
+      { id: 'chat-two', status: 'regular', custom: {}, title: 'Second session' },
+    ];
+    mainThreadIdValue = 'chat-two';
+    rerender();
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new', 'chat-two']);
+    expect(readPersistedIds()).toEqual(['chat-a', 'chat-new', 'chat-two']);
+  });
+
+  it('collapses an already-open ghost without waiting for hydration', () => {
+    // Pins decision 3: a failed list load must not strand a ghost forever.
+    itemsValue = [
+      { id: '__LOCALID_9', status: 'regular', remoteId: 'chat-new' },
+      { id: 'chat-new', status: 'regular', custom: {}, title: 'Fix the parser' },
+    ];
+    mainThreadIdValue = '__LOCALID_9';
+    useSessionTabsStore.setState({ tabIds: ['__LOCALID_9'] });
+
+    renderHook(() => useSessionTabsSync());
+
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-new']);
+    expect(useSessionTabsStore.getState().hydrated).toBe(false);
+  });
 });

--- a/packages/ui/src/features/session-tabs/store.ts
+++ b/packages/ui/src/features/session-tabs/store.ts
@@ -9,11 +9,12 @@
 import { create } from 'zustand';
 
 interface SessionTabsStore {
-  tabIds: string[];
+  /** Replaced wholesale on every change — the open set is never mutated in place. */
+  tabIds: readonly string[];
   /** True once the persisted set has been restored against a loaded thread list. */
   hydrated: boolean;
   /** Restored ids lead; tabs opened before hydration (boot draft/auto-select) follow. */
-  hydrate: (restored: string[]) => void;
+  hydrate: (restored: readonly string[]) => void;
   /** Idempotent append — the membership seam calls this on every active-thread change. */
   ensureTab: (id: string) => void;
   closeTab: (id: string) => void;
@@ -22,7 +23,7 @@ interface SessionTabsStore {
    * knows neither which ids are still valid nor how a session's two identities
    * collapse into one.
    */
-  reconcile: (resolve: (ids: readonly string[]) => string[]) => void;
+  reconcile: (resolve: (ids: readonly string[]) => readonly string[]) => void;
 }
 
 function sameIds(a: readonly string[], b: readonly string[]): boolean {

--- a/packages/ui/src/features/session-tabs/store.ts
+++ b/packages/ui/src/features/session-tabs/store.ts
@@ -17,8 +17,16 @@ interface SessionTabsStore {
   /** Idempotent append — the membership seam calls this on every active-thread change. */
   ensureTab: (id: string) => void;
   closeTab: (id: string) => void;
-  /** Drop tabs whose thread vanished (archived / deleted mid-run). */
-  pruneTo: (valid: ReadonlySet<string>) => void;
+  /**
+   * Rewrite the open set through the sync hook's pure resolver — the store
+   * knows neither which ids are still valid nor how a session's two identities
+   * collapse into one.
+   */
+  reconcile: (resolve: (ids: readonly string[]) => string[]) => void;
+}
+
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 export const useSessionTabsStore = create<SessionTabsStore>((set) => ({
@@ -31,9 +39,14 @@ export const useSessionTabsStore = create<SessionTabsStore>((set) => ({
     })),
   ensureTab: (id) => set((s) => (s.tabIds.includes(id) ? s : { tabIds: [...s.tabIds, id] })),
   closeTab: (id) => set((s) => ({ tabIds: s.tabIds.filter((t) => t !== id) })),
-  pruneTo: (valid) =>
+  reconcile: (resolve) =>
     set((s) => {
-      const next = s.tabIds.filter((id) => valid.has(id));
-      return next.length === s.tabIds.length ? s : { tabIds: next };
+      // Resolve against the CURRENT ids: an array precomputed in the effect
+      // body would be stale after a same-flush `hydrate`.
+      const next = resolve(s.tabIds);
+      // The caller allocates a fresh array on every thread-list tick, so
+      // compare content — a new state object would re-render the whole strip
+      // while a chat streams.
+      return sameIds(next, s.tabIds) ? s : { tabIds: next };
     }),
 }));

--- a/packages/ui/src/features/session-tabs/tabs-model.ts
+++ b/packages/ui/src/features/session-tabs/tabs-model.ts
@@ -94,8 +94,51 @@ export function nextActiveAfterClose(
  * again — a lingering "New Session" tab would be dead weight (and the boot
  * draft would otherwise survive every boot's auto-select redirect).
  */
-export function validTabIds(items: readonly ThreadListEntry[], activeId: string | null): Set<string> {
+function validTabIds(items: readonly ThreadListEntry[], activeId: string | null): Set<string> {
   const valid = new Set(items.filter((t) => t.status === 'regular').map((t) => t.id));
   if (activeId !== null) valid.add(activeId);
   return valid;
+}
+
+/**
+ * A session's ONE tab id. aui keeps both of a session's identities in its
+ * thread map for the run — the first send stamps `remoteId` onto the local
+ * entry (`RemoteThreadListThreadListRuntimeCore.initialize`) and the
+ * `chat.created` reload adds a second, remote-keyed entry (`classifyThreads`),
+ * with nothing deleting the first. `switchToThread` resolves either id, so the
+ * remote-keyed one is the safe canonical form.
+ *
+ * Only collapse once that remote-keyed entry exists: until it lands (and
+ * forever, after a failed list load) the local entry is the session's only
+ * entry, and a tab pointing at an id with no entry would show "New Session"
+ * and no project colour. Lookups are by exact id — matching `remoteId` too
+ * would collapse a session onto itself before its canonical entry arrives.
+ */
+export function canonicalTabId(id: string, items: readonly ThreadListEntry[]): string {
+  const remoteId = items.find((t) => t.id === id)?.remoteId;
+  if (remoteId == null || remoteId === id) return id;
+  return items.some((t) => t.id === remoteId) ? remoteId : id;
+}
+
+/**
+ * The open set, expressed in canonical ids with the dead tabs dropped.
+ *
+ * First-wins dedupe is what makes the local→remote handoff an in-place swap:
+ * the membership seam appends the canonical id at the end, so the set reads
+ * `[…, '__LOCALID_x', 'chat-x']`, and keeping the first occurrence merges the
+ * appended tab into the slot the draft tab already held instead of moving the
+ * session to the end of the strip.
+ */
+export function reconcileTabIds(
+  tabIds: readonly string[],
+  items: readonly ThreadListEntry[],
+  activeId: string | null,
+): string[] {
+  const valid = validTabIds(items, activeId === null ? null : canonicalTabId(activeId, items));
+  const next: string[] = [];
+  for (const id of tabIds) {
+    const canonical = canonicalTabId(id, items);
+    if (valid.has(canonical) && !next.includes(canonical)) next.push(canonical);
+  }
+  return next;
 }

--- a/packages/ui/src/features/session-tabs/use-session-tabs-sync.ts
+++ b/packages/ui/src/features/session-tabs/use-session-tabs-sync.ts
@@ -5,18 +5,25 @@
  * path at once — sidebar click, palette, toast deep-link, boot auto-select,
  * archived-active fallback — without touching any of those call sites.
  *
- * Also owns persistence: restore once a real `list()` has SETTLED carrying at
- * least one session (merging with tabs the boot already opened), prune tabs
- * whose thread vanished, and write the boot-stable id set back on every change.
- * A list that is still loading, holds only the transient boot draft, or failed
- * to load leaves `hydrated` false: the persisted payload survives untouched and
- * a later, real list still restores it.
+ * Also owns reconciliation and persistence: restore once a real `list()` has
+ * SETTLED carrying at least one session (merging with tabs the boot already
+ * opened), reconcile the open set on every thread-list change, and write the
+ * boot-stable id set back. A list that is still loading, holds only the
+ * transient boot draft, or failed to load leaves `hydrated` false: the
+ * persisted payload survives untouched and a later, real list still restores it.
+ *
+ * Reconciling both prunes vanished threads AND collapses identities: a
+ * session's pre-send and post-create ids are ONE member, merged onto the
+ * remote-keyed entry in the slot the draft tab already held. It runs before
+ * hydration on purpose — pre-hydration the set holds only ids the seam added
+ * for an active thread, all valid by construction, and a ghost must not
+ * outlive a list load that failed.
  */
 import { useEffect, useRef } from 'react';
 import { useAuiState } from '@assistant-ui/react';
 import { useSessionListLoadState } from '../sessions/runtime/list-load-state';
 import { useSessionTabsStore } from './store';
-import { SESSION_TABS_STORAGE_KEY, canRestoreTabs, persistTabIds, restoreTabIds, validTabIds } from './tabs-model';
+import { SESSION_TABS_STORAGE_KEY, canRestoreTabs, persistTabIds, reconcileTabIds, restoreTabIds } from './tabs-model';
 
 function readPersisted(): string[] {
   try {
@@ -41,7 +48,7 @@ export function useSessionTabsSync(): void {
   const tabIds = useSessionTabsStore((s) => s.tabIds);
   const hydrate = useSessionTabsStore((s) => s.hydrate);
   const ensureTab = useSessionTabsStore((s) => s.ensureTab);
-  const pruneTo = useSessionTabsStore((s) => s.pruneTo);
+  const reconcile = useSessionTabsStore((s) => s.reconcile);
 
   useEffect(() => {
     if (hydrated || !canRestoreTabs(items, isListLoading, listLoaded)) return;
@@ -53,9 +60,8 @@ export function useSessionTabsSync(): void {
   }, [mainThreadId, ensureTab]);
 
   useEffect(() => {
-    if (!hydrated) return;
-    pruneTo(validTabIds(items, mainThreadId));
-  }, [hydrated, items, mainThreadId, pruneTo]);
+    reconcile((ids) => reconcileTabIds(ids, items, mainThreadId));
+  }, [items, mainThreadId, reconcile]);
 
   // `items` changes identity on every stream tick (title/status updates), so
   // this effect runs hot while a chat is running — skip the write unless the


### PR DESCRIPTION
## Summary
- A new thread's local draft tab and its post-send remote-id tab used to coexist, leaving a dead unclickable pill behind once the first message landed.
- The tab strip now reconciles through a resolver: it canonicalises a local id onto its remote id only when a separate entry already exists under that remote id, then dedupes to the first occurrence — the draft tab's slot absorbs the canonical entry in place instead of appending a duplicate.

## Artifacts
- Plan: `docs/plans/2026-08-11-todo-319-session-tab-identity-plan.md`
- Review verdict: APPROVED (1 round)
- QA: 7/7

## Key decisions
- Canonicalise conditionally: `remoteId != null` alone doesn't mean orphaned — between first send and the `chat.created` reload (and permanently after a failed list load) the local entry is the session's only entry.
- In-place swap via first-wins dedupe: map every open id through `canonicalTabId`, keep the first occurrence, prune the rest — the canonical tab merges into the draft tab's slot.
- The store's `reconcile((ids) => ...)` takes a resolver applied inside `set`, not a precomputed array, so it never races a same-flush `hydrate()`.
- The reconcile effect is intentionally not gated on `hydrated` (unlike the prune effect it replaces); pre-hydration the set holds only seam-added, already-valid ids.
- The `ensureTab` seam is left untouched — canonicalising there too would risk re-opening a tab the user just closed.
- `validTabIds` became module-private; its test cases moved into the `reconcileTabIds` describe.
- No new SessionTabs component test — the change is a one-line substitution onto the already-unit-tested `canonicalTabId`; typecheck + model tests are the gate.
- `restoreTabIds`/`persistTabIds` and the `mf:session-tabs` payload shape are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>