### PR TITLE
feat(demos): recording harness for the product tour

### DIFF
--- a/.agents/demo-env.sh
+++ b/.agents/demo-env.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Demo environment for mainframe — feature-recorder skill contract.
+#   demo-env.sh up [<target>]  ports -> daemon (mock adapter) -> renderer -> seed -> block until ready
+#                              -> print KEY=VALUE facts -> exit 0
+#   demo-env.sh down           port-scoped teardown of what `up` started
+#
+# Sibling of test-env.sh, deliberately separate: a demo films the renderer against a
+# DETERMINISTIC agent (the e2e mock adapter replaying recorded NDJSON) on a seeded,
+# camera-ready workspace — where the test targets want a real adapter and an empty one.
+# Its own ports and data dir, so it can never touch the dev daemon on :31415, the e2e
+# harness on :31416, or ~/.mainframe.
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$PROJECT_ROOT"
+
+DAEMON_PORT="${MF_DEMO_DAEMON_PORT:-31417}"
+VITE_PORT="${MF_DEMO_VITE_PORT:-5183}"
+PORTS=("$DAEMON_PORT" "$VITE_PORT")
+PROTECTED=(31415 31416 5173 4317)      # dev daemon, e2e daemon, dev vite, e2e preview
+DATA_DIR="${MF_DEMO_DATA_DIR:-/tmp/mainframe-demo/data}"
+WORKSPACE="${MF_DEMO_WORKSPACE:-/tmp/mainframe-demo/acme-web}"
+RECORDINGS_DIR="$PROJECT_ROOT/packages/e2e/fixtures/recordings"
+# Which recorded conversation the mock adapter replays. `<key>.<n>.ndjson` = the nth
+# user message of the session. tool-group: "I'll search for that" -> Read + Grep -> answer.
+RECORDING_KEY="${MF_DEMO_RECORDING_KEY:-tool-group}"
+DAEMON_LOG="/tmp/mf-demo-daemon-${DAEMON_PORT}.log"
+UI_LOG="/tmp/mf-demo-ui-${VITE_PORT}.log"
+
+kill_port() {
+  for p in "${PROTECTED[@]}"; do [ "$1" = "$p" ] && { echo "refusing protected port $1" >&2; return 1; }; done
+  lsof -ti ":$1" | xargs kill 2>/dev/null || true
+}
+
+seed() {
+  # A stocked, plausible workspace. Rebuilt from scratch every `up`, so take 2 of a
+  # recording sees exactly what take 1 saw.
+  rm -rf "$WORKSPACE"
+  mkdir -p "$WORKSPACE/src"
+  cat > "$WORKSPACE/README.md" <<'MD'
+# Acme Web
+
+The customer-facing storefront. Vite + React, deployed on every merge to main.
+MD
+  cat > "$WORKSPACE/src/index.ts" <<'TS'
+export const greeting = 'hello';
+TS
+  cat > "$WORKSPACE/src/cart.ts" <<'TS'
+import { greeting } from './index';
+
+export function summarize(items: string[]): string {
+  return `${greeting}: ${items.length} items in the cart`;
+}
+TS
+  cat > "$WORKSPACE/CLAUDE.md" <<'MD'
+# Acme Web
+
+Storefront app. Keep components small and typed.
+MD
+  git -C "$WORKSPACE" init -q -b main
+  git -C "$WORKSPACE" -c user.email=demo@mainframe.dev -c user.name="Acme Demo" \
+    -c commit.gpgsign=false add -A
+  git -C "$WORKSPACE" -c user.email=demo@mainframe.dev -c user.name="Acme Demo" \
+    -c commit.gpgsign=false commit -qm "Initial storefront"
+
+  # Leave real uncommitted work so the diff/review surfaces have something to show.
+  # An empty "no changes" panel is the single most common way a demo beat dies.
+  cat > "$WORKSPACE/src/cart.ts" <<'TS'
+import { greeting } from './index';
+
+export interface CartItem {
+  sku: string;
+  quantity: number;
+}
+
+export function summarize(items: CartItem[]): string {
+  const total = items.reduce((sum, item) => sum + item.quantity, 0);
+  return `${greeting}: ${total} items in the cart`;
+}
+TS
+
+  project_id=$(curl -sf -X POST "http://127.0.0.1:${DAEMON_PORT}/api/projects" \
+    -H 'Content-Type: application/json' \
+    -d "{\"path\":\"$WORKSPACE\",\"name\":\"acme-web\"}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["id"])') \
+    || { echo "seed: POST /api/projects failed" >&2; return 1; }
+
+  # A board with cards. An empty Kanban is the most common dead demo beat.
+  todo() {
+    curl -sf -X POST "http://127.0.0.1:${DAEMON_PORT}/api/plugins/todos/todos" \
+      -H 'Content-Type: application/json' \
+      -d "{\"projectId\":\"$project_id\",\"title\":$1,\"status\":\"$2\",\"type\":\"$3\",\"priority\":\"$4\"}" >/dev/null
+  }
+  todo '"Cart totals ignore quantity"' in_progress bug high
+  todo '"Add checkout summary step"' open feature medium
+  todo '"Type the cart module"' open enhancement medium
+  todo '"Persist the cart between visits"' open feature high
+  todo '"Storefront hero copy pass"' done documentation low
+
+  # Automations, so the surface isn't an empty state either.
+  automation() {
+    curl -sf -X POST "http://127.0.0.1:${DAEMON_PORT}/api/automations" \
+      -H 'Content-Type: application/json' \
+      -d "{\"name\":$1,\"description\":$2,\"scope\":\"project\",\"projectId\":\"$project_id\",
+           \"definition\":{\"triggers\":[$3],
+           \"steps\":[{\"id\":\"s1\",\"kind\":\"ask_agent\",\"prompt\":[$4]},
+                      {\"id\":\"s2\",\"kind\":\"notify\",\"message\":[$5]}]}}" >/dev/null
+  }
+  automation '"Nightly dependency check"' '"Reviews outdated packages every weekday morning"' \
+    '{"id":"t1","kind":"schedule","schedule":{"type":"weekdays","at":"09:00"},"onMissed":"skip"}' \
+    '"List outdated dependencies and open a task for anything major."' '"Dependency report ready"'
+  automation '"Triage new issues"' '"Runs when a session finishes"' \
+    '{"id":"t1","kind":"event","event":"session.finished"}' \
+    '"Summarise what changed and file follow-up tasks."' '"Triage complete"'
+}
+
+up() {
+  for p in "${PORTS[@]}"; do kill_port "$p"; done
+  rm -rf "$DATA_DIR"; mkdir -p "$DATA_DIR"
+
+  cargo build --release --manifest-path packages/core-rs/Cargo.toml -p mainframe-daemon >/dev/null 2>&1 \
+    || { echo "cargo build failed for mainframe-daemon" >&2; exit 1; }
+
+  # E2E_MODE=mock registers the `mock-cli` adapter, which replays RECORDINGS_DIR instead
+  # of spawning a real CLI: no API spend, no non-determinism, identical every take.
+  DAEMON_PORT="$DAEMON_PORT" \
+  MAINFRAME_DATA_DIR="$DATA_DIR" \
+  E2E_MODE=mock \
+  E2E_RECORDINGS_DIR="$RECORDINGS_DIR" \
+  E2E_RECORDING_KEY="$RECORDING_KEY" \
+    packages/core-rs/target/release/mainframe-daemon > "$DAEMON_LOG" 2>&1 &
+
+  VITE_PORT="$VITE_PORT" \
+  VITE_DAEMON_PORT="$DAEMON_PORT" \
+  VITE_DAEMON_HTTP_PORT="$DAEMON_PORT" \
+  VITE_DAEMON_WS_PORT="$DAEMON_PORT" \
+  MAINFRAME_DATA_DIR="$DATA_DIR" \
+    pnpm --filter @qlan-ro/mainframe-ui run dev > "$UI_LOG" 2>&1 &
+
+  deadline=$((SECONDS + 180))
+  until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/projects" >/dev/null 2>&1; do
+    [ $SECONDS -ge $deadline ] && { echo "daemon not ready on :${DAEMON_PORT}" >&2; tail -40 "$DAEMON_LOG" >&2; exit 1; }
+    sleep 2
+  done
+  # localhost, not 127.0.0.1 — Vite 6 binds ::1
+  deadline=$((SECONDS + 120))
+  until curl -sf "http://localhost:${VITE_PORT}" >/dev/null 2>&1; do
+    [ $SECONDS -ge $deadline ] && { echo "vite not ready on :${VITE_PORT}" >&2; tail -40 "$UI_LOG" >&2; exit 1; }
+    sleep 2
+  done
+  until curl -sf "http://127.0.0.1:${DAEMON_PORT}/api/adapters" | grep -q '"mock-cli"'; do
+    [ $SECONDS -ge $((deadline + 30)) ] && { echo "mock adapter never registered" >&2; exit 1; }
+    sleep 1
+  done
+
+  seed || exit 1
+
+  echo "APP_URL=http://localhost:${VITE_PORT}"
+  echo "DAEMON_URL=http://127.0.0.1:${DAEMON_PORT}"
+  echo "PORTS=${PORTS[*]}"
+  echo "WORKSPACE=$WORKSPACE"
+  echo "DATA_DIR=$DATA_DIR"
+  echo "RECORDING_KEY=$RECORDING_KEY"
+  echo "LOG=$DAEMON_LOG"
+  echo "UI_LOG=$UI_LOG"
+  # The first-run tour arms ~1.5s after boot on a workspace with no sessions and would
+  # cover the app mid-take. Seed this before the first paint (addInitScript / localstorage-set).
+  echo 'LOCALSTORAGE_MF_TUTORIAL={"state":{"completed":true,"step":4},"version":0}'
+}
+
+down() {
+  for p in "${PORTS[@]}"; do kill_port "$p"; done
+  rm -rf "$DATA_DIR" "$WORKSPACE"
+}
+
+case "${1:-}" in
+  up) up "${2:-}" ;;
+  down) down ;;
+  *) echo "usage: $0 up [<target>] | down" >&2; exit 64 ;;
+esac

