### PR TITLE
test(e2e): cover the Automations library (#323)

### DIFF
--- a/.changeset/automations-library-e2e-coverage.md
+++ b/.changeset/automations-library-e2e-coverage.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-e2e': patch
+---
+
+Add a Tauri e2e spec covering the Automations library: row delete (confirmed and cancelled), the project badge for scoped and unscoped automations, and cross-project scoping in both directions.

--- a/docs/plans/2026-08-14-automations-library-e2e-plan.md
+++ b/docs/plans/2026-08-14-automations-library-e2e-plan.md
@@ -1,0 +1,279 @@
+# Automations library — e2e coverage (todo #323)
+
+## Goal
+
+The Automations library ships three behaviors with no end-to-end coverage: a per-row delete that
+goes through the shared confirm dialog, a project badge that names the owning project or reads
+"All projects" for an unscoped automation, and a list that the daemon scopes to the selected
+project plus the unscoped rows. Unit tests cover `LibraryRow` in isolation and Rust route tests
+cover the query filter, so the untested seam is the wired UI against a live daemon. This plan adds
+one Playwright spec — `packages/e2e/tests-tauri/automations-library.spec.ts` — that pins delete
+(accepted and cancelled), the badge in both states, and cross-project scoping in both directions,
+plus one REST seeding helper it needs. No product code changes.
+
+## Scope
+
+**In:** one new spec file, one new helper function in the existing e2e setup helper, one changeset.
+
+**Out:** the sidebar pending-interaction dot (needs a paused-run fixture that does not exist), the
+automation editor / describe / run / run-history / enable-toggle surfaces, host open-close from the
+sidebar (covered in `sidebar-chrome.spec.ts`), server-side filter tests (the Rust route already has
+them), and any product-code change. If a scenario turns out to be unreachable because of a product
+bug, stop and report it — do not fix it here.
+
+## Ambiguity resolutions
+
+Read these before writing a line; two of them contradict the brief.
+
+1. **Reopening the automations host does NOT re-fetch the library.** The brief offers "reopen the
+   host or reload" as the way to force a re-fetch after seeding. Only half of that is true.
+   `AutomationsHost` is mounted unconditionally in `AppShell` and its load effect depends on
+   `[projectId, setActiveProjectId, loadAll]` — `open` is absent — and `LibraryList` has no mount
+   fetch of its own. The only refresh triggers are **a change of active project id** and **a page
+   reload**. Every scenario in this spec therefore uses the refresh recipe below; nothing waits on
+   an event or on reopening the dialog.
+2. **A null active project id fetches EVERYTHING.** With no active session,
+   `useActiveIdentity().projectId` is undefined, the store's `activeProjectId` is `null`, and
+   `listAutomations(null)` omits the query param — which the daemon reads as "return every
+   automation". Every assertion in this spec must first pin the active project by making that
+   project's seeded chat the active session, or the scoping tests pass — or fail — for the wrong
+   reason.
+3. **Pin the scope through the active session, not the project-filter row.** The library's scope
+   comes from `useActiveIdentity().projectId` — the active *session's* project. The
+   `sidebar-project-<id>` filter row usually moves both together, but the two can desync across a
+   reload (the filter selection and the boot session auto-selection are separate mechanisms), and a
+   filter row that already reads `aria-pressed="true"` would then skip a click the scope still
+   needed. Select the target project's seeded chat row directly instead; it is deterministic and
+   needs no assumption about what survives a reload.
+
+## The refresh recipe
+
+Every scenario seeds over REST and then brings the UI to a freshly fetched library for a chosen
+project. Encode it once, as a local helper in the spec — `openLibraryFor(page, chatId)`, keyed by
+the target project's seeded chat, not by its project id:
+
+```
+seed over REST
+→ page.reload()
+→ waitConnected(page)
+→ click sidebar-project-all
+   (clearing the filter only WIDENS the list — it never switches the active session — so both
+    projects' rows are visible to click next)
+→ click sessionsSidebar(page).row(chatId) for the target project's seeded chat, and wait for
+   data-active="true" on it
+   (activating a chat in another project changes the active project id, which re-fetches; if it
+    was already active nothing changes, and that is fine — the boot fetch after the reload
+    already ran with that same project id)
+→ click sidebar-action-automations
+→ wait for automations-library to be visible
+```
+
+Closing the host between scenarios is `automations-close`.
+
+Row clicks in this sidebar get eaten by `SessionRow`'s HoverCard, so reuse the
+park-the-pointer-then-retry idiom from `sessions-filters.spec.ts:85-108` (`selectRow`) rather than
+a bare `click()`.
+
+## Established facts
+
+Every external/protocol/dependency behavior verified while planning, with its receipt. Trust these;
+do not re-derive them.
+
+- The library re-fetches only on an active-project-id change or a page reload — the effect's deps
+  are `[projectId, setActiveProjectId, loadAll]`, with no `open`:
+  `packages/ui/src/features/automations/AutomationsHost.tsx:41-44`.
+- `LibraryList` has no mount-time fetch; it renders whatever the store holds — the file contains no
+  `useEffect` at all: `packages/ui/src/features/automations/library/LibraryList.tsx:1-115`.
+- `listAutomations(null)` omits `?projectId=` entirely: `packages/ui/src/lib/api/automations.ts:29-30`.
+- The daemon returns everything when the param is absent, and the selected project's automations
+  **plus** every unscoped (`project_id` null) one when it is present:
+  `packages/core-rs/crates/mainframe-server/src/routes/automations.rs:76-89` (`is_none_or(|p| p == pid)`).
+- The minimal accepted create body is one `notify` step with no triggers —
+  `{"name":…,"scope":"global","definition":{"triggers":[],"steps":[{"id":"n1","kind":"notify","message":["done"]}]}}`:
+  `packages/core-rs/crates/mainframe-server/src/routes/automations_test_support.rs:121-131`.
+  The project-scoped variant is the same body with `"scope":"project"` and `"projectId": <id>`:
+  `packages/core-rs/crates/mainframe-server/src/routes/automations/automations_tests.rs:37-42`.
+- `AutomationCreateInput` is `deny_unknown_fields` — an extra key makes `POST /api/automations`
+  return 400 `invalid automation body`:
+  `packages/core-rs/crates/mainframe-automations/src/domain/automation.rs:26-36` and
+  `packages/core-rs/crates/mainframe-server/src/routes/automations.rs:100-102`.
+- Routes are WS4-enveloped: create returns `{ data: { id, … } }`
+  (`packages/core-rs/crates/mainframe-server/src/routes/automations.rs:104`), delete returns the
+  empty envelope (`…/routes/automations.rs:138`).
+- The row passes `automations-delete-confirm` as the dialog testid
+  (`packages/ui/src/features/automations/library/LibraryRow.tsx:93`), and the shared `ConfirmDialog`
+  derives its buttons from that root as `<testid>-cancel` and `<testid>-confirm`:
+  `packages/ui/src/features/shared/ConfirmDialog.tsx:90,99`.
+- The badge renders the owning project's `name` from the loaded project list, the literal
+  `All projects` when `projectId` is null, and falls back to the raw id for an unknown project:
+  `packages/ui/src/features/automations/library/LibraryRow.tsx:57-60,146`.
+- A seeded project's `name` is `path.basename(projectPath)` — so the scoped badge's expected text is
+  that basename: `packages/e2e/helpers/tauri/setup.ts:35`.
+- Nothing broadcasts an automation-created/deleted event. `useAutomationEvents` handles five
+  `automation.*` events, none of which patch `definitions`
+  (`packages/ui/src/features/automations/data/use-automation-events.ts:24-40`), and the create route
+  emits nothing (`packages/core-rs/crates/mainframe-server/src/routes/automations.rs:96-106`). A
+  post-boot seed is invisible until a refresh.
+- Clicking `sidebar-project-<id>` filters the list **and** activates that project's most recent
+  session, which is what changes the active project id; a second click on the active row is a no-op.
+  Pinned by `packages/e2e/tests-tauri/sessions-filters.spec.ts:152-171` (switch) and `:174-198`
+  (re-click is inert).
+- Clicking `sidebar-project-all` only widens the list — it never switches the active session:
+  `packages/e2e/tests-tauri/sessions-filters.spec.ts:67-68` and the assertion at `:194-198`.
+- Session-row clicks need the hover-card workaround (park the pointer at 0,0, then retry the click
+  until `data-active="true"`): `packages/e2e/tests-tauri/sessions-filters.spec.ts:85-108`.
+- Each `launchTauriApp` starts a daemon on a fresh `mkdtemp` data dir
+  (`packages/e2e/fixtures/daemon.ts:166`) and the automations DB lives inside it
+  (`packages/core-rs/crates/mainframe-server/src/automations_deps/mod.rs:98`). Seeded automations die
+  with the describe's daemon; only the project directories need `cleanupTauriProject`.
+- The library section is the default body of `AutomationsView` (rendered when no run/editor/describe/
+  details target is set): `packages/ui/src/features/automations/AutomationsView.tsx:62-78`.
+- `docs/plans/` is gitignored (`.gitignore:53`), so this plan is committed with `git add -f`.
+
+## Tasks
+
+### T1 — Seeding helper `createTauriAutomation`
+
+**File:** `packages/e2e/helpers/tauri/setup.ts` (add next to `createTauriChat`; do not create a new
+module — this is the REST-seeding helper file).
+
+Add an exported async function that POSTs a minimal automation and returns its id:
+
+- Signature: `createTauriAutomation(opts: { name: string; projectId?: string }): Promise<string>`.
+- Body: the `notify_body` shape from the established facts. When `opts.projectId` is given, send
+  `scope: 'project'` and `projectId`; otherwise send `scope: 'global'` and omit `projectId`
+  entirely (`deny_unknown_fields` tolerates the omission, not a null).
+- Throw with status + response text when `!res.ok`, mirroring `createTauriChat`.
+- Read the id from `body.data.id`; throw if it is missing.
+- One-line doc comment stating that the caller must force a re-fetch (reload or project switch)
+  because nothing broadcasts a create.
+
+**Verify:** `pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit -p tsconfig.json` passes.
+
+### T2 — Spec skeleton, fixture, and refresh helper
+
+**File:** `packages/e2e/tests-tauri/automations-library.spec.ts` (new).
+
+- House-style header comment: a `§automations-library` title naming the surface, a note that every
+  test runs in `E2E_MODE=mock` and never sends a message (so **no** `recordingKey`), the full testid
+  reference (`sidebar-action-automations`, `automations-host`, `automations-view`,
+  `automations-close`, `automations-section-library`, `automations-library`,
+  `automations-library-row-<id>`, `automations-library-delete-<id>`,
+  `automations-library-project-<id>`, `automations-delete-confirm`,
+  `automations-delete-confirm-confirm`, `automations-delete-confirm-cancel`,
+  `sidebar-project-<projectId>`), and a short paragraph restating ambiguity resolutions 1–3 —
+  a future reader will otherwise "simplify" the reload away.
+- One `test.describe`, one `launchTauriApp()` in `beforeAll`, `closeTauriApp` +
+  `cleanupTauriProject` for both projects in `afterAll`. One describe on purpose: the browser/app
+  launch cost is per-describe.
+- `beforeAll` seeds project A + one chat in it, then project B + one chat in it (mirroring
+  `sessions-filters.spec.ts:126-135`; `createTauriProject` reloads the page and REST-seeded chats
+  survive it).
+- Local helper `openLibraryFor(page, chatId)` implementing the refresh recipe verbatim — keyed by
+  the target project's seeded chat id, so the active session (and therefore the library's scope) is
+  pinned deterministically — and `closeLibrary(page)` clicking `automations-close` and asserting
+  `automations-host` reaches count 0. Keep `chatIdA`/`chatIdB` in describe scope beside the two
+  projects.
+- No tests yet beyond a placeholder that opens and closes the library for project A, so the
+  skeleton is provably green before behavior lands.
+
+**Verify:** `cd packages/e2e && E2E_MODE=mock pnpm exec playwright test tests-tauri/automations-library.spec.ts`
+passes (first run builds the daemon and the UI bundle; `MF_E2E_SKIP_BUILD=1` on reruns).
+
+### T3 — Delete, confirmed (implement FIRST of the behavior tests)
+
+**File:** `packages/e2e/tests-tauri/automations-library.spec.ts`.
+
+This test is first on purpose: the confirm dialog is a Radix `AlertDialog` raised from inside the
+modal automations `Dialog`, and that nesting is the spec's one real technical risk. Prove it here
+before building on it.
+
+- Seed a project-A-scoped automation with a name unique to this test, then `openLibraryFor(chatIdA)`.
+- Assert `automations-library-row-<id>` is visible; click `automations-library-delete-<id>`.
+- Assert `automations-delete-confirm` is visible and contains the automation's name.
+- Click `automations-delete-confirm-confirm`; assert the dialog reaches count 0 and
+  `automations-library-row-<id>` reaches count 0.
+- Close the library, run `openLibraryFor(chatIdA)` again, and assert the row is still count 0 — the
+  deletion survives a real re-fetch, not just the local `removeDefinition` patch.
+
+**Do not** reach for `click({ force: true })` or keyboard-only interaction if the confirm button is
+not clickable. A forced click hides exactly the defect it would be masking. If the dialog is
+genuinely unreachable, stop and report it as a product bug per the brief.
+
+**Verify:** the single spec file passes; the test fails for the right reason if you temporarily
+point the locator at a wrong id.
+
+### T4 — Delete, cancelled
+
+**File:** `packages/e2e/tests-tauri/automations-library.spec.ts`.
+
+- Seed a second project-A-scoped automation with its own name; `openLibraryFor(chatIdA)`.
+- Click its delete action, assert `automations-delete-confirm` is visible, click
+  `automations-delete-confirm-cancel`.
+- Assert the dialog reaches count 0 and `automations-library-row-<id>` is still visible.
+- Close, `openLibraryFor(chatIdA)` again, assert the row is still visible — the automation was never
+  deleted server-side.
+
+**Verify:** the single spec file passes.
+
+### T5 — Project badge, scoped and unscoped
+
+**File:** `packages/e2e/tests-tauri/automations-library.spec.ts`.
+
+Two tests, each seeding its own automation so neither depends on T3/T4 leftovers.
+
+- Scoped: seed an automation with `projectId = A`; `openLibraryFor(chatIdA)`; assert
+  `automations-library-project-<id>` has text equal to `path.basename(projectA.projectPath)` (the
+  seeded project's name).
+- Unscoped: seed an automation with no project scope; `openLibraryFor(chatIdA)`; assert
+  `automations-library-project-<id>` has text `All projects`.
+
+**Verify:** the single spec file passes.
+
+### T6 — Cross-project scoping, both directions
+
+**File:** `packages/e2e/tests-tauri/automations-library.spec.ts`.
+
+- Negative: seed an automation scoped to project A; `openLibraryFor(chatIdB)`; assert
+  `automations-library-row-<id>` has count 0. Guard the assertion against a false pass by also
+  asserting `automations-library` is visible and that the unscoped automation's row (below) IS
+  present in the same view — an empty library would otherwise satisfy the negative on its own.
+- Positive: with an unscoped automation seeded, assert its row is visible from project B and, after
+  `openLibraryFor(chatIdA)`, from project A too.
+
+Both directions can share one `openLibraryFor(chatIdB)` pass; keep them as two named tests so a failure
+names the direction.
+
+**Verify:** the single spec file passes.
+
+### T7 — Changeset
+
+**File:** a new file under `.changeset/` (e.g. `automations-library-e2e-coverage.md`).
+
+- `pnpm changeset`, select `@qlan-ro/mainframe-e2e`, bump `patch`. One sentence: what the new spec
+  covers.
+
+**Verify:** the file exists and names the package; the pre-push hook accepts the branch.
+
+### T8 — Full-suite verification
+
+- `pnpm --filter @qlan-ro/mainframe-e2e exec tsc --noEmit -p tsconfig.json`.
+- `cd packages/e2e && E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm exec playwright test` — the whole
+  `tauri` project, green, with no regression in an existing spec. The suite gates only in the
+  Release workflow, so local green is the real signal.
+- Optional hygiene: `pnpm --filter @qlan-ro/mainframe-e2e testids` refreshes
+  `packages/e2e/UNUSED-TESTIDS.md` if the newly asserted ids are listed there. Not gated by CI.
+
+## Risks
+
+- **Nested Radix modals.** The confirm `AlertDialog` opens on top of the modal automations `Dialog`.
+  Both portal to `<body>` and each applies its own scroll-lock, so the later layer should own
+  pointer events — but this exact nesting has no existing e2e precedent (`sessions-tag-delete-confirm`
+  is raised from a popover, not a modal). T3 front-loads the risk. If it fails, report a product
+  bug rather than forcing the click.
+- **Boot-fetch timing.** After `page.reload()` the library fetch races the project list and the
+  active-session resolution. `openLibraryFor` must wait for `automations-library` to be visible and
+  assert on rows with Playwright's auto-retrying `expect`, never a fixed sleep.
+- **Order coupling inside the describe.** Tests share one app and run in file order. Seeding a
+  distinct automation per concern keeps them independent; do not reuse one automation across the
+  delete and badge tests.

--- a/docs/plans/2026-08-14-automations-library-e2e-plan.md
+++ b/docs/plans/2026-08-14-automations-library-e2e-plan.md
@@ -66,6 +66,13 @@ seed over REST
     already ran with that same project id)
 → click sidebar-action-automations
 → wait for automations-library to be visible
