### PR TITLE
chore(e2e): capture the daemon log and the app console

### DIFF
--- a/.changeset/short-steaks-arrive.md
+++ b/.changeset/short-steaks-arrive.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: keep the daemon's logs past teardown and echo the app's console to the run output. No shipped behavior changes.

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ docs/CODE-ANALYSIS*
 packages/e2e/logs/
 .playwright-cli/
 dist-local/
+/packages/e2e/daemon-logs/

--- a/packages/e2e/fixtures/app-tauri.ts
+++ b/packages/e2e/fixtures/app-tauri.ts
@@ -65,6 +65,14 @@ export async function launchTauriApp(opts?: {
       await context.addInitScript((value: string) => localStorage.setItem('mf:tutorial', value), TOUR_SUPPRESS);
     }
     const page = await context.newPage();
+    // Echo the app's warnings/errors to stdout, where the CI job log keeps them.
+    // Without this the renderer's side of a failure is invisible on CI — every
+    // client-side theory this suite has produced was inferred from the DOM alone.
+    page.on('console', (message) => {
+      if (message.type() !== 'warning' && message.type() !== 'error') return;
+      console.log(`[browser:${message.type()}] ${message.text()}`);
+    });
+    page.on('pageerror', (error) => console.log(`[browser:pageerror] ${error.message}`));
     await page.goto(PREVIEW_BASE, { waitUntil: 'domcontentloaded' });
     await waitConnected(page);
 

--- a/packages/e2e/fixtures/daemon.ts
+++ b/packages/e2e/fixtures/daemon.ts
@@ -1,6 +1,16 @@
 import { spawn, execFileSync } from 'child_process';
 import type { ChildProcess } from 'child_process';
-import { mkdtempSync, rmSync, openSync, closeSync, existsSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  openSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -190,6 +200,59 @@ export async function startDaemon(opts?: { recordingKey?: string; mockMaxDelayMs
   }
 }
 
+/**
+ * Keep the daemon's logs before its data dir is deleted.
+ *
+ * The daemon's tracing output goes to `<MAINFRAME_DATA_DIR>/logs/server.<date>.log`
+ * (logging.rs; the stdout layer stays quiet, so the spawn's own capture only ever
+ * holds a panic). That data dir is the temp dir this file removes at teardown — so
+ * on CI the logs of a failing run were destroyed with it, and a Linux-only failure
+ * could only be read through the DOM. Both go next to the report, in their own
+ * directory rather than inside `playwright-report/`, which the HTML reporter wipes
+ * when it writes, and the workflow uploads them.
+ */
+const DAEMON_LOG_DIR = path.resolve(__dirname, '../daemon-logs');
+/** Enough tail to cover a describe; a whole run's logging would dwarf the report. */
+const MAX_KEPT_LOG_BYTES = 1_000_000;
+
+function keepTail(source: string, destination: string): void {
+  if (!existsSync(source)) return;
+  const contents = readFileSync(source);
+  if (contents.byteLength === 0) return;
+  const kept =
+    contents.byteLength > MAX_KEPT_LOG_BYTES ? contents.subarray(contents.byteLength - MAX_KEPT_LOG_BYTES) : contents;
+  mkdirSync(DAEMON_LOG_DIR, { recursive: true });
+  writeFileSync(destination, kept);
+}
+
+async function preserveDaemonLog(handle: DaemonHandle): Promise<void> {
+  const name = path.basename(handle.testDataDir);
+  const kept: string[] = [];
+  try {
+    const tracingDir = path.join(handle.testDataDir, 'logs');
+    if (existsSync(tracingDir)) {
+      for (const file of readdirSync(tracingDir)) {
+        const destination = path.join(DAEMON_LOG_DIR, `${name}-${file}`);
+        keepTail(path.join(tracingDir, file), destination);
+        if (existsSync(destination)) kept.push(destination);
+      }
+    }
+    // Empty unless the daemon panicked — which is exactly when it matters.
+    const stdio = path.join(DAEMON_LOG_DIR, `${name}-stdio.log`);
+    keepTail(path.join(handle.testDataDir, 'daemon.log'), stdio);
+    if (existsSync(stdio)) kept.push(stdio);
+  } catch (err) {
+    console.warn('[e2e] could not preserve the daemon logs', err);
+  }
+
+  // On CI these files are not collected — the workflow uploads only
+  // `playwright-report/`, and an attachment made from an `afterAll` hook never
+  // reaches it. Read them from the artifact-free path: the local directory below,
+  // or add an upload step for `packages/e2e/daemon-logs/` (needs a token with the
+  // `workflow` scope).
+  if (kept.length > 0) console.log(`[e2e] kept ${kept.length} daemon log(s) for ${name} in daemon-logs/`);
+}
+
 export async function stopDaemon(handle: DaemonHandle | undefined): Promise<void> {
   if (!handle) return;
   await new Promise<void>((resolve) => {
@@ -202,5 +265,6 @@ export async function stopDaemon(handle: DaemonHandle | undefined): Promise<void
       resolve();
     }, 3_000);
   });
+  await preserveDaemonLog(handle);
   rmSync(handle.testDataDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Both sides of a failing e2e run were invisible, and that is most of why the transcript bug (red since rc.20) took six wrong hypotheses to close.

- The daemon's tracing goes to `<MAINFRAME_DATA_DIR>/logs/` — the temp dir the fixture **deletes at teardown**.
- The renderer's console went nowhere at all.

So every theory about that failure was inferred from DOM snapshots. The two probes run *after* these captures existed each produced a clean answer on the first attempt.

## What this adds

- `stopDaemon` keeps a tail of each describe's daemon log (plus the stdio capture — empty unless the daemon panicked, which is exactly when it matters) under `packages/e2e/daemon-logs/`, gitignored.
- The app fixture echoes browser warnings/errors and page errors to stdout, where the CI job log keeps them.

Diagnostics only. The `#320`-specific log parsing and the temporary Rust branch logging are deliberately **not** included — this is just the capture.

## Already earning its keep

The console capture immediately surfaced an unrelated live warning that nothing else reported:

```
[browser:warning] [shiki-highlighter] init failed TypeError: (e.langs ?? []).map is not a function
[browser:warning] [shiki-tokens] highlight failed {lang: typescript, err: ...}
```

That fires on every syntax-highlight attempt. Worth a look separately — it means code blocks are falling back to unhighlighted rendering.

## Follow-up

Add an upload step for `packages/e2e/daemon-logs/` to `e2e-mock.yml` so the files ride the CI artifact. I could not push that myself — the token in use lacks the `workflow` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)