### PR TITLE
fix(ui): keep macOS scrollbar tracks transparent

### DIFF
--- a/.changeset/violet-mice-guess.md
+++ b/.changeset/violet-mice-guess.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Keep scrollbar tracks transparent in macOS WKWebView.

--- a/docs/superpowers/plans/2026-08-12-macos-scrollbar-track.md
+++ b/docs/superpowers/plans/2026-08-12-macos-scrollbar-track.md
@@ -4,7 +4,7 @@
 
 **Goal:** Keep scrollbar tracks transparent when macOS WKWebView expands its native scrollbar.
 
-**Architecture:** Select one scrollbar styling API per engine capability. WebKit/Blink engines receive pseudo-element rules that directly paint the track; other engines retain the standard CSS Scrollbars rules.
+**Architecture:** Select one scrollbar styling API per Tauri webview capability. Webviews exposing WebKit scrollbar parts receive pseudo-element rules that directly paint the track; other webviews retain the standard CSS Scrollbars rules.
 
 **Tech Stack:** CSS, Tailwind CSS v4 layers, Vitest, Tauri 2/WKWebView
 

--- a/docs/superpowers/plans/2026-08-12-macos-scrollbar-track.md
+++ b/docs/superpowers/plans/2026-08-12-macos-scrollbar-track.md
@@ -1,0 +1,102 @@
+# macOS Scrollbar Track Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep scrollbar tracks transparent when macOS WKWebView expands its native scrollbar.
+
+**Architecture:** Select one scrollbar styling API per engine capability. WebKit/Blink engines receive pseudo-element rules that directly paint the track; other engines retain the standard CSS Scrollbars rules.
+
+**Tech Stack:** CSS, Tailwind CSS v4 layers, Vitest, Tauri 2/WKWebView
+
+## Global Constraints
+
+- Keep the rules in `@layer base` so scrollbar utility classes retain precedence.
+- Never combine non-default standard scrollbar properties with WebKit pseudo-element styling in the same capability branch.
+- Preserve the transparent-at-rest and hover-revealed-thumb interaction.
+- Do not change theme tokens, components, or application behavior outside scrollbar painting.
+
+---
+
+### Task 1: Split scrollbar styling by engine capability
+
+**Files:**
+- Create: `packages/ui/src/styles/__tests__/scrollbar-styles.test.ts`
+- Modify: `packages/ui/src/styles/app.css:59-73`
+
+**Interfaces:**
+- Consumes: `--border`, Tailwind's `base` and `utilities` layer ordering, and `selector()` support queries.
+- Produces: mutually exclusive WebKit pseudo-element and standards-based scrollbar rules.
+
+- [ ] **Step 1: Write the failing stylesheet contract test**
+
+Create a node-environment Vitest test that reads `app.css`, extracts balanced `@supports` blocks, and asserts:
+
+```ts
+expect(webkit).toContain('*::-webkit-scrollbar-track');
+expect(webkit).toMatch(/background:\s*transparent/);
+expect(webkit).toContain('*:hover::-webkit-scrollbar-thumb');
+expect(webkit).not.toMatch(/scrollbar-(?:color|width)\s*:/);
+expect(standards).toContain('scrollbar-width: thin');
+expect(standards).toContain('scrollbar-color: transparent transparent');
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/styles/__tests__/scrollbar-styles.test.ts`
+
+Expected: FAIL because `app.css` has no WebKit capability branch.
+
+- [ ] **Step 3: Add mutually exclusive scrollbar branches**
+
+Inside the existing `@layer base`, add:
+
+```css
+@supports selector(*::-webkit-scrollbar) {
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  *::-webkit-scrollbar-track,
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 999px;
+  }
+  *:hover::-webkit-scrollbar-thumb {
+    background: var(--border);
+  }
+}
+```
+
+Move the current standard declarations under `@supports not selector(*::-webkit-scrollbar)`.
+
+- [ ] **Step 4: Run the focused test and confirm GREEN**
+
+Run: `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/styles/__tests__/scrollbar-styles.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run static verification**
+
+Run:
+
+```bash
+pnpm --filter @qlan-ro/mainframe-ui typecheck
+pnpm --filter @qlan-ro/mainframe-ui build
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Verify the packaged macOS app**
+
+Build a release-profile QA app, load a long dark-mode chat, capture the native window with `screencapture`, and inspect the right edge. The track must match the chat background both at rest and while the thumb is visible.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/styles/app.css packages/ui/src/styles/__tests__/scrollbar-styles.test.ts docs/superpowers/plans/2026-08-12-macos-scrollbar-track.md
+git commit -m "fix(ui): keep macOS scrollbar tracks transparent"
+```

--- a/docs/superpowers/specs/2026-08-12-macos-scrollbar-track-design.md
+++ b/docs/superpowers/specs/2026-08-12-macos-scrollbar-track-design.md
@@ -1,0 +1,28 @@
+# macOS Scrollbar Track Design
+
+## Problem
+
+Mainframe uses the standard `scrollbar-color` property for a transparent track. macOS WKWebView delegates scrollbar painting to AppKit, whose expanded scrollbar ignores the requested track color. Overlay scrollbars appear correct, but an expanded scrollbar paints an opaque gray gutter in packaged builds.
+
+## Considered approaches
+
+1. Keep the standards-only rule. This preserves the current source but leaves the WebKit failure unresolved.
+2. Add WebKit pseudo-elements beside non-default standard properties. CSS Scrollbars requires WebKit/Blink engines to ignore the pseudo-elements when a standard scrollbar property has a non-default value, so this combination is unreliable.
+3. Select one styling path per engine capability. Use `::-webkit-scrollbar` pseudo-elements in engines that expose them and retain `scrollbar-width`/`scrollbar-color` as the fallback. This avoids conflicting APIs and directly controls the native track. This is the selected approach.
+
+## Design
+
+Keep the scrollbar rules in `packages/ui/src/styles/app.css` and inside `@layer base`, preserving Tailwind utility precedence. A `@supports selector(*::-webkit-scrollbar)` branch will set an 8-pixel scrollbar, keep the track transparent, hide the thumb at rest, and reveal the existing `--border` thumb on hover. A mutually exclusive `@supports not selector(*::-webkit-scrollbar)` branch will retain the current standards-based behavior.
+
+The fix changes no component structure, tokens, or interaction model. Scrollbar opt-outs that set `scrollbar-width: none` remain utilities and continue to outrank the base layer.
+
+## Verification
+
+- Add a source-level Vitest guard that requires mutually exclusive WebKit and standards branches, a transparent WebKit track, and hover-only thumb color.
+- Run the test once before implementation to prove it catches the current stylesheet.
+- Run the focused test, UI typecheck, and production UI build after implementation.
+- Build and capture the packaged macOS app with a long chat thread. Confirm the right-edge track matches the content background at rest and while the thumb is visible.
+
+## Scope
+
+This change only fixes scrollbar painting. It does not change the application palette, macOS scrollbar preferences, or Tauri window behavior.

--- a/docs/superpowers/specs/2026-08-12-macos-scrollbar-track-design.md
+++ b/docs/superpowers/specs/2026-08-12-macos-scrollbar-track-design.md
@@ -8,11 +8,11 @@ Mainframe uses the standard `scrollbar-color` property for a transparent track. 
 
 1. Keep the standards-only rule. This preserves the current source but leaves the WebKit failure unresolved.
 2. Add WebKit pseudo-elements beside non-default standard properties. CSS Scrollbars requires WebKit/Blink engines to ignore the pseudo-elements when a standard scrollbar property has a non-default value, so this combination is unreliable.
-3. Select one styling path per engine capability. Use `::-webkit-scrollbar` pseudo-elements in engines that expose them and retain `scrollbar-width`/`scrollbar-color` as the fallback. This avoids conflicting APIs and directly controls the native track. This is the selected approach.
+3. Select one styling path per Tauri webview capability. Use `::-webkit-scrollbar` pseudo-elements when the webview exposes them and retain `scrollbar-width`/`scrollbar-color` as the fallback. This avoids conflicting APIs and directly controls the native track. This is the selected approach.
 
 ## Design
 
-Keep the scrollbar rules in `packages/ui/src/styles/app.css` and inside `@layer base`, preserving Tailwind utility precedence. A `@supports selector(*::-webkit-scrollbar)` branch will set an 8-pixel scrollbar, keep the track transparent, hide the thumb at rest, and reveal the existing `--border` thumb on hover. A mutually exclusive `@supports not selector(*::-webkit-scrollbar)` branch will retain the current standards-based behavior.
+Keep the scrollbar rules in `packages/ui/src/styles/app.css` and inside `@layer base`, preserving Tailwind utility precedence. A `@supports selector(*::-webkit-scrollbar)` branch will set an 8-pixel scrollbar, keep the track transparent, hide the thumb at rest, and reveal the existing `--border` thumb on hover. A mutually exclusive negated branch will retain the current standards-based behavior when those parts are unavailable.
 
 The fix changes no component structure, tokens, or interaction model. Scrollbar opt-outs that set `scrollbar-width: none` remain utilities and continue to outrank the base layer.
 

--- a/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
+++ b/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const sheet = readFileSync(new URL('../app.css', import.meta.url), 'utf8');
+
+function blockAfter(header: string): string {
+  const headerStart = sheet.indexOf(header);
+  if (headerStart < 0) throw new Error(`missing CSS block: ${header}`);
+
+  const openingBrace = sheet.indexOf('{', headerStart + header.length);
+  if (openingBrace < 0) throw new Error(`missing opening brace after: ${header}`);
+
+  let depth = 0;
+  for (let index = openingBrace; index < sheet.length; index += 1) {
+    if (sheet[index] === '{') depth += 1;
+    if (sheet[index] !== '}') continue;
+    depth -= 1;
+    if (depth === 0) return sheet.slice(openingBrace + 1, index);
+  }
+
+  throw new Error(`missing closing brace after: ${header}`);
+}
+
+describe('scrollbar styling paths', () => {
+  it('directly paints a transparent track in WebKit without conflicting standard properties', () => {
+    const webkit = blockAfter('@supports selector(*::-webkit-scrollbar)');
+
+    expect(webkit).toMatch(
+      /\*::-webkit-scrollbar-track,\s*\*::-webkit-scrollbar-corner\s*{\s*background:\s*transparent/,
+    );
+    expect(webkit).toMatch(/\*::-webkit-scrollbar-thumb\s*{\s*background:\s*transparent/);
+    expect(webkit).toMatch(/\*:hover::-webkit-scrollbar-thumb\s*{\s*background:\s*var\(--border\)/);
+    expect(webkit).not.toMatch(/scrollbar-(?:color|width)\s*:/);
+  });
+
+  it('retains the standards path only when WebKit pseudo-elements are unavailable', () => {
+    const standards = blockAfter('@supports not selector(*::-webkit-scrollbar)');
+
+    expect(standards).toContain('scrollbar-width: thin');
+    expect(standards).toContain('scrollbar-color: transparent transparent');
+    expect(standards).not.toContain('::-webkit-scrollbar');
+  });
+});

--- a/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
+++ b/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
@@ -4,27 +4,30 @@ import { describe, expect, it } from 'vitest';
 
 const sheet = readFileSync(new URL('../app.css', import.meta.url), 'utf8');
 
-function blockAfter(header: string): string {
-  const headerStart = sheet.indexOf(header);
+function blockAfter(source: string, header: string): string {
+  const headerStart = source.indexOf(header);
   if (headerStart < 0) throw new Error(`missing CSS block: ${header}`);
 
-  const openingBrace = sheet.indexOf('{', headerStart + header.length);
+  const openingBrace = source.indexOf('{', headerStart + header.length);
   if (openingBrace < 0) throw new Error(`missing opening brace after: ${header}`);
 
   let depth = 0;
-  for (let index = openingBrace; index < sheet.length; index += 1) {
-    if (sheet[index] === '{') depth += 1;
-    if (sheet[index] !== '}') continue;
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] !== '}') continue;
     depth -= 1;
-    if (depth === 0) return sheet.slice(openingBrace + 1, index);
+    if (depth === 0) return source.slice(openingBrace + 1, index);
   }
 
   throw new Error(`missing closing brace after: ${header}`);
 }
 
 describe('scrollbar styling paths', () => {
+  const base = blockAfter(sheet, '@layer base');
+  const webkitQuery = 'selector(*::-webkit-scrollbar)';
+
   it('directly paints a transparent track in WebKit without conflicting standard properties', () => {
-    const webkit = blockAfter('@supports selector(*::-webkit-scrollbar)');
+    const webkit = blockAfter(base, `@supports ${webkitQuery}`);
 
     expect(webkit).toMatch(
       /\*::-webkit-scrollbar-track,\s*\*::-webkit-scrollbar-corner\s*{\s*background:\s*transparent/,
@@ -34,8 +37,8 @@ describe('scrollbar styling paths', () => {
     expect(webkit).not.toMatch(/scrollbar-(?:color|width)\s*:/);
   });
 
-  it('retains the standards path only when WebKit pseudo-elements are unavailable', () => {
-    const standards = blockAfter('@supports not selector(*::-webkit-scrollbar)');
+  it('retains the standards path when WebKit scrollbar parts are unavailable', () => {
+    const standards = blockAfter(base, `@supports not ${webkitQuery}`);
 
     expect(standards).toContain('scrollbar-width: thin');
     expect(standards).toContain('scrollbar-color: transparent transparent');

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -56,8 +56,7 @@ code {
   -webkit-user-select: text;
 }
 
-/* WebKit delegates standard scrollbar track painting to macOS, which can ignore
-   transparent track colors. Keep the WebKit and standards paths exclusive. */
+/* WebKit needs direct track painting because its native track can ignore scrollbar-color. */
 @layer base {
   @supports selector(*::-webkit-scrollbar) {
     *::-webkit-scrollbar {

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -56,19 +56,35 @@ code {
   -webkit-user-select: text;
 }
 
-/* Thin scrollbar, GLOBAL (hover-revealed thumb, transparent track). Standards
-   path ONLY (scrollbar-width/scrollbar-color): setting either standard property
-   makes engines ignore ::-webkit-scrollbar rules, so the two must never be
-   mixed. In @layer base so utilities keep winning — an unlayered rule would
-   outrank ALL layered ones and silently re-enable scrollbars on
-   [scrollbar-width:none] opt-outs like the tab strips. */
+/* WebKit delegates standard scrollbar track painting to macOS, which can ignore
+   transparent track colors. Keep the WebKit and standards paths exclusive. */
 @layer base {
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
+  @supports selector(*::-webkit-scrollbar) {
+    *::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+    *::-webkit-scrollbar-track,
+    *::-webkit-scrollbar-corner {
+      background: transparent;
+    }
+    *::-webkit-scrollbar-thumb {
+      background: transparent;
+      border-radius: 999px;
+    }
+    *:hover::-webkit-scrollbar-thumb {
+      background: var(--border);
+    }
   }
-  *:hover {
-    scrollbar-color: var(--border) transparent;
+
+  @supports not selector(*::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: transparent transparent;
+    }
+    *:hover {
+      scrollbar-color: var(--border) transparent;
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

- route Tauri webviews with `::-webkit-scrollbar` support to explicit scrollbar-part styling
- paint the track and corner transparent while revealing only the thumb on hover
- retain the standards-based fallback for webviews without those scrollbar parts
- add a stylesheet regression test and UI changeset

## Root cause

The packaged macOS app used only `scrollbar-color`. WKWebView delegates the expanded native scrollbar track to macOS, which can ignore the transparent track color and paint an opaque gray gutter. Explicit WebKit scrollbar-part rules control the track directly.

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/styles/__tests__/scrollbar-styles.test.ts` — 2/2 passed
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — passed
- `pnpm --filter @qlan-ro/mainframe-types build && pnpm --filter @qlan-ro/mainframe-ui build` — passed
- `AutomationsView.test.tsx` isolated rerun — 6/6 passed after one full-suite lazy-load timeout under contention
- release-profile QA `.app` build — passed
- native macOS window capture on a real long chat — track remained transparent at rest and after scrolling

## Notes

The full UI suite completed 6,335/6,336 tests; the sole failure was an unrelated lazy-loaded automation editor timeout, and that spec passed immediately in isolation.