--- a/.agents/demo-notes.md
+++ b/.agents/demo-notes.md
@@ -1,0 +1,73 @@
+# Demo notes — mainframe
+
+Read by the `feature-recorder` skill before it derives a scenario. The run book
+(how to actually record) is `demos/README.md`; this is what's worth filming and
+what to know before you point a camera at it.
+
+## The environment
+
+`.agents/demo-env.sh up` boots an isolated stack — daemon on **:31417**, vite on
+**:5183**, data in `/tmp/mainframe-demo` — so it can never touch the dev daemon
+on :31415, the e2e harness on :31416, or `~/.mainframe`. It seeds:
+
+- **`acme-web`**, a small storefront repo with an uncommitted `src/cart.ts`
+  change, so the diff and review surfaces have real content (`1 file · +8 −2`).
+- **five todos** across Open / In Progress / Done, so the Kanban board isn't empty.
+- **two automations** (a weekday schedule and a `session.finished` event trigger).
+
+Every `up` rebuilds all of it from scratch, so take 2 sees what take 1 saw.
+
+## Deterministic agent
+
+The daemon runs with `E2E_MODE=mock`, replaying NDJSON from
+`packages/e2e/fixtures/recordings/`. No API spend, no non-determinism, identical
+every take. `MF_DEMO_RECORDING_KEY` picks the conversation:
+
+| Key | What it shows |
+|---|---|
+| `tool-group` | "I'll search for that" → grouped Read + Grep → an answer. The general-purpose beat. |
+| `ask-question` | an `AskUserQuestion` gate, answered inline, then a follow-up. |
+| `workflow` | **a four-phase `release-readiness` run**: Scan done, Review mid-flight over two files, Verify queued, Report up next — six agents, 41.2k tokens. Leaves the run **running**, which is what fills the Activity panel and makes its row drill into the run panel. |
+| `task-subagent`, `todo-write`, `plan-approval`, `permissions-*`, … | the rest of the e2e corpus — see the directory. |
+
+The `workflow` fixture is demo-authored (the others are e2e recordings). It works
+because the mock adapter reports background work to the daemon's tracker —
+subagent, background bash and workflow rows — and a fixture can ship a whole
+`ClaudeWorkflowRun` snapshot through the `onWorkflowRun` recorded method. See
+`packages/core-rs/crates/mainframe-adapter-mock/src/task_bridge.rs`.
+
+**A recording that never resolves its tool calls keeps the session running.** The
+composer shows the stop button and the elapsed timer ticks. That's honest for a
+"work in flight" beat; it's wrong for a beat that should look finished.
+
+## Surfaces worth filming
+
+Sessions sidebar and project filter · the composer's model/permission/plan/worktree
+controls · grouped tool cards · the question gate · transcript select-to-quote ·
+the session rail (Session summary, Activity, Tasks quick-add) · the workflow run
+panel · session tabs · Kanban board · Automations · the daemon picker and remote
+pairing · Review Changes with a line-anchored comment.
+
+## Not filmable here
+
+- **Terminal and sandbox preview** — `lib/host/fake-adapter.ts` rejects
+  `terminal.create` and `preview.capture` without `__TAURI_INTERNALS__`.
+- **Native window chrome** — this is browser mode; no traffic lights, no title bar.
+- **Split chat** — `session-tab-ctx-open-split` is disabled unless two *committed*
+  sessions exist, and one boot can only replay one conversation. Seed a second
+  chat via `POST /api/chats` to unblock it.
+
+## Gotchas that have cost takes
+
+- The transcript is a fixed-width centred column; below ~1920 wide the floating
+  session panels overlap it. Record at **1920×1080**.
+- Only the **modified** pane anchors a review comment — a click in `.cm-merge-a`
+  is silently ignored — and CodeMirror splits a line across token spans, so
+  target `.cm-merge-b .cm-line` rather than `getByText`.
+- The Review Changes modal covers the sidebar: film sidebar surfaces **before** it.
+- The Kanban view mode lives in a store, not storage — open it off camera, switch
+  to Board, close, and the on-camera open lands on the board with no extra click.
+- The Session-panel summary button is `session-panel-rail-open`;
+  `session-panel-rail-context` only mounts once there's context-meter data.
+- `locator.selectText()` does not arm the quote toolbar — it needs a real
+  `mouse.down` → `move` → `up` drag, because the toolbar arms on mouseup.

