### PR TITLE
fix(updater): enable prerelease metadata over HTTPS

### DIFF
--- a/.changeset/bright-pills-update.md
+++ b/.changeset/bright-pills-update.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Fix pre-release update checks by enabling HTTPS for GitHub release metadata.

--- a/packages/app-tauri/src-tauri/Cargo.lock
+++ b/packages/app-tauri/src-tauri/Cargo.lock
@@ -3536,6 +3536,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5218,9 +5219,12 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5526,6 +5530,24 @@ name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/packages/app-tauri/src-tauri/Cargo.toml
+++ b/packages/app-tauri/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 dirs = "5"
 which = "6"
 portable-pty = "0.9"
-ureq = { version = "2", default-features = false, features = ["json"] }
+ureq = { version = "2", default-features = false, features = ["json", "tls"] }
 # Matches the `url::Url` type tauri-plugin-updater's `endpoints()` builder expects.
 url = "2"
 # The platform credential-store backends are opt-in in keyring 3.x. Without an

--- a/packages/app-tauri/src-tauri/src/updater/channel.rs
+++ b/packages/app-tauri/src-tauri/src/updater/channel.rs
@@ -90,6 +90,9 @@ fn select_latest_json_url(releases_json: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::thread;
 
     fn release(draft: bool, prerelease: bool, assets: &str) -> String {
         format!(
@@ -99,6 +102,28 @@ mod tests {
 
     fn asset(name: &str, url: &str) -> String {
         format!(r#"{{"name":"{name}","browser_download_url":"{url}"}}"#)
+    }
+
+    #[test]
+    fn https_agent_uses_a_tls_backend() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _ = stream.write_all(b"not a tls handshake");
+        });
+
+        let error = ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_millis(500))
+            .timeout_read(Duration::from_millis(500))
+            .build()
+            .get(&format!("https://{address}"))
+            .call()
+            .unwrap_err()
+            .to_string();
+        server.join().unwrap();
+
+        assert!(!error.contains("no TLS backend"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Enable the ureq TLS backend used by the Tauri prerelease-channel resolver.
- Add a loopback regression test that fails when HTTPS has no TLS backend.
- Add a patch changeset for the Tauri app.

## Why

The prerelease resolver queried the GitHub Releases API over HTTPS, but ureq was compiled with only its JSON feature. Every lookup failed before making an HTTPS request, then silently fell back to the stable latest-release endpoint. That endpoint returned 404 for the RC channel, so the updater emitted an error and the update pill stayed hidden.

## Testing done

- cargo test --lib: 80 passed
- cargo check
- cargo tree -e features -i ureq confirms the tls feature
- Live resolver probe returned the v2.0.0-rc.23 latest.json asset
- git diff --check

## Checklist

- [ ] pnpm test passes
- [ ] pnpm build passes (TypeScript compiles)
- [x] No secrets in staged files
- [x] File size limits respected (max 300 lines/file, 50 lines/function)