### PR TITLE
test(e2e): make the branch-flyout and rail-Escape cases deterministic (#315)

### DIFF
--- a/.changeset/fiery-ads-return.md
+++ b/.changeset/fiery-ads-return.md
@@ -1,0 +1,4 @@
+---
+---
+
+E2E-only: wait for the loaded branch list before opening a flyout, and retry Escape on the floating session panel by outcome instead of a page-wide popper-free precondition. No shipped behavior changes.

--- a/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
+++ b/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
@@ -362,3 +362,54 @@ lists exactly the two spec files plus the changeset (plus this plan). The whole-
   ~10 seconds with the row named. Do not raise the attempt count to make a run go green.
 - **Group A and B cannot run Playwright concurrently** (shared daemon port, preview port and
   `packages/ui/dist`). The dependency edge between them exists for that reason alone.
+
+---
+
+## Appendix — C2 acceptance evidence (2026-08-10, review-fixes stage)
+
+Command run verbatim, three consecutive times, foreground, from the worktree root:
+
+```
+E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm --filter @qlan-ro/mainframe-e2e exec \
+  playwright test tests-tauri/git-branch.spec.ts tests-tauri/session-panel.spec.ts
+```
+
+The four cases this todo's fix targets — `branch row flyout: checkout`, `branch row flyout: new
+branch from a selected branch`, `branch row flyout: merge fast-forwards a clean ancestor branch`,
+and `a rail click floats the panel; Escape dismisses it` — passed on the **first attempt, in single
+digit seconds, in all three runs** (checkout 2.4s/2.5s/2.5s, new-branch-from 1.8s/1.7s/2.2s,
+merge-ff 1.1s/1.1s/1.1s, rail-Escape 3.1s/3.1s/3.1s). No occurrence reached a timeout or a retry.
+The fix this todo describes is confirmed working under the exact joint-run condition the acceptance
+criterion specifies.
+
+**Run 1 — 21:02:44–21:03:44 EEST:** `42 passed (54.6s)`. 0 failed, 0 flaky.
+
+**Run 2 — 21:03:49–21:04:59 EEST:** `41 passed, 1 flaky (1.1m)`. The flaky case was **not** one of
+the four above: `quick actions: fetch, update all, and push current complete without error`
+(git-branch.spec.ts:668) failed on first attempt and passed on Playwright's built-in retry. Failure:
+`git rev-parse e2e-workspace` in the bare "remote" repo raised `fatal: ambiguous argument
+'e2e-workspace': unknown revision` for the full 15s poll window, even though the UI had already
+shown a "Pushed to origin/e2e-workspace" success toast.
+
+**Run 3 — 21:08:54–21:10:20 EEST:** `41 passed, 1 failed (1.3m)`. Same test, same failure signature,
+on both the initial attempt and Playwright's retry — this time it did not recover.
+
+**Verdict: C2 does not close.** The acceptance criterion is "zero flaky and zero failed on every
+run"; the quick-actions case broke that in 2 of 3 runs. This is a **different mechanism** from the
+bug this todo fixes, and reproduces only under the joint two-spec run (Group A's three standalone
+`git-branch.spec.ts` runs, task A6, saw no failures) — it involves a git push landing in the bare
+repo, not a Radix popper/menu race.
+
+Diagnosis so far (not fixed, no code changed for this): `BranchListView`'s push-current handler
+reads `currentBranch` from `BranchPopover`'s `branches.current` state
+(`packages/ui/src/features/git/BranchPopover.tsx:129`), which by this point in the test is the
+*fresh* GET this todo's A2 fix now waits for, so the toast naming `e2e-workspace` is credible — the
+push is real and targets the right branch. The unknown-revision result on the bare repo, persisting
+for the full 15s poll, points at either the daemon reporting push success before the underlying git
+process/ref-write is actually visible on disk, or a repo-path resolution issue specific to the
+worktree under joint-run load; neither is confirmed. `git-fetch` / `git-update-all` / `git-push-current`
+are the non-flyout quick actions the plan's task A4 explicitly scoped out of the click-bounding fix
+("Leave the non-flyout quick actions … alone — they are not the class this todo names"), and the
+mechanism here is unrelated to flyout anchoring or the rail-Escape overlay — fixing it would expand
+this todo into a new investigation. Recommend a follow-up todo: "git-branch quick-actions
+push-current: unknown-revision race in the joint two-spec run."

--- a/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
+++ b/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
@@ -1,0 +1,328 @@
+# Plan — Make the branch-flyout and rail-Escape e2e cases deterministic
+
+Todo #315 (`route:no-spec`, project `rgoM5ZldH0UeeOonms6PK`) · branch `todo/315-flaky-e2e-pair`
+
+## Goal
+
+Two e2e cases flake on every batch and each git-branch occurrence burns a full test timeout. In
+`packages/e2e/tests-tauri/git-branch.spec.ts`, the helper that opens a branch row's flyout waits only
+for the search field, which is visible long before the lazily-loaded branch list exists; the three
+flyout cases (checkout, new-branch-from, merge fast-forward) then click a Radix submenu item while the
+list is still settling, and Playwright retries the click until the test timeout. In
+`packages/e2e/tests-tauri/session-panel.spec.ts`, `settleForEscape` demands a page-wide "no Radix
+popper layer exists" precondition that a hover-driven layer can invalidate at any moment, so the test
+dies in the helper before Escape is ever pressed. This plan fixes both **test-side**: the branch
+helpers wait on the app state that actually gates the interaction (rows loaded, no dying dialog scrim)
+and bound every click with its own timeout, and the panel spec asserts the outcome (the overlay is
+gone) through a bounded Escape retry in the same shape as the shared `closeMenus` helper. No product
+code changes unless the red-phase evidence proves real menu jitter — see [Escalation](#escalation).
+
+## Constraints
+
+From the root `CLAUDE.md` and the todo brief:
+
+- Max 300 lines/file, 50 lines/function. `git-branch.spec.ts` is at 659 lines and
+  `session-panel.spec.ts` at 738 — both are pre-existing spec files over the limit. Do **not** grow
+  either past its current line count by more than the fix needs, and do not attempt a split in this
+  todo (out of scope, and a split would churn every test id reference).
+- No fixed sleeps. `waitForTimeout` is banned in both specs; every new wait is on observable app or
+  Radix state.
+- Comments say *why*. Every comment left in place must describe the mechanism the code now relies on;
+  a comment describing an abandoned approach is a defect, not a leftover.
+- Changesets required before commit (`pnpm changeset --empty` shape, with a body — see
+  `git show 2ba52f9c:.changeset/plenty-lizards-lick.md` for the precedent this repo uses for
+  e2e-only changes).
+- No leftovers: stale references (e.g. the comment naming `settleForEscape`) get fixed in the same
+  pass.
+
+## Ground rules for this fix
+
+These three rules decide every judgement call below. An implementer who deviates must say so.
+
+1. **Wait on data, not on chrome.** `git-branch-search` renders before the branch data arrives
+   (`BranchPopover.tsx` loads lazily on `open`, and `BranchListView` renders the search field
+   unconditionally). The only honest "list is loaded" signal available today is the presence of branch
+   rows — `[data-testid^="git-branch-row-"]`. `busy` is **not** usable: `loadBranches` is the one
+   handler in `use-branch-actions.ts` that is *not* wrapped in `withBusy`, so `git-fetch` never
+   disables during the initial load.
+2. **Retry only side-effect-free steps.** Opening a popover or a flyout can be retried; **clicking a
+   flyout item can not**. A retried `git-submenu-merge` would run a second merge. Any retry loop in
+   this plan wraps opens only.
+3. **Bound every click.** A click that can legitimately race a transient layer gets an explicit
+   `{ timeout: … }` so the failure names the element in seconds instead of riding the 45s (mock) test
+   timeout.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `packages/e2e/tests-tauri/git-branch.spec.ts` | helper rewrite: scrim wait, list-loaded wait, bounded clicks, comment updates |
+| `packages/e2e/tests-tauri/session-panel.spec.ts` | `settleForEscape` → bounded Escape retry; two comment updates |
+| `.changeset/<generated>.md` | e2e-only changeset |
+
+Read-only (do **not** edit): `packages/e2e/helpers/tauri/menus.ts` — `waitForDialogScrimsGone` and
+`closeMenus` are already correct and are imported by six specs; changing them re-risks
+`sessions`, `sessions-tags`, `sessions-filters`, `settings`, `files-tree`, `layout` and
+`directory-picker`.
+
+## Verification commands
+
+Build once per worktree (this is what bakes `VITE_DAEMON_PORT=31416` into the bundle the preview
+server serves, and builds the Rust daemon):
+
+```
+pnpm --filter @qlan-ro/mainframe-e2e build:app:tauri
+```
+
+Then every scoped run below is:
+
+```
+E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm --filter @qlan-ro/mainframe-e2e exec \
+  playwright test tests-tauri/git-branch.spec.ts
+```
+
+(swap in `tests-tauri/session-panel.spec.ts`, or pass both paths, as each task says). Rebuild without
+`MF_E2E_SKIP_BUILD=1` only if `packages/ui` changes.
+
+Static gates, run from the repo root:
+
+```
+pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit
+npx prettier --check packages/e2e/tests-tauri/git-branch.spec.ts packages/e2e/tests-tauri/session-panel.spec.ts
+npx eslint packages/e2e/tests-tauri/git-branch.spec.ts packages/e2e/tests-tauri/session-panel.spec.ts
+```
+
+**Do not change `playwright.config.ts`.** `retries: 1` is what makes a first-attempt failure report as
+"flaky"; that reporting is the acceptance signal, and retry-count changes are out of scope.
+
+**Only one Playwright run may be in flight at a time in this repo.** The daemon port (31416), the vite
+preview port (4317) and `packages/ui/dist` are all shared and global-setup kills whoever holds the
+preview port. Groups A and B therefore run in sequence even though they share no files.
+
+---
+
+## Group A — branch flyout determinism
+
+Files: `packages/e2e/tests-tauri/git-branch.spec.ts`.
+
+### A1 · Red phase: capture the real failure signature
+
+No code change. Run the spec and record what actually fails, because the fix in A2–A4 is only correct
+if the mechanism matches.
+
+1. Build (`pnpm --filter @qlan-ro/mainframe-e2e build:app:tauri`).
+2. Run `tests-tauri/git-branch.spec.ts` twice back to back with the scoped command above.
+3. For each failing/flaky case — "checkout switches the worktree current branch", "new branch from a
+   selected branch", "merge fast-forwards a clean ancestor branch" — record verbatim:
+   - the Playwright error class: *not stable* vs *element was detached* vs *intercepts pointer events*
+     vs *element is not visible*;
+   - which locator it was retrying (`git-submenu-*` item, or the `git-branch-row-*` sub-trigger);
+   - the elapsed time of the failing test from the `list` reporter.
+
+**Verification:** at least one of the three cases reproduces with a recorded signature, and the
+signature is written into the implementation commit message. If **zero** cases reproduce in two runs,
+stop and report that instead of "fixing" a race you never saw — the todo's premise is three batches of
+evidence, so a non-repro is itself a finding the lane must see.
+
+### A2 · `openBranchPopover` waits for a dying dialog scrim, then for the loaded list
+
+Edit `openBranchPopover` in `git-branch.spec.ts` (currently lines 139–143):
+
+- Import `waitForDialogScrimsGone` alongside `closeMenus` from `../helpers/tauri/menus.js`.
+- Call `await waitForDialogScrimsGone(page)` **before** the existing `menuLayers` count assertion. This
+  is the parity fix: five sibling specs already do this, and this spec opens four kinds of dialog
+  (new branch, rename, confirm, conflict) whose `data-slot="dialog-overlay"` scrim outlives the dialog
+  content and intercepts the next trigger click. Putting it in the helper covers every
+  dialog-then-menu transition in the file at once — do not sprinkle it at call sites.
+- After `git-branch-search` is visible, add a wait for the lazily-loaded list:
+  `await expect(page.locator('[data-testid^="git-branch-row-"]').first()).toBeVisible({ timeout: 10_000 })`.
+  The repo under test always has local branches, so zero rows means the load has not landed.
+- Update the helper's doc comment to state both waits and why (scrim interception; the lazy load in
+  `BranchPopover`'s `open`-gated `useEffect`, which leaves the search field visible before any row
+  exists).
+
+**Verification:** `tsc --noEmit` clean; the "toolbar branch trigger opens the menu; branches lazy-load"
+and "search filters the branch list" tests still pass in a scoped run of the spec.
+
+### A3 · `openSubmenu` opens the flyout on settled geometry, and retries only the open
+
+Rewrite `openSubmenu` (currently lines 163–166):
+
+- Resolve the row locator once; assert it visible with an explicit timeout before clicking.
+- Click the row with an explicit `{ timeout: 5_000 }`.
+- Assert `git-submenu` visible with `{ timeout: 5_000 }`.
+- Wrap those three steps in a bounded retry (max 2 attempts). The open is side-effect-free (rule 2),
+  so a flyout that a mid-flight list re-render closed can be re-opened. On the final attempt let the
+  assertion throw so the failure names `git-branch-row-<branch>` or `git-submenu`.
+- Between attempts, re-assert the row is visible rather than sleeping.
+- Keep `openBranchSubmenu` as the two-step composition; the loaded-list wait it inherits from A2 is
+  what makes the row's geometry final before the first click.
+- The comment must describe the mechanism the code now relies on: the flyout anchors to a row whose
+  position is only final once the branch data has landed, and a re-render can close an already-open
+  Sub, which is why the open — and only the open — is retried.
+
+**Verification:** `tsc --noEmit` clean, then a scoped run of `git-branch.spec.ts`: the three flyout
+cases pass on the first attempt and each completes in single-digit seconds per the `list` reporter.
+
+### A4 · Bound the flyout item clicks
+
+Every `page.getByTestId('git-submenu-*').click()` in the file is currently unbounded and inherits the
+whole test timeout. Add a small local helper (name it for what it does, e.g. `clickSubmenuItem`) that
+clicks a `git-submenu-*` testid with `{ timeout: 5_000 }`, and route all `git-submenu-*` call sites
+through it: checkout (×2 sites), new-branch-from, merge, rename, delete, pull, push, delete-worktree,
+new-session. One click, no retry (rule 2). Leave the non-flyout quick actions (`git-fetch`,
+`git-update-all`, `git-push-current`, dialog buttons) alone — they are not the class this todo names.
+
+**Verification:** `tsc --noEmit` clean; grep shows no bare `.click()` left on a `git-submenu-` testid;
+scoped run of the spec still green.
+
+### A5 · Comment hygiene in the touched header
+
+The file header (lines 1–74) documents the menu port and already says `openBranchPopover` "waits for
+the previous layer to unmount". Update the two bullets that describe `openBranchPopover` /
+`closeBranchPopover` so they describe the waits after A2–A4 (scrim, loaded list, bounded clicks).
+Do not rewrite unrelated parts of the header.
+
+**Verification:** `npx prettier --check` on the file; read-through confirms no comment describes a wait
+the code no longer performs.
+
+### A6 · Prove it: three consecutive clean scoped runs
+
+Run `tests-tauri/git-branch.spec.ts` three times in a row with the scoped command. Each run must report
+**0 failed, 0 flaky**. Record each run's per-test durations and confirm no test reaches the 45s mock
+timeout and no menu/overlay interaction costs more than a few seconds.
+
+**Verification:** three run summaries pasted into the group's report. Any flaky result means the fix is
+not done — do not proceed to Group C.
+
+### Escalation
+
+If, after A2–A4, a flyout item click still fails **with the branch list demonstrably loaded and
+quiescent** (rows present, no in-flight load), that is user-visible menu jitter in the popper
+anchoring, not a test bug. Per the todo's Decisions: **stop, do not paper over it with more retries.**
+Report the evidence and the recommendation to split the todo, with the product half labelled
+`needs-ui`. Group C's acceptance run then covers the panel fix only, and the flyout cases stay as they
+are.
+
+---
+
+## Group B — floating panel Escape determinism
+
+Files: `packages/e2e/tests-tauri/session-panel.spec.ts`. Runs **after** Group A: the two groups share
+no files but cannot share the e2e runtime.
+
+### B1 · Red phase: confirm the helper is what times out
+
+Run only the rail-Escape case:
+
+```
+E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm --filter @qlan-ro/mainframe-e2e exec \
+  playwright test tests-tauri/session-panel.spec.ts -g "a rail click floats the panel"
+```
+
+Record whether the failure is `settleForEscape`'s `[data-radix-popper-content-wrapper]` count
+assertion timing out (the brief's claim) or the final `overlay` assertion after the Escape. If the
+solo `-g` run passes, run the whole spec file — the case is order-sensitive and the preceding tests
+leave the hover state that matters.
+
+**Verification:** the failing assertion is identified by line and written into the implementation
+commit message.
+
+### B2 · Replace the global precondition with a bounded Escape retry
+
+Rewrite `settleForEscape` (lines 212–246) into a helper that asserts the **outcome**:
+
+- Keep the real click on the floating card's own `session-panel-section-summary` heading. It is still
+  load-bearing and the reasons in the current comment stay true: a pointerdown closes an open tooltip
+  outright, it takes hover off the `Hint`-wrapped rail button without parking on a sessions row (whose
+  `SessionMetaCard` hover card carries no `role`), and the heading is inert and inside the panel root
+  so light dismiss reads it as "inside".
+- **Delete** the `[data-radix-popper-content-wrapper]` `toHaveCount(0)` precondition. It is not
+  reachable: a hover-driven layer can open after the click, inside the helper's own budget.
+- Loop, at most 3 iterations: press `Escape`, then wait for `session-panel-overlay` to reach
+  `detached` with a short per-press budget (~1.5s), catching the timeout because a transient Radix
+  layer legitimately consumes a press (`use-session-panel-state.ts` bails on
+  `event.defaultPrevented`). Return as soon as the overlay is gone. This is the shape `closeMenus`
+  already uses for menu layers — press once, settle, re-read.
+- Rename the helper to say what it does (e.g. `dismissOverlayWithEscape`) and rewrite the doc comment
+  to describe the retry mechanism and why a press can be swallowed. The abandoned "clear every Radix
+  overlay first" framing must not survive anywhere in the comment.
+- The helper must **not** swallow the final failure: leave the authoritative
+  `await expect(overlay).toHaveCount(0, { timeout: 5_000 })` in the test (line 415) so a genuine
+  regression fails there, naming the overlay.
+
+Update the call site at line 413 accordingly. The test's assertions are otherwise unchanged — same
+overlay, same `role=dialog`, same "inline card stays absent" check.
+
+**Verification:** `tsc --noEmit` clean; the rail-Escape case passes both solo (`-g`) and in a full
+scoped run of the spec.
+
+### B3 · Fix the stale cross-reference
+
+The comment above "right-clicking the rail launch button floats the panel on the Launch section"
+(≈ line 449–453) points at `settleForEscape` by name to explain why that test dismisses with a second
+right-click instead of Escape. Update the name and, if the reasoning changed, the wording — the point
+(a right-click leaves the rail button's tooltip open, and that tooltip owns the first Escape) still
+holds under the retry helper because the retry now presses again rather than requiring a clear page.
+
+**Verification:** grep for `settleForEscape` returns nothing in the repo.
+
+### B4 · Prove it: three consecutive clean scoped runs
+
+Run `tests-tauri/session-panel.spec.ts` three times in a row. Each run must report **0 failed, 0
+flaky**, and no test may reach the mock timeout.
+
+**Verification:** three run summaries in the group's report.
+
+---
+
+## Group C — close-out
+
+Depends on A and B. Files: `.changeset/<generated>.md` only.
+
+### C1 · Changeset
+
+`pnpm changeset --empty`, then write the body in the shape this repo uses for e2e-only work: one or
+two sentences naming both fixes and stating "No shipped behavior changes." Keep the generated file
+name.
+
+**Verification:** the file exists under `.changeset/` and `git status` shows it staged.
+
+### C2 · Joint acceptance run — three consecutive clean runs of both specs
+
+```
+E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm --filter @qlan-ro/mainframe-e2e exec \
+  playwright test tests-tauri/git-branch.spec.ts tests-tauri/session-panel.spec.ts
+```
+
+three times in a row. This is the todo's acceptance criterion; the per-group runs in A6/B4 do not
+substitute for it, because the two specs share a daemon and a preview server within one run.
+
+**Verification:** all three runs report 0 failed and 0 flaky; the durations show no test near the mock
+timeout. Paste the three summaries into the report.
+
+### C3 · Static gates
+
+`pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit`, prettier `--check` and eslint on both spec
+files. Confirm by inspection that neither spec gained a `waitForTimeout`, that no test was deleted,
+weakened, skipped, or had an assertion removed, and that `playwright.config.ts` is untouched.
+
+**Verification:** all three commands exit 0; `git diff --stat origin/main` lists exactly the two spec
+files plus the changeset (plus this plan).
+
+---
+
+## Risks
+
+- **The red phase may not reproduce on this machine.** The flake was measured under batch load; a
+  scoped two-file run is quieter. A1/B1 handle this by making a non-repro a reportable outcome rather
+  than a licence to guess. The waits added here are correct regardless (they close a real window), but
+  claiming the flake is *fixed* requires having seen it fail first.
+- **`--repeat-each` is not a substitute for three separate runs.** The fixtures are per-describe and
+  order-dependent (`checkoutBase()` between mutating tests); repeating a single test inside one process
+  does not reproduce the state the batch does. Use three full runs.
+- **A retry around the flyout open can mask a genuine "the flyout never opens" regression.** Bounded at
+  2 attempts with the real assertion thrown on the last one, a permanent breakage still fails in
+  ~10 seconds with the row named. Do not raise the attempt count to make a run go green.
+- **Group A and B cannot run Playwright concurrently** (shared daemon port, preview port and
+  `packages/ui/dist`). The dependency edge between them exists for that reason alone.

--- a/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
+++ b/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
@@ -34,6 +34,14 @@ From the root `CLAUDE.md` and the todo brief:
   e2e-only changes).
 - No leftovers: stale references (e.g. the comment naming `settleForEscape`) get fixed in the same
   pass.
+- **`packages/e2e` is not typecheck-clean at HEAD, and never has been.** `tsc --noEmit` reports 90
+  errors on branch HEAD (`b5b11f58`) and on a clean `main` checkout: 87 × TS2591 ("Cannot find name
+  'fs' / 'path' / 'os' / 'child_process' / 'Buffer'") plus 3 × TS7006 in `fixtures/daemon.ts` and
+  `fixtures/global-setup.ts`. `@types/node@26.1.1` is installed and its symlink resolves, but
+  `packages/e2e/tsconfig.json` declares no `types` and no `typeRoots`, and the package has no
+  `typecheck` script — so nothing in CI has ever run this. Fixing the tsconfig is **out of scope**:
+  it would touch every file in the package. This plan therefore gates on a scoped typecheck (below),
+  not on a clean `tsc`. An implementer who sees 90 errors has not broken anything.
 
 ## Ground rules for this fix
 
@@ -86,13 +94,32 @@ E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm --filter @qlan-ro/mainframe-e2e exec \
 (swap in `tests-tauri/session-panel.spec.ts`, or pass both paths, as each task says). Rebuild without
 `MF_E2E_SKIP_BUILD=1` only if `packages/ui` changes.
 
-Static gates, run from the repo root:
+Static gates, run from the repo root. Prettier and eslint are clean at HEAD and are plain pass/fail:
 
 ```
-pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit
 npx prettier --check packages/e2e/tests-tauri/git-branch.spec.ts packages/e2e/tests-tauri/session-panel.spec.ts
 npx eslint packages/e2e/tests-tauri/git-branch.spec.ts packages/e2e/tests-tauri/session-panel.spec.ts
 ```
+
+**The scoped typecheck gate.** Every task below that says "the scoped typecheck gate passes" means this
+command, run from the repo root:
+
+```
+pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit 2>&1 \
+  | grep -E 'tests-tauri/(git-branch|session-panel)\.spec\.ts' \
+  | grep -v 'TS2591'
+```
+
+**The gate passes when this command prints nothing.** Judge it by its output, never by its exit code:
+`tsc` exits 2 on the pre-existing errors and a `grep` that matches nothing exits 1, so a passing gate
+still reports a non-zero status.
+
+Why this shape is safe: TS2591 fires only on the known node-global names the package never types. A
+typo'd identifier is TS2304 and a real type error is TS2322/TS2345 — none of them can hide behind the
+allowlist. Baseline at HEAD (`b5b11f58`), for comparison: `git-branch.spec.ts` has exactly 4 errors
+(lines 76–79) and `session-panel.spec.ts` exactly 4 (lines 115–117, 637), all TS2591. Record the
+post-change counts as an observation; the plan adds no node-global usage, so a count above 4 + 4 means
+the change introduced one and deserves a second look before it ships.
 
 **Do not change `playwright.config.ts`.** `retries: 1` is what makes a first-attempt failure report as
 "flaky"; that reporting is the acceptance signal, and retry-count changes are out of scope.
@@ -120,6 +147,11 @@ if the mechanism matches.
      vs *element is not visible*;
    - which locator it was retrying (`git-submenu-*` item, or the `git-branch-row-*` sub-trigger);
    - the elapsed time of the failing test from the `list` reporter.
+4. Confirm the typecheck baseline before touching anything, so later runs have something to compare
+   against: `pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit 2>&1 | grep -c 'error TS'` should
+   print 90, and the scoped typecheck gate command from
+   [Verification commands](#verification-commands) should print nothing. If either differs, say so in
+   the report rather than adjusting the numbers.
 
 **Verification:** at least one of the three cases reproduces with a recorded signature, and the
 signature is written into the implementation commit message. If **zero** cases reproduce in two runs,
@@ -143,7 +175,7 @@ Edit `openBranchPopover` in `git-branch.spec.ts` (currently lines 139–143):
   `BranchPopover`'s `open`-gated `useEffect`, which leaves the search field visible before any row
   exists).
 
-**Verification:** `tsc --noEmit` clean; the "toolbar branch trigger opens the menu; branches lazy-load"
+**Verification:** the scoped typecheck gate passes; the "toolbar branch trigger opens the menu; branches lazy-load"
 and "search filters the branch list" tests still pass in a scoped run of the spec.
 
 ### A3 · `openSubmenu` opens the flyout on settled geometry, and retries only the open
@@ -163,7 +195,7 @@ Rewrite `openSubmenu` (currently lines 163–166):
   position is only final once the branch data has landed, and a re-render can close an already-open
   Sub, which is why the open — and only the open — is retried.
 
-**Verification:** `tsc --noEmit` clean, then a scoped run of `git-branch.spec.ts`: the three flyout
+**Verification:** the scoped typecheck gate passes, then a scoped run of `git-branch.spec.ts`: the three flyout
 cases pass on the first attempt and each completes in single-digit seconds per the `list` reporter.
 
 ### A4 · Bound the flyout item clicks
@@ -175,7 +207,7 @@ through it: checkout (×2 sites), new-branch-from, merge, rename, delete, pull, 
 new-session. One click, no retry (rule 2). Leave the non-flyout quick actions (`git-fetch`,
 `git-update-all`, `git-push-current`, dialog buttons) alone — they are not the class this todo names.
 
-**Verification:** `tsc --noEmit` clean; grep shows no bare `.click()` left on a `git-submenu-` testid;
+**Verification:** the scoped typecheck gate passes; grep shows no bare `.click()` left on a `git-submenu-` testid;
 scoped run of the spec still green.
 
 ### A5 · Comment hygiene in the touched header
@@ -256,7 +288,7 @@ Rewrite `settleForEscape` (lines 212–246) into a helper that asserts the **out
 Update the call site at line 413 accordingly. The test's assertions are otherwise unchanged — same
 overlay, same `role=dialog`, same "inline card stays absent" check.
 
-**Verification:** `tsc --noEmit` clean; the rail-Escape case passes both solo (`-g`) and in a full
+**Verification:** the scoped typecheck gate passes; the rail-Escape case passes both solo (`-g`) and in a full
 scoped run of the spec.
 
 ### B3 · Fix the stale cross-reference
@@ -305,12 +337,14 @@ timeout. Paste the three summaries into the report.
 
 ### C3 · Static gates
 
-`pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit`, prettier `--check` and eslint on both spec
-files. Confirm by inspection that neither spec gained a `waitForTimeout`, that no test was deleted,
-weakened, skipped, or had an assertion removed, and that `playwright.config.ts` is untouched.
+Run prettier `--check` and eslint on both spec files, plus the scoped typecheck gate. Confirm by
+inspection that neither spec gained a `waitForTimeout`, that no test was deleted, weakened, skipped,
+or had an assertion removed, and that `playwright.config.ts` is untouched.
 
-**Verification:** all three commands exit 0; `git diff --stat origin/main` lists exactly the two spec
-files plus the changeset (plus this plan).
+**Verification:** prettier and eslint exit 0; the scoped typecheck gate prints nothing (do not check
+its exit code — see [Verification commands](#verification-commands)); `git diff --stat origin/main`
+lists exactly the two spec files plus the changeset (plus this plan). The whole-package
+`tsc --noEmit` error count is unchanged at 90 — report it, do not fix it.
 
 ---
 

--- a/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
+++ b/docs/plans/2026-08-10-flaky-e2e-branch-flyout-panel-escape-plan.md
@@ -60,6 +60,8 @@ These three rules decide every judgement call below. An implementer who deviates
 | `packages/e2e/tests-tauri/session-panel.spec.ts` | `settleForEscape` → bounded Escape retry; two comment updates |
 | `.changeset/<generated>.md` | e2e-only changeset |
 
+Tasks are numbered globally for hand-off: **A1–A6 = 1–6, B1–B4 = 7–10, C1–C3 = 11–13.**
+
 Read-only (do **not** edit): `packages/e2e/helpers/tauri/menus.ts` — `waitForDialogScrimsGone` and
 `closeMenus` are already correct and are imported by six specs; changing them re-risks
 `sessions`, `sessions-tags`, `sessions-filters`, `settings`, `files-tree`, `layout` and

--- a/packages/e2e/tests-tauri/git-branch.spec.ts
+++ b/packages/e2e/tests-tauri/git-branch.spec.ts
@@ -80,7 +80,7 @@ import path from 'path';
 import { launchTauriApp, closeTauriApp, type TauriAppFixture } from '../fixtures/app-tauri.js';
 import { createTauriProject, createTauriChat, cleanupTauriProject, type TauriProject } from '../helpers/tauri/setup.js';
 import { TOAST } from '../helpers/tauri/testids.js';
-import { closeMenus } from '../helpers/tauri/menus.js';
+import { closeMenus, waitForDialogScrimsGone } from '../helpers/tauri/menus.js';
 import { DAEMON_PORT } from '../fixtures/daemon.js';
 
 const DAEMON_BASE = `http://127.0.0.1:${DAEMON_PORT}`;
@@ -132,14 +132,24 @@ function seedBranchCommit(
 const menuLayers = (page: Page) => page.locator('[role="menu"]');
 
 /**
- * Open the branch menu. Waits for a previous menu layer to unmount first: Radix
- * keeps a closing menu mounted through its exit animation and swallows a trigger
- * click that lands in that window, so the menu would silently fail to open.
+ * Open the branch menu. Waits, in order, for: a previous menu layer to unmount
+ * (Radix keeps a closing menu mounted through its exit animation and swallows a
+ * trigger click that lands in that window, so the menu would silently fail to
+ * open); a dying dialog scrim to clear (this spec opens four kinds of dialog, and
+ * `data-slot="dialog-overlay"` outlives its dialog's content, intercepting the
+ * trigger click underneath it); and, once the search field renders, the branch
+ * list to finish its lazy load. `BranchPopover` fetches branches in an
+ * `open`-gated `useEffect`, and `BranchListView` renders the search field
+ * unconditionally, so the search field is visible well before any row exists —
+ * clicking a row before the list has landed and settled targets geometry that is
+ * still about to shift, which is what leaves the row's flyout mis-anchored.
  */
 async function openBranchPopover(page: Page): Promise<void> {
   await expect(menuLayers(page)).toHaveCount(0, { timeout: 5_000 });
+  await waitForDialogScrimsGone(page);
   await page.getByTestId('main-toolbar-branch').click();
   await expect(page.getByTestId('git-branch-search')).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('[data-testid^="git-branch-row-"]').first()).toBeVisible({ timeout: 10_000 });
 }
 
 /**

--- a/packages/e2e/tests-tauri/git-branch.spec.ts
+++ b/packages/e2e/tests-tauri/git-branch.spec.ts
@@ -23,8 +23,15 @@
  *     TRIGGER (a button), so its value is text, not `toHaveValue`.
  *   • Radix keeps a closing menu mounted through its exit animation and swallows a
  *     trigger click landing in that window, so `openBranchPopover` waits for the
- *     previous layer to unmount, and `closeBranchPopover` closes the flyout and the
- *     root separately (one Escape only pops the innermost layer).
+ *     previous layer to unmount, for a dying dialog scrim to clear, and for the
+ *     branch list's fresh GET to resolve (its `branches` state survives a close, so
+ *     a reopen shows the PREVIOUS open's stale rows instantly — waiting on a row
+ *     being visible is not enough to know the reload has landed); `closeBranchPopover`
+ *     closes the flyout and the root separately (one Escape only pops the innermost
+ *     layer). `openSubmenu` retries the open (never the item click) up to twice, and
+ *     every `git-submenu-*` click is bounded to its own 5s timeout via
+ *     `clickSubmenuItem`, so a stuck interaction fails in seconds and names the
+ *     element instead of riding the whole test timeout.
  *
  * TOOLBAR-CHIP FINDINGS (layout/MainToolbar.tsx — both of this file's older
  * findings are now obsolete):
@@ -137,18 +144,30 @@ const menuLayers = (page: Page) => page.locator('[role="menu"]');
  * trigger click that lands in that window, so the menu would silently fail to
  * open); a dying dialog scrim to clear (this spec opens four kinds of dialog, and
  * `data-slot="dialog-overlay"` outlives its dialog's content, intercepting the
- * trigger click underneath it); and, once the search field renders, the branch
- * list to finish its lazy load. `BranchPopover` fetches branches in an
- * `open`-gated `useEffect`, and `BranchListView` renders the search field
- * unconditionally, so the search field is visible well before any row exists —
- * clicking a row before the list has landed and settled targets geometry that is
- * still about to shift, which is what leaves the row's flyout mis-anchored.
+ * trigger click underneath it); and the branch list's *fresh* reload.
+ *
+ * That last wait has to be on the network response, not on a row being visible.
+ * `BranchPopover` keeps its `branches` state across a close — it is only
+ * refetched by the `open`-gated `useEffect` — so on every open AFTER the first,
+ * a row is visible INSTANTLY from the previous open's stale state, well before
+ * the fresh GET resolves. A row-presence wait is satisfied by that cache and
+ * returns immediately; the real reload then lands mid-test and re-sorts the
+ * list, which can close a flyout the test has already opened on the stale
+ * row's position (confirmed with a MutationObserver: reopening right after a
+ * CLI-side `checkoutBase()` showed the stale row swap out for the fresh one a
+ * beat after the wait had already resolved). Waiting for the GET itself is the
+ * only signal that is honest on both the first open and every reopen.
  */
 async function openBranchPopover(page: Page): Promise<void> {
   await expect(menuLayers(page)).toHaveCount(0, { timeout: 5_000 });
   await waitForDialogScrimsGone(page);
+  const branchesLoaded = page.waitForResponse(
+    (r) => r.request().method() === 'GET' && r.url().includes('/git/branches'),
+    { timeout: 10_000 },
+  );
   await page.getByTestId('main-toolbar-branch').click();
   await expect(page.getByTestId('git-branch-search')).toBeVisible({ timeout: 10_000 });
+  await branchesLoaded;
   await expect(page.locator('[data-testid^="git-branch-row-"]').first()).toBeVisible({ timeout: 10_000 });
 }
 

--- a/packages/e2e/tests-tauri/git-branch.spec.ts
+++ b/packages/e2e/tests-tauri/git-branch.spec.ts
@@ -169,16 +169,52 @@ async function closeBranchPopover(page: Page): Promise<void> {
   await expect(page.getByTestId('git-submenu')).toHaveCount(0);
 }
 
-/** Open a branch row's action flyout (the row is a DropdownMenuSubTrigger). */
+/**
+ * Open a branch row's action flyout (the row is a DropdownMenuSubTrigger). The
+ * flyout anchors to the row's on-screen position, which is only final once the
+ * branch data has landed (the caller's `openBranchPopover` wait for that), but a
+ * mid-flight list re-render can still close an already-open Sub before Radix has
+ * finished anchoring it. Opening is side-effect-free, so this retries the open —
+ * and only the open, never the flyout item click that follows it — up to twice,
+ * re-asserting the row is visible between attempts instead of sleeping. The final
+ * attempt lets the assertion throw so a genuine failure names the row or the
+ * flyout, not a swallowed retry.
+ */
 async function openSubmenu(page: Page, branch: string): Promise<void> {
-  await page.getByTestId(`git-branch-row-${branch}`).click();
-  await expect(page.getByTestId('git-submenu')).toBeVisible({ timeout: 5_000 });
+  const row = page.getByTestId(`git-branch-row-${branch}`);
+  const submenu = page.getByTestId('git-submenu');
+  const maxAttempts = 2;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await expect(row).toBeVisible({ timeout: 5_000 });
+    await row.click({ timeout: 5_000 });
+    if (attempt === maxAttempts) {
+      await expect(submenu).toBeVisible({ timeout: 5_000 });
+      return;
+    }
+    try {
+      await expect(submenu).toBeVisible({ timeout: 5_000 });
+      return;
+    } catch {
+      /* a mid-flight re-render closed the flyout before it settled; retry the open */
+    }
+  }
 }
 
 /** Open the branch menu and a branch's flyout in one step. */
 async function openBranchSubmenu(page: Page, branch: string): Promise<void> {
   await openBranchPopover(page);
   await openSubmenu(page, branch);
+}
+
+/**
+ * Click a flyout action item by its `git-submenu-*` testid. Bounded with its own
+ * timeout rather than inheriting the whole test timeout: selecting an item is a
+ * real git mutation (rule 2 — not retriable), so a failure here must surface in
+ * seconds and name the element, instead of riding the 45s mock test timeout the
+ * way an unbounded `.click()` would.
+ */
+async function clickSubmenuItem(page: Page, testid: string): Promise<void> {
+  await page.getByTestId(testid).click({ timeout: 5_000 });
 }
 
 /**
@@ -397,7 +433,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
     const { page } = app;
     await openBranchSubmenu(page, 'feature/checkout-target');
     await expectItemEnabled(page, 'git-submenu-checkout');
-    await page.getByTestId('git-submenu-checkout').click();
+    await clickSubmenuItem(page, 'git-submenu-checkout');
     // Selecting the item closes the whole menu (BranchSubmenu items don't
     // preventDefault) — the outcome is read from git and from the toolbar chip.
     await expect(page.getByTestId('git-branch-popover')).toHaveCount(0, { timeout: 5_000 });
@@ -421,7 +457,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
   test('branch row flyout: new branch from a selected branch', async () => {
     const { page } = app;
     await openBranchSubmenu(page, 'main');
-    await page.getByTestId('git-submenu-new-branch-from').click();
+    await clickSubmenuItem(page, 'git-submenu-new-branch-from');
     await expect(page.getByTestId('git-new-branch-dialog')).toBeVisible();
     // `git-new-branch-start` is a Select TRIGGER (a button showing SelectValue),
     // not an input — the start point is its text.
@@ -441,7 +477,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
 
     await openBranchSubmenu(page, 'feature/ff-branch');
     await expectItemEnabled(page, 'git-submenu-merge');
-    await page.getByTestId('git-submenu-merge').click();
+    await clickSubmenuItem(page, 'git-submenu-merge');
     await expect(page.getByTestId('git-branch-popover')).toHaveCount(0, { timeout: 5_000 });
 
     await expect.poll(() => git(worktreePath, ['rev-parse', 'HEAD']).trim(), { timeout: 10_000 }).toBe(ffHead);
@@ -451,7 +487,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
   test('branch row flyout: Rename… hands off to the rename dialog', async () => {
     const { page } = app;
     await openBranchSubmenu(page, 'feature/rename-me');
-    await page.getByTestId('git-submenu-rename').click();
+    await clickSubmenuItem(page, 'git-submenu-rename');
 
     // Forms don't live in Radix menus: Rename is its own Dialog and the menu closes
     // behind it (RenameBranchDialog / BranchPopover's DialogState).
@@ -479,7 +515,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
   test('branch row flyout: delete force-deletes a not-yet-merged branch (two-step confirm)', async () => {
     const { page } = app;
     await openBranchSubmenu(page, 'feature/delete-me');
-    await page.getByTestId('git-submenu-delete').click();
+    await clickSubmenuItem(page, 'git-submenu-delete');
 
     const confirmDialog = page.getByTestId('git-confirm-dialog');
     await expect(confirmDialog).toBeVisible({ timeout: 5_000 });
@@ -510,7 +546,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
     expect(git(project.projectPath, ['rev-parse', 'feature/pull-target']).trim()).not.toBe(remoteHead);
 
     await openBranchSubmenu(page, 'feature/pull-target');
-    await page.getByTestId('git-submenu-pull').click();
+    await clickSubmenuItem(page, 'git-submenu-pull');
 
     await expect
       .poll(() => git(project.projectPath, ['rev-parse', 'feature/pull-target']).trim(), { timeout: 15_000 })
@@ -524,7 +560,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
     expect(git(bareRepoPath, ['rev-parse', 'feature/push-target']).trim()).not.toBe(localHead);
 
     await openBranchSubmenu(page, 'feature/push-target');
-    await page.getByTestId('git-submenu-push').click();
+    await clickSubmenuItem(page, 'git-submenu-push');
 
     await expect
       .poll(() => git(bareRepoPath, ['rev-parse', 'feature/push-target']).trim(), { timeout: 15_000 })
@@ -535,13 +571,13 @@ test.describe('§git-branch — Toolbar branch popover', () => {
   test('conflict view: a conflicting merge routes the branch menu to the conflict dialog; abort recovers', async () => {
     const { page } = app;
     await openBranchSubmenu(page, 'feature/conflict-a');
-    await page.getByTestId('git-submenu-checkout').click();
+    await clickSubmenuItem(page, 'git-submenu-checkout');
     await expect
       .poll(() => git(worktreePath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim(), { timeout: 10_000 })
       .toBe('feature/conflict-a');
 
     await openBranchSubmenu(page, 'feature/conflict-b');
-    await page.getByTestId('git-submenu-merge').click();
+    await clickSubmenuItem(page, 'git-submenu-merge');
 
     // Selecting Merge closes the menu, and BranchPopover only swaps in the conflict
     // dialog while the menu is OPEN (`if (open && hasConflict)`), so the conflict
@@ -587,7 +623,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
     // observable server-side outcome the row-disappearance is supposed to reflect.
     const respPromise = page.waitForResponse((r) => r.url().includes('/git/delete-worktree'));
 
-    await page.getByTestId('git-submenu-delete-worktree').click();
+    await clickSubmenuItem(page, 'git-submenu-delete-worktree');
     const confirmDialog = page.getByTestId('git-confirm-dialog');
     await expect(confirmDialog).toBeVisible({ timeout: 5_000 });
     await expect(confirmDialog).toContainText('wt-delete');
@@ -652,7 +688,7 @@ test.describe('§git-branch — Toolbar branch popover', () => {
     // Also moved into the flyout — `git-submenu-new-session` is only rendered for a
     // branch that IS checked out in a worktree (BranchSubmenu's isWorktree branch).
     await openBranchSubmenu(page, 'feature/worktree-session');
-    await page.getByTestId('git-submenu-new-session').click();
+    await clickSubmenuItem(page, 'git-submenu-new-session');
 
     // The menu closes both ways here: the item select closes it, and the new-session
     // flow calls `onDone`/closeMenu as well (useNewSessionAction).

--- a/packages/e2e/tests-tauri/session-panel.spec.ts
+++ b/packages/e2e/tests-tauri/session-panel.spec.ts
@@ -210,21 +210,20 @@ async function selectChat(page: Page, chatId: string): Promise<void> {
 }
 
 /**
- * Clear every Radix overlay before an Escape assertion, by taking hover AND
- * focus somewhere inert.
+ * Dismiss the floating session panel with Escape, retrying the press because a
+ * transient Radix layer can legitimately eat one.
  *
- * ANY open Radix layer consumes the first Escape — its DismissableLayer calls
+ * ANY open Radix layer consumes an Escape — its DismissableLayer calls
  * `preventDefault`, and the panel's own handler bails on `defaultPrevented` by
  * design ("an open dialog owns Escape", use-session-panel-state.ts). A rail
  * click leaves the pointer on a `Hint`-wrapped button and focus inside it, so
- * both doors have to be shut:
+ * both doors have to be shut before Escape can reach the panel:
  *
- * One real click on the floating card's own Summary heading shuts every door at
+ * One real click on the floating card's own Summary heading shuts both doors at
  * once, which merely moving the pointer does not:
  *
  *   - a pointerdown closes an open Radix tooltip outright, instead of racing its
- *     open/close delays — a `toHaveCount(0)` wait can otherwise pass in the
- *     window BEFORE a scheduled layer opens.
+ *     open/close delays.
  *   - it takes hover off the rail without parking on something else that opens a
  *     layer of its own. Parking over the sessions sidebar opens a row's
  *     `SessionMetaCard` hover card, which swallows Escape exactly like a tooltip
@@ -234,15 +233,29 @@ async function selectChat(page: Page, chatId: string): Promise<void> {
  *     toggle. And it is inside the panel root, so light dismiss reads it as
  *     "inside" and the card stays up.
  *
- * The wait is on `[data-radix-popper-content-wrapper]` — the one selector that
- * covers tooltips, hover cards, popovers and menus alike.
+ * That click cannot guarantee every door is shut, though: a hover-driven layer
+ * (a tooltip or hover card whose open timer was already ticking) can still open
+ * AFTER the click, inside this helper's own budget, and it would eat the next
+ * Escape the same way. So this presses Escape up to 3 times, same shape as
+ * `closeMenus` in helpers/tauri/menus.ts — press, give it a short settle to
+ * consume, re-read the outcome — and returns as soon as the overlay is gone. A
+ * press that gets swallowed by a transient layer just costs one more iteration
+ * instead of failing the test; the caller still owns the authoritative
+ * `expect(overlay).toHaveCount(0)` assertion, so a genuine regression fails
+ * there and names the overlay.
  */