--- a/.changeset/demo-harness.md
+++ b/.changeset/demo-harness.md
@@ -1,0 +1,4 @@
+---
+---
+
+Demo recording harness — tooling and docs only, no shipped code.

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ packages/e2e/logs/
 .playwright-cli/
 dist-local/
 /packages/e2e/daemon-logs/
+
+# Recorded demo output — takes are large and regenerated; scripts are versioned, videos are not.
+demos/**/*.mp4
+demos/**/*.webm

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,108 @@
+# Demos
+
+Recorded product demos, driven by the `feature-recorder` skill
+(`~/.agents/skills/feature-recorder/SKILL.md` — read it first; this file only
+covers what is specific to this repo).
+
+`github/` is the shipped tour: four segments concatenated into
+`github/mainframe-demo.mp4` (1920×1080, ~1:21), plus a matching Recordly project
+for editing.
+
+## Prerequisites
+
+```bash
+npm install -g @playwright/cli@latest    # need ≥ 0.1.18 for page.screencast
+which ffmpeg                             # concat + H.264
+```
+
+Never record through `packages/e2e`'s Playwright: `page.screencast` only exists
+in the 1.63-alpha the CLI bundles, and the suite pins 1.61.
+
+## The segments
+
+| Script | Recording key | Beats |
+|---|---|---|
+| `github/a-sessions.demo.js` | `tool-group` | projects and sessions, a prompt, grouped tool cards |
+| `github/b-gate.demo.js` | `ask-question` | the inline question gate, answered without leaving |
+| `github/d-threads.demo.js` | `workflow` | quote from the transcript, session rail, a **live workflow run**, quick task |
+| `github/c-surfaces.demo.js` | any | worktree, board, automations, remote pairing, review + inline comment |
+| `github/e-tabs-split.demo.js` | `tool-group` | tabs and split chat — **not in the cut**, `session-tab-ctx-open-split` is disabled unless two *committed* sessions exist |
+
+## Recording a take
+
+**One recording per boot.** The mock adapter's replay index is global: the first
+send of a daemon boot consumes `<key>.0.ndjson`, and a second send looks for
+`.1` and hangs forever. So every take — including every retake — needs a fresh
+`.agents/demo-env.sh up`.
+
+```bash
+take() {                       # take <recording-key> <script> <session> <out-name>
+  local key=$1 script=$2 sess=$3 out=$4
+  for attempt in 1 2 3 4 5; do
+    MF_DEMO_RECORDING_KEY=$key bash .agents/demo-env.sh up >/dev/null 2>&1
+    playwright-cli close-all >/dev/null 2>&1
+    playwright-cli -s=$sess open >/dev/null 2>&1
+    playwright-cli -s=$sess --raw run-code --filename=$script > /tmp/raw.$out 2>&1
+    if python3 -c "
+import json,sys
+txt=open('/tmp/raw.$out').read().strip(); raw=txt.splitlines()[-1] if txt else ''
+try:
+    d=json.loads(json.loads(raw)) if raw.startswith('\"') else json.loads(raw); assert d.get('marks')
+except Exception: sys.exit(1)
+json.dump(d, open('/tmp/mainframe-demo/out/$out.timeline.json','w'), indent=2)
+print('$out: marks=%d' % len(d['marks']))
+"; then return 0; fi
+    echo "$out attempt $attempt: retake"
+  done
+  echo "$out FAILED"; return 1
+}
+
+take tool-group   demos/github/a-sessions.demo.js s1 tour-a
+take ask-question demos/github/b-gate.demo.js     s2 tour-b
+take workflow     demos/github/d-threads.demo.js  s3 tour-d
+take tool-group   demos/github/c-surfaces.demo.js s4 tour-c
+```
+
+Each script returns its timeline as JSON on stdout — normalized position and
+millisecond of every action — which the Recordly export turns into a cursor
+track and zoom regions. `--raw` is what makes that the only thing printed.
+
+## Rebuilding the cut
+
+```bash
+cd /tmp/mainframe-demo/out
+node ~/.agents/skills/feature-recorder/scripts/to-recordly.mjs mainframe-demo \
+  tour-a.webm tour-a.timeline.json  tour-b.webm tour-b.timeline.json \
+  tour-d.webm tour-d.timeline.json  tour-c.webm tour-c.timeline.json
+cp ~/Library/Application\ Support/Recordly/recordings/mainframe-demo.mp4 \
+   <repo>/demos/github/mainframe-demo.mp4
+```
+
+That writes the H.264 concat, the cursor sidecar and the `.recordly` project, and
+registers it. Open it from **Recordly → Open Projects** — `open -a Recordly <file>`
+does not route the file, the app declares no document types.
+
+## Known flakiness
+
+- **The dropped-send race.** Roughly half of first sends into a fresh draft are
+  dropped client-side: the console logs `new-thread-coordinator: workflow
+  abandoned for __LOCALID_…`, the daemon creates then archives the chat, and no
+  `user message sent` appears. The scripts `throw 'dropped send — retake'` rather
+  than retype on camera. **Retrying inside one page session makes it worse** —
+  opening another draft abandons the in-flight create — so recovery is a fresh
+  take, or at minimum a full page reload.
+- **`Screencast is already started`.** A take that throws leaves it running and
+  masks the real error on every later run; each script calls
+  `page.screencast.stop().catch(() => {})` before starting.
+- **Forced clicks.** The sidebar rail never satisfies Playwright's stability
+  check while the Kanban/Automations surfaces mount — those two use
+  `click({ force: true })`, deliberately.
+- **The session list can read "No sessions match these filters"** even with live
+  sessions; the tab strip is the reliable surface.
+
+## Out of scope for this rig
+
+The terminal and the sandbox preview cannot be filmed: `lib/host/fake-adapter.ts`
+rejects `terminal.create` and `preview.capture` whenever `__TAURI_INTERNALS__` is
+absent, which is every browser. Tauri's WKWebView has no CDP for Playwright, and
+the tauri-mcp bridge cannot record video.

