### PR TITLE
test(e2e): fix the transcript scroll test and stop its retries running empty

### DIFF
--- a/.changeset/brave-files-bet.md
+++ b/.changeset/brave-files-bet.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: make the transcript scroll test survive the viewport re-anchor, and the transcript describes retry-safe. No shipped behavior changes.

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -9,9 +9,13 @@ export default defineConfig({
   // replays recorded NDJSON with every inter-event delay capped at 120ms, so its slowest
   // PASSING test on CI is under 5s — a 2-min budget there only decides how long a hung test
   // takes to be declared dead, and rc.22 spent 12 of its 27 test-minutes doing exactly that.
-  // 45s keeps ~9x headroom over the slowest observed test. A spec that genuinely needs more
-  // (stress-matrix) overrides per-test with `test.setTimeout`.
-  timeout: process.env['E2E_MODE'] === 'mock' ? 45_000 : 120_000,
+  // 60s keeps ~12x headroom over the slowest observed test, and — the binding constraint —
+  // stays ABOVE the longest wait any test performs on itself. At 45s it exactly tied
+  // `tool-cards`' own `waitFor({ timeout: 45_000 })`, so the backstop killed the test first
+  // and reported "Target page has been closed" instead of "waiting for chat-plan-gate": a
+  // backstop below an in-test wait buys nothing and costs the error message. A spec that
+  // genuinely needs more (stress-matrix) overrides per-test with `test.setTimeout`.
+  timeout: process.env['E2E_MODE'] === 'mock' ? 60_000 : 120_000,
   // 40 min total by default — the full AI suite (serial) exceeds 10 min end-to-end. Override via
   // MF_E2E_GLOBAL_TIMEOUT (ms) for targeted multi-file invocations where 40 min would starve later
   // files sharing this one process budget (e.g. running a handful of specs back-to-back).

--- a/packages/e2e/tests-tauri/transcript.spec.ts
+++ b/packages/e2e/tests-tauri/transcript.spec.ts
@@ -76,6 +76,13 @@ async function scrollViewportToTop(page: Page): Promise<void> {
   });
 }
 
+// Serial in fact, so declared serial. Every describe here builds its transcript
+// with sends from its OWN earlier tests, and `beforeAll` re-runs on a retry — so
+// an undeclared retry handed the later tests a brand-new EMPTY chat, and each
+// failure re-seeded the app empty for every test after it. Declared, a retry
+// re-runs the whole block, sends included, and the transcript is there.
+test.describe.configure({ mode: 'serial' });
+
 // ─── §11 Transcript — thread turn (long text + Bash tool call) ────────────────
 
 test.describe('§transcript — thread turn', () => {
@@ -177,10 +184,16 @@ test.describe('§transcript — thread turn', () => {
     // At rest (post-idle autoscroll) the native ScrollToBottom is disabled — already at the tail.
     await expect(scrollBtn).toBeDisabled();
 
-    await scrollViewportToTop(page);
-    await expect(scrollBtn).toBeEnabled({ timeout: 5_000 });
-
-    await scrollBtn.click();
+    // Scroll and click as ONE retried unit: the viewport re-anchors to the tail on
+    // its own, and it did so between the enabled assertion and the click — leaving
+    // the button `disabled:invisible` and the click waiting out the whole test
+    // budget. Retrying the gesture rides that out; a button that can never be
+    // clicked still fails, here, saying so.
+    await expect(async () => {
+      await scrollViewportToTop(page);
+      await expect(scrollBtn).toBeEnabled({ timeout: 2_000 });
+      await scrollBtn.click({ timeout: 2_000 });
+    }).toPass({ timeout: 20_000, intervals: [250, 500, 1_000] });
     await expect(scrollBtn).toBeDisabled({ timeout: 5_000 });
     // Corroborate "disabled" with the actual scroll position: within a few px of the tail.
     await expect


### PR DESCRIPTION
Closes the last two red tests from rc.22 — **with both tests unskipped and passing**, not skipped. Supersedes #600.

## What was actually wrong

An instrumented CI run separated two failures that had looked like one for two releases:

```
23:43:32  CONSTRUCTED <chat> → ACTIVE → history READ 0 msgs
23:43:33  ✓ 383 ✓ 384 ✓ 385 ✓ 386        ← messages present
23:44:19  ✘ 387  (45s, the full budget; nothing logged in between)
23:44:20  CONSTRUCTED __LOCALID_, __LOCALID_, <a DIFFERENT chat>
23:44:26  ✘ 388  (retry)
23:44:31  ✘ 389  find-in-chat
```

Every failure is followed by a fresh app, project and chat — `beforeAll` re-runs on retry. The later tests here build their transcript from sends made by the **earlier** tests in the describe, so a retry handed them a brand-new empty chat, and so did every test after the first failure.

That means **`find-in-chat`'s `0/0` was that empty chat answering honestly** — never a Find bug — and the transcript never "emptied mid-session" (todo #320's original premise, now corrected on the todo).

## The two fixes

- **The scroll test** scrolls and clicks as one retried unit. The viewport re-anchors to the tail on its own and did so between the enabled assertion and the click, leaving the button `disabled:invisible` and the click waiting out the whole budget.
- **Both describes are declared serial**, as they already were in fact. A retry now re-runs the block from the start — sends included — instead of testing a transcript that was never written.

Plus the one salvageable line from #600: the mock budget goes 45s → 60s, so an in-test wait reports before the backstop does.

## Verification

Linux `workflow_dispatch` on current main: **387 passed, 0 failed, 1 flaky, 12m08s** — `scroll-to-bottom` ✓ and `find-in-chat` ✓, both unskipped.

Honest caveat: that run predates the 60s budget line by one commit. Raising a timeout can only allow more time, so I did not re-run for it.

`tool-cards:402` also passed in that run, but **#604 fixed it, not this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)