-async function settleForEscape(page: Page): Promise<void> {
-  await page
-    .getByTestId('session-panel-overlay')
-    .getByTestId('session-panel-section-summary')
-    .click({ position: { x: 4, y: 4 } });
-  await expect(page.locator('[data-radix-popper-content-wrapper]')).toHaveCount(0, { timeout: 5_000 });
+async function dismissOverlayWithEscape(page: Page): Promise<void> {
+  const overlay = page.getByTestId('session-panel-overlay');
+  await overlay.getByTestId('session-panel-section-summary').click({ position: { x: 4, y: 4 } });
+  for (let attempt = 0; attempt < 3 && (await overlay.count()) > 0; attempt++) {
+    await page.keyboard.press('Escape');
+    // Each press needs its own settle before the count is read again — firing
+    // them back-to-back sends every Escape into the same animation window,
+    // where Radix has already handled the first and ignores the rest.
+    await overlay.waitFor({ state: 'detached', timeout: 1_500 }).catch(() => {
+      /* expected when a transient layer ate this press instead of the panel */
+    });
+  }
 }
 
 /**
@@ -410,8 +423,7 @@ test.describe('§session-panel — modes, rail, activity, launch', () => {
     // Not a modal: the card floats over the thread but the inline card stays absent.
     await expect(page.getByTestId('session-panel')).toHaveCount(0);
 
-    await settleForEscape(page);
-    await page.keyboard.press('Escape');
+    await dismissOverlayWithEscape(page);
     await expect(overlay).toHaveCount(0, { timeout: 5_000 });
   });
 
@@ -448,7 +460,8 @@ test.describe('§session-panel — modes, rail, activity, launch', () => {
 
   // Dismissal here is a SECOND right-click, not Escape, and that is deliberate:
   // a right-click leaves the rail button's tooltip open, and that tooltip owns
-  // the first Escape (see `settleForEscape`). Escape-to-dismiss is covered from the
+  // the first Escape (see `dismissOverlayWithEscape`, which retries a press an
+  // open layer swallows this way). Escape-to-dismiss is covered from the
   // left-click route above; this asserts the re-click-to-close branch for a
   // NON-summary section, which nothing else reaches.
   test('right-clicking the rail launch button floats the panel on the Launch section', async () => {


### PR DESCRIPTION
Closes the flaky pair that has been costing a two-minute test timeout per occurrence: the three `git-branch` branch-flyout cases and `session-panel`'s rail-Escape dismissal. Test-side only — no product change.

## The two races

**Branch flyout.** `openBranchPopover` waited only for the search field, and a branch row being *visible* is not evidence the list reloaded: `BranchPopover` keeps its `branches` state across a close and only refetches from the `open`-gated effect, so every reopen renders the previous open's stale rows instantly. The real reload then landed mid-test, re-sorted the list, and closed a flyout already opened on the stale row's position. Confirmed with a MutationObserver: reopening right after a CLI-side `checkoutBase()` showed the stale row swap out a beat after a row-presence wait had resolved. The fix waits on the `/git/branches` GET — the only signal honest on both the first open and every reopen.

**Rail-Escape.** The settle helper required the page to contain zero Radix popper layers before pressing Escape, a precondition a hover-driven layer can invalidate at any moment; the helper's own 5s budget expired before Escape was ever pressed. It now presses Escape up to 3 times and reads the outcome between presses, the same shape as `closeMenus`. The caller keeps the authoritative `toHaveCount(0)` assertion, so a genuine regression still fails there and names the overlay.

Alongside: the spec adopts the shared `waitForDialogScrimsGone` (5 other specs already use it; this spec opens four kinds of dialog and had no scrim wait), and every `git-submenu-*` click is bounded to its own 5s timeout. Retries are permitted only around side-effect-free opens — never an item click, since a retried merge or checkout would run the git action twice.

## Verification

Three consecutive joint runs of both spec files, 2026-08-11 on an idle machine:

| run | result |
|---|---|
| 1 | 42 passed, 0 flaky, 0 failed (52.9s) |
| 2 | 42 passed, 0 flaky, 0 failed (43.1s) |
| 3 | 42 passed, 0 flaky, 0 failed (42.9s) |

Flyout cases now run in 0.7–1.5s each.

## Known follow-up, not fixed here

During the lane's own acceptance runs under heavy load (load average 6–8), `quick actions: fetch, update all, and push current` failed with `git rev-parse e2e-workspace` reporting "unknown revision" for a full 15s poll *after* the app had shown a "Pushed to origin/e2e-workspace" success toast. It does not reproduce on an idle machine and never failed in standalone runs of `git-branch.spec.ts`. Out of scope here; worth its own todo — likely daemon-side (push success reported before the ref-write is visible) or effective-path resolution under load.

## Review notes

- `openSubmenu`'s retry loop duplicates its `expect(submenu).toBeVisible()` in two branches; a try/catch on the first attempt followed by a plain second would read better. Cosmetic.
- `branchesLoaded` is created before the trigger click (correct — avoids the race), but if the `git-branch-search` assertion throws first the promise is never awaited, which surfaces as an unhandled rejection alongside the real failure. Minor hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)