### PR TITLE
fix(ui): keep scrollbar thumbs visible

### DIFF
--- a/.changeset/tidy-cats-scroll.md
+++ b/.changeset/tidy-cats-scroll.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Keep scrollbar thumbs visible in Tauri webviews.

--- a/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
+++ b/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
@@ -26,14 +26,14 @@ describe('scrollbar styling paths', () => {
   const base = blockAfter(sheet, '@layer base');
   const webkitQuery = 'selector(*::-webkit-scrollbar)';
 
-  it('directly paints a transparent track in WebKit without conflicting standard properties', () => {
+  it('keeps the WebKit thumb visible on a transparent track', () => {
     const webkit = blockAfter(base, `@supports ${webkitQuery}`);
 
     expect(webkit).toMatch(
       /\*::-webkit-scrollbar-track,\s*\*::-webkit-scrollbar-corner\s*{\s*background:\s*transparent/,
     );
-    expect(webkit).toMatch(/\*::-webkit-scrollbar-thumb\s*{\s*background:\s*transparent/);
-    expect(webkit).toMatch(/\*:hover::-webkit-scrollbar-thumb\s*{\s*background:\s*var\(--border\)/);
+    expect(webkit).toMatch(/\*::-webkit-scrollbar-thumb\s*{\s*background:\s*var\(--border\)/);
+    expect(webkit).not.toContain('*:hover::-webkit-scrollbar-thumb');
     expect(webkit).not.toMatch(/scrollbar-(?:color|width)\s*:/);
   });
 

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -68,11 +68,8 @@ code {
       background: transparent;
     }
     *::-webkit-scrollbar-thumb {
-      background: transparent;
-      border-radius: 999px;
-    }
-    *:hover::-webkit-scrollbar-thumb {
       background: var(--border);
+      border-radius: 999px;
     }
   }
 


### PR DESCRIPTION
## What changed

- keep WebKit scrollbar thumbs visible with `var(--border)`
- keep scrollbar tracks and corners transparent
- remove hover-only thumb visibility
- update the regression contract and add a UI changeset

## Root cause

PR #615 made the thumb transparent at rest and relied on a scroll-container hover selector. macOS WKWebView did not visibly apply that hover recoloring, leaving no thumb.

## Verification

- 19 focused scrollbar and contrast tests
- UI typecheck
- production UI build
- release-profile QA `.app` on isolated daemon port 32811
- WKWebView computed styles in light and dark themes: thumb resolves to the theme border; track and corner remain transparent
- native light and dark captures show a visible thumb without a gutter

Follow-up to #615.