--- a/demos/archive/README.md
+++ b/demos/archive/README.md
@@ -1,0 +1,11 @@
+# Archived takes
+
+Superseded scripts, kept for what they record rather than for reuse. They target
+1280×800, retype on camera instead of failing the take, and predate the workflow
+fixture — copying their patterns will reintroduce fixed bugs. The live scripts
+are in `../github/`.
+
+- `session-tour.demo.js` — the first working take: session → prompt → tool cards.
+- `first-session.demo.js` — the adaptation of the v1 feature-recorder take of
+  2026-05-09 (recovered from iCloud): first session, model control, the question
+  gate. The only record of that flagship demo's beats.

--- a/demos/archive/first-session.demo.js
+++ b/demos/archive/first-session.demo.js
@@ -1,0 +1,117 @@
+// Mainframe demo — first session, and the agent asking back.
+//
+// Adapted from the v1 feature-recorder take of 2026-05-09 ("create first Claude
+// session in mainframe-web, hover adapter popover, send a tool-use prompt, answer
+// the permission card with a custom answer"), recovered from iCloud. Same beats,
+// current UI: the old selectors (data-mf-composer-input, data-tutorial,
+// data-new-session-popover) all belonged to the Electron renderer. The prompt text
+// is rewritten to match the question the mock adapter replays, so the exchange reads
+// as a conversation rather than a non-sequitur.
+//
+// Boot first:  MF_DEMO_RECORDING_KEY=ask-question .agents/demo-env.sh up
+// Record:      playwright-cli -s=demo run-code --filename=demos/first-session.demo.js
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/first-session.webm';
+  const SIZE = { width: 1280, height: 800 };
+  const TOUR_OFF = '{"state":{"completed":true,"step":4},"version":0}';
+  const PROMPT = 'Set up this project for me — where should we start?';
+
+  const label = (b, text) => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute; top:${b.y + b.height + 10}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), TOUR_OFF);
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(700);
+
+  // A take that throws leaves the screencast running, and every later run then
+  // fails with "Screencast is already started" — masking the real error.
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+
+  // ---- Beat 1: a project, no sessions -------------------------------------
+  await page.screencast.showChapter('Your first session', {
+    description: 'Pick a project and start talking to it.',
+    duration: 2000,
+  });
+
+  const project = page.getByRole('button', { name: /acme-web/ }).first();
+  await project.click();
+  await page.waitForTimeout(800);
+  await page.getByTestId('sessions-new-button').click();
+  const composer = page.getByTestId('chat-composer-input');
+  await composer.waitFor({ timeout: 15000 });
+  await page.waitForTimeout(1000);
+
+  // ---- Beat 2: the session is configurable before it exists ---------------
+  // The v1 take opened the adapter popover here, back when the adapter was chosen
+  // at creation. Its descendant is the composer's model control.
+  const modelButton = page.getByRole('button', { name: /Provider and model/ });
+  const modelMark = await page.screencast.showOverlay(
+    label(await modelButton.boundingBox(), 'Model and permissions, before the first word'),
+  );
+  await page.waitForTimeout(1800);
+  await modelMark.dispose();
+  await page.waitForTimeout(400);
+
+  // ---- Beat 3: ask ---------------------------------------------------------
+  await page.screencast.showChapter('Asking for work', { duration: 1800 });
+
+  await composer.click();
+  await composer.pressSequentially(PROMPT, { delay: 55 });
+  await page.waitForTimeout(700);
+  await composer.press('Enter');
+
+  // ~1 send in 2 is dropped client-side ("workflow abandoned for __LOCALID_…"),
+  // so resend once rather than record a dead take.
+  const sent = await page
+    .getByText(PROMPT, { exact: true })
+    .waitFor({ timeout: 4000 })
+    .then(() => true, () => false);
+  if (!sent) {
+    await composer.click();
+    await composer.pressSequentially(PROMPT, { delay: 55 });
+    await page.waitForTimeout(400);
+    await composer.press('Enter');
+  }
+
+  // ---- Beat 4: the agent asks back ----------------------------------------
+  const gate = page.getByTestId('chat-question-gate');
+  await gate.waitFor({ timeout: 30000 });
+  await page.waitForTimeout(900);
+
+  await page.screencast.showChapter('It asks before it guesses', {
+    description: 'Answer inline and it picks up from there.',
+    duration: 2200,
+  });
+
+  // v1 filmed the custom-answer path ("Other…" + a typed reply) against a real
+  // adapter. Under mock replay the transcript is fixed — the answered card always
+  // renders the recorded selection — so choosing anything else puts a lie on screen.
+  // Film that beat with MF_E2E_ALLOW_REAL_ADAPTER, or record a new fixture.
+  const choice = page.getByTestId('chat-question-option-0-Work on index.ts');
+  const choiceMark = await page.screencast.showOverlay(
+    label(await choice.boundingBox(), 'Answer without leaving the thread'),
+  );
+  await page.waitForTimeout(1400);
+  await choice.click();
+  await choiceMark.dispose();
+  await page.waitForTimeout(700);
+  await page.getByTestId('chat-question-submit').click();
+
+  // ---- Beat 5: it picks up where you pointed it ---------------------------
+  await page.waitForTimeout(2500);
+  await page.mouse.move(950, 520);
+  await page.waitForTimeout(1600);
+
+  await page.screencast.stop();
+  return OUT;
+}

