### PR TITLE
feat(ui): right-click menu on session tabs for the split gestures

### DIFF
--- a/.changeset/session-tab-context-menu.md
+++ b/.changeset/session-tab-context-menu.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': minor
+---
+
+Give session tabs a right-click menu, so the split gestures are reachable without knowing them.
+
+Splitting the chat surface had no discoverable entry point from the strip: ⌘-click opens a split, dragging a tab retargets one, and ⌘\ dissolves one, but a tab announced none of it. Right-clicking a tab now offers Open in Split — disabled precisely when the gesture has nowhere to go — or, on a tab already in the pair, Close Split, which dissolves it and leaves you on the session you pointed at. A parked pair dissolves without moving focus. Keep Open (on the preview tab) and Close round the menu out. The menu performs the existing gestures rather than adding new ones: the enabled state and the action now read from one shared `canOpenInSplit` predicate, so the offer can't drift from what the gesture does.

--- a/packages/ui/src/features/chat/zones/open-in-split.ts
+++ b/packages/ui/src/features/chat/zones/open-in-split.ts
@@ -15,15 +15,29 @@
  */
 import { splitVisible, useZonesStore } from './zones-store';
 
-export function openInSplit(activeId: string | null | undefined, id: string): boolean {
+/**
+ * Whether the gesture has anywhere to go — the same question `openInSplit`
+ * answers by returning false, asked WITHOUT performing it. A menu offering the
+ * action reads its disabled state from here, so the offer and the gesture can
+ * never disagree about what is splittable.
+ */
+export function canOpenInSplit(
+  zones: [string, string] | null,
+  activeId: string | null | undefined,
+  id: string,
+): boolean {
   if (activeId == null || id === activeId || id.startsWith('__LOCALID_')) return false;
+  if (!splitVisible(zones, activeId)) return !activeId.startsWith('__LOCALID_');
+  return zones != null && !zones.includes(id);
+}
+
+export function openInSplit(activeId: string | null | undefined, id: string): boolean {
   const store = useZonesStore.getState();
+  if (!canOpenInSplit(store.zones, activeId, id) || activeId == null) return false;
   if (!splitVisible(store.zones, activeId)) {
-    if (activeId.startsWith('__LOCALID_')) return false;
     store.openSplit(activeId, id);
     return true;
   }
-  if (store.zones != null && store.zones.includes(id)) return false;
   store.replaceZone(store.focusedIndex === 0 ? 1 : 0, id);
   return true;
 }

--- a/packages/ui/src/features/session-tabs/SessionTabContextMenu.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabContextMenu.tsx
@@ -1,0 +1,78 @@
+/**
+ * Right-click menu for a session tab: the split gestures, plus the two tab
+ * actions that otherwise need a hover target (keep-open, close).
+ *
+ * Every gesture here already exists — ⌘-click opens a split, drag-to-split
+ * retargets one, ⌘\ dissolves one, the ✕ closes a tab. None of them announces
+ * itself, so this menu is where they become discoverable; it deliberately adds
+ * no capability of its own.
+ *
+ * Wraps its child — the pill is the trigger — so the whole tab responds,
+ * including the parts its ✕ and pin overlay (the SessionContextMenu pattern).
+ *
+ * data-testid: session-tab-ctx-<action>.
+ */
+import type { ReactNode } from 'react';
+import { Columns2, PinIcon, SquareSplitHorizontal, XIcon } from 'lucide-react';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
+
+interface SessionTabContextMenuProps {
+  /** A member of the open pair — the split actions invert for it. */
+  inSplit: boolean;
+  /** The open-in-split gesture has somewhere to go (`canOpenInSplit`). */
+  canOpenInSplit: boolean;
+  /** The temporary slot — only a preview tab can be kept open. */
+  preview: boolean;
+  onOpenInSplit: () => void;
+  onCloseSplit: () => void;
+  onKeepOpen: () => void;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function SessionTabContextMenu({
+  inSplit,
+  canOpenInSplit,
+  preview,
+  onOpenInSplit,
+  onCloseSplit,
+  onKeepOpen,
+  onClose,
+  children,
+}: SessionTabContextMenuProps) {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        {inSplit ? (
+          <ContextMenuItem data-testid="session-tab-ctx-close-split" onSelect={onCloseSplit}>
+            <SquareSplitHorizontal />
+            Close Split
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem data-testid="session-tab-ctx-open-split" disabled={!canOpenInSplit} onSelect={onOpenInSplit}>
+            <Columns2 />
+            Open in Split
+          </ContextMenuItem>
+        )}
+        {preview && (
+          <ContextMenuItem data-testid="session-tab-ctx-keep-open" onSelect={onKeepOpen}>
+            <PinIcon />
+            Keep Open
+          </ContextMenuItem>
+        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem data-testid="session-tab-ctx-close" onSelect={onClose}>
+          <XIcon />
+          Close
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/packages/ui/src/features/session-tabs/SessionTabPill.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabPill.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import { useTabDragStore } from '@/features/chat/zones/tab-drag-store';
 import { ProjectAvatar } from '@/features/sessions/ProjectAvatar';
 import { projectColor } from '@/features/sessions/sidebar/project-color';
+import { SessionTabContextMenu } from './SessionTabContextMenu';
 
 /** Pixels of pointer travel before a press becomes a drag-to-split. */
 const DRAG_THRESHOLD = 6;
@@ -48,9 +49,22 @@ interface SessionTabPillProps {
   onActivate: (id: string, split: boolean) => void;
   onClose: (id: string) => void;
   onPin: (id: string) => void;
+  /** The open-in-split gesture has somewhere to go from this tab. */
+  canOpenInSplit: boolean;
+  onOpenInSplit: (id: string) => void;
+  onCloseSplit: (id: string) => void;
 }
 
-export function SessionTabPill({ tab, grouped = false, onActivate, onClose, onPin }: SessionTabPillProps) {
+export function SessionTabPill({
+  tab,
+  grouped = false,
+  onActivate,
+  onClose,
+  onPin,
+  canOpenInSplit,
+  onOpenInSplit,
+  onCloseSplit,
+}: SessionTabPillProps) {
   // Drag-to-split: a press that travels DRAG_THRESHOLD becomes a tab drag
   // (tab-drag-store; ZoneDropLayer renders the targets and handles the drop).
   // The flag swallows the click that follows a drag's pointerup. While the
@@ -85,79 +99,89 @@ export function SessionTabPill({ tab, grouped = false, onActivate, onClose, onPi
   };
 
   return (
-    <div
-      data-testid={`session-tab-${tab.id}`}
-      role="tab"
-      aria-selected={tab.active}
-      data-preview={tab.preview ? 'true' : 'false'}
-      data-dragging={dragging || undefined}
-      // preventDefault at MOUSEDOWN, not at the drag threshold: WebKit anchors
-      // a native text selection on mousedown, and once that gesture starts no
-      // later user-select/removeAllRanges stops it from painting the
-      // transcript as the pointer crosses it.
-      onMouseDown={(event) => event.preventDefault()}
-      onPointerDown={onPointerDown}
-      onClick={(event) => {
-        if (draggedRef.current) {
-          draggedRef.current = false;
-          return;
-        }
-        onActivate(tab.id, event.metaKey);
-      }}
-      onDoubleClick={() => {
-        if (tab.preview) onPin(tab.id);
-      }}
-      className={cn(
-        // h-full puts the underline on the toolbar's bottom hairline and the
-        // label on the toolbar midline — one alignment for every tab state.
-        'group relative flex h-full w-45 min-w-24 shrink cursor-pointer items-center gap-1.5 px-2 text-xs select-none',
-        // The dragged pill ghosts so the cursor + drop targets read as the live thing.
-        dragging && 'opacity-40',
-        !grouped &&
-          'after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground after:opacity-0 after:transition-opacity',
-        tab.active
-          ? cn('font-semibold text-foreground', !grouped && 'after:opacity-100')
-          : 'font-medium text-muted-foreground hover:text-foreground',
-      )}
+    <SessionTabContextMenu
+      inSplit={grouped}
+      canOpenInSplit={canOpenInSplit}
+      preview={tab.preview}
+      onOpenInSplit={() => onOpenInSplit(tab.id)}
+      onCloseSplit={() => onCloseSplit(tab.id)}
+      onKeepOpen={() => onPin(tab.id)}
+      onClose={() => onClose(tab.id)}
     >
-      {tab.projectId != null ? (
-        <ProjectAvatar name={tab.projectName ?? '?'} color={projectColor(tab.projectId)} size={14} />
-      ) : (
-        <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" aria-hidden />
-      )}
-      <span className={cn('min-w-0 flex-1 truncate', tab.preview && 'italic')}>{tab.title}</span>
-      {tab.preview && (
-        <Hint label="Keep open">
+      <div
+        data-testid={`session-tab-${tab.id}`}
+        role="tab"
+        aria-selected={tab.active}
+        data-preview={tab.preview ? 'true' : 'false'}
+        data-dragging={dragging || undefined}
+        // preventDefault at MOUSEDOWN, not at the drag threshold: WebKit anchors
+        // a native text selection on mousedown, and once that gesture starts no
+        // later user-select/removeAllRanges stops it from painting the
+        // transcript as the pointer crosses it.
+        onMouseDown={(event) => event.preventDefault()}
+        onPointerDown={onPointerDown}
+        onClick={(event) => {
+          if (draggedRef.current) {
+            draggedRef.current = false;
+            return;
+          }
+          onActivate(tab.id, event.metaKey);
+        }}
+        onDoubleClick={() => {
+          if (tab.preview) onPin(tab.id);
+        }}
+        className={cn(
+          // h-full puts the underline on the toolbar's bottom hairline and the
+          // label on the toolbar midline — one alignment for every tab state.
+          'group relative flex h-full w-45 min-w-24 shrink cursor-pointer items-center gap-1.5 px-2 text-xs select-none',
+          // The dragged pill ghosts so the cursor + drop targets read as the live thing.
+          dragging && 'opacity-40',
+          !grouped &&
+            'after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-foreground after:opacity-0 after:transition-opacity',
+          tab.active
+            ? cn('font-semibold text-foreground', !grouped && 'after:opacity-100')
+            : 'font-medium text-muted-foreground hover:text-foreground',
+        )}
+      >
+        {tab.projectId != null ? (
+          <ProjectAvatar name={tab.projectName ?? '?'} color={projectColor(tab.projectId)} size={14} />
+        ) : (
+          <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40" aria-hidden />
+        )}
+        <span className={cn('min-w-0 flex-1 truncate', tab.preview && 'italic')}>{tab.title}</span>
+        {tab.preview && (
+          <Hint label="Keep open">
+            <Button
+              data-testid={`session-tab-pin-${tab.id}`}
+              variant="ghost"
+              size="icon-2xs"
+              className={cn('opacity-0 group-hover:opacity-100', tab.active && 'opacity-60')}
+              onClick={(e) => {
+                e.stopPropagation();
+                onPin(tab.id);
+              }}
+            >
+              <Pin />
+            </Button>
+          </Hint>
+        )}
+        <Hint label={`Close ${tab.title}`}>
           <Button
-            data-testid={`session-tab-pin-${tab.id}`}
+            data-testid={`session-tab-close-${tab.id}`}
             variant="ghost"
             size="icon-2xs"
-            className={cn('opacity-0 group-hover:opacity-100', tab.active && 'opacity-60')}
+            // Grouped (split) tabs are both ON SCREEN, so both keep the resting
+            // ✕ the active tab gets — it closes the zone, not a hidden session.
+            className={cn('opacity-0 group-hover:opacity-100', (tab.active || grouped) && 'opacity-60')}
             onClick={(e) => {
               e.stopPropagation();
-              onPin(tab.id);
+              onClose(tab.id);
             }}
           >
-            <Pin />
+            <X />
           </Button>
         </Hint>
-      )}
-      <Hint label={`Close ${tab.title}`}>
-        <Button
-          data-testid={`session-tab-close-${tab.id}`}
-          variant="ghost"
-          size="icon-2xs"
-          // Grouped (split) tabs are both ON SCREEN, so both keep the resting
-          // ✕ the active tab gets — it closes the zone, not a hidden session.
-          className={cn('opacity-0 group-hover:opacity-100', (tab.active || grouped) && 'opacity-60')}
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose(tab.id);
-          }}
-        >
-          <X />
-        </Button>
-      </Hint>
-    </div>
+      </div>
+    </SessionTabContextMenu>
   );
 }

--- a/packages/ui/src/features/session-tabs/SessionTabs.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabs.tsx
@@ -22,7 +22,7 @@ import { cn } from '@/lib/utils';
 import { useNewChatHotkeyHandler } from '@/features/sessions/new-thread/use-new-chat-hotkey-handler';
 import { useProjects } from '@/features/sessions/use-projects';
 import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
-import { openInSplit } from '@/features/chat/zones/open-in-split';
+import { canOpenInSplit, openInSplit } from '@/features/chat/zones/open-in-split';
 import { splitVisible, useZonesStore } from '@/features/chat/zones/zones-store';
 import { SessionTabPill, type SessionTabEntry } from './SessionTabPill';
 import { useSessionTabsStore } from './store';
@@ -96,6 +96,24 @@ export function SessionTabs() {
     if (id !== activeTabId) aui.threads.switchToThread(id);
   };
 
+  // The context-menu twin of ⌘-click. The gesture guard lives in
+  // `canOpenInSplit`, so a menu item is enabled exactly when acting would work.
+  const handleOpenInSplit = (id: string) => {
+    openInSplit(activeTabId, id);
+  };
+
+  // The context-menu twin of ⌘\. Dissolving from a tab's own menu leaves you on
+  // THAT session — the one you pointed at — rather than ⌘\'s "other zone wins",
+  // which has no tab to aim at. A parked pair dissolves without moving focus,
+  // the same rule `handleClose` follows.
+  const handleCloseSplit = (id: string) => {
+    const zonesStore = useZonesStore.getState();
+    if (zonesStore.zones == null) return;
+    const visible = splitVisible(zonesStore.zones, activeTabId);
+    zonesStore.closeSplit();
+    if (visible && id !== activeTabId) aui.threads.switchToThread(id);
+  };
+
   const handleClose = (id: string) => {
     // Closing a zone member's tab dissolves the pair: the split collapses to
     // the other chat (VS Code's close-last-tab-closes-the-group). Focus only
@@ -137,6 +155,9 @@ export function SessionTabs() {
                   onActivate={handleActivate}
                   onClose={handleClose}
                   onPin={pinTab}
+                  canOpenInSplit={canOpenInSplit(zones, activeTabId, tab.id)}
+                  onOpenInSplit={handleOpenInSplit}
+                  onCloseSplit={handleCloseSplit}
                 />
               ))}
             {/* The split pair reads as ONE unit: one underline spanning both,
@@ -161,6 +182,9 @@ export function SessionTabs() {
                     onActivate={handleActivate}
                     onClose={handleClose}
                     onPin={pinTab}
+                    canOpenInSplit={canOpenInSplit(zones, activeTabId, tab.id)}
+                    onOpenInSplit={handleOpenInSplit}
+                    onCloseSplit={handleCloseSplit}
                   />
                 ))}
             </div>
@@ -174,12 +198,24 @@ export function SessionTabs() {
                   onActivate={handleActivate}
                   onClose={handleClose}
                   onPin={pinTab}
+                  canOpenInSplit={canOpenInSplit(zones, activeTabId, tab.id)}
+                  onOpenInSplit={handleOpenInSplit}
+                  onCloseSplit={handleCloseSplit}
                 />
               ))}
           </>
         ) : (
           tabs.map((tab) => (
-            <SessionTabPill key={tab.id} tab={tab} onActivate={handleActivate} onClose={handleClose} onPin={pinTab} />
+            <SessionTabPill
+              key={tab.id}
+              tab={tab}
+              onActivate={handleActivate}
+              onClose={handleClose}
+              onPin={pinTab}
+              canOpenInSplit={canOpenInSplit(zones, activeTabId, tab.id)}
+              onOpenInSplit={handleOpenInSplit}
+              onCloseSplit={handleCloseSplit}
+            />
           ))
         )}
       </div>

--- a/packages/ui/src/features/session-tabs/__tests__/SessionTabs.split.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/SessionTabs.split.test.tsx
@@ -187,6 +187,93 @@ describe('plain click', () => {
   });
 });
 
+describe('the tab context menu', () => {
+  // The menu adds no capability — it makes the ⌘-click / ⌘\ gestures reachable
+  // without knowing them. So each case asserts the SAME zones-store transition
+  // the keyboard gesture produces.
+  const rightClick = (testId: string) => fireEvent.contextMenu(screen.getByTestId(testId));
+
+  it('opens a split against the focused session, like ⌘-click', () => {
+    seed('chat-a');
+    render();
+
+    rightClick('session-tab-chat-p');
+    fireEvent.click(screen.getByTestId('session-tab-ctx-open-split'));
+
+    expect(zones()).toEqual(['chat-a', 'chat-p']);
+    expect(focusedIndex()).toBe(0);
+  });
+
+  it('offers Open in Split as DISABLED on the active tab — there is nothing to split against', () => {
+    seed('chat-a');
+    render();
+
+    rightClick('session-tab-chat-a');
+
+    expect(screen.getByTestId('session-tab-ctx-open-split').getAttribute('data-disabled')).not.toBeNull();
+    expect(zones()).toBeNull();
+  });
+
+  it('offers Close Split on a member instead of Open in Split', () => {
+    seed('chat-a');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    rightClick('session-tab-chat-b');
+
+    expect(screen.getByTestId('session-tab-ctx-close-split')).toBeTruthy();
+    expect(screen.queryByTestId('session-tab-ctx-open-split')).toBeNull();
+  });
+
+  it('dissolves the pair and lands on the session you pointed at', () => {
+    seed('chat-a');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    rightClick('session-tab-chat-b');
+    fireEvent.click(screen.getByTestId('session-tab-ctx-close-split'));
+
+    expect(zones()).toBeNull();
+    expect(switchToThread).toHaveBeenCalledWith('chat-b');
+    // Dissolving the split must not close either session's tab.
+    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-b']);
+  });
+
+  it('dissolves a PARKED pair without yanking focus off what you are reading', () => {
+    seed('chat-p');
+    useZonesStore.setState({ zones: ['chat-a', 'chat-b'], focusedIndex: 0 });
+    render();
+
+    rightClick('session-tab-chat-a');
+    fireEvent.click(screen.getByTestId('session-tab-ctx-close-split'));
+
+    expect(zones()).toBeNull();
+    expect(switchToThread).not.toHaveBeenCalled();
+  });
+
+  it('closes the tab from the menu, the same path as the ✕', () => {
+    seed('chat-a');
+    render();
+
+    rightClick('session-tab-chat-p');
+    fireEvent.click(screen.getByTestId('session-tab-ctx-close'));
+
+    expect(useSessionTabsStore.getState().previewId).toBeNull();
+  });
+
+  it('offers Keep Open on the preview tab only', () => {
+    seed('chat-a');
+    render();
+
+    rightClick('session-tab-chat-p');
+    expect(screen.getByTestId('session-tab-ctx-keep-open')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('session-tab-ctx-keep-open'));
+
+    expect(useSessionTabsStore.getState().tabIds).toContain('chat-p');
+    expect(useSessionTabsStore.getState().previewId).toBeNull();
+  });
+});
+
 describe("the pair's shared underline", () => {
   // The underline is the SELECTION signal, and a split can be open while parked
   // behind a third session. Lighting it on membership rather than on visibility


### PR DESCRIPTION
## Why

Splitting the chat surface works, but nothing in the tab strip says so. ⌘-click opens a split, dragging a tab retargets one, ⌘\ dissolves one — a tab announces none of it. Right-click is where people look for exactly these actions.

## What

Right-clicking a session tab now offers:

| item | when | does |
|---|---|---|
| **Open in Split** | tab is not in the pair | `openInSplit(active, id)` — the ⌘-click gesture. **Disabled** exactly when the gesture has nowhere to go (the active tab itself, either end a draft, already in the visible pair). |
| **Close Split** | tab is in the pair | dissolves it and lands on **the tab you pointed at**. A *parked* pair dissolves without moving focus. |
| **Keep Open** | preview tab | the existing pin — the hover-only affordance made reachable. |
| **Close** | always | the existing ✕ path. |

The menu adds **no capability** — every item performs a gesture that already exists. `Open in Split`'s enabled state and the gesture itself now read from one shared `canOpenInSplit(zones, activeId, id)` predicate extracted from `openInSplit`, so the offer can't drift from what acting would do.

Close Split deliberately diverges from ⌘\, which hands the surface to the *unfocused* zone. That rule is right for a keyboard shortcut with no target; a menu opened on a specific tab has one, so it keeps you on that session.

## Notes

- Separate `SessionTabContextMenu.tsx` (78 lines) rather than growing the pill — mirrors `SessionContextMenu.tsx` (the D11 pattern): shadcn `ContextMenu` wrapping the trigger with `asChild`, so the whole tab responds including the area its ✕ and pin overlay.
- The pill `preventDefault`s on mousedown (a WebKit text-selection fix) — verified live that right-click still opens the menu, and that left-click activate and drag-to-split still work through the wrapped trigger.
- **Left out of v1:** Rename, Tags, Archive (present in the sidebar's menu). Tags needs the `use-tag-popover-target` plumbing and Rename is aui-row-coupled — real work, not menu items. Also skipped "Pin" — the sidebar's Pin (pinned session group) and a tab's pin (preview → permanent) are different concepts sharing a word, and only the latter belongs here, as "Keep Open".

## Tests

7 cases in `SessionTabs.split.test.tsx` asserting the same zones-store transitions as the keyboard gestures, plus the disabled state, the member/non-member item swap, and that dissolving never closes a tab. Mutation-checked: breaking the focus target and forcing the item enabled each fail a case.

`typecheck` clean; 208 tests green across `session-tabs/` and `chat/zones/`. Exercised live in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)