### PR TITLE
fix(ui): shrink the update pill to its title-bar slot

### DIFF
--- a/.changeset/update-pill-fits-the-title-bar.md
+++ b/.changeset/update-pill-fits-the-title-bar.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Shrink the update pill so it fits the title-bar row it lives in.
+
+"Install update — v2.0.0-rc.25 is available" measured 249px in a slot that is under 100px wide at the default sidebar width, and it rendered in bold primary — the loudest thing in otherwise muted chrome. The pill now reads Update / 47% / Restart, carries the version and the next step in its hint, and is built on the `Badge` primitive it used to hand-roll, so it inherits the focus ring and the 12px icon.

--- a/packages/ui/src/layout/UpdatePill.tsx
+++ b/packages/ui/src/layout/UpdatePill.tsx
@@ -7,22 +7,41 @@
  *  - 'available'  → triggers host.updates.download().
  *  - 'downloading' → inert (progress label only).
  *  - 'downloaded' → triggers host.updates.install() (restart).
+ *
+ * Labels are one word wide on purpose: the pill shares the title-bar row with
+ * the traffic-light reserve and the header actions, which leave it under 100px
+ * at the default 16rem sidebar. The sentence lives in the hint.
  */
 import { useEffect, useState } from 'react';
-import { Download } from 'lucide-react';
+import { Download, RefreshCw } from 'lucide-react';
 import type { UpdateStatus } from '@qlan-ro/mainframe-types';
+import { Badge } from '@/components/ui/badge';
+import { Hint } from '@/components/ui/hint';
 import { useHost } from '@/lib/host';
 
 function pillLabel(status: UpdateStatus): string | null {
   switch (status.state) {
     case 'available':
-      return `Install update — v${status.version} is available`;
+      return 'Update';
     case 'downloading':
-      return `Downloading update — ${Math.round(status.percent)}%`;
+      return `${Math.round(status.percent)}%`;
     case 'downloaded':
-      return 'Restart to update';
+      return 'Restart';
     default:
       return null;
+  }
+}
+
+function pillHint(status: UpdateStatus): string | undefined {
+  switch (status.state) {
+    case 'available':
+      return `Version ${status.version} is available. Download it now — it installs on restart.`;
+    case 'downloading':
+      return 'Downloading the update…';
+    case 'downloaded':
+      return `Restart Mainframe to finish installing version ${status.version}.`;
+    default:
+      return undefined;
   }
 }
 
@@ -46,16 +65,26 @@ export function UpdatePill() {
     else if (status.state === 'downloaded') host.updates.install();
   };
 
+  const Icon = status.state === 'downloaded' ? RefreshCw : Download;
+
   return (
-    <button
-      data-testid="sidebar-update-pill"
-      type="button"
-      onClick={handleClick}
-      disabled={status.state === 'downloading'}
-      className="inline-flex h-6 shrink-0 items-center gap-1 rounded-full bg-primary/8 px-2.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/15 disabled:cursor-default"
-    >
-      <Download className="size-4" aria-hidden />
-      <span>{label}</span>
-    </button>
+    <Hint label={pillHint(status)} side="bottom">
+      {/* Tinted over `default`, not `ghost`: ghost's `dark:hover:bg-muted/50` is a variant twMerge can't dedupe. */}
+      <Badge
+        asChild
+        className="min-w-0 shrink bg-primary/10 text-primary hover:bg-primary/15 aria-disabled:hover:bg-primary/10"
+      >
+        {/* aria-disabled, not disabled: a disabled button swallows the pointer events its own hint needs. */}
+        <button
+          data-testid="sidebar-update-pill"
+          type="button"
+          onClick={handleClick}
+          aria-disabled={status.state === 'downloading'}
+        >
+          <Icon aria-hidden />
+          <span className="truncate">{label}</span>
+        </button>
+      </Badge>
+    </Hint>
   );
 }