--- a/demos/archive/session-tour.demo.js
+++ b/demos/archive/session-tour.demo.js
@@ -1,0 +1,99 @@
+// Mainframe demo — start a session and ask a question.
+// Boot first:  .agents/demo-env.sh up
+// Record:      playwright-cli -s=demo run-code --filename=demos/session-tour.demo.js
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/session-tour.webm';
+  const SIZE = { width: 1280, height: 800 };
+  const TOUR_OFF = '{"state":{"completed":true,"step":4},"version":0}';
+
+  const label = (b, text, place = 'below') => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute;
+      top:${place === 'below' ? b.y + b.height + 10 : b.y - 40}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), TOUR_OFF);
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(700);
+
+  // A take that throws leaves the screencast running, and every later run then
+  // fails with "Screencast is already started" — masking the real error.
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+
+  // ---- Beat 1: the workspace ------------------------------------------------
+  await page.screencast.showChapter('A project in Mainframe', {
+    description: 'One workspace, no sessions yet.',
+    duration: 2000,
+  });
+
+  const project = page.getByRole('button', { name: /acme-web/ }).first();
+  const marker = await page.screencast.showOverlay(label(await project.boundingBox(), 'Filter to one project'));
+  await page.waitForTimeout(1200);
+  await project.click();
+  await marker.dispose();
+  await page.waitForTimeout(900);
+
+  // ---- Beat 2: start a session ---------------------------------------------
+  await page.screencast.showChapter('Starting a session', { duration: 1800 });
+
+  const newSession = page.getByTestId('sessions-new-button');
+  await newSession.click();
+  const composer = page.getByTestId('chat-composer-input');
+  await composer.waitFor({ timeout: 15000 });
+  await page.waitForTimeout(1000);
+
+  // ---- Beat 3: ask ----------------------------------------------------------
+  await page.screencast.showChapter('Asking a question', {
+    description: 'The agent reads the repo before it answers.',
+    duration: 2000,
+  });
+
+  const PROMPT = 'Where is greeting defined?';
+  await composer.click();
+  await composer.pressSequentially(PROMPT, { delay: 60 });
+  await page.waitForTimeout(700);
+  await composer.press('Enter');
+
+  // Roughly one send in two is dropped client-side: the new-thread coordinator logs
+  // "workflow abandoned for __LOCALID_…", archives the chat it just created, and the
+  // message never reaches the daemon. Retype and resend once rather than record a
+  // dead take — the second send commits the same slot.
+  const sent = await page
+    .getByText(PROMPT, { exact: true })
+    .waitFor({ timeout: 4000 })
+    .then(() => true, () => false);
+  if (!sent) {
+    await composer.click();
+    await composer.pressSequentially(PROMPT, { delay: 60 });
+    await page.waitForTimeout(400);
+    await composer.press('Enter');
+  }
+
+  // ---- Beat 4: the answer ---------------------------------------------------
+  await page.getByText("I'll search for that.").waitFor({ timeout: 30000 });
+  await page.waitForTimeout(900);
+
+  const toolGroup = page.getByRole('button', { name: /Read 1 file/ }).first();
+  await toolGroup.waitFor({ timeout: 15000 });
+  const callout = await page.screencast.showOverlay(
+    label(await toolGroup.boundingBox(), 'Every tool call, grouped and inspectable'),
+  );
+  await page.waitForTimeout(2400);
+  await callout.dispose();
+
+  // Park the cursor over empty transcript space. Anywhere near the composer toolbar
+  // and its tooltip ("Permission: Interactive") sits open through the whole held frame.
+  await page.mouse.move(900, 520);
+  await page.waitForTimeout(1600);
+
+  await page.screencast.stop();
+  return OUT;
+}

--- a/demos/github/a-sessions.demo.js
+++ b/demos/github/a-sessions.demo.js
@@ -1,0 +1,101 @@
+// GitHub tour, segment A — projects, sessions, and a working agent.
+// Boot: MF_DEMO_RECORDING_KEY=tool-group .agents/demo-env.sh up
+//
+// Returns a TIMELINE as JSON: every action's normalized position and the ms it
+// happened at, relative to the first recorded frame. `to-recordly.mjs` turns that
+// into a Recordly cursor track and zoom regions — the coordinates are exact, so
+// nothing downstream has to infer where a click landed.
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/tour-a.webm';
+  // 1920 wide: the transcript is a fixed-width centred column, so the floating
+  // session panels only clear it once there is real margin to the right.
+  const SIZE = { width: 1920, height: 1080 };
+
+  // Chapter cards are off for the shipped cut. Flip CHAPTERS to true to get the
+  // full-screen title cards back; the pause keeps the pacing either way.
+  const CHAPTERS = false;
+  const chapter = (title, opts) =>
+    CHAPTERS ? page.screencast.showChapter(title, opts) : page.waitForTimeout(700);
+
+  const PROMPT = 'Where is greeting defined?';
+
+  const label = (b, text) => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute; top:${b.y + b.height + 10}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  let t0 = 0;
+  const marks = [];
+  const mark = async (locator, kind, cursorType, note) => {
+    const b = await locator.boundingBox();
+    if (!b) return;
+    marks.push({
+      tMs: Date.now() - t0,
+      kind,
+      cursorType,
+      note,
+      cx: (b.x + b.width / 2) / SIZE.width,
+      cy: (b.y + b.height / 2) / SIZE.height,
+      w: b.width / SIZE.width,
+      h: b.height / SIZE.height,
+    });
+  };
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), '{"state":{"completed":true,"step":4},"version":0}');
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(700);
+
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+  t0 = Date.now();
+
+  await chapter('Every project, every session', {
+    description: 'One list, grouped by when you last touched it.',
+    duration: 2000,
+  });
+  const project = page.getByRole('button', { name: /acme-web/ }).first();
+  await mark(project, 'click', 'pointer', 'filter to the project');
+  await project.click();
+  await page.waitForTimeout(1100);
+
+  await chapter('Ask, and watch it work', { duration: 1800 });
+  const newSession = page.getByTestId('sessions-new-button');
+  await mark(newSession, 'click', 'pointer', 'new session');
+  await newSession.click();
+  const composer = page.getByTestId('chat-composer-input');
+  await composer.waitFor({ timeout: 15000 });
+  await page.waitForTimeout(1000);
+  await mark(composer, 'click', 'text', 'composer');
+  await composer.click();
+  await composer.pressSequentially(PROMPT, { delay: 55 });
+  await page.waitForTimeout(600);
+  await composer.press('Enter');
+  const sent = await page.getByText(PROMPT, { exact: true }).waitFor({ timeout: 4000 }).then(() => true, () => false);
+  // The dropped-send race (see demos/README) must never be filmed: a retype on
+  // camera reads as a bug. Fail the take and let the harness re-run it clean.
+  if (!sent) throw new Error('dropped send — retake');
+
+  // Wait for the FINAL line, not the opening one: the reply is still streaming when
+  // "I'll search for that." lands, and the take used to end on a "Thinking…" frame.
+  await page.getByText("I'll search for that.").waitFor({ timeout: 30000 });
+  await page.getByText(/Found it:/).waitFor({ timeout: 30000 });
+  await page.waitForTimeout(900);
+  const toolGroup = page.getByRole('button', { name: /Read 1 file/ }).first();
+  await toolGroup.waitFor({ timeout: 15000 });
+  await mark(toolGroup, 'dwell', 'arrow', 'tool group lands');
+  const callout = await page.screencast.showOverlay(label(await toolGroup.boundingBox(), 'Every tool call, grouped and inspectable'));
+  await page.waitForTimeout(2200);
+  await callout.dispose();
+  await page.mouse.move(950, 540);
+  await page.waitForTimeout(1200);
+
+  await page.screencast.stop();
+  return JSON.stringify({ video: OUT, size: SIZE, durationMs: Date.now() - t0, marks });
+}