+→ wait for automations-library-loading to reach count 0
+   (the loading branch renders the SAME automations-library container with zero rows inside, so
+    "visible" alone does not mean the fetch landed — a `toHaveCount(0)` row assertion would pass
+    on the loading render. After the reload `definitions` starts empty and `loadAll` sets
+    `loading: true` synchronously, so the loading node is present whenever a fetch is in flight.
+    Treat this as a no-fetch-in-flight guard, not proof that a fetch ran: a scenario that asserts
+    an EMPTY view still needs a positive anchor row, as T3 and T6 do.)
 ```
 
 Closing the host between scenarios is `automations-close`.
@@ -84,6 +91,13 @@ do not re-derive them.
   `packages/ui/src/features/automations/AutomationsHost.tsx:41-44`.
 - `LibraryList` has no mount-time fetch; it renders whatever the store holds — the file contains no
   `useEffect` at all: `packages/ui/src/features/automations/library/LibraryList.tsx:1-115`.
+- **`automations-library` is also the loading container.** The `definitions.length === 0 && loading`
+  branch renders the same `data-testid="automations-library"` div wrapping an
+  `automations-library-loading` node and no rows:
+  `packages/ui/src/features/automations/library/LibraryList.tsx:43-55`. `loadAll` sets
+  `loading: true` synchronously before it awaits
+  (`packages/ui/src/features/automations/data/use-automations-store.ts:71-73`), so the loading node
+  is present for as long as a fetch is in flight — and absent once one has landed.
 - `listAutomations(null)` omits `?projectId=` entirely: `packages/ui/src/lib/api/automations.ts:29-30`.
 - The daemon returns everything when the param is absent, and the selected project's automations
   **plus** every unscoped (`project_id` null) one when it is present:
@@ -158,7 +172,7 @@ Add an exported async function that POSTs a minimal automation and returns its i
   test runs in `E2E_MODE=mock` and never sends a message (so **no** `recordingKey`), the full testid
   reference (`sidebar-action-automations`, `automations-host`, `automations-view`,
   `automations-close`, `automations-section-library`, `automations-library`,
-  `automations-library-row-<id>`, `automations-library-delete-<id>`,
+  `automations-library-loading`, `automations-library-row-<id>`, `automations-library-delete-<id>`,
   `automations-library-project-<id>`, `automations-delete-confirm`,
   `automations-delete-confirm-confirm`, `automations-delete-confirm-cancel`,
   `sidebar-project-<projectId>`), and a short paragraph restating ambiguity resolutions 1–3 —
@@ -171,7 +185,9 @@ Add an exported async function that POSTs a minimal automation and returns its i
   survive it).
 - Local helper `openLibraryFor(page, chatId)` implementing the refresh recipe verbatim — keyed by
   the target project's seeded chat id, so the active session (and therefore the library's scope) is
-  pinned deterministically — and `closeLibrary(page)` clicking `automations-close` and asserting
+  pinned deterministically. It must not return until `automations-library-loading` has reached
+  count 0; returning on `automations-library` visibility alone lets a row-absence assertion pass
+  against the loading render — and `closeLibrary(page)` clicking `automations-close` and asserting
   `automations-host` reaches count 0. Keep `chatIdA`/`chatIdB` in describe scope beside the two
   projects.
 - No tests yet beyond a placeholder that opens and closes the library for project A, so the
@@ -188,13 +204,19 @@ This test is first on purpose: the confirm dialog is a Radix `AlertDialog` raise
 modal automations `Dialog`, and that nesting is the spec's one real technical risk. Prove it here
 before building on it.
 
-- Seed a project-A-scoped automation with a name unique to this test, then `openLibraryFor(chatIdA)`.
-- Assert `automations-library-row-<id>` is visible; click `automations-library-delete-<id>`.
-- Assert `automations-delete-confirm` is visible and contains the automation's name.
+- Seed **two** project-A-scoped automations with names unique to this test: the *target* to delete
+  and an *anchor* that is never deleted. The anchor is what makes the re-fetch assertion real — the
+  target is otherwise the only row, so a post-delete library is empty and `toHaveCount(0)` would be
+  satisfied by any view that never fetched. Then `openLibraryFor(chatIdA)`.
+- Assert `automations-library-row-<targetId>` is visible; click `automations-library-delete-<targetId>`.
+- Assert `automations-delete-confirm` is visible and contains the target's name.
 - Click `automations-delete-confirm-confirm`; assert the dialog reaches count 0 and
-  `automations-library-row-<id>` reaches count 0.
-- Close the library, run `openLibraryFor(chatIdA)` again, and assert the row is still count 0 — the
-  deletion survives a real re-fetch, not just the local `removeDefinition` patch.
+  `automations-library-row-<targetId>` reaches count 0.
+- Close the library and run `openLibraryFor(chatIdA)` again. Assert **in this order**: the anchor
+  row `automations-library-row-<anchorId>` IS visible, then `automations-library-row-<targetId>` is
+  count 0. After the reload `definitions` starts empty, so the anchor can only appear from a landed
+  re-fetch — it proves the view under test is the server's, and only then does the target's absence
+  mean the deletion survived rather than that nothing loaded.
 
 **Do not** reach for `click({ force: true })` or keyboard-only interaction if the confirm button is
 not clickable. A forced click hides exactly the defect it would be masking. If the dialog is
@@ -207,7 +229,7 @@ point the locator at a wrong id.
 
 **File:** `packages/e2e/tests-tauri/automations-library.spec.ts`.
 
-- Seed a second project-A-scoped automation with its own name; `openLibraryFor(chatIdA)`.
+- Seed another project-A-scoped automation with its own name; `openLibraryFor(chatIdA)`.
 - Click its delete action, assert `automations-delete-confirm` is visible, click
   `automations-delete-confirm-cancel`.
 - Assert the dialog reaches count 0 and `automations-library-row-<id>` is still visible.
@@ -272,8 +294,12 @@ names the direction.
   is raised from a popover, not a modal). T3 front-loads the risk. If it fails, report a product
   bug rather than forcing the click.
 - **Boot-fetch timing.** After `page.reload()` the library fetch races the project list and the
-  active-session resolution. `openLibraryFor` must wait for `automations-library` to be visible and
-  assert on rows with Playwright's auto-retrying `expect`, never a fixed sleep.
+  active-session resolution, and the loading render reuses the `automations-library` testid. So
+  `openLibraryFor` must wait for `automations-library` to be visible **and** for
+  `automations-library-loading` to reach count 0, then assert on rows with Playwright's
+  auto-retrying `expect`, never a fixed sleep. Any test whose expected view is empty needs a
+  positive anchor row on top of that (T3, T6).
 - **Order coupling inside the describe.** Tests share one app and run in file order. Seeding a
   distinct automation per concern keeps them independent; do not reuse one automation across the
-  delete and badge tests.
+  delete and badge tests. T3's anchor automation survives into T4–T6 by design and is harmless:
+  every later assertion is keyed to that test's own automation id, and no test asserts a row total.

--- a/docs/qa/2026-08-14-todo-323-full-sweep-regression.md
+++ b/docs/qa/2026-08-14-todo-323-full-sweep-regression.md
@@ -93,11 +93,21 @@ Notes on specs the prior session flagged:
 
 ## Cleanup
 
-Verified after the sweep: no leftover `playwright`, `mainframe-daemon`, or
-`vite` processes from the run — one stray `vite preview --port 4317` process
-was found and killed by port. Production (`/Applications/Mainframe.app`,
-`:31415`, pid unrelated to the sweep) was confirmed alive and untouched
-before and after (`GET /health` → `200`) throughout.
+Verified after the sweep: no leftover `playwright` or `mainframe-daemon`
+processes. One leftover `vite preview --port 4317` process remained from the
+last spec file; killed by port (`lsof -ti :4317 | xargs kill`), then
+reverified no listener on that port. Production
+(`/Applications/Mainframe.app`, `:31415`, pid unrelated to the sweep) was
+confirmed alive and untouched before and after (`GET /health` → `200`)
+throughout.
+
+The prior interrupted session reported a suite total of 422 tests (from a
+`pnpm test:e2e` run cut short at 323/422); this complete per-spec sweep
+accounts for 431 (395 passed + 36 skipped) across all 34 spec files, with
+zero failures. The two totals aren't reconciled here — differences in
+per-run conditional skip counts or "did not run" bookkeeping between the
+two invocation styles are plausible but unverified; reporting both numbers
+as observed rather than guessing at the gap.
 
 ## Conclusion
 

--- a/docs/qa/2026-08-14-todo-323-full-sweep-regression.md
+++ b/docs/qa/2026-08-14-todo-323-full-sweep-regression.md
@@ -1,0 +1,106 @@
+# todo #323 — full Tauri e2e regression sweep
+
+Closes the QA session's one open item: the prior `pnpm test:e2e` run was
+SIGTERM'd mid-flight at 323/422 tests, so no-regression couldn't be certified
+for the untested tail (settings.spec.ts onward).
+
+## Why the sweep script, not `pnpm test:e2e`
+
+`packages/e2e/run-tauri-sweep.sh` runs one Playwright invocation per spec
+file instead of one invocation for the whole suite. Its own header explains
+why that's the repo-canonical way to get a trustworthy complete local run:
+multi-file runs share one 40-minute `globalTimeout` and starve the tail —
+which is exactly the failure mode the prior interrupted run hit. Each spec
+gets its own daemon + preview server and its own budget.
+
+## Run
+
+```
+MF_E2E_SKIP_BUILD=1 E2E_MODE=mock ./packages/e2e/run-tauri-sweep.sh
+```
+
+against commit `d98b0928` (this branch's tip — the automations-library spec
+and its supporting helper/plan/changeset commits, plus the earlier
+skeleton-drop commit). UI bundle was pre-built for `VITE_DAEMON_PORT=31416`;
+`packages/core-rs/target/release/mainframe-daemon` was the release binary the
+sweep's daemon fixture resolved.
+
+## Result: 34/34 spec files green, zero regressions
+
+| Metric | Count |
+|---|---|
+| Spec files run | 34 (full `tests-tauri/*.spec.ts`, including the new `automations-library.spec.ts`) |
+| Files with a nonzero exit code | 0 |
+| Tests passed | 395 |
+| Tests skipped (documented `TODO(bug)` / conditional skips) | 36 |
+| Tests flaky (needed the suite's 1-retry policy) | 0 |
+| Tests failed | 0 |
+| Total accounted for | 431 |
+
+Full per-file breakdown (`exit=0 <playwright summary line>` for every file):
+
+```
+automations-library: exit=0 6 passed (6.0s)
+chat-header: exit=0 1 skipped 5 passed (4.4s)
+chat: exit=0 3 skipped 8 passed (8.2s)
+composer-advanced: exit=0 8 skipped 12 passed (9.0s)
+composer: exit=0 1 skipped 14 passed (12.8s)
+daemon-picker: exit=0 10 passed (13.8s)
+directory-picker: exit=0 1 skipped 13 passed (6.6s)
+editor-comments-review: exit=0 1 skipped 11 passed (10.7s)
+editor-diff: exit=0 1 skipped 5 passed (5.6s)
+editor: exit=0 1 skipped 12 passed (7.1s)
+files-tree: exit=0 17 passed (7.8s)
+find-in-path: exit=0 9 passed (12.9s)
+gates: exit=0 6 passed (10.8s)
+git-branch: exit=0 17 passed (29.8s)
+layout: exit=0 11 passed (12.7s)
+preview: exit=0 4 skipped 9 passed (12.5s)
+review-panel: exit=0 17 passed (13.3s)
+session-panel: exit=0 28 passed (10.7s)
+session-tabs: exit=0 6 passed (5.6s)
+sessions-draft: exit=0 15 passed (34.3s)
+sessions-filters: exit=0 2 skipped 15 passed (12.8s)
+sessions-rows: exit=0 1 skipped 11 passed (11.2s)
+sessions-tags: exit=0 1 skipped 11 passed (8.5s)
+sessions: exit=0 14 passed (14.8s)
+settings: exit=0 19 passed (17.4s)
+sidebar-chrome: exit=0 1 skipped 6 passed (3.4s)
+spotlight: exit=0 1 skipped 12 passed (11.3s)
+stress-matrix: exit=0 1 passed (6.3s)
+tasks: exit=0 1 skipped 17 passed (21.1s)
+tool-cards: exit=0 21 passed (29.5s)
+transcript: exit=0 4 skipped 10 passed (8.8s)
+viewers: exit=0 1 skipped 9 passed (4.2s)
+window-states: exit=0 2 skipped 7 passed (16.5s)
+workspace-surface: exit=0 1 skipped 11 passed (7.2s)
+```
+
+Notes on specs the prior session flagged:
+
+- **`automations-library.spec.ts`** (this todo's new spec): 6/6 passed, no
+  retries needed.
+- **`sessions.spec.ts`**: the prior session reported an auto-recovered flake
+  at `sessions.spec.ts:320` (archive-dialog worktree deletion, retry #1).
+  This sweep's `sessions` line shows `14 passed`, `0` flaky, `exit=0` — the
+  scenario passed on its first attempt this run, consistent with the prior
+  report's characterization of it as an AI-response flake rather than a
+  regression.
+- **`transcript.spec.ts`**: the repo memory notes a CI-only flake on the
+  transcript pair (`e2e-red-since-rc20`). Locally this run passed clean
+  (10 passed, 4 documented skips, 0 flaky) — no local reproduction, no new
+  information contradicting the "CI-only" characterization.
+
+## Cleanup
+
+Verified after the sweep: no leftover `playwright`, `mainframe-daemon`, or
+`vite` processes from the run — one stray `vite preview --port 4317` process
+was found and killed by port. Production (`/Applications/Mainframe.app`,
+`:31415`, pid unrelated to the sweep) was confirmed alive and untouched
+before and after (`GET /health` → `200`) throughout.
+
+## Conclusion
+
+Acceptance criterion "the full Tauri e2e project passes locally with the new
+spec included, and no existing spec regresses" is met. No product code was
+touched to get here — this document is the artifact.

--- a/packages/e2e/helpers/tauri/setup.ts
+++ b/packages/e2e/helpers/tauri/setup.ts
@@ -10,6 +10,10 @@ import { waitConnected } from './wait.js';
 const DAEMON_BASE = `http://127.0.0.1:${DAEMON_PORT}`;
 const DEFAULT_CLAUDE_MD =
   '# E2E Test Project\n\nAutomated test environment. Do not use plan mode. Execute tool calls directly.\n';
+const NOTIFY_DEFINITION = {
+  triggers: [],
+  steps: [{ id: 'n1', kind: 'notify', message: ['done'] }],
+};
 
 export interface TauriProject {
   projectPath: string;
@@ -87,6 +91,26 @@ export async function createTauriChat(
     if ((await toggle.getAttribute('aria-pressed')) !== 'true') await toggle.click();
   }
   return chatId;
+}
+
+/** Seed an automation via REST. Returns its id. Nothing broadcasts a create — the
+ *  caller must force a re-fetch (reload or active-project switch) to see it. */
+export async function createTauriAutomation(opts: { name: string; projectId?: string }): Promise<string> {
+  const body = opts.projectId
+    ? { name: opts.name, scope: 'project', projectId: opts.projectId, definition: NOTIFY_DEFINITION }
+    : { name: opts.name, scope: 'global', definition: NOTIFY_DEFINITION };
+
+  const res = await fetch(`${DAEMON_BASE}/api/automations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok)
+    throw new Error(`createTauriAutomation: POST /api/automations failed (${res.status} ${await res.text()})`);
+  const created = (await res.json()) as { data?: { id?: string } };
+  const automationId = created.data?.id;
+  if (!automationId) throw new Error(`createTauriAutomation: no automation id (${JSON.stringify(created)})`);
+  return automationId;
 }
 
 export function cleanupTauriProject(project?: TauriProject): void {

--- a/packages/e2e/tests-tauri/automations-library.spec.ts
+++ b/packages/e2e/tests-tauri/automations-library.spec.ts
@@ -45,6 +45,7 @@
  *    below, never a bare wait.
  */
 
+import path from 'path';
 import { test, expect, type Page } from '@playwright/test';
 import { launchTauriApp, closeTauriApp, type TauriAppFixture } from '../fixtures/app-tauri.js';
 import {
@@ -185,5 +186,51 @@ test.describe('§automations-library', () => {
     // landed re-fetch too, not just the un-refreshed DOM from before the
     // cancel.
     await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
+  });
+
+  test('badge, scoped: a project-scoped automation shows its project name', async () => {
+    const { page } = app;
+    const targetId = await createTauriAutomation({ name: 'badge scoped target', projectId: projectA.projectId });
+
+    await openLibraryFor(page, chatIdA);
+
+    await expect(page.getByTestId(`automations-library-project-${targetId}`)).toHaveText(
+      path.basename(projectA.projectPath),
+    );
+  });
+
+  test('badge, unscoped: an automation with no project scope reads "All projects"', async () => {
+    const { page } = app;
+    const targetId = await createTauriAutomation({ name: 'badge unscoped target' });
+
+    await openLibraryFor(page, chatIdA);
+
+    await expect(page.getByTestId(`automations-library-project-${targetId}`)).toHaveText('All projects');
+  });
+
+  test('scoping, negative: an automation scoped to project A is absent from project B', async () => {
+    const { page } = app;
+    const scopedId = await createTauriAutomation({ name: 'scoping negative scoped', projectId: projectA.projectId });
+    const unscopedId = await createTauriAutomation({ name: 'scoping negative unscoped' });
+
+    await openLibraryFor(page, chatIdB);
+
+    // Guard against an empty-library false pass: the library must actually be
+    // showing rows (the unscoped automation) for the scoped row's absence to
+    // mean "filtered out" rather than "nothing loaded".
+    await expect(page.getByTestId('automations-library')).toBeVisible();
+    await expect(page.getByTestId(`automations-library-row-${unscopedId}`)).toBeVisible();
+    await expect(page.getByTestId(`automations-library-row-${scopedId}`)).toHaveCount(0);
+  });
+
+  test('scoping, positive: an unscoped automation is visible from both projects', async () => {
+    const { page } = app;
+    const unscopedId = await createTauriAutomation({ name: 'scoping positive unscoped' });
+
+    await openLibraryFor(page, chatIdB);
+    await expect(page.getByTestId(`automations-library-row-${unscopedId}`)).toBeVisible();
+
+    await openLibraryFor(page, chatIdA);
+    await expect(page.getByTestId(`automations-library-row-${unscopedId}`)).toBeVisible();
   });
 });

--- a/packages/e2e/tests-tauri/automations-library.spec.ts
+++ b/packages/e2e/tests-tauri/automations-library.spec.ts
@@ -94,11 +94,6 @@ async function openLibraryFor(page: Page, chatId: string): Promise<void> {
   await expect(page.getByTestId('automations-library-loading')).toHaveCount(0, { timeout: 15_000 });
 }
 
-async function closeLibrary(page: Page): Promise<void> {
-  await page.getByTestId('automations-close').click();
-  await expect(page.getByTestId('automations-host')).toHaveCount(0, { timeout: 10_000 });
-}
-
 // ─── §automations-library ─────────────────────────────────────────────────
 
 test.describe('§automations-library', () => {
@@ -124,13 +119,6 @@ test.describe('§automations-library', () => {
     await closeTauriApp(app);
   });
 
-  test('opens and closes the library for project A', async () => {
-    const { page } = app;
-    await openLibraryFor(page, chatIdA);
-    await expect(page.getByTestId('automations-section-library')).toBeVisible();
-    await closeLibrary(page);
-  });
-
   test('delete, confirmed: accepting the confirm dialog removes the row and it stays gone after a re-fetch', async () => {
     const { page } = app;
     // Two automations: the anchor is never deleted, so the post-delete
@@ -152,7 +140,6 @@ test.describe('§automations-library', () => {
     await expect(confirmDialog).toHaveCount(0);
     await expect(page.getByTestId(`automations-library-row-${targetId}`)).toHaveCount(0);
 
-    await closeLibrary(page);
     await openLibraryFor(page, chatIdA);
 
     // Order matters: the anchor row can only appear from a landed re-fetch
@@ -179,7 +166,6 @@ test.describe('§automations-library', () => {
     await expect(confirmDialog).toHaveCount(0);
     await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
 
-    await closeLibrary(page);
     await openLibraryFor(page, chatIdA);
 
     // The automation was never deleted server-side, so the row survives a

--- a/packages/e2e/tests-tauri/automations-library.spec.ts
+++ b/packages/e2e/tests-tauri/automations-library.spec.ts
@@ -161,4 +161,29 @@ test.describe('§automations-library', () => {
     await expect(page.getByTestId(`automations-library-row-${anchorId}`)).toBeVisible();
     await expect(page.getByTestId(`automations-library-row-${targetId}`)).toHaveCount(0);
   });
+
+  test('delete, cancelled: dismissing the confirm dialog leaves the row intact after a re-fetch', async () => {
+    const { page } = app;
+    const targetId = await createTauriAutomation({ name: 'delete-cancelled target', projectId: projectA.projectId });
+
+    await openLibraryFor(page, chatIdA);
+
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
+    await page.getByTestId(`automations-library-delete-${targetId}`).click();
+
+    const confirmDialog = page.getByTestId('automations-delete-confirm');
+    await expect(confirmDialog).toBeVisible();
+
+    await page.getByTestId('automations-delete-confirm-cancel').click();
+    await expect(confirmDialog).toHaveCount(0);
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
+
+    await closeLibrary(page);
+    await openLibraryFor(page, chatIdA);
+
+    // The automation was never deleted server-side, so the row survives a
+    // landed re-fetch too, not just the un-refreshed DOM from before the
+    // cancel.
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
+  });
 });

--- a/packages/e2e/tests-tauri/automations-library.spec.ts
+++ b/packages/e2e/tests-tauri/automations-library.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * §automations-library — Automations library row spec for app-tauri browser mode.
+ *
+ * Covers the three behaviors the library ships with no prior e2e coverage: a
+ * per-row delete through the shared confirm dialog (accepted and cancelled),
+ * the project badge (owning project's name, or "All projects" when unscoped),
+ * and cross-project scoping (the daemon returns a selected project's
+ * automations plus every unscoped one). Runs entirely in E2E_MODE=mock — every
+ * test seeds over REST and never sends a message, so there is no
+ * `recordingKey`.
+ *
+ * Testid reference (verified against packages/ui/src/features/automations/):
+ *   sidebar-action-automations       — sidebar entry point that opens the host
+ *   automations-host                 — the Radix Dialog content root (absent when closed)
+ *   automations-view                 — the view root inside the host
+ *   automations-close                — the view's close button
+ *   automations-section-library      — the library's section container
+ *   automations-library              — the library list root (ALSO the loading
+ *                                       container — see the refresh recipe below)
+ *   automations-library-loading      — present only while a fetch is in flight
+ *   automations-library-row-<id>     — one row, keyed by automation id
+ *   automations-library-delete-<id>  — a row's delete action
+ *   automations-library-project-<id> — a row's project badge
+ *   automations-delete-confirm       — the shared ConfirmDialog root the row raises
+ *   automations-delete-confirm-confirm / -cancel — its derived button pair
+ *   sidebar-project-<projectId>      — sidebar project-switcher row (also
+ *                                       activates that project's most recent
+ *                                       session — see below)
+ *   sidebar-project-all              — clears the project filter WITHOUT
+ *                                       switching the active session
+ *
+ * Three facts every test here leans on — read before "simplifying" a scenario:
+ *
+ * 1. Reopening the host does NOT re-fetch the library. `AutomationsHost`'s
+ *    load effect depends on `[projectId, setActiveProjectId, loadAll]` — `open`
+ *    is absent — and `LibraryList` has no mount-time fetch of its own. The only
+ *    refresh triggers are an active-project-id change or a page reload.
+ * 2. The library's scope is the active SESSION's project
+ *    (`useActiveIdentity().projectId`), not the sidebar filter row. The two
+ *    usually move together but can desync across a reload, so every scenario
+ *    pins scope by selecting the target project's seeded chat directly.
+ * 3. Nothing broadcasts an automation create or delete over the WS event bus,
+ *    so a REST seed or delete is invisible until the next refresh — assertions
+ *    that need to observe a mutation always go through the refresh recipe
+ *    below, never a bare wait.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { launchTauriApp, closeTauriApp, type TauriAppFixture } from '../fixtures/app-tauri.js';
+import { createTauriProject, createTauriChat, cleanupTauriProject, type TauriProject } from '../helpers/tauri/setup.js';
+import { sessionsSidebar } from '../helpers/tauri/page-objects.js';
+import { waitConnected } from '../helpers/tauri/wait.js';
+
+/**
+ * Bring the UI to a freshly fetched library for the project that owns
+ * `chatId`. Selecting that chat's row is what pins `useActiveIdentity().projectId`
+ * — the library's actual scope — deterministically, independent of whatever the
+ * sidebar filter row last showed.
+ *
+ * Row clicks in the sessions sidebar get eaten by `SessionRow`'s HoverCard
+ * (500ms openDelay), so this parks the pointer and retries the whole
+ * click-then-assert step as a unit, mirroring `sessions-filters.spec.ts`'s
+ * `selectRow`.
+ */
+async function openLibraryFor(page: Page, chatId: string): Promise<void> {
+  await page.reload();
+  await waitConnected(page);
+
+  // Widens the sidebar to both projects' rows without switching the active
+  // session, so the target chat's row is guaranteed clickable next.
+  await page.getByTestId('sidebar-project-all').click();
+
+  const row = sessionsSidebar(page).row(chatId);
+  await expect(async () => {
+    await page.mouse.move(0, 0);
+    await expect(page.locator('[data-slot="hover-card-content"]')).toHaveCount(0, { timeout: 2_000 });
+    await row.click({ timeout: 5_000 });
+    await expect(row).toHaveAttribute('data-active', 'true', { timeout: 5_000 });
+  }).toPass({ timeout: 45_000, intervals: [500, 1_000, 2_000] });
+
+  await page.getByTestId('sidebar-action-automations').click();
+  await expect(page.getByTestId('automations-library')).toBeVisible({ timeout: 10_000 });
+  // The loading branch renders the SAME `automations-library` testid with zero
+  // rows inside it, so "visible" alone doesn't mean the fetch landed — this is
+  // a no-fetch-in-flight guard, not proof a fetch ran (scenarios asserting an
+  // empty view still need a positive anchor row on top of this).
+  await expect(page.getByTestId('automations-library-loading')).toHaveCount(0, { timeout: 15_000 });
+}
+
+async function closeLibrary(page: Page): Promise<void> {
+  await page.getByTestId('automations-close').click();
+  await expect(page.getByTestId('automations-host')).toHaveCount(0, { timeout: 10_000 });
+}
+
+// ─── §automations-library ─────────────────────────────────────────────────
+
+test.describe('§automations-library', () => {
+  let app: TauriAppFixture;
+  let projectA: TauriProject;
+  let projectB: TauriProject;
+  let chatIdA: string;
+  let chatIdB: string;
+
+  test.beforeAll(async () => {
+    app = await launchTauriApp();
+    projectA = await createTauriProject(app.page);
+    chatIdA = await createTauriChat(app.page, projectA.projectId, 'default');
+    // createTauriProject reloads the page — the chat just created is
+    // REST-seeded and survives that reload.
+    projectB = await createTauriProject(app.page);
+    chatIdB = await createTauriChat(app.page, projectB.projectId, 'default');
+  });
+
+  test.afterAll(async () => {
+    cleanupTauriProject(projectA);
+    cleanupTauriProject(projectB);
+    await closeTauriApp(app);
+  });
+
+  test('opens and closes the library for project A', async () => {
+    const { page } = app;
+    await openLibraryFor(page, chatIdA);
+    await expect(page.getByTestId('automations-section-library')).toBeVisible();
+    await closeLibrary(page);
+  });
+});

--- a/packages/e2e/tests-tauri/automations-library.spec.ts
+++ b/packages/e2e/tests-tauri/automations-library.spec.ts
@@ -47,7 +47,13 @@
 
 import { test, expect, type Page } from '@playwright/test';
 import { launchTauriApp, closeTauriApp, type TauriAppFixture } from '../fixtures/app-tauri.js';
-import { createTauriProject, createTauriChat, cleanupTauriProject, type TauriProject } from '../helpers/tauri/setup.js';
+import {
+  createTauriProject,
+  createTauriChat,
+  createTauriAutomation,
+  cleanupTauriProject,
+  type TauriProject,
+} from '../helpers/tauri/setup.js';
 import { sessionsSidebar } from '../helpers/tauri/page-objects.js';
 import { waitConnected } from '../helpers/tauri/wait.js';
 
@@ -122,5 +128,37 @@ test.describe('§automations-library', () => {
     await openLibraryFor(page, chatIdA);
     await expect(page.getByTestId('automations-section-library')).toBeVisible();
     await closeLibrary(page);
+  });
+
+  test('delete, confirmed: accepting the confirm dialog removes the row and it stays gone after a re-fetch', async () => {
+    const { page } = app;
+    // Two automations: the anchor is never deleted, so the post-delete
+    // re-fetch assertion is real — without it, a view that never fetched
+    // anything would also show zero rows for the (otherwise sole) target.
+    const anchorId = await createTauriAutomation({ name: 'delete-confirmed anchor', projectId: projectA.projectId });
+    const targetId = await createTauriAutomation({ name: 'delete-confirmed target', projectId: projectA.projectId });
+
+    await openLibraryFor(page, chatIdA);
+
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toBeVisible();
+    await page.getByTestId(`automations-library-delete-${targetId}`).click();
+
+    const confirmDialog = page.getByTestId('automations-delete-confirm');
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog).toContainText('delete-confirmed target');
+
+    await page.getByTestId('automations-delete-confirm-confirm').click();
+    await expect(confirmDialog).toHaveCount(0);
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toHaveCount(0);
+
+    await closeLibrary(page);
+    await openLibraryFor(page, chatIdA);
+
+    // Order matters: the anchor row can only appear from a landed re-fetch
+    // (definitions starts empty after the reload), which is what makes the
+    // target's absence next mean "deleted server-side" rather than "nothing
+    // loaded yet".
+    await expect(page.getByTestId(`automations-library-row-${anchorId}`)).toBeVisible();
+    await expect(page.getByTestId(`automations-library-row-${targetId}`)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
Adds a Playwright Tauri e2e spec covering the Automations library: row delete (confirmed and cancelled), the per-project badge for scoped vs. unscoped automations, and cross-project scoping in both directions. Also adds a `createTauriAutomation` REST-seeding helper alongside the existing project/chat seeding helpers.

## Artifacts
- Plan: docs/plans/2026-08-14-automations-library-e2e-plan.md
- Review verdict: APPROVED (2 rounds)
- QA: 20/20

## Key decisions
- Reopening the automations host does not re-fetch the library (no `open` dependency in the load effect, no mount fetch in `LibraryList`); refresh recipe uses reload + session activation instead of "reopen the host."
- Scope is pinned by activating the target project's seeded chat, not by clicking the sidebar project filter row — the library scopes off the active session's project, a separate mechanism from the filter selection.
- Single spec file / single describe / single app fixture / two projects with one chat each, to avoid tripling per-describe browser launch cost; each concern seeds its own automations so delete tests never perturb badge/scoping tests.
- `createTauriAutomation` lives in `packages/e2e/helpers/tauri/setup.ts` beside the existing seeding helpers rather than a new module.
- Delete-confirmed is implemented first since it's the only scenario exercising a Radix AlertDialog nested inside the automations Dialog; `click({force:true})` is explicitly forbidden as a workaround.
- Confirmed a pre-existing, repo-wide `tsc --noEmit` gap in `packages/e2e` (TS2591 "Cannot find name fs/path/Buffer/...") unrelated to this change — reproduced identically on a clean `main` checkout; root cause is a missing `types` field in `packages/e2e/tsconfig.json`. Not fixed here (shared config, out of scope); isolated `--types node` run and the actual Playwright run are both green.

## Test plan
- [x] `E2E_MODE=mock MF_E2E_SKIP_BUILD=1 pnpm exec playwright test tests-tauri/automations-library.spec.ts` — green
- [x] QA pass: 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>