### PR TITLE
fix(github-sync): real token flow — imports stop failing with 401 Bad credentials

### DIFF
--- a/.changeset/github-sync-real-token.md
+++ b/.changeset/github-sync-real-token.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+GitHub sync: store a real personal access token instead of the Automations placeholder. The link dialog now takes a pasted PAT, the sync pill menu gains "Update GitHub token…", and an auth failure in the import dialog shows a readable message with a one-click path to fix the token. The daemon also stops offering pull requests as importable issues.

--- a/packages/core-rs/crates/mainframe-automations/src/github_issues.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_issues.rs
@@ -73,7 +73,13 @@ impl GitHubIssuesClient {
             let response = check_status(self.send(request).await?).await?;
             let next = next_page_url(response.headers());
             let page: Vec<RawIssue> = parse_body(response).await?;
-            issues.extend(page.into_iter().map(IssueSnapshot::from));
+            // The issues endpoint returns pull requests too — a PR paired
+            // with a task would sync task edits into the PR, so drop them.
+            issues.extend(
+                page.into_iter()
+                    .filter(|raw| !raw.is_pull_request())
+                    .map(IssueSnapshot::from),
+            );
             match next {
                 Some(next_url) => url = next_url,
                 None => break,

--- a/packages/core-rs/crates/mainframe-automations/src/github_issues_errors_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_issues_errors_tests.rs
@@ -3,11 +3,31 @@
 //! `github_issues_tests.rs` to keep both files under the 300-line limit.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::github_issues::GitHubError;
-use super::github_issues_tests::{client, repo};
+use super::github_issues_tests::{client, issue_json, repo};
+
+#[tokio::test]
+async fn requests_carry_a_user_agent() {
+    // The live API answers 403 "Request forbidden by administrative rules" to a
+    // request without one; reqwest sends none by default, so only a header
+    // assertion catches the regression before it reaches GitHub.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/qlan/mainframe/issues/5"))
+        .and(header("user-agent", "mainframe"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(issue_json(5, "t", "open")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client(server.uri())
+        .get_issue(&repo(), 5, "tok")
+        .await
+        .unwrap();
+}
 
 /// Mounts a single `GET issues/1` response and returns the error `get_issue` produces.
 async fn get_issue_error(response: ResponseTemplate, token: &str) -> GitHubError {

--- a/packages/core-rs/crates/mainframe-automations/src/github_issues_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_issues_tests.rs
@@ -23,7 +23,7 @@ pub(super) fn repo() -> RepoRef {
     }
 }
 
-fn issue_json(number: u64, title: &str, state: &str) -> serde_json::Value {
+pub(super) fn issue_json(number: u64, title: &str, state: &str) -> serde_json::Value {
     json!({
         "number": number, "title": title, "body": "body text",
         "labels": [{"name": "bug"}], "state": state,
@@ -88,23 +88,30 @@ async fn list_open_issues_follows_pagination() {
 }
 
 #[tokio::test]
-async fn requests_carry_a_user_agent() {
-    // The live API answers 403 "Request forbidden by administrative rules" to a
-    // request without one; reqwest sends none by default, so only a header
-    // assertion catches the regression before it reaches GitHub.
+async fn list_open_issues_drops_pull_requests() {
+    // The issues endpoint also returns PRs, marked by a `pull_request` key.
     let server = MockServer::start().await;
+    let mut pull_request = issue_json(2, "a pull request", "open");
+    pull_request["pull_request"] =
+        json!({"url": "https://api.github.com/repos/qlan/mainframe/pulls/2"});
     Mock::given(method("GET"))
-        .and(path("/repos/qlan/mainframe/issues/5"))
-        .and(header("user-agent", "mainframe"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(issue_json(5, "t", "open")))
+        .and(path("/repos/qlan/mainframe/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            issue_json(1, "one", "open"),
+            pull_request,
+            issue_json(3, "three", "open"),
+        ])))
         .expect(1)
         .mount(&server)
         .await;
 
-    client(server.uri())
-        .get_issue(&repo(), 5, "tok")
+    let issues = client(server.uri())
+        .list_open_issues(&repo(), "tok")
         .await
         .unwrap();
+
+    let numbers: Vec<u64> = issues.iter().map(|issue| issue.number).collect();
+    assert_eq!(numbers, vec![1, 3]);
 }
 
 #[tokio::test]

--- a/packages/core-rs/crates/mainframe-automations/src/github_issues_types.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_issues_types.rs
@@ -87,6 +87,15 @@ pub(crate) struct RawIssue {
     state: String,
     html_url: String,
     updated_at: String,
+    // GitHub's issues endpoints return pull requests too, marked by this key.
+    #[serde(default)]
+    pull_request: Option<serde::de::IgnoredAny>,
+}
+
+impl RawIssue {
+    pub(crate) fn is_pull_request(&self) -> bool {
+        self.pull_request.is_some()
+    }
 }
 
 impl From<RawIssue> for IssueSnapshot {

--- a/packages/ui/src/features/tasks/TasksBoard.tsx
+++ b/packages/ui/src/features/tasks/TasksBoard.tsx
@@ -28,6 +28,7 @@ import { LinkRepoDialog } from './github/LinkRepoDialog';
 import { ImportIssuesDialog } from './github/ImportIssuesDialog';
 import { PublishTaskDialog } from './github/PublishTaskDialog';
 import { SyncReportDialog } from './github/SyncReportDialog';
+import { UpdateTokenDialog } from './github/UpdateTokenDialog';
 import { useGitHubSyncStore } from './github/use-github-sync-store';
 import type { Todo } from '@/lib/api/todos';
 
@@ -199,6 +200,7 @@ export function TasksBoard({ port, projectId, onStartSession, onClose }: Props):
       <ImportIssuesDialog />
       <PublishTaskDialog />
       <SyncReportDialog />
+      <UpdateTokenDialog />
     </div>
   );
 }

--- a/packages/ui/src/features/tasks/github/GitHubSyncControl.tsx
+++ b/packages/ui/src/features/tasks/github/GitHubSyncControl.tsx
@@ -7,7 +7,7 @@
  * GitHub brand mark, and a hand-rolled one is not worth the drift.
  */
 import React from 'react';
-import { ChevronDown, CircleDot, Download, FileText, RefreshCw, Unlink } from 'lucide-react';
+import { ChevronDown, CircleDot, Download, FileText, KeyRound, RefreshCw, Unlink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Hint } from '@/components/ui/hint';
 import {
@@ -90,6 +90,11 @@ export function GitHubSyncControl(): React.ReactElement {
           >
             <FileText className={ITEM_ICON} aria-hidden />
             Last sync report
+          </DropdownMenuItem>
+
+          <DropdownMenuItem data-testid="tasks-github-menu-token" onSelect={() => openDialog({ kind: 'token' })}>
+            <KeyRound className={ITEM_ICON} aria-hidden />
+            Update GitHub token…
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />

--- a/packages/ui/src/features/tasks/github/GitHubTokenField.tsx
+++ b/packages/ui/src/features/tasks/github/GitHubTokenField.tsx
@@ -1,0 +1,79 @@
+/**
+ * GitHubTokenField — a paste-a-PAT input with a save button.
+ *
+ * The sync feature talks to the real GitHub API, so unlike the Automations
+ * placeholder connect (`CredentialConnect`) it must store a token that
+ * actually authenticates. The backing store is still the shared automations
+ * credential store, under the fixed `github` label the link rows reference.
+ */
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { mfToast } from '@/lib/toast';
+import { useAutomationsStore } from '@/features/automations/data/use-automations-store';
+
+export const GITHUB_CREDENTIAL_LABEL = 'github';
+
+export function useSaveGitHubToken(): { busy: boolean; save: (token: string) => Promise<boolean> } {
+  const gateway = useAutomationsStore((s) => s.gateway);
+  const addCredential = useAutomationsStore((s) => s.addCredential);
+  const [busy, setBusy] = React.useState(false);
+
+  const save = async (token: string): Promise<boolean> => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      await gateway.putCredential(GITHUB_CREDENTIAL_LABEL, token);
+      addCredential(GITHUB_CREDENTIAL_LABEL);
+      return true;
+    } catch (err) {
+      mfToast.error('Could not save the GitHub token', {
+        description: err instanceof Error ? err.message : undefined,
+      });
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return { busy, save };
+}
+
+export interface GitHubTokenFieldProps {
+  busy: boolean;
+  onSave: (token: string) => void;
+  testId: string;
+}
+
+export function GitHubTokenField({ busy, onSave, testId }: GitHubTokenFieldProps): React.ReactElement {
+  const [token, setToken] = React.useState('');
+  const trimmed = token.trim();
+  const canSave = trimmed.length > 0 && !busy;
+
+  const submit = (): void => {
+    if (canSave) onSave(trimmed);
+  };
+
+  return (
+    <div className="flex w-full items-center gap-2">
+      <Input
+        data-testid={`${testId}-input`}
+        type="password"
+        value={token}
+        onChange={(event) => setToken(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="ghp_… or github_pat_…"
+        autoComplete="off"
+        className="h-8 flex-1 font-mono text-xs"
+      />
+      <Button data-testid={`${testId}-save`} size="sm" disabled={!canSave} onClick={submit}>
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/features/tasks/github/ImportIssuesDialog.tsx
+++ b/packages/ui/src/features/tasks/github/ImportIssuesDialog.tsx
@@ -65,7 +65,7 @@ function IssueRow({ issue, selected, onToggle }: RowProps): React.ReactElement {
 }
 
 export function ImportIssuesDialog(): React.ReactElement | null {
-  const { dialog, issues, error, importIssues, closeDialog } = useGitHubSyncStore();
+  const { dialog, issues, error, errorAuth, importIssues, openDialog, closeDialog } = useGitHubSyncStore();
   const [selected, setSelected] = React.useState<ReadonlySet<number>>(new Set());
   const isOpen = dialog?.kind === 'import';
 
@@ -113,9 +113,21 @@ export function ImportIssuesDialog(): React.ReactElement | null {
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           {issues.length === 0 ? (
             error !== null ? (
-              <p data-testid="tasks-github-import-error" className="px-2 py-4 text-sm text-destructive">
-                {error}
-              </p>
+              <div className="flex flex-col items-start gap-2 px-2 py-4">
+                <p data-testid="tasks-github-import-error" className="text-sm text-destructive">
+                  {error}
+                </p>
+                {errorAuth && (
+                  <Button
+                    data-testid="tasks-github-import-update-token"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openDialog({ kind: 'token', returnTo: 'import' })}
+                  >
+                    Update GitHub token…
+                  </Button>
+                )}
+              </div>
             ) : (
               <p className="px-2 py-4 text-sm text-muted-foreground">No open issues to import.</p>
             )

--- a/packages/ui/src/features/tasks/github/LinkRepoDialog.tsx
+++ b/packages/ui/src/features/tasks/github/LinkRepoDialog.tsx
@@ -18,12 +18,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { listGitHubRemotes, type GitHubRemote } from '@/lib/api/git';
-import { CredentialConnect } from '@/features/automations/steps/CredentialConnect';
 import { useAutomationsStore } from '@/features/automations/data/use-automations-store';
 import { runOrToast } from './run-or-toast';
+import { GITHUB_CREDENTIAL_LABEL, GitHubTokenField, useSaveGitHubToken } from './GitHubTokenField';
 import { useGitHubSyncStore } from './use-github-sync-store';
-
-const GITHUB_SERVICE = 'github';
 
 function RemoteRow({ remote }: { remote: GitHubRemote }): React.ReactElement {
   return (
@@ -37,14 +35,31 @@ function RemoteRow({ remote }: { remote: GitHubRemote }): React.ReactElement {
 
 export function LinkRepoDialog(): React.ReactElement {
   const { port, projectId, linkRepo, closeDialog } = useGitHubSyncStore();
-  const connectedCredential = useAutomationsStore((s) =>
-    s.credentials.includes(GITHUB_SERVICE) ? GITHUB_SERVICE : null,
-  );
+  const gateway = useAutomationsStore((s) => s.gateway);
+  const { busy, save } = useSaveGitHubToken();
 
   const [remotes, setRemotes] = React.useState<GitHubRemote[]>([]);
   const [loadError, setLoadError] = React.useState<string | null>(null);
   const [selected, setSelected] = React.useState<string | null>(null);
-  const [connected, setConnected] = React.useState<string | null>(null);
+  const [connected, setConnected] = React.useState(false);
+  const [editingToken, setEditingToken] = React.useState(false);
+
+  // The automations store only knows the labels once its surface has loaded,
+  // so the connected state is seeded from the daemon, not from that store.
+  React.useEffect(() => {
+    let live = true;
+    void gateway
+      .listCredentialLabels()
+      .then((labels) => {
+        if (live) setConnected(labels.includes(GITHUB_CREDENTIAL_LABEL));
+      })
+      .catch(() => {
+        /* expected — an unreachable daemon reads as "not connected" */
+      });
+    return () => {
+      live = false;
+    };
+  }, [gateway]);
 
   React.useEffect(() => {
     if (port === null || projectId === null) return;
@@ -61,19 +76,25 @@ export function LinkRepoDialog(): React.ReactElement {
     };
   }, [port, projectId]);
 
-  const credentialLabel = connected ?? connectedCredential;
   const remote = remotes.find((candidate) => candidate.name === selected);
-  const canConfirm = remote !== undefined && credentialLabel !== null && projectId !== null;
+  const canConfirm = remote !== undefined && connected && projectId !== null;
+
+  const saveToken = async (token: string): Promise<void> => {
+    if (await save(token)) {
+      setConnected(true);
+      setEditingToken(false);
+    }
+  };
 
   const confirm = (): Promise<void> =>
     runOrToast('Could not link the repository', async () => {
-      if (remote === undefined || credentialLabel === null || projectId === null) return;
+      if (remote === undefined || !connected || projectId === null) return;
       await linkRepo({
         projectId,
         owner: remote.owner,
         repo: remote.repo,
         remoteName: remote.name,
-        credentialLabel,
+        credentialLabel: GITHUB_CREDENTIAL_LABEL,
       });
       closeDialog();
     });
@@ -109,13 +130,32 @@ export function LinkRepoDialog(): React.ReactElement {
             </RadioGroup>
           )}
 
-          <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
-            <span className="text-xs text-muted-foreground">GitHub credential</span>
-            <CredentialConnect
-              service={GITHUB_SERVICE}
-              testId="tasks-github-credential"
-              onChange={(label) => setConnected(label ?? null)}
-            />
+          <div className="flex flex-col gap-2 border-t border-border pt-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">GitHub token</span>
+              {connected && !editingToken && (
+                <span data-testid="tasks-github-credential-connected" className="inline-flex items-center gap-1.5">
+                  <span className="size-1.5 shrink-0 rounded-full bg-success" aria-hidden />
+                  <span className="text-xs text-foreground">connected</span>
+                  <Button
+                    data-testid="tasks-github-credential-replace"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingToken(true)}
+                    className="h-6 px-1.5 text-xs text-muted-foreground"
+                  >
+                    Replace…
+                  </Button>
+                </span>
+              )}
+            </div>
+            {(!connected || editingToken) && (
+              <GitHubTokenField
+                busy={busy}
+                onSave={(token) => void saveToken(token)}
+                testId="tasks-github-credential"
+              />
+            )}
           </div>
         </div>
 

--- a/packages/ui/src/features/tasks/github/UpdateTokenDialog.tsx
+++ b/packages/ui/src/features/tasks/github/UpdateTokenDialog.tsx
@@ -1,0 +1,46 @@
+/**
+ * UpdateTokenDialog — replaces the stored GitHub token without touching the
+ * repository link. Reached from the sync pill's menu, and from the import
+ * dialog's auth-failure state (which passes `returnTo: 'import'` so a saved
+ * token flows straight back into a fresh issue fetch).
+ */
+import React from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { mfToast } from '@/lib/toast';
+import { GitHubTokenField, useSaveGitHubToken } from './GitHubTokenField';
+import { useGitHubSyncStore } from './use-github-sync-store';
+
+export function UpdateTokenDialog(): React.ReactElement | null {
+  const { dialog, openDialog, closeDialog } = useGitHubSyncStore();
+  const { busy, save } = useSaveGitHubToken();
+
+  if (dialog?.kind !== 'token') return null;
+  const returnTo = dialog.returnTo;
+
+  const onSave = async (token: string): Promise<void> => {
+    if (!(await save(token))) return;
+    mfToast.success('GitHub token updated');
+    if (returnTo === 'import') openDialog({ kind: 'import' });
+    else closeDialog();
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) closeDialog();
+      }}
+    >
+      <DialogContent data-testid="tasks-github-token-dialog">
+        <DialogHeader>
+          <DialogTitle>Update GitHub token</DialogTitle>
+          <DialogDescription>
+            Paste a personal access token that can read and write this repository&apos;s issues. It replaces the token
+            stored on this machine.
+          </DialogDescription>
+        </DialogHeader>
+        <GitHubTokenField busy={busy} onSave={(token) => void onSave(token)} testId="tasks-github-token" />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/features/tasks/github/__tests__/GitHubSyncControl.test.tsx
+++ b/packages/ui/src/features/tasks/github/__tests__/GitHubSyncControl.test.tsx
@@ -11,12 +11,16 @@
  *  2. Clicking it opens the link dialog (`openDialog({ kind: 'link' })`).
  *  3. Linked -> renders `tasks-github-pill` showing `owner/repo` and the syncedAgo text
  *     ("never synced" / "synced ... ago").
- *  4. Clicking the pill opens the menu with its four items in order, each carrying its
- *     frozen testid and copy: Sync now / Import issues… / Last sync report / Unlink repo….
+ *  4. Clicking the pill opens the menu with its five items in order, each carrying its
+ *     frozen testid and copy: Sync now / Import issues… / Last sync report /
+ *     Update GitHub token… / Unlink repo….
  *  5. `tasks-github-menu-report` is disabled until a run exists (`lastRun` present).
  *  6. `tasks-github-menu-sync` is disabled while `running`, and the pill reads "syncing…" (AC35).
+ *     `tasks-github-menu-token` stays enabled during a run — repairing the token is how a
+ *     run that failed on the credential gets fixed.
  *  7. Clicking an enabled `tasks-github-menu-sync` calls `sync()`; clicking
- *     `tasks-github-menu-import` calls `openDialog({ kind: 'import' })`.
+ *     `tasks-github-menu-import` calls `openDialog({ kind: 'import' })`; clicking
+ *     `tasks-github-menu-token` calls `openDialog({ kind: 'token' })` with no return target.
  */
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -136,7 +140,7 @@ describe('GitHubSyncControl — menu', () => {
     storeState.link = LINK_FIXTURE;
   });
 
-  it('opens with the four items reading Sync now / Import issues… / Last sync report / Unlink repo…', async () => {
+  it('opens with the five items reading Sync now / Import issues… / Last sync report / Update GitHub token… / Unlink repo…', async () => {
     render(
       <TooltipProvider>
         <GitHubSyncControl />
@@ -147,6 +151,7 @@ describe('GitHubSyncControl — menu', () => {
     expect(screen.getByTestId('tasks-github-menu-sync').textContent).toContain('Sync now');
     expect(screen.getByTestId('tasks-github-menu-import').textContent).toContain('Import issues…');
     expect(screen.getByTestId('tasks-github-menu-report').textContent).toContain('Last sync report');
+    expect(screen.getByTestId('tasks-github-menu-token').textContent).toContain('Update GitHub token…');
     expect(screen.getByTestId('tasks-github-menu-unlink').textContent).toContain('Unlink repo…');
   });
 
@@ -191,6 +196,28 @@ describe('GitHubSyncControl — menu', () => {
     await userEvent.click(screen.getByTestId('tasks-github-pill'));
     await userEvent.click(screen.getByTestId('tasks-github-menu-sync'));
     expect(sync).toHaveBeenCalledOnce();
+  });
+
+  it('calls openDialog({ kind: "token" }) with no return target when tasks-github-menu-token is clicked', async () => {
+    render(
+      <TooltipProvider>
+        <GitHubSyncControl />
+      </TooltipProvider>,
+    );
+    await userEvent.click(screen.getByTestId('tasks-github-pill'));
+    await userEvent.click(screen.getByTestId('tasks-github-menu-token'));
+    expect(openDialog).toHaveBeenCalledWith({ kind: 'token' });
+  });
+
+  it('leaves tasks-github-menu-token enabled while a run is in progress', async () => {
+    storeState.running = true;
+    render(
+      <TooltipProvider>
+        <GitHubSyncControl />
+      </TooltipProvider>,
+    );
+    await userEvent.click(screen.getByTestId('tasks-github-pill'));
+    expect(screen.getByTestId('tasks-github-menu-token').getAttribute('aria-disabled')).not.toBe('true');
   });
 
   it('calls openDialog({ kind: "import" }) when tasks-github-menu-import is clicked', async () => {

--- a/packages/ui/src/features/tasks/github/__tests__/GitHubTokenField.test.tsx
+++ b/packages/ui/src/features/tasks/github/__tests__/GitHubTokenField.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+/**
+ * GitHubTokenField.test.tsx
+ *
+ * The paste-a-PAT field and its saving hook (`../GitHubTokenField`), which
+ * replaced the Automations placeholder `CredentialConnect` for GitHub sync —
+ * that one stored a fake token GitHub answered with 401.
+ *
+ * Behaviors covered:
+ *  1. Save is disabled while the input is empty or whitespace-only, and while busy.
+ *  2. Clicking Save and pressing Enter both submit the trimmed token.
+ *  3. useSaveGitHubToken writes the token under the fixed `github` label and
+ *     registers that label with the automations store.
+ *  4. A gateway failure toasts and reports failure, leaving no credential behind.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock('@/lib/toast', () => ({
+  mfToast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+import { useAutomationsStore } from '@/features/automations/data/use-automations-store';
+import { createFakeGateway as fakeGateway } from '@/features/automations/data/__tests__/fake-gateway';
+import { GITHUB_CREDENTIAL_LABEL, GitHubTokenField, useSaveGitHubToken } from '../GitHubTokenField';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAutomationsStore.setState({ credentials: [], gateway: fakeGateway() });
+});
+
+describe('GITHUB_CREDENTIAL_LABEL', () => {
+  it('is the fixed "github" label the link rows reference', () => {
+    expect(GITHUB_CREDENTIAL_LABEL).toBe('github');
+  });
+});
+
+describe('GitHubTokenField — save enablement', () => {
+  it('disables Save while the input is empty', () => {
+    render(<GitHubTokenField busy={false} onSave={vi.fn()} testId="tasks-github-token" />);
+    expect(screen.getByTestId('tasks-github-token-save')).toBeDisabled();
+  });
+
+  it('keeps Save disabled for a whitespace-only token', async () => {
+    render(<GitHubTokenField busy={false} onSave={vi.fn()} testId="tasks-github-token" />);
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), '   ');
+    expect(screen.getByTestId('tasks-github-token-save')).toBeDisabled();
+  });
+
+  it('enables Save once a token is typed', async () => {
+    render(<GitHubTokenField busy={false} onSave={vi.fn()} testId="tasks-github-token" />);
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), 'ghp_abc123');
+    expect(screen.getByTestId('tasks-github-token-save')).toBeEnabled();
+  });
+
+  it('disables Save while a save is in flight', async () => {
+    const onSave = vi.fn();
+    render(<GitHubTokenField busy onSave={onSave} testId="tasks-github-token" />);
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), 'ghp_abc123');
+
+    expect(screen.getByTestId('tasks-github-token-save')).toBeDisabled();
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), '{Enter}');
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});
+
+describe('GitHubTokenField — submission', () => {
+  it('submits the trimmed token when Save is clicked', async () => {
+    const onSave = vi.fn();
+    render(<GitHubTokenField busy={false} onSave={onSave} testId="tasks-github-token" />);
+
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), '  ghp_abc123  ');
+    await userEvent.click(screen.getByTestId('tasks-github-token-save'));
+
+    expect(onSave).toHaveBeenCalledWith('ghp_abc123');
+  });
+
+  it('submits the trimmed token when Enter is pressed in the input', async () => {
+    const onSave = vi.fn();
+    render(<GitHubTokenField busy={false} onSave={onSave} testId="tasks-github-token" />);
+
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), '  ghp_abc123  {Enter}');
+
+    expect(onSave).toHaveBeenCalledWith('ghp_abc123');
+  });
+
+  it('does not submit on Enter with an empty input', async () => {
+    const onSave = vi.fn();
+    render(<GitHubTokenField busy={false} onSave={onSave} testId="tasks-github-token" />);
+
+    await userEvent.type(screen.getByTestId('tasks-github-token-input'), '{Enter}');
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('renders the input as a password field so the token is not shoulder-readable', () => {
+    render(<GitHubTokenField busy={false} onSave={vi.fn()} testId="tasks-github-token" />);
+    expect(screen.getByTestId('tasks-github-token-input').getAttribute('type')).toBe('password');
+  });
+});
+
+describe('useSaveGitHubToken', () => {
+  it('stores the token under the "github" label and registers it with the automations store', async () => {
+    const putCredential = vi.fn(async () => {});
+    useAutomationsStore.setState({ gateway: fakeGateway({ putCredential }) });
+
+    const { result } = renderHook(() => useSaveGitHubToken());
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await result.current.save('ghp_live_abc');
+    });
+
+    expect(putCredential).toHaveBeenCalledWith('github', 'ghp_live_abc');
+    expect(saved).toBe(true);
+    expect(useAutomationsStore.getState().credentials).toEqual(['github']);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts and reports failure without registering a credential when the gateway rejects', async () => {
+    useAutomationsStore.setState({
+      gateway: fakeGateway({
+        putCredential: async () => {
+          throw new Error('keyring locked');
+        },
+      }),
+    });
+
+    const { result } = renderHook(() => useSaveGitHubToken());
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await result.current.save('ghp_live_abc');
+    });
+
+    expect(saved).toBe(false);
+    expect(toastError).toHaveBeenCalledWith('Could not save the GitHub token', { description: 'keyring locked' });
+    expect(useAutomationsStore.getState().credentials).toEqual([]);
+  });
+});

--- a/packages/ui/src/features/tasks/github/__tests__/ImportIssuesDialog.test.tsx
+++ b/packages/ui/src/features/tasks/github/__tests__/ImportIssuesDialog.test.tsx
@@ -19,6 +19,9 @@
  *  5. The footer reads "Import {n} issues" for the current selection count.
  *  6. `tasks-github-import-confirm` calls `importIssues` with exactly the
  *     selected, importable issue numbers (never a paired one).
+ *  7. A rejected credential (`errorAuth`) offers `tasks-github-import-update-token`,
+ *     which opens the token dialog with `returnTo: 'import'`; any other failure
+ *     offers no such button.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -33,13 +36,15 @@ const ISSUES: RemoteIssue[] = [
 
 const importIssues = vi.fn();
 const closeDialog = vi.fn();
+const openDialog = vi.fn();
 
 let dialog: null | { kind: 'import' } | { kind: 'link' };
 let issues: RemoteIssue[];
 let error: string | null;
+let errorAuth: boolean;
 
 vi.mock('../use-github-sync-store', () => ({
-  useGitHubSyncStore: () => ({ dialog, issues, error, importIssues, closeDialog }),
+  useGitHubSyncStore: () => ({ dialog, issues, error, errorAuth, importIssues, openDialog, closeDialog }),
 }));
 
 const { ImportIssuesDialog } = await import('../ImportIssuesDialog');
@@ -49,6 +54,7 @@ beforeEach(() => {
   dialog = { kind: 'import' };
   issues = ISSUES;
   error = null;
+  errorAuth = false;
 });
 
 describe('ImportIssuesDialog — visibility', () => {
@@ -90,6 +96,39 @@ describe('ImportIssuesDialog — load failure', () => {
     render(<ImportIssuesDialog />);
     expect(screen.getByText('No open issues to import.')).toBeTruthy();
     expect(screen.queryByTestId('tasks-github-import-error')).toBeNull();
+  });
+});
+
+describe('ImportIssuesDialog — rejected credential', () => {
+  const AUTH_ERROR = 'GitHub rejected the stored credential — the token is missing, expired, or revoked.';
+
+  it('offers the token fix when GitHub refused the stored credential', () => {
+    issues = [];
+    error = AUTH_ERROR;
+    errorAuth = true;
+    render(<ImportIssuesDialog />);
+    expect(screen.getByTestId('tasks-github-import-error').textContent).toBe(AUTH_ERROR);
+    expect(screen.getByTestId('tasks-github-import-update-token').textContent).toContain('Update GitHub token…');
+  });
+
+  it('offers no token fix for a failure that is not a credential problem', () => {
+    issues = [];
+    error = 'daemon unreachable';
+    errorAuth = false;
+    render(<ImportIssuesDialog />);
+    expect(screen.getByTestId('tasks-github-import-error').textContent).toBe('daemon unreachable');
+    expect(screen.queryByTestId('tasks-github-import-update-token')).toBeNull();
+  });
+
+  it('opens the token dialog set to return to the import dialog', async () => {
+    issues = [];
+    error = AUTH_ERROR;
+    errorAuth = true;
+    render(<ImportIssuesDialog />);
+
+    await userEvent.click(screen.getByTestId('tasks-github-import-update-token'));
+
+    expect(openDialog).toHaveBeenCalledWith({ kind: 'token', returnTo: 'import' });
   });
 });
 

--- a/packages/ui/src/features/tasks/github/__tests__/LinkRepoDialog.test.tsx
+++ b/packages/ui/src/features/tasks/github/__tests__/LinkRepoDialog.test.tsx
@@ -2,27 +2,29 @@
 /**
  * LinkRepoDialog.test.tsx
  *
- * Red-phase test for the link dialog (`../LinkRepoDialog`, not yet created —
- * task 36 of the plan implements it against this file, per the spec's
- * "Linking a project to a repository" section and task 30's
- * `listGitHubRemotes(port, projectId, chatId?)` client, added to `lib/api/git.ts`).
+ * The link dialog (`../LinkRepoDialog`), per the spec's "Linking a project to
+ * a repository" section and task 30's `listGitHubRemotes(port, projectId,
+ * chatId?)` client in `lib/api/git.ts`.
  *
  * Behaviors covered:
  *  1. Lists exactly the remotes the route returned, one radio per remote, the derived
  *     `owner/repo` as the label and the remote name as secondary text.
  *  2. `tasks-github-link-confirm` is disabled with neither a remote selected nor a
- *     credential connected, and while only one of the two is satisfied.
+ *     token stored, and while only one of the two is satisfied.
  *  3. `tasks-github-link-confirm` is enabled once both a remote is selected and a
- *     credential is connected, and confirming calls `linkRepo` with the selected remote's
- *     owner/repo/remoteName and the connected credential label.
- *  4. `tasks-github-link-cancel` calls `closeDialog()`.
+ *     token is stored, and confirming calls `linkRepo` with the selected remote's
+ *     owner/repo/remoteName and the `github` credential label.
+ *  4. Connectedness is seeded from the daemon's credential labels: 'github' present
+ *     shows the connected pill; absent shows the paste-a-PAT field.
+ *  5. Pasting and saving a token stores it and flips the dialog to connected.
+ *  6. `tasks-github-link-cancel` calls `closeDialog()`.
  *
- * The credential row reuses `CredentialConnect` (an existing, separately tested
- * component) — stubbed here to a single button that fires `onChange`, so this file
- * exercises only LinkRepoDialog's own confirm-enablement logic.
+ * The token row is the real `GitHubTokenField` on the real automations store
+ * with a fake gateway — the old `CredentialConnect` stub is gone, along with
+ * the placeholder token GitHub rejected with a 401.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const PORT = 31415;
@@ -37,13 +39,8 @@ vi.mock('../use-github-sync-store', () => ({
   useGitHubSyncStore: () => ({ port: PORT, projectId: PROJECT_ID, linkRepo, closeDialog }),
 }));
 
-vi.mock('@/features/automations/steps/CredentialConnect', () => ({
-  CredentialConnect: ({ onChange }: { onChange: (label: string | undefined) => void }) => (
-    <button data-testid="stub-credential-connect" onClick={() => onChange('github-creds')}>
-      Connect GitHub
-    </button>
-  ),
-}));
+import { useAutomationsStore } from '@/features/automations/data/use-automations-store';
+import { createFakeGateway as fakeGateway } from '@/features/automations/data/__tests__/fake-gateway';
 
 const { LinkRepoDialog } = await import('../LinkRepoDialog');
 
@@ -52,9 +49,15 @@ const REMOTES = [
   { name: 'upstream', owner: 'qlan-ro', repo: 'mainframe-fork' },
 ];
 
+/** Seeds the daemon's stored credential labels the dialog reads connectedness from. */
+const withStoredLabels = (labels: string[]): void => {
+  useAutomationsStore.setState({ credentials: [], gateway: fakeGateway({ listCredentialLabels: async () => labels }) });
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   listGitHubRemotes.mockResolvedValue(REMOTES);
+  withStoredLabels([]);
 });
 
 describe('LinkRepoDialog — remote list', () => {
@@ -78,30 +81,72 @@ describe('LinkRepoDialog — remote list', () => {
   });
 });
 
+describe('LinkRepoDialog — token row', () => {
+  it('shows the paste-a-PAT field when no github token is stored', async () => {
+    render(<LinkRepoDialog />);
+    expect(await screen.findByTestId('tasks-github-credential-input')).toBeTruthy();
+    expect(screen.queryByTestId('tasks-github-credential-connected')).toBeNull();
+  });
+
+  it('shows the connected pill instead of the field when a github token is stored', async () => {
+    withStoredLabels(['github']);
+    render(<LinkRepoDialog />);
+
+    expect((await screen.findByTestId('tasks-github-credential-connected')).textContent).toContain('connected');
+    expect(screen.queryByTestId('tasks-github-credential-input')).toBeNull();
+  });
+
+  it('reveals the field again when Replace… is clicked', async () => {
+    withStoredLabels(['github']);
+    render(<LinkRepoDialog />);
+
+    await userEvent.click(await screen.findByTestId('tasks-github-credential-replace'));
+
+    expect(screen.getByTestId('tasks-github-credential-input')).toBeTruthy();
+    expect(screen.queryByTestId('tasks-github-credential-connected')).toBeNull();
+  });
+
+  it('stores a pasted token under the github label and flips the row to connected', async () => {
+    const putCredential = vi.fn(async () => {});
+    useAutomationsStore.setState({
+      credentials: [],
+      gateway: fakeGateway({ listCredentialLabels: async () => [], putCredential }),
+    });
+    render(<LinkRepoDialog />);
+
+    await userEvent.type(await screen.findByTestId('tasks-github-credential-input'), 'ghp_live_abc');
+    await userEvent.click(screen.getByTestId('tasks-github-credential-save'));
+
+    expect(putCredential).toHaveBeenCalledWith('github', 'ghp_live_abc');
+    expect((await screen.findByTestId('tasks-github-credential-connected')).textContent).toContain('connected');
+  });
+});
+
 describe('LinkRepoDialog — confirm enablement', () => {
-  it('is disabled with neither a remote selected nor a credential connected', async () => {
+  it('is disabled with neither a remote selected nor a token stored', async () => {
     render(<LinkRepoDialog />);
     await screen.findByTestId('tasks-github-remote-origin');
     expect(screen.getByTestId('tasks-github-link-confirm')).toBeDisabled();
   });
 
-  it('stays disabled with a remote selected but no credential connected', async () => {
+  it('stays disabled with a remote selected but no token stored', async () => {
     render(<LinkRepoDialog />);
     await userEvent.click(await screen.findByTestId('tasks-github-remote-origin'));
     expect(screen.getByTestId('tasks-github-link-confirm')).toBeDisabled();
   });
 
-  it('stays disabled with a credential connected but no remote selected', async () => {
+  it('stays disabled with a token stored but no remote selected', async () => {
+    withStoredLabels(['github']);
     render(<LinkRepoDialog />);
-    await screen.findByTestId('tasks-github-remote-origin');
-    await userEvent.click(screen.getByTestId('stub-credential-connect'));
+    await screen.findByTestId('tasks-github-credential-connected');
     expect(screen.getByTestId('tasks-github-link-confirm')).toBeDisabled();
   });
 
-  it('enables once both a remote is selected and a credential is connected, and confirm calls linkRepo', async () => {
+  it('enables once both a remote is selected and a token is stored, and confirm calls linkRepo', async () => {
+    withStoredLabels(['github']);
     render(<LinkRepoDialog />);
+    await screen.findByTestId('tasks-github-credential-connected');
     await userEvent.click(await screen.findByTestId('tasks-github-remote-origin'));
-    await userEvent.click(screen.getByTestId('stub-credential-connect'));
 
     const confirm = screen.getByTestId('tasks-github-link-confirm');
     expect(confirm).toBeEnabled();
@@ -112,7 +157,20 @@ describe('LinkRepoDialog — confirm enablement', () => {
       owner: 'qlan-ro',
       repo: 'mainframe',
       remoteName: 'origin',
-      credentialLabel: 'github-creds',
+      credentialLabel: 'github',
+    });
+  });
+
+  it('enables after a token is pasted and saved with a remote already selected', async () => {
+    render(<LinkRepoDialog />);
+    await userEvent.click(await screen.findByTestId('tasks-github-remote-origin'));
+    expect(screen.getByTestId('tasks-github-link-confirm')).toBeDisabled();
+
+    await userEvent.type(screen.getByTestId('tasks-github-credential-input'), 'ghp_live_abc');
+    await userEvent.click(screen.getByTestId('tasks-github-credential-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tasks-github-link-confirm')).toBeEnabled();
     });
   });
 });

--- a/packages/ui/src/features/tasks/github/__tests__/UpdateTokenDialog.test.tsx
+++ b/packages/ui/src/features/tasks/github/__tests__/UpdateTokenDialog.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/**
+ * UpdateTokenDialog.test.tsx
+ *
+ * The standalone "Update GitHub token" dialog (`../UpdateTokenDialog`), opened
+ * from the sync pill's menu and from the import dialog's auth-failure state.
+ *
+ * Behaviors covered:
+ *  1. Renders only for `{ kind: 'token' }`.
+ *  2. A saved token is stored under the `github` label and confirmed by a toast.
+ *  3. `returnTo: 'import'` reopens the import dialog; without it the dialog closes.
+ *  4. A failed save leaves the dialog open, with no success toast and no navigation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock('@/lib/toast', () => ({
+  mfToast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+const openDialog = vi.fn();
+const closeDialog = vi.fn();
+let dialog: null | { kind: 'import' } | { kind: 'token'; returnTo?: 'import' };
+
+vi.mock('../use-github-sync-store', () => ({
+  useGitHubSyncStore: () => ({ dialog, openDialog, closeDialog }),
+}));
+
+import { useAutomationsStore } from '@/features/automations/data/use-automations-store';
+import { createFakeGateway as fakeGateway } from '@/features/automations/data/__tests__/fake-gateway';
+
+const { UpdateTokenDialog } = await import('../UpdateTokenDialog');
+
+const typeAndSave = async (token: string): Promise<void> => {
+  await userEvent.type(screen.getByTestId('tasks-github-token-input'), token);
+  await userEvent.click(screen.getByTestId('tasks-github-token-save'));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dialog = { kind: 'token' };
+  useAutomationsStore.setState({ credentials: [], gateway: fakeGateway() });
+});
+
+describe('UpdateTokenDialog — visibility', () => {
+  it('renders nothing when the open dialog is not the token dialog', () => {
+    dialog = { kind: 'import' };
+    render(<UpdateTokenDialog />);
+    expect(screen.queryByTestId('tasks-github-token-dialog')).toBeNull();
+  });
+
+  it('renders nothing when no dialog is open', () => {
+    dialog = null;
+    render(<UpdateTokenDialog />);
+    expect(screen.queryByTestId('tasks-github-token-dialog')).toBeNull();
+  });
+
+  it('renders the token dialog with the paste-a-PAT field', () => {
+    render(<UpdateTokenDialog />);
+    expect(screen.getByTestId('tasks-github-token-dialog')).toBeTruthy();
+    expect(screen.getByTestId('tasks-github-token-input')).toBeTruthy();
+  });
+});
+
+describe('UpdateTokenDialog — saving', () => {
+  it('stores the token under the github label and confirms with a toast', async () => {
+    const putCredential = vi.fn(async () => {});
+    useAutomationsStore.setState({ gateway: fakeGateway({ putCredential }) });
+    render(<UpdateTokenDialog />);
+
+    await typeAndSave('ghp_live_abc');
+
+    expect(putCredential).toHaveBeenCalledWith('github', 'ghp_live_abc');
+    expect(toastSuccess).toHaveBeenCalledWith('GitHub token updated');
+  });
+
+  it('reopens the import dialog when it was reached from the import failure', async () => {
+    dialog = { kind: 'token', returnTo: 'import' };
+    render(<UpdateTokenDialog />);
+
+    await typeAndSave('ghp_live_abc');
+
+    expect(openDialog).toHaveBeenCalledWith({ kind: 'import' });
+    expect(closeDialog).not.toHaveBeenCalled();
+  });
+
+  it('just closes when it was reached from the sync menu', async () => {
+    render(<UpdateTokenDialog />);
+
+    await typeAndSave('ghp_live_abc');
+
+    expect(closeDialog).toHaveBeenCalledOnce();
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+});
+
+describe('UpdateTokenDialog — failed save', () => {
+  it('keeps the dialog open, toasts the failure, and navigates nowhere', async () => {
+    dialog = { kind: 'token', returnTo: 'import' };
+    useAutomationsStore.setState({
+      gateway: fakeGateway({
+        putCredential: async () => {
+          throw new Error('keyring locked');
+        },
+      }),
+    });
+    render(<UpdateTokenDialog />);
+
+    await typeAndSave('ghp_live_abc');
+
+    expect(toastError).toHaveBeenCalledWith('Could not save the GitHub token', { description: 'keyring locked' });
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(openDialog).not.toHaveBeenCalled();
+    expect(closeDialog).not.toHaveBeenCalled();
+    expect(screen.getByTestId('tasks-github-token-dialog')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-dialog.test.ts
+++ b/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-dialog.test.ts
@@ -9,7 +9,8 @@
  *
  * Behaviors covered:
  *  1. openDialog / closeDialog — sets and clears `dialog`.
- *  2. dismissBanner — sets `bannerDismissed` to true.
+ *  2. openDialog — the token dialog keeps its `returnTo` target and fetches nothing.
+ *  3. dismissBanner — sets `bannerDismissed` to true.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
@@ -32,6 +33,7 @@ vi.mock('../../use-todos-store', () => ({
 }));
 
 import { useGitHubSyncStore } from '../use-github-sync-store';
+import * as githubApi from '@/lib/api/todos-github';
 
 const INITIAL_STATE = {
   port: null,
@@ -45,6 +47,7 @@ const INITIAL_STATE = {
   issues: [],
   loading: false,
   error: null,
+  errorAuth: false,
   dialog: null,
   bannerDismissed: false,
 };
@@ -69,6 +72,30 @@ describe('useGitHubSyncStore.openDialog / closeDialog', () => {
       result.current.closeDialog();
     });
     expect(result.current.dialog).toBeNull();
+  });
+});
+
+describe('useGitHubSyncStore.openDialog — token dialog', () => {
+  it('keeps the return target so a saved token can flow back into the import dialog', () => {
+    const { result } = renderHook(() => useGitHubSyncStore());
+
+    act(() => {
+      result.current.openDialog({ kind: 'token', returnTo: 'import' });
+    });
+
+    expect(result.current.dialog).toEqual({ kind: 'token', returnTo: 'import' });
+  });
+
+  it('fetches nothing — the token dialog reads no remote state', () => {
+    const { result } = renderHook(() => useGitHubSyncStore());
+
+    act(() => {
+      result.current.init(31415, 'proj-abc');
+      result.current.openDialog({ kind: 'token' });
+    });
+
+    expect(githubApi.listIssues).not.toHaveBeenCalled();
+    expect(githubApi.getReport).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-issues.test.ts
+++ b/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-issues.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+/**
+ * use-github-sync-store-issues.test.ts
+ *
+ * `../use-github-sync-store`'s issue fetch and its failure classification.
+ * Split out of use-github-sync-store-mutations.test.ts when the token-repair
+ * flow landed — init/load lives in use-github-sync-store-load.test.ts, dialog
+ * and banner state in use-github-sync-store-dialog.test.ts.
+ *
+ * Behaviors covered:
+ *  1. loadIssues — calls the client and sets `issues`; never refetches the todos store.
+ *  2. loadIssues — a 503 from the daemon is GitHub refusing the credential: the raw
+ *     body is replaced by the repair-friendly sentence and `errorAuth` is set.
+ *  3. loadIssues — any other failure keeps its own message and leaves `errorAuth` false.
+ *  4. loadIssues / load — both clear a stale error and `errorAuth` on a fresh attempt.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+vi.mock('@/lib/api/todos-github', () => ({
+  getLink: vi.fn(),
+  linkRepo: vi.fn(),
+  unlinkRepo: vi.fn(),
+  listPairs: vi.fn(),
+  deletePair: vi.fn(),
+  listIssues: vi.fn(),
+  importIssues: vi.fn(),
+  publishTask: vi.fn(),
+  runSync: vi.fn(),
+  getReport: vi.fn(),
+}));
+
+const mockTodosLoad = vi.fn();
+vi.mock('../../use-todos-store', () => ({
+  useTodosStore: { getState: () => ({ load: mockTodosLoad }) },
+}));
+
+import { useGitHubSyncStore } from '../use-github-sync-store';
+import { ApiRequestError } from '@/lib/api/http';
+import * as githubApi from '@/lib/api/todos-github';
+import type { RemoteIssue } from '@/lib/api/todos-github';
+
+const PORT = 31415;
+const PROJECT_ID = 'proj-abc';
+
+const ISSUE_FIXTURE: RemoteIssue = { number: 42, title: 'Fix the login bug', labels: ['bug'], pairedTodoNumber: null };
+
+const INITIAL_STATE = {
+  port: null,
+  projectId: null,
+  link: null,
+  workflowLabels: { prefixes: [], labels: [] },
+  pairs: {},
+  running: false,
+  lastRun: null,
+  report: null,
+  issues: [],
+  loading: false,
+  error: null,
+  errorAuth: false,
+  dialog: null,
+  bannerDismissed: false,
+};
+
+beforeEach(() => {
+  act(() => {
+    useGitHubSyncStore.setState(INITIAL_STATE);
+  });
+  vi.clearAllMocks();
+});
+
+/** The store hook with port and projectId already set — every case below needs both. */
+function initializedStore(): { current: ReturnType<typeof useGitHubSyncStore.getState> } {
+  const { result } = renderHook(() => useGitHubSyncStore());
+  act(() => {
+    result.current.init(PORT, PROJECT_ID);
+  });
+  return result;
+}
+
+describe('useGitHubSyncStore.loadIssues — success', () => {
+  it('calls listIssues and sets issues, without refetching the todos store', async () => {
+    vi.mocked(githubApi.listIssues).mockResolvedValue([ISSUE_FIXTURE]);
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+
+    expect(githubApi.listIssues).toHaveBeenCalledWith(PORT, PROJECT_ID);
+    expect(result.current.issues).toEqual([ISSUE_FIXTURE]);
+    expect(mockTodosLoad).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGitHubSyncStore.loadIssues — rejected credential', () => {
+  it('replaces a 503 with the repair-friendly sentence and flags it as an auth failure', async () => {
+    vi.mocked(githubApi.listIssues).mockRejectedValue(
+      new ApiRequestError('GitHub API 401: {"message":"Bad credentials"}', [], 503),
+    );
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+
+    expect(result.current.error).toBe(
+      'GitHub rejected the stored credential — the token is missing, expired, or revoked.',
+    );
+    expect(result.current.errorAuth).toBe(true);
+  });
+});
+
+describe('useGitHubSyncStore.loadIssues — other failures', () => {
+  it('keeps the raw message and leaves errorAuth false for a non-503 API error', async () => {
+    vi.mocked(githubApi.listIssues).mockRejectedValue(new ApiRequestError('internal server error', [], 500));
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+
+    expect(result.current.error).toBe('internal server error');
+    expect(result.current.errorAuth).toBe(false);
+  });
+
+  it('keeps the raw message and leaves errorAuth false for a transport error', async () => {
+    vi.mocked(githubApi.listIssues).mockRejectedValue(new Error('daemon unreachable'));
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+
+    expect(result.current.error).toBe('daemon unreachable');
+    expect(result.current.errorAuth).toBe(false);
+  });
+});
+
+describe('useGitHubSyncStore — clearing a stale issue-fetch failure', () => {
+  it('clears the error and the auth flag once a retry succeeds', async () => {
+    vi.mocked(githubApi.listIssues)
+      .mockRejectedValueOnce(new ApiRequestError('GitHub API 401', [], 503))
+      .mockResolvedValueOnce([]);
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+    expect(result.current.errorAuth).toBe(true);
+
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorAuth).toBe(false);
+    expect(result.current.issues).toEqual([]);
+  });
+
+  it('clears the error and the auth flag when the sync state reloads', async () => {
+    vi.mocked(githubApi.listIssues).mockRejectedValue(new ApiRequestError('GitHub API 401', [], 503));
+    vi.mocked(githubApi.getLink).mockResolvedValue({
+      link: null,
+      running: false,
+      latestRunId: null,
+      workflowLabels: { prefixes: [], labels: [] },
+    });
+    vi.mocked(githubApi.listPairs).mockResolvedValue([]);
+
+    const result = initializedStore();
+    await act(async () => {
+      await result.current.loadIssues();
+    });
+    expect(result.current.errorAuth).toBe(true);
+
+    await act(async () => {
+      await result.current.load();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorAuth).toBe(false);
+  });
+});

--- a/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-load.test.ts
+++ b/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-load.test.ts
@@ -73,6 +73,7 @@ const INITIAL_STATE = {
   issues: [],
   loading: false,
   error: null,
+  errorAuth: false,
   dialog: null,
   bannerDismissed: false,
 };

--- a/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-mutations.test.ts
+++ b/packages/ui/src/features/tasks/github/__tests__/use-github-sync-store-mutations.test.ts
@@ -5,11 +5,11 @@
  * `../use-github-sync-store`'s link/task/run mutations. Split from
  * use-github-sync-store.test.ts (finding #13, todo #286) — init/load lives
  * in use-github-sync-store-load.test.ts, dialog/banner state in
- * use-github-sync-store-dialog.test.ts.
+ * use-github-sync-store-dialog.test.ts, the issue fetch and its failure
+ * classification in use-github-sync-store-issues.test.ts.
  *
  * Behaviors covered:
  *  - linkRepo/unlinkRepo — call the client then refetch this store's own load, never the todos store.
- *  - loadIssues — calls the client and sets `issues`; never refetches the todos store.
  *  - importIssues/publish/unlinkPair — call the client, refetch this store's load, AND the todos store.
  *  - sync — sets running true during the call and false after, sets lastRun, refetches both stores.
  *  - sync running gating — a second call while already running is refused (client not called again).
@@ -37,7 +37,7 @@ vi.mock('../../use-todos-store', () => ({
 
 import { useGitHubSyncStore } from '../use-github-sync-store';
 import * as githubApi from '@/lib/api/todos-github';
-import type { Link, Pair, RemoteIssue, RunSummary, WorkflowLabelSet } from '@/lib/api/todos-github';
+import type { Link, Pair, RunSummary, WorkflowLabelSet } from '@/lib/api/todos-github';
 
 const PORT = 31415;
 const PROJECT_ID = 'proj-abc';
@@ -62,8 +62,6 @@ const PAIR_A: Pair = {
   stateReason: null,
 };
 
-const ISSUE_FIXTURE: RemoteIssue = { number: 42, title: 'Fix the login bug', labels: ['bug'], pairedTodoNumber: null };
-
 const RUN_FIXTURE: RunSummary = {
   runId: 'run-1',
   finishedAt: '2026-07-31T14:22:00.000Z',
@@ -86,6 +84,7 @@ const INITIAL_STATE = {
   issues: [],
   loading: false,
   error: null,
+  errorAuth: false,
   dialog: null,
   bannerDismissed: false,
 };
@@ -154,46 +153,6 @@ describe('useGitHubSyncStore.unlinkRepo', () => {
     expect(githubApi.getLink).toHaveBeenCalledOnce();
     expect(result.current.link).toBeNull();
     expect(mockTodosLoad).not.toHaveBeenCalled();
-  });
-});
-
-describe('useGitHubSyncStore.loadIssues', () => {
-  it('calls listIssues and sets issues, without refetching the todos store', async () => {
-    vi.mocked(githubApi.listIssues).mockResolvedValue([ISSUE_FIXTURE]);
-
-    const { result } = renderHook(() => useGitHubSyncStore());
-    act(() => {
-      result.current.init(PORT, PROJECT_ID);
-    });
-
-    await act(async () => {
-      await result.current.loadIssues();
-    });
-
-    expect(githubApi.listIssues).toHaveBeenCalledWith(PORT, PROJECT_ID);
-    expect(result.current.issues).toEqual([ISSUE_FIXTURE]);
-    expect(mockTodosLoad).not.toHaveBeenCalled();
-  });
-
-  it('clears a stale error from a previous failed attempt once a retry succeeds', async () => {
-    vi.mocked(githubApi.listIssues).mockRejectedValueOnce(new Error('no credential'));
-    vi.mocked(githubApi.listIssues).mockResolvedValueOnce([]);
-
-    const { result } = renderHook(() => useGitHubSyncStore());
-    act(() => {
-      result.current.init(PORT, PROJECT_ID);
-    });
-
-    await act(async () => {
-      await result.current.loadIssues();
-    });
-    expect(result.current.error).toBe('no credential');
-
-    await act(async () => {
-      await result.current.loadIssues();
-    });
-    expect(result.current.error).toBeNull();
-    expect(result.current.issues).toEqual([]);
   });
 });
 

--- a/packages/ui/src/features/tasks/github/use-github-sync-store.ts
+++ b/packages/ui/src/features/tasks/github/use-github-sync-store.ts
@@ -35,10 +35,16 @@ import {
   type WorkflowLabelSet,
 } from '@/lib/api/todos-github';
 import type { Todo } from '@/lib/api/todos';
+import { ApiRequestError } from '@/lib/api/http';
 import { useTodosStore } from '../use-todos-store';
 
 export type GitHubSyncDialog =
-  null | { kind: 'link' } | { kind: 'import' } | { kind: 'publish'; todo: Todo } | { kind: 'report' };
+  | null
+  | { kind: 'link' }
+  | { kind: 'import' }
+  | { kind: 'publish'; todo: Todo }
+  | { kind: 'report' }
+  | { kind: 'token'; returnTo?: 'import' };
 
 interface GitHubSyncState {
   port: number | null;
@@ -54,6 +60,8 @@ interface GitHubSyncState {
   issues: RemoteIssue[];
   loading: boolean;
   error: string | null;
+  /** The last `error` was GitHub refusing our credential — offer the token fix, not a retry. */
+  errorAuth: boolean;
   dialog: GitHubSyncDialog;
   bannerDismissed: boolean;
   init: (port: number, projectId: string) => void;
@@ -101,6 +109,7 @@ export const useGitHubSyncStore = create<GitHubSyncState>((set, get) => {
     issues: [],
     loading: false,
     error: null,
+    errorAuth: false,
     dialog: null,
     bannerDismissed: false,
 
@@ -110,7 +119,7 @@ export const useGitHubSyncStore = create<GitHubSyncState>((set, get) => {
       const { port, projectId } = get();
       if (port === null || projectId === null) return;
       const seq = ++_loadSeq;
-      set({ loading: true, error: null });
+      set({ loading: true, error: null, errorAuth: false });
       try {
         const [status, pairs] = await Promise.all([getLink(port, projectId), listPairs(port, projectId)]);
         if (seq !== _loadSeq) return;
@@ -158,11 +167,20 @@ export const useGitHubSyncStore = create<GitHubSyncState>((set, get) => {
     loadIssues: async () => {
       const { port, projectId } = get();
       if (port === null || projectId === null) return;
-      set({ error: null });
+      set({ error: null, errorAuth: false });
       try {
         set({ issues: await listIssues(port, projectId) });
       } catch (err) {
-        set({ error: messageOf(err, 'Failed to load the repository issues') });
+        // 503 is the daemon's "integration not ready to talk to GitHub" —
+        // a missing or rejected credential. The raw message embeds GitHub's
+        // JSON body, so it is replaced, not shown.
+        const auth = err instanceof ApiRequestError && err.status === 503;
+        set({
+          error: auth
+            ? 'GitHub rejected the stored credential — the token is missing, expired, or revoked.'
+            : messageOf(err, 'Failed to load the repository issues'),
+          errorAuth: auth,
+        });
       }
     },
 


### PR DESCRIPTION
## What

The GitHub issues import always failed with **401 Bad credentials**: connecting a repo stored a placeholder string instead of a real token. This adds a real PAT flow and fixes the import itself.

- **Token field + update flow**: `LinkRepoDialog` takes a real token on connect (with a connected pill + Replace); a new `UpdateTokenDialog` is reachable from the sync menu and straight from the import dialog's auth-error state.
- **Auth errors are classified**: the daemon maps GitHub auth failures to 503, and the UI shows "GitHub rejected the stored credential — the token is missing, expired, or revoked" with a one-click *Update token* instead of a raw failure.
- **Imports were syncing pull requests**: GitHub's `/issues` endpoint returns PRs too — the Rust sync now filters them by the `pull_request` marker field.

## Testing

Unit suites on both sides (UI dialogs/store classification; Rust filter + error mapping), plus a live end-to-end check against a real repo: connect → import → issues only, and a revoked-token round-trip through the update flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)