--- a/demos/github/b-gate.demo.js
+++ b/demos/github/b-gate.demo.js
@@ -1,0 +1,87 @@
+// GitHub tour, segment B — the agent asks instead of guessing.
+// Boot: MF_DEMO_RECORDING_KEY=ask-question .agents/demo-env.sh up
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/tour-b.webm';
+  // 1920 wide: the transcript is a fixed-width centred column, so the floating
+  // session panels only clear it once there is real margin to the right.
+  const SIZE = { width: 1920, height: 1080 };
+
+  let t0 = 0;
+  const marks = [];
+  const mark = async (locator, kind, cursorType, note) => {
+    const b = await locator.boundingBox().catch(() => null);
+    if (!b) return;
+    marks.push({ tMs: Date.now() - t0, kind, cursorType, note,
+      cx: (b.x + b.width / 2) / SIZE.width, cy: (b.y + b.height / 2) / SIZE.height,
+      w: b.width / SIZE.width, h: b.height / SIZE.height });
+  };
+  const tap = async (locator, cursorType, note, opts) => {
+    await mark(locator, 'click', cursorType, note);
+    await locator.click(opts ?? {});
+  };
+
+  // Chapter cards are off for the shipped cut. Flip CHAPTERS to true to get the
+  // full-screen title cards back; the pause keeps the pacing either way.
+  const CHAPTERS = false;
+  const chapter = (title, opts) =>
+    CHAPTERS ? page.screencast.showChapter(title, opts) : page.waitForTimeout(700);
+
+  const PROMPT = 'Set up this project for me — where should we start?';
+
+  const label = (b, text) => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute; top:${b.y + b.height + 10}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), '{"state":{"completed":true,"step":4},"version":0}');
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(600);
+  await page.getByRole('button', { name: /acme-web/ }).first().click();
+  await page.waitForTimeout(600);
+  await page.getByTestId('sessions-new-button').click();
+  const composer = page.getByTestId('chat-composer-input');
+  await composer.waitFor({ timeout: 15000 });
+  await page.waitForTimeout(900);
+
+  // A take that throws leaves the screencast running, and every later run then
+  // fails with "Screencast is already started" — masking the real error.
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+  t0 = Date.now();
+  await chapter('It asks before it guesses', {
+    description: 'Questions arrive inline, and are answered inline.',
+    duration: 2000,
+  });
+
+  await tap(composer, 'text', 'composer');
+  await composer.pressSequentially(PROMPT, { delay: 50 });
+  await page.waitForTimeout(500);
+  await composer.press('Enter');
+  const sent = await page.getByText(PROMPT, { exact: true }).waitFor({ timeout: 4000 }).then(() => true, () => false);
+  // The dropped-send race (see demos/README) must never be filmed: a retype on
+  // camera reads as a bug. Fail the take and let the harness re-run it clean.
+  if (!sent) throw new Error('dropped send — retake');
+
+  await page.getByTestId('chat-question-gate').waitFor({ timeout: 30000 });
+  await page.waitForTimeout(1000);
+  const choice = page.getByTestId('chat-question-option-0-Work on index.ts');
+  const choiceMark = await page.screencast.showOverlay(label(await choice.boundingBox(), 'Answer without leaving the thread'));
+  await page.waitForTimeout(1500);
+  await tap(choice, 'pointer', 'answer inline');
+  await choiceMark.dispose();
+  await page.waitForTimeout(600);
+  await tap(page.getByTestId('chat-question-submit'), 'pointer', 'submit');
+  await page.waitForTimeout(2600);
+  await page.mouse.move(950, 560);
+  await page.waitForTimeout(1200);
+
+  await page.screencast.stop();
+  return JSON.stringify({ video: OUT, size: SIZE, durationMs: Date.now() - t0, marks });
+}

--- a/demos/github/c-surfaces.demo.js
+++ b/demos/github/c-surfaces.demo.js
@@ -1,0 +1,137 @@
+// GitHub tour, segment C — worktrees, the board, automations, review + inline
+// comments, and pairing a remote daemon.
+//
+// Needs no adapter replay, so nothing here can hit the dropped-send race.
+// Beat order matters: Review Changes is a modal that covers the sidebar, so the
+// surfaces that live in the sidebar are filmed before it opens.
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/tour-c.webm';
+  // 1920 wide: the transcript is a fixed-width centred column, so the floating
+  // session panels only clear it once there is real margin to the right.
+  const SIZE = { width: 1920, height: 1080 };
+
+  let t0 = 0;
+  const marks = [];
+  const mark = async (locator, kind, cursorType, note) => {
+    const b = await locator.boundingBox().catch(() => null);
+    if (!b) return;
+    marks.push({ tMs: Date.now() - t0, kind, cursorType, note,
+      cx: (b.x + b.width / 2) / SIZE.width, cy: (b.y + b.height / 2) / SIZE.height,
+      w: b.width / SIZE.width, h: b.height / SIZE.height });
+  };
+  const tap = async (locator, cursorType, note, opts) => {
+    await mark(locator, 'click', cursorType, note);
+    await locator.click(opts ?? {});
+  };
+
+  // Chapter cards are off for the shipped cut. Flip CHAPTERS to true to get the
+  // full-screen title cards back; the pause keeps the pacing either way.
+  const CHAPTERS = false;
+  const chapter = (title, opts) =>
+    CHAPTERS ? page.screencast.showChapter(title, opts) : page.waitForTimeout(700);
+
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), '{"state":{"completed":true,"step":4},"version":0}');
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(600);
+  await page.getByRole('button', { name: /acme-web/ }).first().click();
+  await page.waitForTimeout(600);
+  await page.getByTestId('sessions-new-button').click();
+  await page.getByTestId('chat-composer-input').waitFor({ timeout: 15000 });
+  await page.waitForTimeout(900);
+
+  // Warm the board view off camera. The tasks store keeps `view` for the page
+  // session, so the on-camera open lands straight on the board — one less click,
+  // and no cursor jump across the modal.
+  await page.getByTestId('sidebar-action-kanban').click();
+  await page.getByTestId('tasks-view-board').click({ force: true });
+  await page.waitForTimeout(600);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(600);
+
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+  t0 = Date.now();
+
+  // ---- Worktrees -----------------------------------------------------------
+  await chapter('Isolate the work', {
+    description: 'Give a session its own worktree and branch.',
+    duration: 1800,
+  });
+  await tap(page.getByTestId('composer-worktree-trigger'), 'pointer', 'worktree');
+  await page.waitForTimeout(2400);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(700);
+
+  // ---- The board -----------------------------------------------------------
+  await chapter('Track the work', {
+    description: 'A board per project — start a session straight from a card.',
+    duration: 1800,
+  });
+  await tap(page.getByTestId('sidebar-action-kanban'), 'pointer', 'board');
+  await page.waitForTimeout(1400);
+  await page.waitForTimeout(3200);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(700);
+
+  // ---- Automations ---------------------------------------------------------
+  await chapter('Put it on a schedule', {
+    description: 'Automations run the agent on a trigger, unattended.',
+    duration: 1800,
+  });
+  // The rail keeps re-laying out while these surfaces mount, so Playwright's
+  // stability check never settles; force past the actionability wait.
+  await tap(page.getByTestId('sidebar-action-automations'), 'pointer', 'automations', { force: true });
+  await page.waitForTimeout(3000);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(700);
+
+  // ---- Remote daemons ------------------------------------------------------
+  await chapter('Or run it somewhere else', {
+    description: 'Point the app at a daemon on another machine.',
+    duration: 1800,
+  });
+  await tap(page.getByTestId('daemon-footer-trigger'), 'pointer', 'daemon picker');
+  await page.waitForTimeout(2000);
+  await page.getByTestId('daemon-picker-add').click();
+  await page.waitForTimeout(1200);
+  const url = page.getByTestId('daemon-add-url');
+  if (await url.isVisible().catch(() => false)) {
+    await url.click();
+    await url.pressSequentially('https://studio.remote:31415', { delay: 55 });
+    await page.waitForTimeout(1400);
+  }
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(700);
+
+  // ---- Review + inline comments, last: the modal covers everything ---------
+  await chapter('Review before you commit', {
+    description: 'Side-by-side diffs, comments on a line, and the commit.',
+    duration: 1900,
+  });
+  await tap(page.getByTestId('surface-rail-workspace'), 'pointer', 'workspace');
+  await page.waitForTimeout(1200);
+  await tap(page.getByTestId('workspace-picker-view-changes'), 'pointer', 'view changes');
+  await page.waitForTimeout(2600);
+
+  // Anchor a comment on a diff line, the way a reviewer would.
+  // Two things bite here: CodeMirror splits a line across token spans (so getByText
+  // never matches the statement), and only the MODIFIED pane anchors a comment —
+  // a click in `.cm-merge-a` is silently ignored.
+  await tap(page.locator('.cm-merge-b .cm-line').filter({ hasText: 'reduce' }).first(), 'text', 'anchor a comment');
+  await page.waitForTimeout(900);
+  const comment = page.getByTestId('review-comment-input');
+  await comment.click();
+  await comment.pressSequentially('Guard against a negative quantity here.', { delay: 50 });
+  await page.waitForTimeout(700);
+  await tap(page.getByTestId('review-comment-submit'), 'pointer', 'post the comment');
+  await page.waitForTimeout(2600);
+  await page.mouse.move(640, 470);
+  await page.waitForTimeout(1400);
+
+  await page.screencast.stop();
+  return JSON.stringify({ video: OUT, size: SIZE, durationMs: Date.now() - t0, marks });
+}

