### PR TITLE
fix(ui): keep a new session's tab open until it is sent

### DIFF
--- a/.changeset/session-tab-draft-slot.md
+++ b/.changeset/session-tab-draft-slot.md
@@ -1,0 +1,7 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Keep a new session's tab open while it is a draft, and make it temporary once it is sent.
+
+Creating a session used to pin its tab immediately, so every new session accumulated a permanent tab wherever the pinned set happened to end. The strip now has a third slot: an unsent draft opens into it, where opening another session cannot displace it, and the first send demotes it into the ordinary preview slot — it turns italic, grows the "Keep open" pin, and the next session you open replaces it. The draft always renders last, so a new session is the end tab. The runtime's transient boot draft is told apart from a deliberate one by whether the session list had loaded when it was activated, so booting still leaves no stray "New Session" tab.

--- a/packages/ui/src/features/session-tabs/SessionTabPill.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabPill.tsx
@@ -3,7 +3,9 @@
  * dot, the session title, and a hover close (×).
  *
  * A PREVIEW tab (editor-style temporary slot) renders its title italic and
- * grows a hover pin; double-click also pins. Pinned tabs are the plain form.
+ * grows a hover pin; double-click also pins. Pinned tabs are the plain form —
+ * and so is an unsent draft, which is kept open until its first send demotes
+ * it into the preview slot.
  *
  * Styled as the v2 Tabs primitive's `line` variant (verdict after trying the
  * boxed and Chrome-filled treatments): transparent pills, the active tab

--- a/packages/ui/src/features/session-tabs/SessionTabs.tsx
+++ b/packages/ui/src/features/session-tabs/SessionTabs.tsx
@@ -3,11 +3,11 @@
  * session is whichever tab is focused; there is ONE chat surface and tabs
  * switch its content (docs/plans/2026-08-08-session-tabs-and-workspace-files.md).
  *