--- a/packages/ui/src/layout/__tests__/UpdatePill.test.tsx
+++ b/packages/ui/src/layout/__tests__/UpdatePill.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { UpdateStatus } from '@qlan-ro/mainframe-types';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { HostProvider } from '@/lib/host';
+import { FakeHostBridge } from '@/lib/host/fake-adapter';
+import { UpdatePill } from '@/layout/UpdatePill';
+
+function renderPill(status: UpdateStatus, host = new FakeHostBridge({ updates: { status } })) {
+  render(
+    <TooltipProvider>
+      <HostProvider host={host}>
+        <UpdatePill />
+      </HostProvider>
+    </TooltipProvider>,
+  );
+  return host;
+}
+
+const pill = () => screen.queryByTestId('sidebar-update-pill');
+
+describe('UpdatePill', () => {
+  it('stays hidden while no update is pending', async () => {
+    renderPill({ state: 'not-available' });
+    await waitFor(() => expect(pill()).toBeNull());
+  });
+
+  it('offers the download for an available update', async () => {
+    const host = renderPill({ state: 'available', version: '2.0.0-rc.25' });
+    const download = vi.spyOn(host.updates, 'download');
+
+    const button = await screen.findByTestId('sidebar-update-pill');
+    expect(button).toHaveTextContent('Update');
+    expect(button).not.toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(button);
+    expect(download).toHaveBeenCalledOnce();
+  });
+
+  it('reports progress inertly while downloading', async () => {
+    const host = renderPill({ state: 'downloading', percent: 46.6 });
+    const install = vi.spyOn(host.updates, 'install');
+
+    const button = await screen.findByTestId('sidebar-update-pill');
+    expect(button).toHaveTextContent('47%');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(button);
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it('installs on click once the update is downloaded', async () => {
+    const host = renderPill({ state: 'downloaded', version: '2.0.0-rc.25' });
+    const install = vi.spyOn(host.updates, 'install');
+
+    const button = await screen.findByTestId('sidebar-update-pill');
+    expect(button).toHaveTextContent('Restart');
+
+    await userEvent.click(button);
+    expect(install).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
The update pill shares the sidebar header with the traffic-light reserve (80px) and the header actions (66px), which leave it under 100px at the default 16rem width. `Install update — v2.0.0-rc.25 is available` measures **249px**, in bold `text-primary` — the loudest thing in chrome the previous pass had just muted (#619).

| state | before | after | hint |
|---|---|---|---|
| available | Install update — v2.0.0-rc.25 is available (249px) | **Update** (73px) | Version 2.0.0-rc.25 is available. Download it now — it installs on restart. |
| downloading | Downloading update — 47% (182px) | **47%** (58px) | Downloading the update… |
| downloaded | Restart to update (125px) | **Restart** (73px, `RefreshCw`) | Restart Mainframe to finish installing version 2.0.0-rc.25. |

Rebuilt on the `Badge` primitive it was hand-rolling, so it inherits the focus ring it never had and the 12px icon grid; `font-medium` over a `bg-primary/10` tint instead of bold solid ink. `min-w-0 shrink` + `truncate` means a longer version string truncates rather than shoving the settings and collapse buttons out of the row.

`aria-disabled` replaces `disabled` on the downloading state: a disabled button swallows the pointer events its own hint needs, and the click was already a no-op in the handler.

## Verification

Rendered the real component against the real tokens in a throwaway Vite probe, driven with Playwright — `getComputedStyle` / `getBoundingClientRect` for all three states at 256px and 320px, light and dark. That caught a bug mid-fix: `variant="ghost"` carries `dark:hover:bg-muted/50`, a variant twMerge cannot dedupe against `hover:bg-primary/15`, so the pill turned gray on hover in dark mode. The default variant has no such leftover.

New `UpdatePill.test.tsx` covers the four states, including that clicking mid-download does not install. Typecheck clean.

Known non-blocker, unchanged by this PR: `text-primary` at 11px on a `/10` tint is borderline contrast in light mode — the same ink the old pill used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)