### PR TITLE
fix(ui): light the split pair's tab underline only while it is visible

### DIFF
--- a/.changeset/split-pair-underline-only-when-visible.md
+++ b/.changeset/split-pair-underline-only-when-visible.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Light the split pair's shared tab underline only while the split is on screen.
+
+A split groups two session tabs under one container in the title-bar strip, and that container drew its 2px underline unconditionally. Because a pair stays open while parked behind a third session, the strip could show three tabs wearing the selected underline at once — the pair's plus the focused tab's — leaving no way to tell which session you were actually looking at. The underline now lights on exactly the terms a lone tab's does: a member of the pair is the focused session. The container's faint tint is dropped with it, so grouping reads from the two tabs sitting adjacent rather than from a mark that outlives the split it describes.

--- a/packages/ui/src/features/session-tabs/SessionTabs.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabs.tsx
@@ -18,11 +18,12 @@ import { Plus } from 'lucide-react';
 import { useAui, useAuiState } from '@assistant-ui/react';
 import { Button } from '@/components/ui/button';
 import { Hint } from '@/components/ui/hint';
+import { cn } from '@/lib/utils';
 import { useNewChatHotkeyHandler } from '@/features/sessions/new-thread/use-new-chat-hotkey-handler';
 import { useProjects } from '@/features/sessions/use-projects';
 import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
 import { openInSplit } from '@/features/chat/zones/open-in-split';
-import { useZonesStore } from '@/features/chat/zones/zones-store';
+import { splitVisible, useZonesStore } from '@/features/chat/zones/zones-store';
 import { SessionTabPill, type SessionTabEntry } from './SessionTabPill';
 import { useSessionTabsStore } from './store';
 import { canonicalTabId, nextActiveAfterClose } from './tabs-model';
@@ -76,6 +77,9 @@ export function SessionTabs() {
   const zones = useZonesStore((s) => s.zones);
   const zoneMembers = zones == null ? [] : zones.filter((id) => displayIds.includes(id));
   const grouped = zoneMembers.length === 2;
+  // A PARKED pair still renders its container — the two sessions are still a
+  // pair — but the split isn't what you're looking at, so its underline is dark.
+  const splitOnScreen = splitVisible(zones, mainThreadId);
   const ordered = grouped
     ? (() => {
         const firstAt = displayIds.findIndex((id) => zoneMembers.includes(id));
@@ -135,10 +139,17 @@ export function SessionTabs() {
                   onPin={pinTab}
                 />
               ))}
-            {/* The split pair reads as ONE unit: shared underline across both. */}
+            {/* The split pair reads as ONE unit: one underline spanning both,
+                lit on exactly the terms a lone tab's is — the split is ON
+                SCREEN. So the line only ever means "this is live", and a parked
+                pair leaves the strip unmarked rather than claiming focus it
+                doesn't have. Adjacency is what says "these two go together". */}
             <div
               data-testid="session-tabs-zone-group"
-              className="relative flex h-full shrink items-center rounded-t-sm bg-foreground/4 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground"
+              className={cn(
+                'relative flex h-full shrink items-center after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground after:transition-opacity',
+                splitOnScreen ? 'after:opacity-100' : 'after:opacity-0',
+              )}
             >
               {tabs
                 .filter((tab) => zoneMembers.includes(tab.id))

--- a/packages/ui/src/features/session-tabs/__tests__/SessionTabs.split.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/SessionTabs.split.test.tsx
@@ -187,6 +187,40 @@ describe('plain click', () => {
   });
 });
 
+describe("the pair's shared underline", () => {
+  // The underline is the SELECTION signal, and a split can be open while parked
+  // behind a third session. Lighting it on membership rather than on visibility
+  // is what used to make three tabs read as selected at once.
+  const groupMark = () => screen.getByTestId('session-tabs-zone-group').className;
+
+  it('is lit while a member of the pair is the focused session', () => {
+    seed('chat-a');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    expect(groupMark()).toContain('after:opacity-100');
+  });
+
+  it('goes dark while the pair is PARKED behind another session', () => {
+    seed('chat-p');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    expect(groupMark()).toContain('after:opacity-0');
+    expect(groupMark()).not.toContain('after:opacity-100');
+  });
+
+  it('leaves the parked pair with exactly one lit tab in the strip — the focused one', () => {
+    seed('chat-p');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    expect(screen.getByTestId('session-tab-chat-p').getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByTestId('session-tab-chat-a').getAttribute('aria-selected')).toBe('false');
+    expect(screen.getByTestId('session-tab-chat-b').getAttribute('aria-selected')).toBe('false');
+  });
+});
+
 describe('closing a zone tab', () => {
   it("collapses the split to the other chat when the FOCUSED zone's tab closes", () => {
     seed('chat-a');


### PR DESCRIPTION
## The bug

A split groups two session tabs under one container in the title-bar strip, and that container drew its 2px underline **unconditionally**. A pair stays open while *parked* behind a third session, so the strip could show three tabs wearing the selected underline at once — the pair's, plus the focused tab's.

One channel was being asked to say two things: *these belong together* and *this is live*. Whichever it meant, the other reading was wrong somewhere in the strip.

## The fix

The pair's underline now lights on exactly the terms a lone tab's does — a member of the pair is the focused session (`splitVisible`). The container's faint tint is dropped along with it, so grouping reads from the two tabs sitting adjacent rather than from a mark that outlives the split it describes.

Net effect, measured in the running app by counting lit 2px marks in the strip:

| state | lit underlines |
|---|---|
| split focused | the pair's, spanning both members — 1 |
| parked, third tab focused | the focused tab's — 1 |
| refocus a member | the pair's — 1 |

Exactly one, in every state.

## Trade-off worth naming

While parked, the pair now carries **no** persistent grouping mark — only adjacency. That is deliberate: freeing the underline to mean one thing is the point, and the pairing is restored the instant you focus either member. Four richer treatments (group-as-one-tab, named container, recessed well, fold-to-stack) were prototyped in the design project's `Window Tab Groups Review.html`; this PR takes the cheapest correct one.

## Tests

Three cases added to `SessionTabs.split.test.tsx` — lit while a member is focused, dark while parked, and exactly one selected tab in the parked strip. Mutation-checked: forcing the underline back on makes the parked case fail. The group container previously had **zero** coverage.

`pnpm --filter @qlan-ro/mainframe-ui typecheck` clean; 16 tests green in the split suite, 31 across both SessionTabs suites. Verified live in classic light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)