### PR TITLE
fix(ui): mute the sidebar action labels

### DIFF
--- a/.changeset/sidebar-action-label-ink.md
+++ b/.changeset/sidebar-action-label-ink.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Mute the sidebar action labels so New Thread, Kanban and Automations sit at the same ink as the rows below them.
+
+Their icons were already muted, but the labels rendered at full sidebar foreground, making the three rows read as the loudest thing in the sidebar. They now use `text-muted-foreground`, the resting ink the project rows already use.

--- a/packages/ui/src/features/sessions/SidebarActions.tsx
+++ b/packages/ui/src/features/sessions/SidebarActions.tsx
@@ -36,7 +36,7 @@ export function SidebarActions({ filterProjectId }: { filterProjectId: string | 
         <SidebarMenuItem>
           <SidebarMenuButton size="sm" data-testid="sidebar-action-new-thread" onClick={newThread}>
             <SquarePen className="text-muted-foreground" />
-            <span>New Thread</span>
+            <span className="text-muted-foreground">New Thread</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
         <SidebarMenuItem>
@@ -48,13 +48,13 @@ export function SidebarActions({ filterProjectId }: { filterProjectId: string | 
             onClick={() => window.dispatchEvent(new CustomEvent('mf:open-tasks'))}
           >
             <SquareKanban className="text-muted-foreground" />
-            <span>Kanban</span>
+            <span className="text-muted-foreground">Kanban</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
         <SidebarMenuItem>
           <SidebarMenuButton size="sm" data-testid="sidebar-action-automations" onClick={openAutomations}>
             <Zap className="text-muted-foreground" />
-            <span>Automations</span>
+            <span className="text-muted-foreground">Automations</span>
             {pendingAutomations > 0 && (
               <span
                 data-testid="sidebar-action-automations-pending"


### PR DESCRIPTION
New Thread, Kanban and Automations rendered their labels at full sidebar foreground while their icons were already muted, so the three rows read as the loudest text in the sidebar — louder than the project rows they sit above.

They now carry `text-muted-foreground`, the same resting ink `ProjectRow` uses for an inactive row. Verified in the running app: all three labels compute to `oklch(0.708 0 0)`, identical to a project row's label.

Class-only change; UI typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)