### PR TITLE
fix(adapters): clear the provider padlock once the probe reports installed

### DIFF
--- a/.changeset/adapter-installed-flag-stays-stale.md
+++ b/.changeset/adapter-installed-flag-stays-stale.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-ui': patch
+---
+
+Stop showing a padlock on providers that are installed. The boot snapshot reports every adapter as uninstalled when the CLI probe outruns the daemon's 2s cap, and the follow-up catalog event refreshed the models without clearing that flag — so a brand-new session could offer Claude's full model list while both provider tabs sat disabled. The event now carries the probe's verdict, and the client applies it.

--- a/docs/rust-port/CONTRACT/ws-events.json
+++ b/docs/rust-port/CONTRACT/ws-events.json
@@ -347,6 +347,11 @@
           "name": "modelsRevision",
           "optional": false,
           "type": "number"
+        },
+        {
+          "name": "installed",
+          "optional": true,
+          "type": "boolean"
         }
       ]
     },

--- a/docs/rust-port/fixtures/event.adapter-models-updated.json
+++ b/docs/rust-port/fixtures/event.adapter-models-updated.json
@@ -33,6 +33,7 @@
         "supportsPersonality": false
       }
     ],
-    "modelsRevision": 2
+    "modelsRevision": 2,
+    "installed": true
   }
 }

--- a/packages/core-rs/crates/mainframe-adapter-api/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-api/src/lib.rs
@@ -367,6 +367,7 @@ impl AdapterRegistry {
         let Some(prev) = self.snapshots.get(adapter_id).map(|e| e.value().clone()) else {
             return;
         };
+        let installed = patch.installed;
         let models_changed = patch.models.is_some();
         let models_revision = if models_changed {
             Some(prev.models_revision.unwrap_or(1) + 1)
@@ -403,6 +404,7 @@ impl AdapterRegistry {
                 adapter_id: adapter_id.to_string(),
                 models,
                 models_revision: rev,
+                installed,
             });
         }
     }

--- a/packages/core-rs/crates/mainframe-adapter-api/src/lib.rs
+++ b/packages/core-rs/crates/mainframe-adapter-api/src/lib.rs
@@ -404,7 +404,7 @@ impl AdapterRegistry {
                 adapter_id: adapter_id.to_string(),
                 models,
                 models_revision: rev,
-                installed,
+                installed: Some(installed),
             });
         }
     }

--- a/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
+++ b/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
@@ -340,6 +340,8 @@ async fn bumps_revision_flips_catalog_source_and_emits_after_allow_refresh() {
                 adapter_id: "claude".into(),
                 models: probed.clone(),
                 models_revision: 2,
+                // The client's only correction when the boot snapshot said false.
+                installed: true,
             })
     );
     assert_eq!(a.probe_args(), vec![Some("/abs/claude".to_string())]);

--- a/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
+++ b/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
@@ -341,7 +341,7 @@ async fn bumps_revision_flips_catalog_source_and_emits_after_allow_refresh() {
                 models: probed.clone(),
                 models_revision: 2,
                 // The client's only correction when the boot snapshot said false.
-                installed: true,
+                installed: Some(true),
             })
     );
     assert_eq!(a.probe_args(), vec![Some("/abs/claude".to_string())]);

--- a/packages/core-rs/crates/mainframe-server/src/websocket.rs
+++ b/packages/core-rs/crates/mainframe-server/src/websocket.rs
@@ -709,6 +709,7 @@ fn build_connect_replay_events(
                     adapter_id: s.id.clone(),
                     models: s.models.clone(),
                     models_revision,
+                    installed: s.installed,
                 })
             }
             _ => None,

--- a/packages/core-rs/crates/mainframe-server/src/websocket.rs
+++ b/packages/core-rs/crates/mainframe-server/src/websocket.rs
@@ -709,7 +709,7 @@ fn build_connect_replay_events(
                     adapter_id: s.id.clone(),
                     models: s.models.clone(),
                     models_revision,
-                    installed: s.installed,
+                    installed: Some(s.installed),
                 })
             }
             _ => None,

