### PR TITLE
fix(ui): prevent Tauri scrollbar compositor bounce

### DIFF
--- a/.changeset/twelve-mangos-agree.md
+++ b/.changeset/twelve-mangos-agree.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Prevent release Tauri webviews from rubber-banding the app shell when scrolling past a transcript boundary.

--- a/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
+++ b/packages/ui/src/styles/__tests__/scrollbar-styles.test.ts
@@ -29,9 +29,8 @@ describe('scrollbar styling paths', () => {
   it('keeps the WebKit thumb visible on a transparent track', () => {
     const webkit = blockAfter(base, `@supports ${webkitQuery}`);
 
-    expect(webkit).toMatch(
-      /\*::-webkit-scrollbar-track,\s*\*::-webkit-scrollbar-corner\s*{\s*background:\s*transparent/,
-    );
+    expect(webkit).toMatch(/\*::-webkit-scrollbar-track\s*{\s*background:\s*transparent/);
+    expect(webkit).not.toMatch(/::-webkit-scrollbar-(?:track|corner)\s*,\s*\*::-webkit-scrollbar-(?:track|corner)/);
     expect(webkit).toMatch(/\*::-webkit-scrollbar-thumb\s*{\s*background:\s*var\(--border\)/);
     expect(webkit).not.toContain('*:hover::-webkit-scrollbar-thumb');
     expect(webkit).not.toMatch(/scrollbar-(?:color|width)\s*:/);

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -63,8 +63,7 @@ code {
       width: 8px;
       height: 8px;
     }
-    *::-webkit-scrollbar-track,
-    *::-webkit-scrollbar-corner {
+    *::-webkit-scrollbar-track {
       background: transparent;
     }
     *::-webkit-scrollbar-thumb {


### PR DESCRIPTION
## What changed

- stop grouping the WebKit scrollbar track and corner pseudo-elements
- keep the scrollbar track transparent and the thumb visible
- add a regression assertion for the release-only WKWebView trigger
- add a UI patch changeset

## Root cause

PR #615 introduced a comma-grouped `*::-webkit-scrollbar-track, *::-webkit-scrollbar-corner` rule. In release-profile Tauri WKWebView, that author rule activates a compositor bug when a trusted wheel event continues past the transcript boundary: the rendered app layer moves even though DOM offsets remain unchanged. Todo #335 tracks the symptom.

Same-build release QA isolated the trigger:

- current grouped selector: reproduces
- no custom scrollbar CSS: does not reproduce
- pre-#615 standards CSS: does not reproduce
- track only: does not reproduce
- corner only: does not reproduce
- track and corner as separate rules: does not reproduce
- visible thumb plus transparent track without the corner selector: does not reproduce

## Verification

- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/styles/__tests__/scrollbar-styles.test.ts`
- `pnpm --filter @qlan-ro/mainframe-ui typecheck`
- `pnpm --filter @qlan-ro/mainframe-ui build`
- isolated release-profile Tauri QA with trusted native wheel events at the transcript bottom

Follow-up to #615 and #626.