--- a/demos/github/d-threads.demo.js
+++ b/demos/github/d-threads.demo.js
@@ -1,0 +1,135 @@
+// GitHub tour, segment D — quoting the transcript, the session rail, a live
+// workflow run, and capturing a task without leaving.
+//
+// Boot: MF_DEMO_RECORDING_KEY=workflow .agents/demo-env.sh up
+//
+// The workflow fixture leaves a four-phase run mid-flight, so the Activity panel
+// has real work in it and the row drills into the run panel. The conversation is
+// sent BEFORE recording starts: segment A already showed a prompt being typed, so
+// this segment opens on the payoff.
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/tour-d.webm';
+  // 1920 wide: the transcript is a fixed-width centred column, so the floating
+  // session panels only clear it once there is real margin to the right.
+  const SIZE = { width: 1920, height: 1080 };
+  const PROMPT = 'Run the release-readiness workflow';
+
+  let t0 = 0;
+  const marks = [];
+  const mark = async (locator, kind, cursorType, note) => {
+    const b = await locator.boundingBox().catch(() => null);
+    if (!b) return;
+    marks.push({ tMs: Date.now() - t0, kind, cursorType, note,
+      cx: (b.x + b.width / 2) / SIZE.width, cy: (b.y + b.height / 2) / SIZE.height,
+      w: b.width / SIZE.width, h: b.height / SIZE.height });
+  };
+  const tap = async (locator, cursorType, note, opts) => {
+    await mark(locator, 'click', cursorType, note);
+    await locator.click(opts ?? {});
+  };
+
+  const CHAPTERS = false;
+  const chapter = (title, opts) =>
+    CHAPTERS ? page.screencast.showChapter(title, opts) : page.waitForTimeout(700);
+
+  const label = (b, text) => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute; top:${b.y + b.height + 10}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), '{"state":{"completed":true,"step":4},"version":0}');
+
+  // Off camera: get the workflow running. A dropped send can only be recovered by
+  // a full reload — retrying inside one page session abandons the create again.
+  let sent = false;
+  for (let attempt = 0; attempt < 5 && !sent; attempt++) {
+    await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1800);
+    await page.getByRole('button', { name: /acme-web/ }).first().click();
+    await page.waitForTimeout(700);
+    await page.getByTestId('sessions-new-button').click();
+    const composer = page.getByTestId('chat-composer-input');
+    await composer.waitFor({ timeout: 15000 });
+    await page.waitForTimeout(1100);
+    await composer.click();
+    await composer.fill(PROMPT);
+    await composer.press('Enter');
+    sent = await page.getByText(PROMPT, { exact: true }).waitFor({ timeout: 5000 }).then(() => true, () => false);
+  }
+  if (!sent) throw new Error('dropped send — retake');
+  await page.getByText(/Review is running over/).waitFor({ timeout: 30000 });
+  await page.waitForTimeout(1200);
+
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+  t0 = Date.now();
+
+  // ---- Quote from the transcript ------------------------------------------
+  await chapter('Quote what matters', {
+    description: 'Select any part of the transcript and reply to just that.',
+    duration: 1800,
+  });
+
+  // A real drag, not locator.selectText(): the toolbar arms on mouseup, and a
+  // DOM-range selection never fires one, so the quote button never appears.
+  const answer = page.getByText(/Review is running over/).last();
+  const ab = await answer.boundingBox();
+  await page.mouse.move(ab.x + 3, ab.y + 12);
+  await page.mouse.down();
+  await page.mouse.move(ab.x + ab.width - 3, ab.y + 12, { steps: 24 });
+  await page.mouse.up();
+  const quoteButton = page.getByTestId('chat-selection-quote');
+  await quoteButton.waitFor({ timeout: 10000 });
+  const quoteMark = await page.screencast.showOverlay(label(await quoteButton.boundingBox(), 'Quote it into your reply'));
+  await page.waitForTimeout(1300);
+  await tap(quoteButton, 'pointer', 'quote it');
+  await quoteMark.dispose();
+  await page.getByTestId('composer-quote-preview').waitFor({ timeout: 10000 });
+  await page.waitForTimeout(1500);
+
+  // ---- The session rail ----------------------------------------------------
+  await chapter('The session at a glance', {
+    description: 'Summary, activity, launches and tasks — one rail.',
+    duration: 1800,
+  });
+  await tap(page.getByTestId('session-panel-rail-open'), 'pointer', 'session summary');
+  await page.waitForTimeout(2200);
+
+  // ---- The live workflow run ----------------------------------------------
+  await chapter('Watch a workflow run', {
+    description: 'Phases, agents, tokens — while it is still going.',
+    duration: 1800,
+  });
+  await tap(page.getByTestId('session-panel-rail-activity'), 'pointer', 'activity');
+  await page.waitForTimeout(1400);
+
+  const runRow = page.locator('[data-testid=session-panel]').getByText('release-readiness').first();
+  await runRow.waitFor({ timeout: 10000 });
+  const runMark = await page.screencast.showOverlay(label(await runRow.boundingBox(), 'A workflow still running — open it'));
+  await page.waitForTimeout(1800);
+  await tap(runRow, 'pointer', 'drill into the run');
+  await runMark.dispose();
+  // Hold on the run panel: four phases, the agent grid, tokens, and what is up next.
+  await page.waitForTimeout(4200);
+
+  // ---- Quick task ----------------------------------------------------------
+  await chapter('Capture a task without leaving', { duration: 1600 });
+  await tap(page.getByTestId('session-panel-rail-tasks'), 'pointer', 'tasks');
+  await page.waitForTimeout(1400);
+  const taskInput = page.getByTestId('session-panel-tasks-new');
+  await tap(taskInput, 'text', 'quick task');
+  await taskInput.pressSequentially('Cover summarize() with tests', { delay: 55 });
+  await page.waitForTimeout(600);
+  await taskInput.press('Enter');
+  await page.waitForTimeout(2400);
+
+  await page.screencast.stop();
+  return JSON.stringify({ video: OUT, size: SIZE, durationMs: Date.now() - t0, marks });
+}