--- a/packages/core-rs/crates/mainframe-types/src/events.rs
+++ b/packages/core-rs/crates/mainframe-types/src/events.rs
@@ -305,6 +305,10 @@ pub enum DaemonEvent {
         adapter_id: String,
         models: Vec<AdapterModel>,
         models_revision: i64,
+        /// The probe's install verdict. Boot serves `/api/adapters` from the
+        /// static seed (`installed: false`) when the probe outruns the 2s cap,
+        /// so this event is a client's only correction until it reconnects.
+        installed: bool,
     },
     #[serde(rename = "provider.quota.updated")]
     ProviderQuotaUpdated {

--- a/packages/core-rs/crates/mainframe-types/src/events.rs
+++ b/packages/core-rs/crates/mainframe-types/src/events.rs
@@ -308,7 +308,10 @@ pub enum DaemonEvent {
         /// The probe's install verdict. Boot serves `/api/adapters` from the
         /// static seed (`installed: false`) when the probe outruns the 2s cap,
         /// so this event is a client's only correction until it reconnects.
-        installed: bool,
+        /// Optional on the wire: a client may be talking to a daemon older
+        /// than the field, and then keeps the flag it already has.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        installed: Option<bool>,
     },
     #[serde(rename = "provider.quota.updated")]
     ProviderQuotaUpdated {

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -79,6 +79,8 @@ export type DaemonEvent =
       adapterId: string;
       models: import('./adapter.js').AdapterModel[];
       modelsRevision: number;
+      /** The probe's install verdict. Optional only for daemons older than the field. */
+      installed?: boolean;
     }
   | {
       type: 'provider.quota.updated';

--- a/packages/ui/src/store/__tests__/adapters.test.ts
+++ b/packages/ui/src/store/__tests__/adapters.test.ts
@@ -33,11 +33,11 @@ import {
   installAdapterModelsSubscriber,
 } from '../adapters.js';
 
-const info = (id: string, rev: number, models: any[]) => ({
+const info = (id: string, rev: number, models: any[], installed = true) => ({
   id,
   name: id,
   description: '',
-  installed: true,
+  installed,
   models,
   modelsRevision: rev,
   catalogSource: 'fallback' as const,
@@ -79,6 +79,39 @@ describe('ui adapters store', () => {
     seedAdapters([info('codex', 1, [{ id: 'old', label: 'O' }])]); // identity fills, newer models kept
     expect(useAdaptersStore.getState().byId.codex!.name).toBe('codex');
     expect(useAdaptersStore.getState().byId.codex!.models[0]!.id).toBe('m');
+  });
+
+  // The daemon serves /api/adapters from a static seed (installed:false) whenever the probe
+  // outruns its 2s cap, so the WS event is the only correction before a reconnect. A stale
+  // flag left the provider tab disabled with a padlock for the whole session.
+  it('corrects a stale installed:false from the WS event', () => {
+    seedAdapters([info('codex', 1, [{ id: 'a', label: 'A' }], false)]);
+    const unsub = installAdapterModelsSubscriber();
+    handlers.forEach((h) =>
+      h({
+        type: 'adapter.models.updated',
+        adapterId: 'codex',
+        models: [{ id: 'x', label: 'X' }],
+        modelsRevision: 2,
+        installed: true,
+      }),
+    );
+    expect(useAdaptersStore.getState().byId.codex!.installed).toBe(true);
+    expect(useAdaptersStore.getState().byId.codex!.models[0]!.id).toBe('x');
+    unsub();
+  });
+
+  it('applies installed even when the revision guard rejects the models', () => {
+    seedAdapters([info('codex', 5, [{ id: 'a', label: 'A' }], false)]);
+    applyAdapterModels('codex', [{ id: 'x', label: 'X' }], 3, true);
+    expect(useAdaptersStore.getState().byId.codex!.installed).toBe(true);
+    expect(useAdaptersStore.getState().byId.codex!.models[0]!.id).toBe('a'); // stale models still ignored
+  });
+
+  it('keeps the known flag when the daemon omits installed', () => {
+    seedAdapters([info('codex', 1, [], true)]);
+    applyAdapterModels('codex', [{ id: 'x', label: 'X' }], 2);
+    expect(useAdaptersStore.getState().byId.codex!.installed).toBe(true);
   });
 
   it('reset clears the store', () => {

--- a/packages/ui/src/store/adapters.ts
+++ b/packages/ui/src/store/adapters.ts
@@ -48,14 +48,27 @@ export function seedAdapters(list: AdapterInfo[]): void {
   });
 }
 
-export function applyAdapterModels(adapterId: string, models: AdapterModel[], modelsRevision: number): void {
+/** `installed` is the probe's verdict, applied OUTSIDE the revision guard — that guard gates the
+ *  model list only. The boot snapshot reads `installed:false` whenever the probe outruns the
+ *  daemon's 2s list cap, and this event is the only correction before a reconnect. */
+export function applyAdapterModels(
+  adapterId: string,
+  models: AdapterModel[],
+  modelsRevision: number,
+  installed?: boolean,
+): void {
   useAdaptersStore.setState((s) => {
     const cur = s.byId[adapterId];
     if (cur) {
-      if (!isNewer(cur.modelsRevision, modelsRevision)) return s;
-      return { byId: { ...s.byId, [adapterId]: { ...cur, models, modelsRevision, catalogSource: 'probed' } } };
+      const withInstall = installed === undefined || installed === cur.installed ? cur : { ...cur, installed };
+      if (!isNewer(cur.modelsRevision, modelsRevision)) {
+        return withInstall === cur ? s : { byId: { ...s.byId, [adapterId]: withInstall } };
+      }
+      return {
+        byId: { ...s.byId, [adapterId]: { ...withInstall, models, modelsRevision, catalogSource: 'probed' } },
+      };
     }
-    // Placeholder identity (installed:true / planMode:false / id-as-name) that BRIEFLY lies until
+    // Placeholder identity (planMode:false / id-as-name) that BRIEFLY lies until
     // the seed that follows reset-on-connect refreshes it via seedAdapters (blocker #11). The
     // ordering guarantee: seedAdaptersFor always fires getAdapters right after resetRevisionBaseline,
     // so the real snapshot overwrites identity within a few ms.
@@ -63,7 +76,7 @@ export function applyAdapterModels(adapterId: string, models: AdapterModel[], mo
       id: adapterId,
       name: adapterId,
       description: '',
-      installed: true,
+      installed: installed ?? true,
       models,
       modelsRevision,
       catalogSource: 'probed',
@@ -92,6 +105,6 @@ export function resetAdapters(): void {
 export function installAdapterModelsSubscriber(): () => void {
   return daemonWs.onEvent((event) => {
     if (event.type !== 'adapter.models.updated') return;
-    applyAdapterModels(event.adapterId, event.models, event.modelsRevision);
+    applyAdapterModels(event.adapterId, event.models, event.modelsRevision, event.installed);
   });
 }


### PR DESCRIPTION
## The bug

A brand-new session showed **both** provider tabs disabled behind a padlock, while the menu listed Claude's full 27-model probed catalog. Nothing was locked mid-session — the footer still read "Pick a provider before your first message." The padlock came from the other condition, `!adapter.installed`.

Boot sequence:

1. The daemon seeds every adapter with `installed: false` (`adapter-api/src/lib.rs:186`) before probing.
2. `GET /api/adapters` races the probe against a 2s cap (`REFRESH_LIST_CAP_MS`). On a slow probe the client's seed fetch gets `installed: false`. Yesterday's log: daemon ready at 07:11:01.5, claude catalog at 07:11:05.77, codex at 07:11:06.16 — both well past the cap.
3. The probe then emits `adapter.models.updated`, carrying models only. The client's handler copied `models`/`modelsRevision`/`catalogSource` and never touched `installed`, so the false flag survived the rest of the connection.

Opening Settings cleared it (that fires `refreshAdapters`), which is why it looked intermittent.

## The fix

- `adapter.models.updated` carries the probe's `installed` verdict — the Rust variant, the refresh emit, and the connect-replay path, so a reconnect corrects the flag as well.
- The TS field is optional: an older daemon over the tunnel won't send it, and the client then keeps what it has.
- `store/adapters.ts` applies `installed` **outside** the revision guard. That guard gates the model list only; inside it, an install correction at an unchanged revision would be dropped.

Additive on the wire, so the mobile contract is unaffected.

## Verification

- 11 UI store tests (3 new: stale flag corrected, applied despite a rejected revision, preserved when the field is absent)
- 6 Rust registry tests, `cargo check --tests`, `cargo fmt --check`
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` + types `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)