- * The open set lives in `store.ts`; membership + persistence in
- * `useSessionTabsSync` (mounted here — the strip is the feature's one
- * always-rendered component). Closing removes from the set only — it never
- * archives. Closing the last tab falls back to the new-session flow, the same
- * behavior as the sidebar "+" / ⌘N.
+ * The open set lives in `store.ts` — pinned tabs, one peek, one unsent draft,
+ * rendered in that order; membership + persistence in `useSessionTabsSync`
+ * (mounted here — the strip is the feature's one always-rendered component).
+ * Closing removes from the set only — it never archives. Closing the last tab
+ * falls back to the new-session flow, the same behavior as the sidebar "+" / ⌘N.
  *
  * Overflow: pills shrink from w-45 to min-w-24, then the row scrolls
  * horizontally (no scrollbar — the app's opt-out idiom). The trailing spacer
@@ -55,6 +55,7 @@ export function SessionTabs() {
   const mainThreadId = useAuiState((s) => s.threads.mainThreadId);
   const tabIds = useSessionTabsStore((s) => s.tabIds);
   const previewId = useSessionTabsStore((s) => s.previewId);
+  const draftId = useSessionTabsStore((s) => s.draftId);
   const closeTab = useSessionTabsStore((s) => s.closeTab);
   const pinTab = useSessionTabsStore((s) => s.pinTab);
   const newSession = useNewChatHotkeyHandler(aui);
@@ -67,8 +68,9 @@ export function SessionTabs() {
   // in that window. aui switches on either id, so clicks pass the tab id.
   const activeTabId = canonicalTabId(mainThreadId, items);
 
-  // Pinned tabs in order; the preview slot renders last (editor-style).
-  const displayIds = previewId === null ? tabIds : [...tabIds, previewId];
+  // Pinned tabs in order, then the peek, then the unsent draft — whichever
+  // session was just created is always the last tab in the strip.
+  const displayIds = [...tabIds, previewId, draftId].filter((id): id is string => id !== null);
 
   // While split, the two zone tabs regroup ADJACENT (in zone order, at the
   // first member's position) so the strip mirrors the surface — a visual

--- a/packages/ui/src/features/session-tabs/__tests__/SessionTabs.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/SessionTabs.test.tsx
@@ -1,8 +1,8 @@
 /**
  * SessionTabs — the strip's rendering and its three affordances over the
- * pinned-plus-preview model: the preview always renders LAST, pinning promotes
- * it in place, and closing resolves the next active over the DISPLAYED order
- * (so a pinned tab's right neighbor can be the preview).
+ * pinned-preview-draft model: the peek and then the unsent draft render LAST,
+ * pinning promotes the peek in place, and closing resolves the next active over
+ * the DISPLAYED order (so a pinned tab's right neighbor can be the preview).
  *
  * The membership seam is mocked away: `useSessionTabsSync` would open a tab for
  * whatever thread is active and rewrite the state each test seeds. It has its
@@ -64,7 +64,39 @@ const tabOrder = () =>
 beforeEach(() => {
   switchToThread.mockReset();
   newSession.mockReset();
-  useSessionTabsStore.setState({ tabIds: [], previewId: null, hydrated: false });
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
+});
+
+describe('the draft tab', () => {
+  /** The seeded strip plus the unsent draft the user just created. */
+  function seedWithDraft(): void {
+    seed('__LOCALID_1');
+    itemsValue = [...SESSIONS, { id: '__LOCALID_1', status: 'new' }];
+    useSessionTabsStore.setState({ draftId: '__LOCALID_1' });
+  }
+
+  it('renders last, after the preview — a new session is always the end tab', () => {
+    seedWithDraft();
+
+    render();
+
+    expect(tabOrder()).toEqual([
+      'session-tab-chat-a',
+      'session-tab-chat-b',
+      'session-tab-chat-p',
+      'session-tab-__LOCALID_1',
+    ]);
+  });
+
+  it('reads as kept open, not as a peek: no italic title, no pin button', () => {
+    seedWithDraft();
+
+    render();
+
+    expect(screen.getByText('New Session').className).not.toContain('italic');
+    expect(screen.queryByTestId('session-tab-pin-__LOCALID_1')).toBeNull();
+    expect(screen.getByTestId('session-tab-close-__LOCALID_1')).toBeDefined();
+  });
 });
 
 describe('rendering', () => {

--- a/packages/ui/src/features/session-tabs/__tests__/store.draft.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/store.draft.test.ts
@@ -1,0 +1,108 @@
+/**
+ * session-tabs store — the DRAFT slot, the third one: a temporary tab that
+ * activating another session does NOT replace, so an unsent draft survives a
+ * peek at history. (The pinned set and the preview slot live in store.test.ts,
+ * which is at its size limit.)
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSessionTabsStore } from '../store';
+
+const pinned = () => useSessionTabsStore.getState().tabIds;
+const preview = () => useSessionTabsStore.getState().previewId;
+const draft = () => useSessionTabsStore.getState().draftId;
+
+beforeEach(() => {
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
+});
+
+describe('ensureTab', () => {
+  it('opens a draft in its own slot, leaving the peek and the pins alone', () => {
+    useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p' });
+
+    useSessionTabsStore.getState().ensureTab('__LOCALID_1', 'draft');
+
+    expect(draft()).toBe('__LOCALID_1');
+    expect(preview()).toBe('p');
+    expect(pinned()).toEqual(['a']);
+  });
+
+  it('keeps the draft when another session is activated', () => {
+    // The protection rule: the peek lands in the preview slot instead.
+    useSessionTabsStore.setState({ draftId: '__LOCALID_1' });
+
+    useSessionTabsStore.getState().ensureTab('chat-a');
+
+    expect(draft()).toBe('__LOCALID_1');
+    expect(preview()).toBe('chat-a');
+  });
+
+  it('is idempotent for the draft that is already open', () => {
+    useSessionTabsStore.setState({ draftId: '__LOCALID_1' });
+    const before = useSessionTabsStore.getState();
+
+    useSessionTabsStore.getState().ensureTab('__LOCALID_1', 'draft');
+
+    expect(useSessionTabsStore.getState()).toBe(before);
+  });
+});
+
+describe('pinTab', () => {
+  it('promotes the draft into the pinned set and empties the slot', () => {
+    // "Keep open" on a draft survives its first send: nothing demotes a pin.
+    useSessionTabsStore.setState({ tabIds: ['a'], draftId: '__LOCALID_1' });
+
+    useSessionTabsStore.getState().pinTab('__LOCALID_1');
+
+    expect(pinned()).toEqual(['a', '__LOCALID_1']);
+    expect(draft()).toBeNull();
+  });
+});
+
+describe('closeTab', () => {
+  it('clears only the draft slot when the draft is closed', () => {
+    useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p', draftId: '__LOCALID_1' });
+
+    useSessionTabsStore.getState().closeTab('__LOCALID_1');
+
+    expect(draft()).toBeNull();
+    expect(preview()).toBe('p');
+    expect(pinned()).toEqual(['a']);
+  });
+});
+
+describe('reconcile', () => {
+  it('writes the resolved three-slot state', () => {
+    useSessionTabsStore.setState({ tabIds: ['a', 'gone'], previewId: 'stale', draftId: '__LOCALID_1' });
+
+    useSessionTabsStore.getState().reconcile((s) => ({
+      tabIds: s.tabIds.filter((id) => id !== 'gone'),
+      previewId: s.draftId,
+      draftId: null,
+    }));
+
+    expect(pinned()).toEqual(['a']);
+    expect(preview()).toBe('__LOCALID_1');
+    expect(draft()).toBeNull();
+  });
+
+  it('leaves the state object untouched when only the draft slot is re-resolved to itself', () => {
+    // Identity matters: reconcile runs on every thread-list tick, and a fresh
+    // object each time would re-render the whole strip while a chat streams.
+    useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p', draftId: '__LOCALID_1' });
+    const before = useSessionTabsStore.getState();
+
+    useSessionTabsStore.getState().reconcile((s) => ({ ...s, tabIds: [...s.tabIds] }));
+
+    expect(useSessionTabsStore.getState()).toBe(before);
+  });
+
+  it('writes new state when only the draft slot changed', () => {
+    useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p', draftId: '__LOCALID_1' });
+
+    useSessionTabsStore.getState().reconcile((s) => ({ ...s, draftId: null }));
+
+    expect(draft()).toBeNull();
+    expect(pinned()).toEqual(['a']);
+    expect(preview()).toBe('p');
+  });
+});

--- a/packages/ui/src/features/session-tabs/__tests__/store.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/store.test.ts
@@ -1,9 +1,11 @@
 /**
  * session-tabs store — the open set, editor-style: an ordered PINNED list plus
  * ONE preview slot, both held as runtime thread ids. Two invariants carry the
- * feature: an activation is a peek (it replaces the preview) unless it pins,
- * and restore must not clobber the tabs the boot already opened — including the
- * preview that is on screen while the persisted one is still being restored.
+ * feature: an activation is a peek (it replaces the preview) unless it opens
+ * elsewhere, and restore must not clobber the tabs the boot already opened —
+ * including the preview that is on screen while the persisted one is still
+ * being restored. The third slot (the protected draft) lives in
+ * store.draft.test.ts.
  */
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useSessionTabsStore } from '../store';
@@ -12,7 +14,7 @@ const pinned = () => useSessionTabsStore.getState().tabIds;
 const preview = () => useSessionTabsStore.getState().previewId;
 
 beforeEach(() => {
-  useSessionTabsStore.setState({ tabIds: [], previewId: null, hydrated: false });
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
 });
 
 describe('ensureTab', () => {
@@ -33,13 +35,13 @@ describe('ensureTab', () => {
     expect(pinned()).toEqual([]);
   });
 
-  it('appends to the pinned set and leaves the preview alone when pin is true', () => {
-    // A just-created draft is a deliberate tab, not a peek (`shouldPinOnOpen`).
+  it('appends to the pinned set and leaves the preview alone for the pinned slot', () => {
+    // Splitting a session onto a zone is a "keep this open" signal.
     useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p' });
 
-    useSessionTabsStore.getState().ensureTab('__LOCALID_1', { pin: true });
+    useSessionTabsStore.getState().ensureTab('b', 'pinned');
 
-    expect(pinned()).toEqual(['a', '__LOCALID_1']);
+    expect(pinned()).toEqual(['a', 'b']);
     expect(preview()).toBe('p');
   });
 
@@ -65,12 +67,12 @@ describe('ensureTab', () => {
     expect(preview()).toBe('p');
   });
 
-  it('does not promote the previewed session even when asked to pin it', () => {
-    // Already-open wins over `pin`: the seam only reaches this with a
-    // `shouldPinOnOpen` id, which pinned on its first activation.
+  it('does not promote the previewed session even when asked for the pinned slot', () => {
+    // Already-open wins over the requested slot: membership is decided once,
+    // on the activation that opened the tab.
     useSessionTabsStore.setState({ tabIds: [], previewId: '__LOCALID_1' });
 
-    useSessionTabsStore.getState().ensureTab('__LOCALID_1', { pin: true });
+    useSessionTabsStore.getState().ensureTab('__LOCALID_1', 'pinned');
 
     expect(pinned()).toEqual([]);
     expect(preview()).toBe('__LOCALID_1');
@@ -191,30 +193,17 @@ describe('hydrate', () => {
 });
 
 describe('reconcile', () => {
-  it('applies both resolvers to the live state', () => {
+  it('applies the resolver to the live state', () => {
     useSessionTabsStore.setState({ tabIds: ['a', 'gone', 'b'], previewId: 'stale' });
 
-    useSessionTabsStore.getState().reconcile(
-      (ids) => ids.filter((id) => id !== 'gone'),
-      () => 'fresh',
-    );
+    useSessionTabsStore.getState().reconcile((s) => ({
+      ...s,
+      tabIds: s.tabIds.filter((id) => id !== 'gone'),
+      previewId: 'fresh',
+    }));
 
     expect(pinned()).toEqual(['a', 'b']);
     expect(preview()).toBe('fresh');
-  });
-
-  it('dissolves a resolved preview that lands inside the resolved pinned set', () => {
-    // The local→remote handoff can resolve both slots onto one session; the pin
-    // wins so the strip never shows the same session twice.
-    useSessionTabsStore.setState({ tabIds: ['__LOCALID_9'], previewId: '__LOCALID_9' });
-
-    useSessionTabsStore.getState().reconcile(
-      () => ['chat-new'],
-      () => 'chat-new',
-    );
-
-    expect(pinned()).toEqual(['chat-new']);
-    expect(preview()).toBeNull();
   });
 
   it('swaps a pinned id in place — the tab keeps its slot', () => {
@@ -222,15 +211,15 @@ describe('reconcile', () => {
     // id to another without removing and re-appending it.
     useSessionTabsStore.setState({ tabIds: ['a', 'local', 'b'] });
 
-    useSessionTabsStore.getState().reconcile(
-      (ids) => ids.map((id) => (id === 'local' ? 'remote' : id)),
-      (id) => id,
-    );
+    useSessionTabsStore.getState().reconcile((s) => ({
+      ...s,
+      tabIds: s.tabIds.map((id) => (id === 'local' ? 'remote' : id)),
+    }));
 
     expect(pinned()).toEqual(['a', 'remote', 'b']);
   });
 
-  it('leaves the state object untouched when both resolvers return what they got', () => {
+  it('leaves the state object untouched when the resolver returns what it got', () => {
     // Identity matters, not just equality: the seam reconciles on every
     // thread-list change, and a fresh object each time would re-render the
     // whole strip while a chat streams — even though the resolver allocates a
@@ -238,10 +227,7 @@ describe('reconcile', () => {
     useSessionTabsStore.setState({ tabIds: ['a', 'b'], previewId: 'p' });
     const before = useSessionTabsStore.getState();
 
-    useSessionTabsStore.getState().reconcile(
-      (ids) => [...ids],
-      (id) => id,
-    );
+    useSessionTabsStore.getState().reconcile((s) => ({ ...s, tabIds: [...s.tabIds] }));
 
     expect(useSessionTabsStore.getState()).toBe(before);
   });
@@ -249,22 +235,16 @@ describe('reconcile', () => {
   it('writes new state when only the preview changed', () => {
     useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p' });
 
-    useSessionTabsStore.getState().reconcile(
-      (ids) => [...ids],
-      () => null,
-    );
+    useSessionTabsStore.getState().reconcile((s) => ({ ...s, previewId: null }));
 
     expect(pinned()).toEqual(['a']);
     expect(preview()).toBeNull();
   });
 
-  it('empties the strip when the resolvers return nothing', () => {
+  it('empties the strip when the resolver returns nothing', () => {
     useSessionTabsStore.setState({ tabIds: ['a'], previewId: 'p' });
 
-    useSessionTabsStore.getState().reconcile(
-      () => [],
-      () => null,
-    );
+    useSessionTabsStore.getState().reconcile(() => ({ tabIds: [], previewId: null, draftId: null }));
 
     expect(pinned()).toEqual([]);
     expect(preview()).toBeNull();
@@ -274,10 +254,7 @@ describe('reconcile', () => {
     useSessionTabsStore.setState({ tabIds: ['a'] });
 
     useSessionTabsStore.getState().ensureTab('b');
-    useSessionTabsStore.getState().reconcile(
-      (ids) => ids,
-      (id) => id,
-    );
+    useSessionTabsStore.getState().reconcile((s) => s);
 
     expect(pinned()).toEqual(['a']);
     expect(preview()).toBe('b');

--- a/packages/ui/src/features/session-tabs/__tests__/tabs-model.draft.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/tabs-model.draft.test.ts
@@ -1,0 +1,143 @@
+/**
+ * tabs-model — the DRAFT slot: the third, protected temporary tab.
+ *
+ * A draft the user just created is kept while it is unsent (activating another
+ * session must not throw away typing), and stops being protected the moment it
+ * is sent: it demotes into the ordinary preview slot, where the next activation
+ * replaces it. `reconcileTabs` is where that transition happens, because it
+ * moves an id BETWEEN slots — something the per-slot resolvers cannot express.
+ */
+import { describe, expect, it } from 'vitest';
+import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
+import { isDraftThread, reconcileTabs } from '../tabs-model';
+
+/** A real session row: a regular thread-list entry, optionally remoteId-stamped. */
+function entry(id: string, over: Partial<ThreadListEntry> = {}): ThreadListEntry {
+  return { id, status: 'regular', ...over };
+}
+
+const EMPTY = { tabIds: [], previewId: null, draftId: null };
+
+describe('isDraftThread', () => {
+  it('is true for a local draft id that has no thread-list entry yet', () => {
+    expect(isDraftThread('__LOCALID_1', [])).toBe(true);
+  });
+
+  it('is true for the unsent draft the user just created', () => {
+    const items: ThreadListEntry[] = [{ id: '__LOCALID_1', status: 'new' }];
+
+    expect(isDraftThread('__LOCALID_1', items)).toBe(true);
+  });
+
+  it('is false for a SENT session re-opened by the local id it kept', () => {
+    const items = [entry('__LOCALID_1', { remoteId: 'chat-a' })];
+
+    expect(isDraftThread('__LOCALID_1', items)).toBe(false);
+  });
+
+  it('is false for an existing session opened from the sidebar', () => {
+    const items = [entry('chat-a', { custom: {}, title: 'Fix the parser' })];
+
+    expect(isDraftThread('chat-a', items)).toBe(false);
+  });
+
+  it('is true for a status-new entry even when its id is not a local one', () => {
+    const items: ThreadListEntry[] = [{ id: 'chat-a', status: 'new' }];
+
+    expect(isDraftThread('chat-a', items)).toBe(true);
+  });
+
+  it('is false for a non-local id with no entry at all', () => {
+    expect(isDraftThread('chat-a', [])).toBe(false);
+  });
+
+  it('is false for an archived session', () => {
+    const items = [entry('chat-a', { status: 'archived', custom: {} })];
+
+    expect(isDraftThread('chat-a', items)).toBe(false);
+  });
+
+  it('matches on the entry id only — a remoteId hit is not a draft', () => {
+    const items: ThreadListEntry[] = [{ id: '__LOCALID_1', status: 'new', remoteId: 'chat-a' }];
+
+    expect(isDraftThread('chat-a', items)).toBe(false);
+  });
+});
+
+describe('reconcileTabs', () => {
+  it('keeps the unsent draft while another session is active', () => {
+    // The protection rule: peeking at a session does not discard the draft.
+    const items: ThreadListEntry[] = [entry('chat-a', { custom: {} }), { id: '__LOCALID_1', status: 'new' }];
+
+    const next = reconcileTabs({ tabIds: [], previewId: 'chat-a', draftId: '__LOCALID_1' }, items, 'chat-a');
+
+    expect(next).toEqual({ tabIds: [], previewId: 'chat-a', draftId: '__LOCALID_1' });
+  });
+
+  it('keeps a brand-new draft that has no thread-list entry yet', () => {
+    const items = [entry('chat-a', { custom: {} })];
+
+    const next = reconcileTabs({ tabIds: ['chat-a'], previewId: null, draftId: '__LOCALID_1' }, items, 'chat-a');
+
+    expect(next.draftId).toBe('__LOCALID_1');
+  });
+
+  it('demotes the draft into the preview slot once it is sent', () => {
+    // The first send stamps the local entry regular: the tab stops being
+    // protected and becomes THE temporary tab.
+    const items = [entry('chat-a', { custom: {} }), entry('__LOCALID_1', { remoteId: 'chat-new' })];
+
+    const next = reconcileTabs({ tabIds: [], previewId: 'chat-a', draftId: '__LOCALID_1' }, items, '__LOCALID_1');
+
+    expect(next).toEqual({ tabIds: [], previewId: '__LOCALID_1', draftId: null });
+  });
+
+  it('demotes onto the canonical session id once the remote entry lands', () => {
+    const items = [
+      entry('__LOCALID_1', { remoteId: 'chat-new' }),
+      entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+    ];
+
+    const next = reconcileTabs({ tabIds: [], previewId: null, draftId: '__LOCALID_1' }, items, 'chat-new');
+
+    expect(next).toEqual({ tabIds: [], previewId: 'chat-new', draftId: null });
+  });
+
+  it('drops the demoted draft when its session is already pinned', () => {
+    // One session, one tab: the pin wins and the slot stays free.
+    const items = [
+      entry('__LOCALID_1', { remoteId: 'chat-new' }),
+      entry('chat-new', { custom: {}, title: 'Fix the parser' }),
+    ];
+
+    const next = reconcileTabs({ tabIds: ['chat-new'], previewId: null, draftId: '__LOCALID_1' }, items, 'chat-new');
+
+    expect(next).toEqual({ tabIds: ['chat-new'], previewId: null, draftId: null });
+  });
+
+  it('prunes the pinned set and the preview slot exactly as their own rules do', () => {
+    const items = [entry('chat-a', { custom: {} })];
+
+    const next = reconcileTabs(
+      { tabIds: ['chat-a', 'chat-gone'], previewId: 'chat-archived', draftId: null },
+      items,
+      'chat-a',
+    );
+
+    expect(next).toEqual({ tabIds: ['chat-a'], previewId: null, draftId: null });
+  });
+
+  it('dissolves a preview that resolves onto a pinned session', () => {
+    // The local→remote handoff can resolve both slots onto one session; the pin
+    // wins so the strip never shows the same session twice.
+    const items = [entry('__LOCALID_9', { remoteId: 'chat-new' }), entry('chat-new', { custom: {} })];
+
+    const next = reconcileTabs({ tabIds: ['chat-new'], previewId: '__LOCALID_9', draftId: null }, items, 'chat-new');
+
+    expect(next).toEqual({ tabIds: ['chat-new'], previewId: null, draftId: null });
+  });
+
+  it('leaves an empty strip empty', () => {
+    expect(reconcileTabs(EMPTY, [], null)).toEqual(EMPTY);
+  });
+});

--- a/packages/ui/src/features/session-tabs/__tests__/tabs-model.preview.test.ts
+++ b/packages/ui/src/features/session-tabs/__tests__/tabs-model.preview.test.ts
@@ -3,12 +3,12 @@
  * in tabs-model.test.ts, which is at its size limit).
  *
  * `reconcilePreviewId` is `reconcileTabIds` collapsed to one nullable id: same
- * canonicalisation, same validity rule. `shouldPinOnOpen` decides whether an
- * activation is a peek at history or a tab the user deliberately created.
+ * canonicalisation, same validity rule. The protected draft slot and the
+ * transitions between the three slots live in tabs-model.draft.test.ts.
  */
 import { describe, expect, it } from 'vitest';
 import type { ThreadListEntry } from '@/features/sessions/view-model/chat-to-thread-custom';
-import { reconcilePreviewId, shouldPinOnOpen } from '../tabs-model';
+import { reconcilePreviewId } from '../tabs-model';
 
 /** A real session row: a regular thread-list entry, optionally remoteId-stamped. */
 function entry(id: string, over: Partial<ThreadListEntry> = {}): ThreadListEntry {
@@ -74,52 +74,5 @@ describe('reconcilePreviewId', () => {
 
   it('empties the slot when the thread list is empty and nothing is active', () => {
     expect(reconcilePreviewId('chat-a', [], null)).toBeNull();
-  });
-});
-
-describe('shouldPinOnOpen', () => {
-  it('pins a local draft id that has no thread-list entry yet', () => {
-    expect(shouldPinOnOpen('__LOCALID_1', [])).toBe(true);
-  });
-
-  it('pins the unsent draft the user just created', () => {
-    const items: ThreadListEntry[] = [{ id: '__LOCALID_1', status: 'new' }];
-
-    expect(shouldPinOnOpen('__LOCALID_1', items)).toBe(true);
-  });
-
-  it('previews a SENT session re-opened by the local id it kept — only drafts pin', () => {
-    const items = [entry('__LOCALID_1', { remoteId: 'chat-a' })];
-
-    expect(shouldPinOnOpen('__LOCALID_1', items)).toBe(false);
-  });
-
-  it('previews an existing session opened from the sidebar', () => {
-    const items = [entry('chat-a', { custom: {}, title: 'Fix the parser' })];
-
-    expect(shouldPinOnOpen('chat-a', items)).toBe(false);
-  });
-
-  it('pins a status-new entry even when its id is not a local one', () => {
-    const items: ThreadListEntry[] = [{ id: 'chat-a', status: 'new' }];
-
-    expect(shouldPinOnOpen('chat-a', items)).toBe(true);
-  });
-
-  it('previews an id with no entry at all', () => {
-    expect(shouldPinOnOpen('chat-a', [])).toBe(false);
-  });
-
-  it('previews an archived session', () => {
-    const items = [entry('chat-a', { status: 'archived', custom: {} })];
-
-    expect(shouldPinOnOpen('chat-a', items)).toBe(false);
-  });
-
-  it('matches on the entry id only — a remoteId hit does not pin', () => {
-    // The seam passes the ACTIVE id; the canonical entry is the one that counts.
-    const items: ThreadListEntry[] = [{ id: '__LOCALID_1', status: 'new', remoteId: 'chat-a' }];
-
-    expect(shouldPinOnOpen('chat-a', items)).toBe(false);
   });
 });

--- a/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.draft.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.draft.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * useSessionTabsSync — the draft tab's life: protected while unsent, temporary
+ * once sent, and never a leftover from boot.
+ *
+ * Two drafts are indistinguishable by state — the runtime's transient boot
+ * draft and the one the user created with "+" are both a `__LOCALID_*` entry
+ * with status 'new'. What separates them is WHEN they were activated: the boot
+ * draft is active before `adapter.list()` has ever returned, so the seam reads
+ * the load flag at activation time and only protects a draft opened after it.
+ */
+import { it, expect, vi, beforeEach, describe } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { SESSION_TABS_STORAGE_KEY } from '../tabs-model';
+import { useSessionTabsStore } from '../store';
+import { useSessionListLoadState } from '@/features/sessions/runtime/list-load-state';
+
+// ---------------------------------------------------------------------------
+// Mutable module-scope state the mocked @assistant-ui/react selector reads.
+// ---------------------------------------------------------------------------
+
+let itemsValue: Array<{ id: string; status?: string; custom?: unknown; remoteId?: string; title?: string }>;
+let isLoadingValue: boolean;
+let mainThreadIdValue: string | null;
+
+vi.mock('@assistant-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@assistant-ui/react')>('@assistant-ui/react');
+  return {
+    ...actual,
+    useAuiState: (
+      sel: (s: {
+        threads: {
+          threadItems: typeof itemsValue;
+          isLoading: boolean;
+          mainThreadId: string | null;
+        };
+      }) => unknown,
+    ) => sel({ threads: { threadItems: itemsValue, isLoading: isLoadingValue, mainThreadId: mainThreadIdValue } }),
+  };
+});
+
+import { useSessionTabsSync } from '../use-session-tabs-sync';
+
+/** A settled, real list: what `adapter.list()` returning looks like to the hook. */
+function settledList(items: typeof itemsValue): void {
+  itemsValue = items;
+  isLoadingValue = false;
+  useSessionListLoadState.setState({ loaded: true });
+}
+
+const SESSION_A = { id: 'chat-a', status: 'regular', custom: {}, title: 'Fix the parser' };
+const SESSION_B = { id: 'chat-b', status: 'regular', custom: {}, title: 'Write the docs' };
+const DRAFT = { id: '__LOCALID_1', status: 'new' };
+
+beforeEach(() => {
+  itemsValue = [];
+  isLoadingValue = true;
+  mainThreadIdValue = null;
+  localStorage.clear();
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
+  useSessionListLoadState.setState({ loaded: false });
+});
+
+describe('an unsent draft', () => {
+  it('opens in the protected draft slot, beside the peek it did not replace', () => {
+    settledList([SESSION_A, SESSION_B]);
+    mainThreadIdValue = 'chat-b';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    itemsValue = [SESSION_A, SESSION_B, DRAFT];
+    mainThreadIdValue = '__LOCALID_1';
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.draftId).toBe('__LOCALID_1');
+    expect(state.previewId).toBe('chat-b');
+    expect(state.tabIds).toEqual([]);
+  });
+
+  it('survives opening another session from the sidebar', () => {
+    // The whole point of the slot: a peek must not throw away unsent typing.
+    settledList([SESSION_A, SESSION_B, DRAFT]);
+    mainThreadIdValue = '__LOCALID_1';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    mainThreadIdValue = 'chat-a';
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.draftId).toBe('__LOCALID_1');
+    expect(state.previewId).toBe('chat-a');
+  });
+});
+
+describe('the first send', () => {
+  it('demotes the draft to the temporary slot, which the next session then replaces', () => {
+    settledList([SESSION_A, SESSION_B, DRAFT]);
+    mainThreadIdValue = '__LOCALID_1';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    // First send + chat.created reload: the local entry is remoteId-stamped, a
+    // canonical entry lands, and the router hands the active thread over.
+    itemsValue = [
+      SESSION_A,
+      SESSION_B,
+      { id: '__LOCALID_1', status: 'regular', remoteId: 'chat-new' },
+      { id: 'chat-new', status: 'regular', custom: {}, title: 'Ship the release' },
+    ];
+    mainThreadIdValue = 'chat-new';
+    rerender();
+
+    expect(useSessionTabsStore.getState()).toMatchObject({ tabIds: [], previewId: 'chat-new', draftId: null });
+
+    // Clicking another session now dismisses it, like any temporary tab.
+    mainThreadIdValue = 'chat-a';
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.previewId).toBe('chat-a');
+    expect(state.tabIds).toEqual([]);
+    expect(state.draftId).toBeNull();
+  });
+
+  it('leaves a draft the user kept open pinned, with the slot free for the next one', () => {
+    settledList([SESSION_A, DRAFT]);
+    mainThreadIdValue = '__LOCALID_1';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+    useSessionTabsStore.getState().pinTab('__LOCALID_1');
+
+    itemsValue = [
+      SESSION_A,
+      { id: '__LOCALID_1', status: 'regular', remoteId: 'chat-new' },
+      { id: 'chat-new', status: 'regular', custom: {}, title: 'Ship the release' },
+    ];
+    mainThreadIdValue = 'chat-new';
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.tabIds).toEqual(['chat-new']);
+    expect(state.previewId).toBeNull();
+    expect(state.draftId).toBeNull();
+  });
+});
+
+describe('the boot draft', () => {
+  it('leaves no leftover tab once the list settles and a session is auto-selected', () => {
+    // The runtime seeds a draft before `list()` resolves; it is not the user's
+    // "+", so it peeks (and is replaced) instead of claiming the draft slot.
+    itemsValue = [DRAFT];
+    mainThreadIdValue = '__LOCALID_1';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    expect(useSessionTabsStore.getState().draftId).toBeNull();
+
+    settledList([SESSION_A, SESSION_B]);
+    mainThreadIdValue = 'chat-a';
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.previewId).toBe('chat-a');
+    expect(state.draftId).toBeNull();
+    expect(state.tabIds).toEqual([]);
+  });
+
+  it('does not eat the persisted preview when the list settles under it', () => {
+    // The boot draft holds the preview slot only because nothing real is on
+    // screen yet — unlike a deep-link peek, it must not outrank the restore.
+    localStorage.setItem(SESSION_TABS_STORAGE_KEY, JSON.stringify({ v: 3, ids: ['chat-a'], preview: 'chat-b' }));
+    itemsValue = [DRAFT];
+    mainThreadIdValue = '__LOCALID_1';
+    const { rerender } = renderHook(() => useSessionTabsSync());
+
+    settledList([SESSION_A, SESSION_B, DRAFT]);
+    rerender();
+
+    const state = useSessionTabsStore.getState();
+    expect(state.tabIds).toEqual(['chat-a']);
+    expect(state.previewId).toBe('chat-b');
+  });
+});

--- a/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.preview.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.preview.test.tsx
@@ -61,7 +61,7 @@ beforeEach(() => {
   isLoadingValue = true;
   mainThreadIdValue = null;
   localStorage.clear();
-  useSessionTabsStore.setState({ tabIds: [], previewId: null, hydrated: false });
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
   useSessionListLoadState.setState({ loaded: false });
 });
 
@@ -104,23 +104,8 @@ describe('activation', () => {
     expect(state.previewId).toBe('chat-b');
   });
 
-  it('pins a just-created draft immediately and keeps the peek beside it', () => {
-    // "+" is a deliberate new tab, not a peek at history.
-    settledList([SESSION_A, SESSION_B]);
-    mainThreadIdValue = 'chat-b';
-    const { rerender } = renderHook(() => useSessionTabsSync());
-
-    itemsValue = [SESSION_A, SESSION_B, { id: '__LOCALID_1', status: 'new' }];
-    mainThreadIdValue = '__LOCALID_1';
-    rerender();
-
-    const state = useSessionTabsStore.getState();
-    expect(state.tabIds).toEqual(['__LOCALID_1']);
-    expect(state.previewId).toBe('chat-b');
-  });
-
   it('previews a session re-opened by the local id it kept after its first send', () => {
-    // `shouldPinOnOpen` reads the ENTRY's status, not the id shape: a session
+    // `isDraftThread` reads the ENTRY's status, not the id shape: a session
     // created this run still answers to `__LOCALID_*`, but once sent it is a
     // regular session and re-opening it peeks like any other.
     settledList([SESSION_A, { id: '__LOCALID_5', status: 'regular', remoteId: 'chat-b', custom: {} }]);
@@ -167,8 +152,8 @@ describe('persistence (v3)', () => {
 
     renderHook(() => useSessionTabsSync());
 
-    // The draft pinned, so it is the dropped pin — and the restored preview
-    // stays as the only survivor of the write.
+    // The draft holds its own slot, which is never persisted — the restored
+    // preview stays as the only survivor of the write.
     expect(readPersisted()).toEqual({ v: 3, ids: ['chat-a'], preview: 'chat-b', zones: [], zonesFrac: null });
   });
 

--- a/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx
+++ b/packages/ui/src/features/session-tabs/__tests__/use-session-tabs-sync.test.tsx
@@ -52,7 +52,7 @@ beforeEach(() => {
   isLoadingValue = true;
   mainThreadIdValue = null;
   localStorage.clear();
-  useSessionTabsStore.setState({ tabIds: [], hydrated: false });
+  useSessionTabsStore.setState({ tabIds: [], previewId: null, draftId: null, hydrated: false });
   useSessionListLoadState.setState({ loaded: false });
 });
 
@@ -151,9 +151,11 @@ it('keeps the payload through a failed load, a first send, and a deep-link fetch
   listSucceeded();
   rerender();
 
+  // The sent draft left no tab of its own: it was never protected (the list had
+  // not loaded when it was activated), so the deep-link peek replaced it.
   const state = useSessionTabsStore.getState();
   expect(state.hydrated).toBe(true);
-  expect(state.tabIds).toEqual(['chat-a', 'chat-b', '__LOCALID_1']);
+  expect(state.tabIds).toEqual(['chat-a', 'chat-b']);
 });
 
 it('boots clean on a genuinely session-less install', () => {
@@ -164,8 +166,11 @@ it('boots clean on a genuinely session-less install', () => {
 
   renderHook(() => useSessionTabsSync());
 
+  // The list DID load, so this draft is the user's own — it holds the protected
+  // slot, and nothing persists until it becomes a session.
   const state = useSessionTabsStore.getState();
-  expect(state.tabIds).toEqual(['__LOCALID_1']);
+  expect(state.draftId).toBe('__LOCALID_1');
+  expect(state.tabIds).toEqual([]);
   expect(state.hydrated).toBe(false);
   expect(localStorage.getItem(SESSION_TABS_STORAGE_KEY)).toBeNull();
 });
@@ -182,7 +187,7 @@ it('boots clean on a genuinely session-less install', () => {
  * pruning — the pre-existing #312 cases above must stay green throughout.
  */
 describe('first-send identity handoff', () => {
-  it('collapses the orphaned draft onto the canonical session, in place, across repeated sessions', () => {
+  it('collapses the orphaned draft onto ONE canonical tab, session after session', () => {
     useSessionTabsStore.setState({ tabIds: ['chat-a'] });
     itemsValue = [
       { id: 'chat-a', status: 'regular', custom: {} },
@@ -193,11 +198,11 @@ describe('first-send identity handoff', () => {
     listSucceeded();
     const { rerender } = renderHook(() => useSessionTabsSync());
 
-    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', '__LOCALID_9']);
+    expect(useSessionTabsStore.getState().draftId).toBe('__LOCALID_9');
 
     // First send + chat.created reload: the local entry is remoteId-stamped and
     // a second, canonical entry lands — but the router has not handed the
-    // active thread over yet.
+    // active thread over yet. The draft demotes onto the canonical id, once.
     itemsValue = [
       { id: 'chat-a', status: 'regular', custom: {} },
       { id: '__LOCALID_9', status: 'regular', remoteId: 'chat-new' },
@@ -205,21 +210,31 @@ describe('first-send identity handoff', () => {
     ];
     rerender();
 
-    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new']);
+    expect(useSessionTabsStore.getState()).toMatchObject({
+      tabIds: ['chat-a'],
+      previewId: 'chat-new',
+      draftId: null,
+    });
 
-    // The router's handover lands; nothing changes — the seam appends the
-    // canonical id, and reconciliation collapses it in the same flush.
+    // The router's handover lands; nothing changes — the seam finds the
+    // canonical id already open.
     mainThreadIdValue = 'chat-new';
     rerender();
 
-    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new']);
+    expect(useSessionTabsStore.getState()).toMatchObject({ tabIds: ['chat-a'], previewId: 'chat-new' });
 
-    // A second session runs the same dance: N sessions leaves N tabs, not 2N.
+    // Kept open, it leaves the temporary slot free for the next session.
+    useSessionTabsStore.getState().pinTab('chat-new');
+
+    // A second session runs the same dance: N sessions leave N tabs, not 2N.
     itemsValue = [...itemsValue, { id: '__LOCALID_10', status: 'new' }];
     mainThreadIdValue = '__LOCALID_10';
     rerender();
 
-    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new', '__LOCALID_10']);
+    expect(useSessionTabsStore.getState()).toMatchObject({
+      tabIds: ['chat-a', 'chat-new'],
+      draftId: '__LOCALID_10',
+    });
 
     itemsValue = [
       { id: 'chat-a', status: 'regular', custom: {} },
@@ -231,8 +246,12 @@ describe('first-send identity handoff', () => {
     mainThreadIdValue = 'chat-two';
     rerender();
 
-    expect(useSessionTabsStore.getState().tabIds).toEqual(['chat-a', 'chat-new', 'chat-two']);
-    expect(readPersistedIds()).toEqual(['chat-a', 'chat-new', 'chat-two']);
+    expect(useSessionTabsStore.getState()).toMatchObject({
+      tabIds: ['chat-a', 'chat-new'],
+      previewId: 'chat-two',
+      draftId: null,
+    });
+    expect(readPersistedIds()).toEqual(['chat-a', 'chat-new']);
   });
 
   it('collapses an already-open ghost without waiting for hydration', () => {

--- a/packages/ui/src/features/session-tabs/store.ts
+++ b/packages/ui/src/features/session-tabs/store.ts
@@ -1,20 +1,24 @@
 /**
  * session-tabs store — the open session tabs, editor-style: an ordered PINNED
- * set plus ONE preview slot. Activating a session fills the preview slot
- * (replacing whatever was previewed); pinning moves it into the pinned set,
- * where it stays until closed. Ids are runtime thread ids in display order.
+ * set, ONE preview slot, and ONE draft slot. Activating a session fills the
+ * preview slot (replacing whatever was previewed); an unsent draft fills the
+ * draft slot instead, where a peek at another session cannot displace it until
+ * its first send demotes it to preview. Ids are runtime thread ids.
  *
  * Deliberately not zustand-persist: runtime ids aren't boot-stable, and mapping
  * them to storable ids needs the live thread list. `useSessionTabsSync` owns
  * that translation (restore on hydrate, persist on change) via `tabs-model`.
  */
 import { create } from 'zustand';
+import type { TabSlot, TabsState } from './tabs-model';
 
-interface SessionTabsStore {
+interface SessionTabsStore extends TabsState {
   /** Pinned tabs — replaced wholesale on every change, never mutated in place. */
   tabIds: readonly string[];
   /** The one temporary tab; the next activation of an unpinned session replaces it. */
   previewId: string | null;
+  /** The unsent draft's tab — temporary too, but protected from replacement. */
+  draftId: string | null;
   /** True once the persisted set has been restored against a loaded thread list. */
   hydrated: boolean;
   /** Restored pins lead; pins opened before hydration (boot draft) follow. The
@@ -22,24 +26,21 @@ interface SessionTabsStore {
   hydrate: (restored: readonly string[], preview: string | null) => void;
   /**
    * The membership seam, called on every active-thread change. A session
-   * already open (pinned or previewed) is left alone; otherwise it lands in
-   * the preview slot — or straight in the pinned set when `pin` is true (a
-   * draft the user just created is a deliberate tab, not a peek).
+   * already open is left alone; otherwise it lands in the slot the caller
+   * names — `preview` for a peek at history, `draft` for the unsent draft the
+   * user just created, `pinned` for a tab something else is keeping open.
    */
-  ensureTab: (id: string, opts?: { pin?: boolean }) => void;
-  /** Preview → pinned. A no-op for anything already pinned or not open. */
+  ensureTab: (id: string, slot?: TabSlot) => void;
+  /** Preview or draft → pinned. A no-op for anything already pinned or not open. */
   pinTab: (id: string) => void;
   closeTab: (id: string) => void;
   /**
    * Rewrite the open set through the sync hook's pure resolver — the store
-   * knows neither which ids are still valid nor how a session's two identities
-   * collapse into one. The preview id goes through its own resolver; a preview
-   * whose canonical id is pinned dissolves into that pin.
+   * knows neither which ids are still valid, nor how a session's two identities
+   * collapse into one, nor when a draft has been sent. One resolver over all
+   * three slots, because those transitions move ids BETWEEN slots.
    */
-  reconcile: (
-    resolvePinned: (ids: readonly string[]) => readonly string[],
-    resolvePreview: (id: string | null) => string | null,
-  ) => void;
+  reconcile: (resolve: (state: TabsState) => TabsState) => void;
 }
 
 function sameIds(a: readonly string[], b: readonly string[]): boolean {
@@ -49,6 +50,7 @@ function sameIds(a: readonly string[], b: readonly string[]): boolean {
 export const useSessionTabsStore = create<SessionTabsStore>((set) => ({
   tabIds: [],
   previewId: null,
+  draftId: null,
   hydrated: false,
   hydrate: (restored, preview) =>
     set((s) => ({
@@ -56,34 +58,36 @@ export const useSessionTabsStore = create<SessionTabsStore>((set) => ({
       tabIds: [...restored, ...s.tabIds.filter((id) => !restored.includes(id))],
       previewId: s.previewId ?? (preview !== null && !restored.includes(preview) ? preview : null),
     })),
-  ensureTab: (id, opts) =>
+  ensureTab: (id, slot = 'preview') =>
     set((s) => {
-      if (s.tabIds.includes(id) || s.previewId === id) return s;
-      if (opts?.pin) return { tabIds: [...s.tabIds, id] };
+      if (s.tabIds.includes(id) || s.previewId === id || s.draftId === id) return s;
+      if (slot === 'pinned') return { tabIds: [...s.tabIds, id] };
+      if (slot === 'draft') return { draftId: id };
       return { previewId: id };
     }),
   pinTab: (id) =>
     set((s) => {
-      if (s.previewId !== id || s.tabIds.includes(id)) return s;
-      return { tabIds: [...s.tabIds, id], previewId: null };
+      if (s.tabIds.includes(id)) return s;
+      if (s.previewId === id) return { tabIds: [...s.tabIds, id], previewId: null };
+      if (s.draftId === id) return { tabIds: [...s.tabIds, id], draftId: null };
+      return s;
     }),
   closeTab: (id) =>
     set((s) => {
       if (s.previewId === id) return { previewId: null };
+      if (s.draftId === id) return { draftId: null };
       if (!s.tabIds.includes(id)) return s;
       return { tabIds: s.tabIds.filter((t) => t !== id) };
     }),
-  reconcile: (resolvePinned, resolvePreview) =>
+  reconcile: (resolve) =>
     set((s) => {
-      // Resolve against the CURRENT ids: an array precomputed in the effect
+      // Resolve against the CURRENT state: a value precomputed in the effect
       // body would be stale after a same-flush `hydrate`.
-      const nextPinned = resolvePinned(s.tabIds);
-      const rawPreview = resolvePreview(s.previewId);
-      const nextPreview = rawPreview !== null && nextPinned.includes(rawPreview) ? null : rawPreview;
+      const next = resolve({ tabIds: s.tabIds, previewId: s.previewId, draftId: s.draftId });
       // The caller allocates a fresh array on every thread-list tick, so
       // compare content — a new state object would re-render the whole strip
       // while a chat streams.
-      if (sameIds(nextPinned, s.tabIds) && nextPreview === s.previewId) return s;
-      return { tabIds: nextPinned, previewId: nextPreview };
+      if (sameIds(next.tabIds, s.tabIds) && next.previewId === s.previewId && next.draftId === s.draftId) return s;
+      return next;
     }),
 }));

--- a/packages/ui/src/features/session-tabs/tabs-model.ts
+++ b/packages/ui/src/features/session-tabs/tabs-model.ts
@@ -156,12 +156,46 @@ export function reconcilePreviewId(
   return valid.has(canonical) ? canonical : null;
 }
 
-/** Whether an activated thread should open PINNED rather than as a preview: a
- *  draft the user just created is a deliberate tab, not a peek at history.
- *  Judged by the ENTRY's status, not the id shape — a session created this run
- *  keeps its `__LOCALID_*` id for life, and re-opening it later must preview
- *  like any other session. A local id with no entry yet is a brand-new draft. */
-export function shouldPinOnOpen(id: string, items: readonly ThreadListEntry[]): boolean {
+/** Whether an activated thread is an UNSENT draft, which opens in the protected
+ *  draft slot rather than as a peek at history. Judged by the ENTRY's status,
+ *  not the id shape — a session created this run keeps its `__LOCALID_*` id for
+ *  life, and re-opening it later previews like any other session. A local id
+ *  with no entry yet is a brand-new draft. */
+export function isDraftThread(id: string, items: readonly ThreadListEntry[]): boolean {
   const entry = items.find((t) => t.id === id);
   return entry == null ? isLocalId(id) : entry.status === 'new';
+}
+
+/** Which slot an activation opens into. */
+export type TabSlot = 'pinned' | 'preview' | 'draft';
+
+/** The three slots the strip is made of, in display order. */
+export interface TabsState {
+  tabIds: readonly string[];
+  previewId: string | null;
+  draftId: string | null;
+}
+
+/**
+ * The whole open set's reconcile, in one pass — the per-slot rules plus the two
+ * transitions that move an id BETWEEN slots and so cannot live in either:
+ *
+ * - the first send demotes the draft into the preview slot: it stops being the
+ *   protected tab and becomes the temporary one, replacing whatever was peeked at;
+ * - a preview (demoted or not) that resolves onto a pinned session dissolves
+ *   into that pin, so the strip never shows one session twice.
+ */
+export function reconcileTabs(state: TabsState, items: readonly ThreadListEntry[], activeId: string | null): TabsState {
+  const sent = state.draftId !== null && !isDraftThread(state.draftId, items);
+  const draftId = sent ? null : reconcileDraftId(state.draftId, items);
+  const tabIds = reconcileTabIds(state.tabIds, items, activeId);
+  const preview = reconcilePreviewId(sent ? state.draftId : state.previewId, items, activeId);
+  return { tabIds, previewId: preview !== null && tabIds.includes(preview) ? null : preview, draftId };
+}
+
+/** The draft slot's own rule: it survives going inactive (that is the point of
+ *  the slot) and only leaves when it stops being a draft — sent, or gone. */
+function reconcileDraftId(draftId: string | null, items: readonly ThreadListEntry[]): string | null {
+  if (draftId === null) return null;
+  return isDraftThread(draftId, items) ? draftId : null;
 }

--- a/packages/ui/src/features/session-tabs/use-session-tabs-sync.ts
+++ b/packages/ui/src/features/session-tabs/use-session-tabs-sync.ts
@@ -5,7 +5,8 @@
  * path at once — sidebar click, palette, toast deep-link, boot auto-select,
  * archived-active fallback — without touching any of those call sites. An
  * activation lands in the PREVIEW slot (editor-style: the next one replaces
- * it); only a just-created draft pins immediately — see `shouldPinOnOpen`.
+ * it); an unsent draft lands in the protected DRAFT slot instead, and stays
+ * there until its first send demotes it to preview (`reconcileTabs`).
  *
  * Also owns reconciliation and persistence: restore once a real `list()` has
  * SETTLED carrying at least one session (merging with tabs the boot already
@@ -29,11 +30,10 @@ import { useSessionTabsStore } from './store';
 import {
   SESSION_TABS_STORAGE_KEY,
   canRestoreTabs,
+  isDraftThread,
   persistTabIds,
-  reconcilePreviewId,
-  reconcileTabIds,
+  reconcileTabs,
   restoreTabIds,
-  shouldPinOnOpen,
 } from './tabs-model';
 
 interface PersistedTabs {
@@ -81,11 +81,18 @@ export function useSessionTabsSync(): void {
   const previewId = useSessionTabsStore((s) => s.previewId);
   const hydrate = useSessionTabsStore((s) => s.hydrate);
   const ensureTab = useSessionTabsStore((s) => s.ensureTab);
+  const closeTab = useSessionTabsStore((s) => s.closeTab);
   const reconcile = useSessionTabsStore((s) => s.reconcile);
 
   useEffect(() => {
     if (hydrated || !canRestoreTabs(items, isListLoading, listLoaded)) return;
     const persisted = readPersisted();
+    // A live peek outranks the persisted one — but the boot draft is not a
+    // peek. It holds the slot only because nothing real is on screen yet, and
+    // auto-select is about to replace it, so it must not cost the user the
+    // preview they left behind.
+    const live = useSessionTabsStore.getState().previewId;
+    if (live !== null && isDraftThread(live, items)) closeTab(live);
     hydrate(
       restoreTabIds(persisted.ids, items),
       persisted.preview === null ? null : (restoreTabIds([persisted.preview], items)[0] ?? null),
@@ -102,12 +109,19 @@ export function useSessionTabsSync(): void {
       useZonesStore.getState().openSplit(left, right);
       if (persisted.zonesFrac != null) useZonesStore.getState().setFrac(persisted.zonesFrac);
     }
-  }, [hydrated, items, isListLoading, listLoaded, hydrate]);
+  }, [hydrated, items, isListLoading, listLoaded, hydrate, closeTab]);
 
   useEffect(() => {
-    if (mainThreadId) ensureTab(mainThreadId, { pin: shouldPinOnOpen(mainThreadId, items) });
-    // `items` is deliberately not a dep: membership reacts to ACTIVATION, and
-    // re-running on list ticks would re-preview a session the user just closed.
+    if (!mainThreadId) return;
+    // The runtime's transient boot draft and the user's "+" draft are the same
+    // state; only WHEN they are activated tells them apart. A draft active
+    // before `list()` ever returned is the boot one — it peeks, so auto-select
+    // replaces it instead of leaving a "New Session" tab behind.
+    const protect = isDraftThread(mainThreadId, items) && listLoaded;
+    ensureTab(mainThreadId, protect ? 'draft' : 'preview');
+    // `items` and `listLoaded` are deliberately not deps: membership reacts to
+    // ACTIVATION and reads both as of that moment, and re-running on list ticks
+    // would re-preview a session the user just closed.
   }, [mainThreadId, ensureTab]);
 
   // Zones ⊆ pinned tabs, always: splitting is a "keep this open" signal, so a
@@ -120,16 +134,13 @@ export function useSessionTabsSync(): void {
     if (zonesPair == null) return;
     const store = useSessionTabsStore.getState();
     for (const id of zonesPair) {
-      store.ensureTab(id, { pin: true });
-      store.pinTab(id); // ensureTab won't promote an existing preview
+      store.ensureTab(id, 'pinned');
+      store.pinTab(id); // ensureTab won't promote a tab that is already open
     }
   }, [zonesPair, previewId]);
 
   useEffect(() => {
-    reconcile(
-      (ids) => reconcileTabIds(ids, items, mainThreadId),
-      (id) => reconcilePreviewId(id, items, mainThreadId),
-    );
+    reconcile((state) => reconcileTabs(state, items, mainThreadId));
   }, [items, mainThreadId, reconcile]);
 
   // `items` changes identity on every stream tick (title/status updates), so


### PR DESCRIPTION
Creating a session pinned its tab immediately, so every new session left a permanent tab — and it landed wherever the pinned set happened to end, not at the end of the strip.

## What changes

The strip gets a third slot, in `packages/ui/src/features/session-tabs/`:

- **While a draft is unsent** it holds a protected slot. Opening another session from the sidebar fills the preview slot beside it instead of replacing it, so unsent typing survives a peek at history.
- **The first send demotes it** into the ordinary preview slot: the tab turns italic, grows the "Keep open" pin, and the next session opened replaces it.
- **The draft renders last**, after the peek — a new session is always the end tab.

`reconcileTabs` is a single pure pass over all three slots, because the demotion moves an id *between* slots, which the per-slot resolvers could not express. The store's `reconcile` takes one resolver accordingly, and `ensureTab(id, slot)` replaces the `{ pin }` flag.

The runtime's transient boot draft and a deliberate "+" draft are indistinguishable by state, so the membership seam separates them by *when* they were activated: a draft active before `adapter.list()` ever returned is the boot one and merely peeks. That also keeps it from outranking the persisted preview at restore.

## Consequences worth naming

- Consecutive new sessions no longer accumulate tabs: sending in session 2 replaces session 1's tab. Pinning is how a sent session earns a permanent tab.
- There is no pre-send "keep open" gesture — the pin affordance appears only once the tab becomes temporary.

## Verification

- 166 session-tabs tests green: 3 new files (`tabs-model.draft`, `store.draft`, `use-session-tabs-sync.draft`), 4 old-contract cases updated to the new rules.
- Full `packages/ui` suite green (652 files / 6368 tests), typecheck, eslint and prettier clean.
- The e2e `session-tabs.spec.ts` never asserted pin-on-create, so no e2e debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)