--- a/demos/github/e-tabs-split.demo.js
+++ b/demos/github/e-tabs-split.demo.js
@@ -1,0 +1,82 @@
+// GitHub tour, segment E — session tabs and two threads side by side.
+// Boot: MF_DEMO_RECORDING_KEY=tool-group .agents/demo-env.sh up
+async page => {
+  const APP_URL = 'http://localhost:5183';
+  const OUT = '/tmp/mainframe-demo/out/tour-e.webm';
+  // 1920 wide: the transcript is a fixed-width centred column, so the floating
+  // session panels only clear it once there is real margin to the right.
+  const SIZE = { width: 1920, height: 1080 };
+
+  // Chapter cards are off for the shipped cut. Flip CHAPTERS to true to get the
+  // full-screen title cards back; the pause keeps the pacing either way.
+  const CHAPTERS = false;
+  const chapter = (title, opts) =>
+    CHAPTERS ? page.screencast.showChapter(title, opts) : page.waitForTimeout(700);
+
+  const PROMPT = 'Where is greeting defined?';
+
+  const label = (b, text) => `
+    <div style="position:absolute; top:${b.y - 3}px; left:${b.x - 3}px;
+      width:${b.width + 6}px; height:${b.height + 6}px;
+      border:2px solid #3b82f6; border-radius:8px;"></div>
+    <div style="position:absolute; top:${b.y + b.height + 10}px;
+      left:${b.x + b.width / 2}px; transform:translateX(-50%);
+      padding:6px 12px; background:rgba(0,0,0,.75); border-radius:8px;
+      font:13px -apple-system,system-ui; color:#fff; white-space:nowrap;">${text}</div>`;
+
+  await page.setViewportSize(SIZE);
+  await page.addInitScript((v) => localStorage.setItem('mf:tutorial', v), '{"state":{"completed":true,"step":4},"version":0}');
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(600);
+  await page.getByRole('button', { name: /acme-web/ }).first().click();
+  await page.waitForTimeout(600);
+
+  // Off-camera: one finished session, then a second one open as a draft, so the
+  // tab strip has two entries and there is something to put in the other pane.
+  await page.getByTestId('sessions-new-button').click();
+  const composer = page.getByTestId('chat-composer-input');
+  await composer.waitFor({ timeout: 15000 });
+  await page.waitForTimeout(1200);
+  await composer.click();
+  await composer.fill(PROMPT);
+  await composer.press('Enter');
+  const landed = await page.getByText(PROMPT, { exact: true }).waitFor({ timeout: 5000 }).then(() => true, () => false);
+  if (!landed) {
+    await composer.click();
+    await composer.fill(PROMPT);
+    await composer.press('Enter');
+  }
+  await page.getByText(/Found it:/).waitFor({ timeout: 30000 });
+  await page.waitForTimeout(1000);
+  // A second tab, so the strip has two entries and there is a thread to split with.
+  await page.getByTestId('session-tabs-new').click();
+  await page.waitForTimeout(1800);
+
+  await page.screencast.stop().catch(() => {});
+  await page.screencast.start({ path: OUT, size: SIZE });
+
+  await chapter('Several sessions at once', {
+    description: 'Tabs across the top — or two threads side by side.',
+    duration: 1900,
+  });
+
+  const tabs = page.getByTestId('session-tabs');
+  const tabsMark = await page.screencast.showOverlay(label(await tabs.boundingBox(), 'Every open session, one strip'));
+  await page.waitForTimeout(1900);
+  await tabsMark.dispose();
+  await page.waitForTimeout(500);
+
+  // Split from the TAB context menu: under a project filter the sidebar list can
+  // be empty even when sessions exist, but the tab strip always has them.
+  const firstTab = page.locator('[data-testid^=session-tab-]:not([data-testid*=close]):not([data-testid*=pin]):not([data-testid=session-tabs-new])').first();
+  await firstTab.click({ button: 'right' });
+  await page.waitForTimeout(1000);
+  await page.getByTestId('session-tab-ctx-open-split').click();
+  await page.waitForTimeout(3200);
+  await page.mouse.move(640, 250);
+  await page.waitForTimeout(1500);
+
+  await page.screencast.stop();
+  return OUT;
+}


### PR DESCRIPTION
## What

The environment, scripts and run book behind the demo videos, so a take is reproducible instead of a thing someone once did.

- **`.agents/demo-env.sh`** — sibling of `test-env.sh`, with its own ports (:31417 daemon, :5183 vite) and data dir, so it can never touch the dev daemon on :31415, the e2e harness on :31416, or `~/.mainframe`. Boots the renderer against the mock adapter and seeds what the camera needs: a storefront repo with an uncommitted change (so the diff surfaces aren't empty), five todos across the board's three columns, two automations.
- **`demos/github/*.demo.js`** — the four segments of the shipped tour plus one that isn't in the cut. Each is a single `playwright-cli run-code` function that also returns a timeline of every action's position and time, which the `feature-recorder` skill turns into a Recordly cursor track and zoom regions.
- **`demos/README.md`** — the run book: per-segment recording keys, the take/retake loop, the rebuild command, and the known flakiness.
- **`.agents/demo-notes.md`** — what the skill reads before deriving a scenario: available fixtures, filmable surfaces, and the gotchas that each cost a take.

## Notes

- **Videos are gitignored.** Scripts are versioned; output is regenerated. The shipped MP4 gets attached where it's used rather than committed.
- **Tooling only** — nothing here ships in a package, hence the empty changeset.
- The `d-threads` segment needs the `workflow` fixture from #630 to show a live run; the other three work against fixtures already in the repo.
- macOS-only for the editing step: the Recordly export in the skill writes a project for a macOS app. Recording itself is portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)