### PR TITLE
feat(claude): add support for Auto permissions mode (#325)

### DIFF
--- a/.changeset/claude-auto-permission-mode.md
+++ b/.changeset/claude-auto-permission-mode.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-ui': minor
+---
+
+Add the Claude CLI's native `auto` permission mode as a fourth, capability-gated execution mode. The composer picker, provider settings, automations Ask-Agent chip, and plan gate all offer Auto for adapters that advertise it, letting Claude decide which actions need approval without leaving Mainframe's permission gate.

--- a/docs/adapters/claude/PERMISSIONS.md
+++ b/docs/adapters/claude/PERMISSIONS.md
@@ -210,7 +210,11 @@ rather than degrading to a prompt.
 | `plan` | Enforced by prompt, not the permission engine; only engine effect is the step-2a bypass when `isBypassPermissionsModeAvailable` |
 | `bypassPermissions` | Step-2a allow. Still stopped by: deny rules, tool denies, content-specific ask rules (1f), safetyCheck asks (1g) |
 | `dontAsk` | Every ask becomes a deny before the protocol — **no `can_use_tool` is ever emitted** |
-| `auto` | Leak: internal-only (ant `TRANSCRIPT_CLASSIFIER` builds). **2.1.220: present in `EXTERNAL_PERMISSION_MODES`** (binary: `["acceptEdits","auto","bypassPermissions","default","dontAsk","plan"]`), so `--permission-mode auto` and `setMode: auto` validate. Whether the LLM classifier actually runs in the public build is **unverified** — classifier scaffolding (`CLASSIFIER_UNAVAILABLE_REASON` etc.) is present, but its activation gate is not readable from strings |
+| `auto` | Leak: internal-only (ant `TRANSCRIPT_CLASSIFIER` builds). **2.1.220: present in `EXTERNAL_PERMISSION_MODES`** (binary: `["acceptEdits","auto","bypassPermissions","default","dontAsk","plan"]`), so `--permission-mode auto` and `setMode: auto` validate. **Classifier confirmed live on 2.1.224** (headless `-p` probe, 2026-08-14, one turn per mode): a file write was allowed with no prompt (vs. refused under `default`), a network `curl` was allowed with no prompt (vs. refused under `acceptEdits`), and `rm -rf <file>` ran with no prompt. Mainframe requires **CLI ≥ 2.1.220**, the version where `auto` entered `EXTERNAL_PERMISSION_MODES`, and now exposes the mode through the `autoMode` adapter capability |
+
+CLI 2.1.224 renamed the interactive mode to `manual` in `--permission-mode --help` output, but
+`default` still passes argument validation (`claude --permission-mode default -p ""` fails only
+later, on the missing prompt) — Mainframe's existing spawn path is unaffected by the rename.
 
 The bypass killswitch (`bypassPermissionsKillswitch.ts`) can demote a running
 `bypassPermissions` session via a remote gate — a long-lived Mainframe session

--- a/docs/plans/2026-08-14-todo-325-claude-auto-permissions-mode.md
+++ b/docs/plans/2026-08-14-todo-325-claude-auto-permissions-mode.md
@@ -1,0 +1,431 @@
+# Implementation plan — Claude "Auto" permission mode
+
+Todo #325 · route: full · branch `todo/325-claude-auto-permissions-mode`
+Spec: `docs/specs/2026-08-14-todo-325-claude-auto-permissions-mode.md`
+
+## Goal
+
+Add the Claude CLI's native `auto` permission mode as a fourth value of Mainframe's one canonical
+execution mode, carried end-to-end: the shared TypeScript union and its Rust mirror gain `auto`; a
+new `autoMode` capability flag on the existing adapter-capabilities contract says who supports it
+(Claude yes, Codex no); the Claude adapter maps it 1:1 to the CLI's `--permission-mode auto` at
+spawn and to the same value on the mid-session `set_permission_mode` control request, so plan-mode
+restore returns to `auto` like any other base mode; the Codex adapter handles the variant as an
+explicit arm that coerces to its Interactive policy and logs the coercion instead of falling
+through; and the four surfaces that list modes — the composer picker, the provider default-mode
+radio, the automations Ask-Agent chip, and the plan gate's exec-mode segmented control — offer Auto
+only when the resolved adapter advertises the capability, with a caution (warning) tint that is
+visibly not the destructive tint Unattended keeps. The approval gate itself is untouched.
+
+## Constraints
+
+- Max 300 lines/file, 50 lines/function (root `CLAUDE.md`). No file here approaches either.
+- Single canonical type: `ExecutionMode` is defined once in `@qlan-ro/mainframe-types` and mirrored
+  in `mainframe-types` (Rust). Both mirrors move in the same commit or the wire desyncs.
+- The daemon WS/REST contract is co-owned by the mobile submodule: changes must be **additive**.
+  `autoMode` is a new optional key on an existing object; `auto` is a new value of an existing
+  field. Do not bump the submodule pointer.
+- `data-testid` on every new interactive element, kebab-case, following the existing naming.
+- No `console.*` in core; Rust logs via `tracing`.
+- A changeset is required (`.changeset/`), and `docs/plans/` is gitignored — commit with `git add -f`.
+- Read the `mainframe-design-system` skill before writing any markup or class names in `packages/ui`.
+
+## Established facts
+
+Verified while planning. Downstream implementers and reviewers should trust these rather than
+re-deriving them.
+
+- Installed Claude CLI is **2.1.224** (`claude --version`).
+- `--permission-mode` accepts `auto`. Probing an invalid value prints the allow-list:
+  `error: option '--permission-mode <mode>' argument 'zzz' is invalid. Allowed choices are
+  acceptEdits, auto, bypassPermissions, manual, dontAsk, plan.` (`claude --permission-mode zzz -p ""`,
+  run 2026-08-14).
+- `default` still passes CLI argument validation on 2.1.224 even though help now lists `manual`
+  instead: `claude --permission-mode default -p ""` fails only later, with
+  `Error: Input must be provided either through stdin or as a prompt argument when using --print`.
+  The existing spawn path is therefore not broken by the rename.
+- `auto` is in the CLI's `EXTERNAL_PERMISSION_MODES` as of 2.1.220, which is what makes both
+  `--permission-mode auto` and the `setMode: auto` control request validate —
+  `docs/adapters/claude/PERMISSIONS.md:213`.
+- The mid-session control request Mainframe sends is `{"subtype":"set_permission_mode","mode":<cli mode>}`
+  and it is forwarded session-scoped — `packages/core-rs/crates/mainframe-adapter-claude/src/session.rs:786-790`,
+  `docs/adapters/claude/PERMISSIONS.md:296`.
+- Plan-mode restore reads a single stored string, not an enum: `base_permission_mode: Mutex<String>`
+  is set from `execution_mode_cli(mode)` on every `set_permission_mode` and replayed verbatim by
+  `set_plan_mode(false)` — `packages/core-rs/crates/mainframe-adapter-claude/src/session.rs:333, 749-783`.
+  Nothing there needs a new branch; it inherits `auto` once the mapping emits it.
+- The chat-config route validates `permissionMode` purely by serde enum parse — a bad string fails
+  `parse_body` and returns 400 — `packages/core-rs/crates/mainframe-server/src/routes/chat_commands.rs:88-110`.
+  This is the **only** deserialization site for that field: `update_chat_config` has no WS message
+  path (grep for `update_chat_config` finds only the REST route, `chat_manager/config_api.rs`, and
+  `config_manager.rs`).
+- The provider-settings route does **not** use serde for the mode: `validate_provider_patch` hardcodes
+  `in_enum(&p.default_mode, &["default", "acceptEdits", "yolo"])` —
+  `packages/core-rs/crates/mainframe-server/src/routes/settings.rs:492`. Widening the enum alone
+  leaves this rejecting `auto`. The same file already converted the effort list to a serde-driven
+  check (`is_effort_or_clear`, `settings.rs:481-489`) precisely to stop this class of desync.
+- The stored chat mode is written as a raw string and parsed on read with
+  `serde_json::from_value::<ExecutionMode>` — `packages/core-rs/crates/mainframe-db/src/chats.rs:84-88, 699`.
+  So `auto` persists and round-trips automatically once the enum has the variant; an unparseable
+  value reads back as `None`, unchanged.
+- Automations never validate the mode string: `AskAgentStep.permission_mode` is
+  `Option<String>` (`packages/core-rs/crates/mainframe-automations/src/domain/step.rs:105`), passed
+  through `AgentRequest` (`ports/agent.rs:29`) into `create_chat_with_defaults` as `Option<&str>`
+  (`packages/core-rs/crates/mainframe-chat/src/lifecycle_manager.rs:283-289`). No allow-list blocks
+  `auto` on that path.
+- `AdapterCapabilities` (Rust) is a plain struct with one field and **nine** literal construction
+  sites, so adding a field is compiler-enforced everywhere:
+  `mainframe-adapter-claude/src/adapter.rs:125`, `mainframe-adapter-codex/src/adapter.rs:165`,
+  `mainframe-adapter-mock/src/adapter.rs:93`, `mainframe-adapter-api/tests/registry.rs:202`,
+  `mainframe-chat/src/context_tracker.rs:421`, `mainframe-server/tests/chat_default_model_catalog.rs:55`,
+  `mainframe-server/tests/transcript_presence_support/mod.rs:66`, and twice in
+  `mainframe-server/src/routes/session_transcripts.rs:154, 198`.
+- TypeScript declares the capabilities object **twice** — `AdapterInfo.capabilities`
+  (`packages/types/src/adapter.ts:239-241`) and `Adapter.capabilities`
+  (`packages/types/src/adapter.ts:358-360`). Both need the new key.
+- Two TS maps are keyed `Record<ExecutionMode, …>` and therefore break the moment the union widens:
+  `EXEC_MODE_LABELS` (`packages/ui/src/features/chat/messages/PlanBubble.tsx:26`) and `MODE_COPY`
+  (`packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx:25`).
+- The `--warning` token is live and first-class in the UI theme: declared at
+  `packages/ui/src/styles/globals.css:137` (light) / `:180` (dark), exported as `--color-warning`
+  at `:77`, and already used as `text-warning` / `bg-warning/10` on the gate surface
+  (`packages/ui/src/features/chat/gates/PermissionGate.tsx:101`).
+- The adapters store seeds a placeholder identity with `capabilities: { planMode: false }` before
+  the real snapshot arrives — `packages/ui/src/store/adapters.ts:71-84`. That is spec edge case 1.
+- `packages/types/dist/` is **not** git-tracked (`git ls-files packages/types/dist` is empty); the
+  stale `dist/settings.d.ts` on disk is a build artifact and needs no edit, only a rebuild.
+
+## Decisions taken in-lane
+
+1. **`autoMode` is optional in TypeScript, required in Rust.** TS: `autoMode?: boolean` on both
+   capabilities declarations — absent means unsupported, which keeps the change additive for mobile
+   and leaves every existing TS fixture compiling. Rust: `pub auto_mode: bool`, no default, so the
+   compiler forces a considered value at all nine construction sites.
+2. **The mock adapter reports `auto_mode: false`.** The e2e suite drives the mock adapter, so Auto
+   never appears in a Playwright run and no existing spec (`composer.spec.ts`, `settings.spec.ts`,
+   `gates.spec.ts`, …) changes. Both capability directions are covered in vitest instead.
+3. **The plan gate's exec-mode control gains a capability-gated Auto segment, but its initial value
+   stays `'default'`.** Adding the segment closes the hole where an Auto user approving a plan can
+   only pick from three modes. Seeding the control from the chat's current mode would also change
+   behavior for Unattended users (today the gate always defaults to the safest mode) — out of scope
+   here; noted as a follow-up. Cheap alternative if the reviewer wants less scope: skip Group G
+   entirely and document that plan approval always re-picks from the original three.
+4. **`resolveStepAdapter` is extracted** from `steps/agent/ModelMenu.tsx` into
+   `steps/agent/resolve-step-adapter.ts` and shared with `PermissionMenu`. Two call sites is below
+   the 3+ extraction rule, but the fallback chain (`by id → first installed → first`) is exactly the
+   kind of subtlety that drifts when copied, and a step's model chip and permission chip disagreeing
+   about which provider they describe would be a visible bug.
+5. **The provider-settings allow-list becomes serde-driven** rather than gaining a fourth hardcoded
+   string, following the `is_effort_or_clear` precedent in the same file. This removes the desync
+   class rather than paying it again.
+6. **Copy is fixed by the spec:** label `Auto`, description "Claude decides which actions need
+   approval". Do not editorialize it into a promise of fewer prompts.
+
+## Task groups
+
+Cross-group red-phase TDD is not achievable here: in **both** languages a test that names the new
+mode fails to *compile* until the enum widens, so a separate "tests first" group would only produce
+a build break for every other group. Each group therefore runs test-first internally — the task
+order below is the TDD order, and it is binding.
+
+---
+
+### Group A — `core-types` (tasks 1–6) · kind: core · depends on: nothing
+
+Widens both mirrors of the mode and the capabilities contract, plus every edit the compiler forces.
+Leaves `cargo check` and the UI typecheck green.
+
+**Task 1 (red).** In `packages/core-rs/crates/mainframe-types/src/settings.rs`, in the existing
+`mod tests`, extend `execution_mode_serializes_camelcase` with
+`assert_eq!(serde_json::to_string(&ExecutionMode::Auto).unwrap(), "\"auto\"")`, add
+`permission_mode_auto_serializes_as_auto` for `PermissionMode::Auto`, add a round-trip assertion
+that `serde_json::from_str::<ExecutionMode>("\"auto\"")` yields `ExecutionMode::Auto`, and add
+`execution_modes_constant_lists_four_modes_in_permissiveness_order` asserting `EXECUTION_MODES ==
+[Default, AcceptEdits, Auto, Yolo]`.
+*Verify:* `cargo test -p mainframe-types settings` from `packages/core-rs` fails to compile
+(`no variant named Auto`). That is the red.
+
+**Task 2 (green).** Same file: add `Auto` to `ExecutionMode` (between `AcceptEdits` and `Yolo`), add
+`Auto` to `PermissionMode` (same position), and widen `EXECUTION_MODES` to
+`[ExecutionMode; 4]` with `ExecutionMode::Auto` third. Update the `PORT STATUS` note at the bottom of
+the file to record the fourth variant.
+*Verify:* `cargo test -p mainframe-types settings` passes.
+
+**Task 3.** Add `pub auto_mode: bool` to `AdapterCapabilities` in
+`packages/core-rs/crates/mainframe-types/src/adapter.rs:299-303` (one-line doc comment: which
+adapters advertise the CLI's native `auto` mode). Then set it at all nine construction sites:
+`true` in `mainframe-adapter-claude/src/adapter.rs:125`; `false` in
+`mainframe-adapter-codex/src/adapter.rs:165`, `mainframe-adapter-mock/src/adapter.rs:93`,
+`mainframe-adapter-api/tests/registry.rs:202`, `mainframe-chat/src/context_tracker.rs:421`,
+`mainframe-server/tests/chat_default_model_catalog.rs:55`,
+`mainframe-server/tests/transcript_presence_support/mod.rs:66`, and both sites in
+`mainframe-server/src/routes/session_transcripts.rs:154, 198`.
+*Verify:* `cargo check --workspace --all-targets` from `packages/core-rs` is green.
+
+**Task 4.** Adapter mode mappings.
+- `packages/core-rs/crates/mainframe-adapter-claude/src/session.rs:235-240` — add
+  `ExecutionMode::Auto => "auto"` to `execution_mode_cli`.
+- `packages/core-rs/crates/mainframe-adapter-codex/src/session.rs:163-169` — replace the
+  `if mode == ExecutionMode::Yolo { … } else { … }` body of `map_permission_mode` with a delegation
+  to a new free function `fn permission_mode_policy(mode: ExecutionMode) -> (String, String)` in the
+  same file, written as an exhaustive `match` with four explicit arms: `Yolo` →
+  `("never", "danger-full-access")`; `Default` and `AcceptEdits` → `("on-request", "workspace-write")`;
+  `Auto` → the same Interactive pair, preceded by
+  `tracing::warn!("chat is set to the Claude-only `auto` permission mode; Codex runs it as Interactive")`.
+  A free function keeps the mapping unit-testable without constructing a `CodexSession`.
+- Add `permission_mode_policy_coerces_auto_to_interactive` to the `mod tests` at
+  `mainframe-adapter-codex/src/session.rs:828`, asserting `Auto` and `Default` produce the identical
+  pair and that `Yolo` still produces the danger pair.
+*Verify:* `cargo test -p mainframe-adapter-codex permission_mode_policy` passes;
+`cargo check --workspace --all-targets` green.
+
+**Task 5.** TypeScript mirrors.
+- `packages/types/src/settings.ts:3` — `export const EXECUTION_MODES = ['default', 'acceptEdits', 'auto', 'yolo'] as const;`
+- `packages/types/src/adapter.ts:239-241` and `:358-360` — add `autoMode?: boolean;` to both
+  capabilities objects, with a one-line comment that absent means unsupported (mobile-additive).
+*Verify:* `pnpm --filter @qlan-ro/mainframe-types build` succeeds.
+
+**Task 6.** Compile-forced TS consumers.
+- `packages/ui/src/features/chat/messages/PlanBubble.tsx:26-30` — add `auto: 'Auto'` to
+  `EXEC_MODE_LABELS`.
+- `packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx:25-29` — add
+  `auto: { label: 'Auto', hint: 'Claude decides which actions need approval' }` to `MODE_COPY`.
+  Copy only; the capability filtering is Group F.
+*Verify:* `pnpm --filter @qlan-ro/mainframe-ui typecheck` is green and reports no other
+`Record<ExecutionMode, …>` breakage.
+
+---
+
+### Group B — `core-claude` (tasks 7–9) · kind: test · depends on: `core-types`
+
+Pins the Claude spawn, control-request and plan-restore behavior for `auto`. Shares
+`adapter-claude/src/session.rs` with Group A, so it must run after it.
+
+**Task 7.** In `packages/core-rs/crates/mainframe-adapter-claude/src/session.rs` `mod tests`
+(alongside `accept_edits_mode_passes_permission_mode_accept_edits`, line ~1345), add
+`auto_mode_passes_permission_mode_auto`: `build_args(&spawn_opts(Some(ExecutionMode::Auto)), &None)`
+→ `mode_arg(&args) == "auto"`.
+*Verify:* `cargo test -p mainframe-adapter-claude auto_mode_passes` passes.
+
+**Task 8.** Same test module, alongside `set_permission_mode_maps_yolo_to_bypass_permissions`
+(line ~1435), add two tests:
+- `set_permission_mode_sends_auto_verbatim` — after `s.set_permission_mode(ExecutionMode::Auto)`, the
+  captured control payload has `request.subtype == "set_permission_mode"` and `request.mode == "auto"`.
+- `leaving_plan_mode_restores_auto` — `set_permission_mode(Auto)`, then `set_plan_mode(true)` (payload
+  mode `"plan"`), then `set_plan_mode(false)` → payload mode `"auto"`, not `"default"`. Follow the
+  existing spawned-session harness used at lines ~1423-1500.
+*Verify:* `cargo test -p mainframe-adapter-claude permission_mode` passes.
+
+**Task 9.** In `packages/core-rs/crates/mainframe-adapter-claude/src/plan_mode_handler.rs` `mod tests`
+(the recorder harness at lines ~141-260), add `on_approve_with_auto_sets_auto_base_mode`: a
+`ControlResponse` carrying `execution_mode: Some(ExecutionMode::Auto)` results in
+`rec.set_permission_mode == vec![ExecutionMode::Auto]` and a `PlanChatUpdate` with
+`plan_mode: Some(false)` and `permission_mode: Some(ExecutionMode::Auto)`.
+*Verify:* `cargo test -p mainframe-adapter-claude plan_mode_handler` passes.
+
+---
+
+### Group C — `core-routes-db` (tasks 10–12) · kind: core · depends on: `core-types`
+
+The two validation/persistence gaps the enum widening does not close by itself.
+
+**Task 10 (test first, then fix).** In `packages/core-rs/crates/mainframe-server/tests/routes_settings.rs`,
+add a case that `PATCH`es a provider patch with `defaultMode: "auto"` and expects 200 plus `auto` on
+the subsequent read, and a case with `defaultMode: "bogus"` expecting the existing 400 shape. Watch it
+fail. Then in `packages/core-rs/crates/mainframe-server/src/routes/settings.rs`, replace
+`in_enum(&p.default_mode, &["default", "acceptEdits", "yolo"])` at line 492 with a new
+`fn is_execution_mode(value: &Option<String>) -> bool` modeled on `is_effort_or_clear`
+(lines 481-489): `None` → true, otherwise `serde_json::from_value::<ExecutionMode>(Value::String(v.clone())).is_ok()`.
+Do **not** admit `""` — the current check does not, and `set_or_delete` semantics for this field are
+unchanged. Import `ExecutionMode` alongside the existing `EffortLevel` import.
+*Verify:* `cargo test -p mainframe-server --test routes_settings` passes.
+
+**Task 11.** In the `#[cfg(test)] mod tests` at
+`packages/core-rs/crates/mainframe-server/src/routes/chat_commands.rs:267`, add
+`update_chat_config_body_accepts_auto` (`parse_body::<UpdateChatConfigBody>(br#"{"permissionMode":"auto"}"#)`
+→ `Some` with `permission_mode == Some(ExecutionMode::Auto)`) and
+`update_chat_config_body_rejects_unknown_mode` (`{"permissionMode":"turbo"}` → `None`, which is what
+the route turns into the existing 400). This is the route's only validation seam; an end-to-end HTTP
+test is not available because `AppCtx.chat_manager` is absent in the integration harness and the
+handler short-circuits to 500 before touching the body.
+*Verify:* `cargo test -p mainframe-server chat_commands` passes.
+
+**Task 12.** In `packages/core-rs/crates/mainframe-db/tests/chats.rs`, add
+`permission_mode_auto_survives_a_reopen`: build with `setup_with_conn()`, create a chat with
+`permission_mode = Some("auto")`, then construct a **second** `ChatsRepository` over the same
+`Rc<Connection>` (the in-memory stand-in for a daemon restart) and assert the re-read chat reports
+`Some(ExecutionMode::Auto)`. Add a sibling assertion that a junk value (`"turbo"`) still reads back as
+`None` rather than erroring, pinning spec edge case 3.
+*Verify:* `cargo test -p mainframe-db --test chats permission_mode` passes.
+
+---
+
+### Group D — `ui-picker` (tasks 13–15) · kind: ui · depends on: `core-types`
+
+**Task 13 (red).** Extend
+`packages/ui/src/features/chat/composer/config-toolbar/__tests__/PermissionSelect.test.tsx` with four
+cases: (a) Auto option renders when the passed adapter has `capabilities.autoMode === true`;
+(b) it does not render when `autoMode` is `false` **and** when the capabilities object omits the key
+entirely (the placeholder-adapter case); (c) with `chat.permissionMode === 'auto'` and no adapter
+passed, the trigger label still reads `Auto`, never the raw mode string; (d) the Auto option and the
+Auto trigger carry `text-warning` and do **not** carry `text-destructive`, while Unattended still does.
+Use `data-testid="composer-permission-mode-select-option-auto"`.
+*Verify:* `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/composer/config-toolbar/__tests__/PermissionSelect.test.tsx` fails on all four.
+
+**Task 14 (green).** `packages/ui/src/features/chat/composer/config-toolbar/PermissionSelect.tsx`:
+add an optional `adapter?: AdapterInfo` prop; add a fourth entry to `PERMISSION_MODES` between
+`acceptEdits` and `yolo` — `{ id: 'auto', label: 'Auto', description: 'Claude decides which actions need approval', tone: 'caution' }`
+(give `yolo` `tone: 'destructive'` and the other two no tone); keep **one** unfiltered list and derive
+`currentLabel` from it (line 44) so a filtered-out mode never leaks a raw string; render
+`PERMISSION_MODES.filter((m) => m.id !== 'auto' || adapter?.capabilities.autoMode === true)`; replace
+the `isYolo ? 'text-destructive' : 'text-muted-foreground'` trigger tint (line 62) with a
+three-way tone lookup (`destructive` → `text-destructive`, `caution` → `text-warning`, else
+`text-muted-foreground`) and apply the same tone class to the option's label span. Update the file's
+header comment, which currently claims a fixed three-mode list.
+*Verify:* the Task 13 tests pass; `pnpm --filter @qlan-ro/mainframe-ui typecheck` green.
+
+**Task 15.** `packages/ui/src/features/chat/composer/config-toolbar/ComposerToolbar.tsx:65` — pass
+`adapter={adapter}` (already resolved on line 29). `packages/ui/src/store/adapters.ts:83` — add
+`autoMode: false` to the placeholder `capabilities` literal and extend the adjacent comment to say the
+placeholder under-reports capabilities on purpose.
+*Verify:* `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/composer/config-toolbar/__tests__ src/store/__tests__/adapters.test.ts` passes.
+
+---
+
+### Group E — `ui-settings` (tasks 16–17) · kind: ui · depends on: `core-types`
+
+**Task 16 (red).** New file
+`packages/ui/src/features/settings/panes/providers/__tests__/SessionModeRadio.test.tsx`: Auto radio
+(`data-testid="settings-claude-mode-option-auto"`) renders for an adapter with `autoMode: true`;
+absent for one without; the Auto row uses the warning tint and not the destructive tint Unattended
+keeps; selecting it calls `onChange({ defaultMode: 'auto' })`.
+*Verify:* the file fails.
+
+**Task 17 (green).** `packages/ui/src/features/settings/settings-tabs.ts:15-33` — add the `auto`
+entry between `acceptEdits` and `yolo` (`label: 'Auto'`, `description: 'Claude decides which actions need approval'`)
+and add a `caution?: boolean` flag alongside the existing `danger?: boolean`, set on the new entry
+only. `packages/ui/src/features/settings/panes/providers/SessionModeRadio.tsx` — accept an
+`adapter: AdapterInfo` prop, filter the `auto` entry out unless `adapter.capabilities.autoMode`, and
+map `caution` to `border-warning/50 text-warning` on the radio item plus `text-warning` on the label,
+mirroring the existing `danger` branch on lines 30 and 33. Update the "Three-option radio group"
+doc comment. `ProviderConfigForm.tsx:139` — pass `adapter={adapter}` (already in scope, see line 177).
+*Verify:* Task 16 tests pass; `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/settings/panes/providers/__tests__` all green.
+
+---
+
+### Group F — `ui-automations` (tasks 18–20) · kind: ui · depends on: `core-types`
+
+Shares `steps/agent/PermissionMenu.tsx` with Group A (Task 6), so it must run after it.
+
+**Task 18 (red).** Extend
+`packages/ui/src/features/automations/steps/agent/__tests__/PermissionMenu.test.tsx`: with an
+adapters store seeded so that `claude` has `autoMode: true` and `codex` does not, a menu given
+`adapterId="claude"` lists `…-permission-option-auto` and one given `adapterId="codex"` does not; a
+step whose stored `permissionMode` is `'auto'` on a non-supporting provider still shows the chip
+label `Auto` rather than falling back to `Interactive`. Note that the existing test iterates
+`EXECUTION_MODES` wholesale (line 29) — that loop must be scoped to the supporting provider.
+*Verify:* fails.
+
+**Task 19.** Create `packages/ui/src/features/automations/steps/agent/resolve-step-adapter.ts`
+exporting the `resolveAdapter` function currently private in `ModelMenu.tsx:31-33`
+(`by id → first installed → first`), and import it in `ModelMenu.tsx` in place of the local copy.
+No behavior change.
+*Verify:* `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/automations/steps/agent/__tests__/ModelMenu.test.tsx` still passes.
+
+**Task 20 (green).** `packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx` — add an
+`adapterId: string | undefined` prop, resolve the adapter with `useAdapters()` + `resolveStepAdapter`,
+keep `active` resolution against the full `EXECUTION_MODES` (so the label is right either way) and
+filter only the rendered list; pass `caution` to `ChipButton` when `active === 'auto'` (add a
+`caution?: boolean` prop to `packages/ui/src/features/automations/steps/agent/ChipButton.tsx`
+alongside its existing `destructive`, mapping to `text-warning`). Update the file header, which
+currently states the list comes straight from the contract. `steps/AgentConfig.tsx:57` — pass
+`adapterId={step.adapterId}`.
+*Verify:* Task 18 tests pass; `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/automations/steps/agent/__tests__ src/features/automations/steps/__tests__/AgentConfig.test.tsx` green.
+
+---
+
+### Group G — `ui-plan-gate` (tasks 21–22) · kind: ui · depends on: `core-types`
+
+**Task 21 (red).** New file
+`packages/ui/src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx`: the Auto segment
+(`data-testid="chat-plan-execmode-auto"`) renders when `autoAllowed` is true, is absent when it is
+false or omitted, sits between Auto-edits and Unattended, and when selected carries `text-warning`
+while a selected Unattended still carries `text-destructive`.
+*Verify:* fails.
+
+**Task 22 (green).** `packages/ui/src/features/chat/gates/PlanExecModeControl.tsx` — add an
+`autoAllowed?: boolean` prop and a fourth `EXEC_MODE_OPTIONS` entry
+(`{ id: 'auto', label: 'Auto', Icon: SparklesIcon, desc: 'Claude decides which actions need approval' }`)
+placed third, filtered out unless `autoAllowed`; extend the two-way selected tint (lines 50-51) to a
+three-way one so a selected `auto` reads `bg-background text-warning shadow-sm`.
+`packages/ui/src/features/chat/gates/PlanGate.tsx` — resolve the chat's adapter from
+`useChatExtras()?.state.chatConfig?.adapterId` plus `useAdapters()` and pass
+`autoAllowed={adapter?.capabilities.autoMode === true}` down through `ControlsPanel` to the control.
+Leave the `useState<ExecutionMode>('default')` seed on line 136 untouched (decision 3).
+*Verify:* Task 21 tests pass; `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/gates/__tests__/PlanGate.test.tsx src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx` green.
+
+---
+
+### Group H — `docs-changeset` (tasks 23–24) · kind: core · depends on: nothing
+
+**Task 23.** `docs/adapters/claude/PERMISSIONS.md` — rewrite the `auto` row (line 213) to record the
+2026-08-14 probe on CLI 2.1.224: the mode is external, `--permission-mode auto` and `setMode: auto`
+both validate, and the classifier is live (the probe allowed a file write, a network `curl` and an
+`rm`, where `acceptEdits` refused the network call). State the minimum CLI version Mainframe requires
+for Auto — **2.1.220**, where `auto` entered `EXTERNAL_PERMISSION_MODES` — and note that Mainframe now
+exposes the mode through the `autoMode` adapter capability. In the same table's surrounding prose, note
+that 2.1.224 renamed the interactive mode to `manual` in `--permission-mode` help while still accepting
+`default`, so Mainframe's spawn path is unaffected (spec "Not Included").
+*Verify:* the file states a concrete minimum version and no other row is edited (`git diff --stat`).
+
+**Task 24.** Add `.changeset/claude-auto-permission-mode.md` bumping `'@qlan-ro/mainframe-types'` and
+`'@qlan-ro/mainframe-ui'` **minor** (a new user-facing mode and a new contract value), with a
+one-sentence summary in the house style of `.changeset/adapter-model-catalog-fixes.md`.
+*Verify:* the file parses (`pnpm changeset status` runs without error).
+
+---
+
+## Verification before handing the branch back
+
+1. `cargo check --workspace --all-targets` and `cargo test --workspace` from `packages/core-rs`.
+2. `pnpm --filter @qlan-ro/mainframe-types build`, then
+   `pnpm --filter @qlan-ro/mainframe-ui typecheck`.
+3. Targeted vitest per Groups D–G (single files, per the repo's batch-`React.act` caveat).
+4. One e2e run at the end of the series, not per group. Expect zero spec changes: the mock adapter
+   reports `auto_mode: false`, so no Playwright surface lists Auto.
+
+## Acceptance-criteria coverage notes
+
+Three of the spec's sixteen criteria are satisfied without a task of their own. Reviewers should
+check these claims rather than look for a missing task.
+
+- **AC1, TypeScript side.** The spec asks for a serialization test on each side. `ExecutionMode` is a
+  string-literal union derived from `EXECUTION_MODES`, so the wire value *is* the literal `'auto'` by
+  construction — there is no encoder to test. Task 13 nevertheless asserts the picker renders
+  `data-testid="composer-permission-mode-select-option-auto"`, which fails if the constant carries any
+  other spelling. The Rust round-trip test (Task 1) is the real serialization guard.
+- **AC11, gate invariance.** No task touches the gate because nothing in the gate path reads the
+  permission mode: `ChatGateMount` dispatches on `ControlRequest.toolName`, and `PermissionGate` /
+  `AskUserQuestionGate` / `PlanGate` receive only the request entry and the reply function. A tool use
+  the CLI auto-allows never produces a `control_request` at all, so it cannot reach them. The existing
+  `packages/ui/src/features/chat/gates/__tests__/PermissionGate.test.tsx` suite therefore covers AC11
+  unchanged; run it in the Group G verification pass and record that it is green.
+- **AC12, the inheritance leg.** A new chat with no explicit mode inherits the provider default as a
+  raw string: `create_chat_with_defaults` reads `<adapterId>.defaultMode` from settings and passes it
+  straight through (`packages/core-rs/crates/mainframe-chat/src/lifecycle_manager.rs:296-320`) into the
+  same insert Task 12 round-trips. Task 10 proves the setting can hold `auto`; Task 12 proves the row
+  reads back as `ExecutionMode::Auto`. No lifecycle test is added.
+
+## Risks and open follow-ups
+
+- **CLI floor is documented, not enforced.** A user on a CLI older than 2.1.220 who selects Auto gets
+  a spawn-time argument error from the CLI. The spec declines version probing; the only mitigation is
+  the docs line in Task 23.
+- **The plan gate still defaults to Interactive on approval** (decision 3). An Auto user must re-pick
+  Auto in the gate. Fixing this means seeding the control from the chat's current mode, which also
+  changes Unattended behavior — worth its own todo.
+- **`packages/mobile` is untouched.** The wire change is additive (a new enum value, a new optional
+  capability key), so mobile ignores it; a mobile picker is a separate PR in that repo.
+- **`PermissionMode::Auto` (the flattened enum that also carries `plan`) gains a variant that nothing
+  constructs today.** It exists for mirror fidelity with the TS `PermissionMode` union and is asserted
+  by Task 1 only. That is intentional, not dead code to be pruned.

--- a/docs/plans/2026-08-14-todo-325-claude-auto-permissions-mode.md
+++ b/docs/plans/2026-08-14-todo-325-claude-auto-permissions-mode.md
@@ -160,11 +160,15 @@ adapters advertise the CLI's native `auto` mode). Then set it at all nine constr
 `mainframe-server/tests/chat_default_model_catalog.rs:55`,
 `mainframe-server/tests/transcript_presence_support/mod.rs:66`, and both sites in
 `mainframe-server/src/routes/session_transcripts.rs:154, 198`.
+Then add `ExecutionMode::Auto => "auto"` to `execution_mode_cli` at
+`packages/core-rs/crates/mainframe-adapter-claude/src/session.rs:235-240`. That arm belongs to this
+task, not to Task 4: it is the workspace's only exhaustive `match` on `ExecutionMode` (Codex's
+`map_permission_mode` is an `if`/`else`; every other site constructs a variant or derives serde), so
+without it this task's workspace check fails with `error[E0004]: non-exhaustive patterns:
+`ExecutionMode::Auto` not covered`. Task 7 is what pins the arm's value.
 *Verify:* `cargo check --workspace --all-targets` from `packages/core-rs` is green.
 
-**Task 4.** Adapter mode mappings.
-- `packages/core-rs/crates/mainframe-adapter-claude/src/session.rs:235-240` — add
-  `ExecutionMode::Auto => "auto"` to `execution_mode_cli`.
+**Task 4.** Codex mode mapping.
 - `packages/core-rs/crates/mainframe-adapter-codex/src/session.rs:163-169` — replace the
   `if mode == ExecutionMode::Yolo { … } else { … }` body of `map_permission_mode` with a delegation
   to a new free function `fn permission_mode_policy(mode: ExecutionMode) -> (String, String)` in the
@@ -353,16 +357,39 @@ false or omitted, sits between Auto-edits and Unattended, and when selected carr
 while a selected Unattended still carries `text-destructive`.
 *Verify:* fails.
 
-**Task 22 (green).** `packages/ui/src/features/chat/gates/PlanExecModeControl.tsx` — add an
-`autoAllowed?: boolean` prop and a fourth `EXEC_MODE_OPTIONS` entry
-(`{ id: 'auto', label: 'Auto', Icon: SparklesIcon, desc: 'Claude decides which actions need approval' }`)
-placed third, filtered out unless `autoAllowed`; extend the two-way selected tint (lines 50-51) to a
-three-way one so a selected `auto` reads `bg-background text-warning shadow-sm`.
-`packages/ui/src/features/chat/gates/PlanGate.tsx` — resolve the chat's adapter from
-`useChatExtras()?.state.chatConfig?.adapterId` plus `useAdapters()` and pass
-`autoAllowed={adapter?.capabilities.autoMode === true}` down through `ControlsPanel` to the control.
-Leave the `useState<ExecutionMode>('default')` seed on line 136 untouched (decision 3).
-*Verify:* Task 21 tests pass; `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/gates/__tests__/PlanGate.test.tsx src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx` green.
+**Task 22 (green).** The adapter is resolved in `ChatGateMount`, not in `PlanGate`. `PlanGate`
+documents itself as "fully prop-driven: no hooks, no context beyond TooltipProvider" and its suite
+(`__tests__/PlanGate.test.tsx:1-31`) renders it bare under a `TooltipProvider`; `ChatGateMount` is
+already runtime-coupled and already mocks that module. Threading a prop keeps both suites' strategies
+intact.
+
+- `packages/ui/src/features/chat/gates/PlanExecModeControl.tsx` — add an `autoAllowed?: boolean` prop
+  and a fourth `EXEC_MODE_OPTIONS` entry
+  (`{ id: 'auto', label: 'Auto', Icon: SparklesIcon, desc: 'Claude decides which actions need approval' }`)
+  placed third, filtered out unless `autoAllowed`; extend the two-way selected tint (lines 50-51) to a
+  three-way one so a selected `auto` reads `bg-background text-warning shadow-sm`.
+- `packages/ui/src/features/chat/gates/PlanGate.tsx` — add `autoAllowed?: boolean` to `PlanGateProps`
+  (line 23) and pass it through `ControlsPanel` (line 46) to `PlanExecModeControl` (line 59). Add no
+  hooks. Omitted means no Auto segment, so the existing `PlanGate.test.tsx` cases and the file's
+  prop-driven header stay correct and untouched. Leave the `useState<ExecutionMode>('default')` seed on
+  line 136 alone (decision 3).
+- `packages/ui/src/features/chat/gates/ChatGateMount.tsx` — call `useChatExtras()` and `useAdapters()`
+  **above** the `if (!front) return null` early return (hooks must not sit behind it), match the
+  adapter by `extras?.state.chatConfig?.adapterId`, and pass
+  `autoAllowed={adapter?.capabilities.autoMode === true}` on the `PlanGate` branch only.
+- `packages/ui/src/features/chat/gates/__tests__/ChatGateMount.test.tsx` — the `vi.mock` factory on
+  lines 31-33 exports **only** `useChatPermissionFront`, so the moment `ChatGateMount` imports
+  `useChatExtras` from that module the import resolves to `undefined` and behaviors 3, 6 and 7 throw
+  `useChatExtras is not a function`. Add `useChatExtras: vi.fn()` to that factory (its `undefined`
+  default keeps every existing case green) and correct the strategy header, which claims only
+  `useChatPermissionFront` is mocked. Then add one positive case: `resetAdapters()` in `beforeEach`,
+  `seedAdapters([...])` with a `claude` adapter carrying `capabilities.autoMode: true`, `useChatExtras`
+  returning extras whose `state.chatConfig.adapterId` is `'claude'`, an ExitPlanMode front → the plan
+  gate shows `chat-plan-execmode-auto`; with `autoMode` absent it does not. The suite renders the real
+  gates, so this reaches the segment end to end. Follow the `resetAdapters`/`seedAdapters` pattern in
+  `packages/ui/src/features/settings/__tests__/SettingsSidebar.test.tsx:38-41`.
+
+*Verify:* Task 21 tests pass; `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx src/features/chat/gates/__tests__/PlanGate.test.tsx src/features/chat/gates/__tests__/ChatGateMount.test.tsx` all green (run as separate files per the batch-`React.act` caveat).
 
 ---
 
@@ -404,10 +431,13 @@ check these claims rather than look for a missing task.
   construction — there is no encoder to test. Task 13 nevertheless asserts the picker renders
   `data-testid="composer-permission-mode-select-option-auto"`, which fails if the constant carries any
   other spelling. The Rust round-trip test (Task 1) is the real serialization guard.
-- **AC11, gate invariance.** No task touches the gate because nothing in the gate path reads the
-  permission mode: `ChatGateMount` dispatches on `ControlRequest.toolName`, and `PermissionGate` /
-  `AskUserQuestionGate` / `PlanGate` receive only the request entry and the reply function. A tool use
-  the CLI auto-allows never produces a `control_request` at all, so it cannot reach them. The existing
+- **AC11, gate invariance.** No permission mode ever decides whether a gate appears or what it can
+  answer: `ChatGateMount` dispatches purely on `ControlRequest.toolName`, and `PermissionGate` /
+  `AskUserQuestionGate` receive only the request entry and the reply function. A tool use the CLI
+  auto-allows never produces a `control_request` at all, so it cannot reach them. Task 22 does edit
+  this path, but only to widen a choice: `PlanGate` gains a display-only `autoAllowed` prop and
+  `ChatGateMount` resolves it from the chat's adapter. Neither reads the chat's *current* mode nor
+  changes any reply payload the gates already send. The existing
   `packages/ui/src/features/chat/gates/__tests__/PermissionGate.test.tsx` suite therefore covers AC11
   unchanged; run it in the Group G verification pass and record that it is green.
 - **AC12, the inheritance leg.** A new chat with no explicit mode inherits the provider default as a

--- a/docs/rust-port/fixtures/route.adapters-list.json
+++ b/docs/rust-port/fixtures/route.adapters-list.json
@@ -31,7 +31,8 @@
       "modelsRevision": 2,
       "catalogSource": "probed",
       "capabilities": {
-        "planMode": true
+        "planMode": true,
+        "autoMode": true
       }
     }
   ]

--- a/docs/specs/2026-08-14-todo-325-claude-auto-permissions-mode.md
+++ b/docs/specs/2026-08-14-todo-325-claude-auto-permissions-mode.md
@@ -1,0 +1,178 @@
+# Claude "Auto" permission mode
+
+Todo #325 · route: full · branch `todo/325-claude-auto-permissions-mode`
+
+## Problem
+
+Mainframe offers three permission modes — Interactive, Auto-Edits and Unattended. The Claude
+CLI offers six, and one of them, `auto`, sits in the gap users keep landing in: Auto-Edits still
+stops for every command, Unattended stops for nothing. In `auto` the CLI decides per tool use
+which actions need approval and asks only for the rest. A 2026-08-14 probe of CLI 2.1.224
+confirmed the mode is live, not dormant: under `auto` the CLI wrote a file, ran a network
+`curl` and deleted a file without prompting, where `acceptEdits` refused the network call.
+
+Mainframe has no way to select it. A user who wants the CLI's Auto behavior has to leave
+Mainframe and run the CLI directly, or pick Unattended and give up prompting entirely.
+
+## Behavior
+
+Auto becomes a fourth permission mode, offered only where the running adapter supports it.
+Claude supports it; Codex does not.
+
+**Choosing Auto.** The composer's permission picker lists Auto between Auto-Edits and
+Unattended, preserving the least-to-most-permissive reading. Its description says what the
+mechanism is, not how smart it is: Claude decides which actions need approval. The option
+appears only when the session's adapter advertises auto-mode support, and the picker is
+otherwise unchanged — a Codex session still sees exactly three options.
+
+**Before the first send.** Auto chosen on a draft is stored on the draft and reaches the CLI as
+the spawn-time mode on the very first turn. No warm-up turn in another mode.
+
+**Mid-session.** Switching to Auto on a live session takes effect for the next tool use through
+the same runtime mode-change path the other three modes use. The CLI is not respawned and the
+session is not lost. Switching away from Auto behaves symmetrically.
+
+**Plan mode.** Turning plan mode on and then off restores Auto when Auto was the mode the user
+last chose, exactly as it restores the other three today. Plan remains a separate toggle, not a
+fourth-and-a-half mode.
+
+**The approval gate is invariant.** Any tool use the CLI still asks about arrives as an ordinary
+permission request and renders the same gate card, the same queue and the same reply path as in
+any other mode. Tool uses the CLI auto-allows never reach Mainframe at all. Nothing about the
+gate changes because of this mode.
+
+**Provider default.** A provider's default session mode can be set to Auto when that provider
+supports it, and a new chat created with no explicit mode inherits it through the existing
+default-resolution path. The provider settings list is filtered by the same capability as the
+composer picker, so the two lists never disagree.
+
+**Automation steps.** The Ask-Agent step's permission picker is filtered by the same capability,
+resolved from the provider that step runs on. A step pointed at Claude offers Auto; a step
+pointed at Codex does not.
+
+**Visual treatment.** Auto reads as a caution: a warning tint, matching the CLI's own
+presentation of the mode and reusing the tint the app already applies to warnings elsewhere.
+Unattended keeps its destructive tint. The two must not look alike, in either the picker option
+or the picker trigger when that mode is active.
+
+**Unsupported combinations.** A chat whose stored mode is `auto` but whose adapter has no
+auto support starts in Interactive and logs the coercion. It never fails the spawn.
+
+**Validation.** An unknown or unsupported mode string sent to the chat-config update route is
+still rejected with the existing validation error. `auto` is now a recognized value everywhere
+the other three are: request body, stored row, and the value read back after a daemon restart.
+
+## Not Included
+
+- The CLI's other unexposed modes — `dontAsk`, and `plan` as an execution-mode value rather
+  than the existing boolean. `deferred`
+- The CLI's rename of interactive mode to `manual` in `--permission-mode` help. `default` is
+  still accepted by CLI 2.1.224, so the existing spawn path is unaffected. `deferred`
+- Any Codex-side equivalent of Auto, or teaching Codex to act on the mode beyond coercing it.
+  `declined`
+- Mobile UI for the new mode. The daemon contract change is additive — a new enum value on an
+  existing field — which is all the submodule needs; a mobile picker is a separate PR in that
+  repo. `platform`
+- Version detection or per-flag capability probing of the installed CLI. Older CLI builds that
+  predate external `auto` are handled by documenting a minimum version, not by probing.
+  `declined`
+- Any Mainframe-side classification or auto-approval logic. Every allow/ask decision stays with
+  the CLI. `declined`
+- The known gap where replying to a restored permission whose CLI process died fails with
+  "stream closed". Unrelated to this mode and unchanged by it. `deferred`
+
+## Edge cases
+
+1. **Capability not yet known.** The adapters store seeds a placeholder that reports no
+   capabilities until the real snapshot arrives. During that window Auto is absent from the
+   list, which is correct — but a chat already on Auto must still show "Auto" on the picker
+   trigger, not a raw mode string. An option filtered out of the list must never produce a
+   wrong label.
+2. **Auto on a Codex chat.** Stored `auto` on an adapter without the capability spawns in
+   Interactive with the coercion logged. No error, no failed spawn, no silent drop.
+3. **Unparseable stored mode.** A mode string the daemon cannot parse reads back as unset
+   (falling through to the provider default), not as an error — the behavior that exists today
+   for any junk value. Adding `auto` does not change it, and `auto` itself must now parse.
+4. **Plan mode over Auto.** Plan on, then plan off, restores `auto` — not `default`.
+5. **Switching mid-turn.** Selecting Auto while a turn is running applies from the next tool
+   use, as the existing modes do; it does not retroactively affect an in-flight approval
+   already showing in the gate.
+6. **Provider default set to Auto, then the provider loses the capability** (downgraded CLI,
+   adapter uninstalled): existing chats fall back per case 2, and the setting is simply not
+   offered on the next visit to the settings pane.
+
+## Acceptance criteria
+
+1. The shared TypeScript execution-mode union and its Rust mirror both expose `auto`, and a
+   serialization test on each side asserts the wire value is the literal string `auto`,
+   including the flattened permission-mode enum that also carries `plan`.
+2. A Claude session spawned with Auto passes the CLI mode flag with the value `auto`, asserted
+   by an argv test alongside the existing `default` / `acceptEdits` / `bypassPermissions` cases.
+3. A mid-session switch to Auto sends the runtime mode-change request carrying `auto`, asserted
+   the same way the existing modes are.
+4. Turning plan mode on and then off while the base mode is Auto restores `auto`, not `default`.
+5. The chat-config update route accepts `auto`, persists it, and returns it on a subsequent
+   read; an unrecognized mode string still fails validation with the existing 400 error shape.
+6. A stored `auto` survives a daemon restart: the chat row read back after restart still
+   reports `auto`.
+7. The composer permission picker shows Auto for an adapter advertising the capability and does
+   not show it for one that does not; a test covers both.
+8. The Auto option and the Auto trigger render with the caution treatment, and a test asserts
+   they do not carry the destructive treatment reserved for Unattended.
+9. When the chat's mode is `auto` and the adapter capability is not yet known, the picker
+   trigger still reads "Auto".
+10. A chat whose stored mode is `auto` running on an adapter without the capability spawns
+    successfully in Interactive, and the coercion is logged (the Codex mode mapping handles the
+    variant as an explicit branch, not a fallthrough).
+11. A permission request received while the mode is Auto renders and replies exactly as it does
+    in the other modes, covered by an existing or added gate test.
+12. The provider default-mode setting accepts Auto for a supporting adapter and does not offer
+    it for a non-supporting one; a new chat created with no explicit mode inherits it.
+13. The automation Ask-Agent step's permission picker offers Auto only when the step's resolved
+    provider advertises the capability; a test covers both directions.
+14. Every new interactive element carries a kebab-case `data-testid` following the existing
+    naming — `composer-permission-mode-select-option-auto`, `settings-<adapterId>-mode-option-auto`.
+15. The minimum Claude CLI version required for `auto` is documented in the Claude adapter docs.
+16. `cargo check` and the UI typecheck pass, the new and existing adapter/route/UI tests pass,
+    and the PR includes a changeset.
+
+## Decisions
+
+- **Native CLI `auto`, not a Mainframe-invented mode.** `reversible` — the mode is external and
+  valid in the installed CLI and its allow path is live (probe, 2026-08-14); a synthetic mode
+  under the same label would diverge from what the CLI does.
+- **No CLI version detection; document a floor instead.** `reversible` — the adapter has no
+  per-flag capability probe today, and building one for a single mode is disproportionate.
+- **Claude-only, gated by an adapter capability flag on the existing capabilities contract.**
+  `hard-to-reverse` — adds a member to the wire-visible capabilities object consumed by the UI
+  and by mobile. Follows the `planMode` precedent; never an adapter-id string comparison.
+- **`auto` is a fourth value of the one canonical execution mode, not a Claude-local type.**
+  `hard-to-reverse` — the enum is mirrored in Rust, persisted in SQLite, and carried on the
+  daemon wire; widening it later is easy, narrowing it after rows exist is not.
+- **A Codex session carrying `auto` runs as Interactive and logs the coercion.** `reversible` —
+  most conservative reading; failing the spawn would punish the user for a config they cannot
+  see. Codex's mapping already lands there via its `else` branch, but it becomes an explicit arm
+  so the next mode addition cannot inherit it by accident.
+- **UI copy describes the mechanism, not the intelligence** — "Claude decides which actions need
+  approval". `reversible` — stays honest whichever way the CLI's classifier behaves, and
+  promises no reduction in prompts.
+- **Caution treatment, not destructive.** `reversible` — the CLI itself colors Auto at warning
+  level, and the app already ships a warning tint used on the same composer surface where
+  Unattended uses the destructive tint; matching that pair keeps the risk ordering readable.
+  The user's 2026-08-14 ruling upheld this after the probe showed Auto is permissive in headless
+  runs; do not re-litigate it in this lane.
+- **The provider default-mode setting offers Auto too, filtered by the same capability.**
+  `reversible` — keeps the two mode lists consistent; a default the composer cannot show would
+  be a trap.
+- **Auto sits between Auto-Edits and Unattended in the picker.** `reversible` — preserves the
+  least-to-most-permissive reading of the list.
+- **The automations Ask-Agent permission picker is filtered by the step's resolved provider**
+  (lane ruling; the brief does not mention this surface). `reversible` — that picker iterates
+  the shared mode list, so without a filter Auto would leak into Codex steps; the step already
+  carries an adapter id, and the brief's own principle is that mode lists become
+  capability-filtered. The cheap alternative, if the reviewer prefers less scope: leave the
+  automations picker on the three original modes and defer Auto in automations.
+- **Design direction was delegated to the lane** (user, 2026-08-14). `reversible` — the visual
+  calls above were made from the brief's Decisions section and the closest shipped patterns
+  (the composer picker's existing destructive tint for Unattended, and the app's existing
+  warning tint), not from a prototype.

--- a/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
+++ b/packages/core-rs/crates/mainframe-adapter-api/tests/registry.rs
@@ -199,7 +199,10 @@ impl Adapter for FakeAdapter {
         &self.name
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: true }
+        AdapterCapabilities {
+            plan_mode: true,
+            auto_mode: false,
+        }
     }
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
         self.is_installed_calls.fetch_add(1, Ordering::SeqCst);

--- a/packages/core-rs/crates/mainframe-adapter-claude/src/adapter.rs
+++ b/packages/core-rs/crates/mainframe-adapter-claude/src/adapter.rs
@@ -122,7 +122,10 @@ impl Adapter for ClaudeAdapter {
         CLAUDE_ADAPTER_NAME
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: true }
+        AdapterCapabilities {
+            plan_mode: true,
+            auto_mode: true,
+        }
     }
 
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {

--- a/packages/core-rs/crates/mainframe-adapter-claude/src/plan_mode_handler.rs
+++ b/packages/core-rs/crates/mainframe-adapter-claude/src/plan_mode_handler.rs
@@ -262,6 +262,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn on_approve_with_auto_sets_auto_base_mode() {
+        let ctx = MockCtx::new(true);
+        let handler = ClaudePlanModeHandler;
+        let mut resp = base_response();
+        resp.execution_mode = Some(ExecutionMode::Auto);
+        handler.on_approve(resp, &ctx).await.unwrap();
+
+        let rec = ctx.rec();
+        assert_eq!(rec.set_permission_mode, vec![ExecutionMode::Auto]);
+        assert_eq!(
+            rec.updates,
+            vec![PlanChatUpdate {
+                plan_mode: Some(false),
+                permission_mode: Some(ExecutionMode::Auto),
+                clear_claude_session_id: false,
+            }]
+        );
+    }
+
+    #[tokio::test]
     async fn on_reject_forwards_the_deny_response_to_respond_to_permission() {
         let ctx = MockCtx::new(true);
         let handler = ClaudePlanModeHandler;

--- a/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
@@ -236,6 +236,7 @@ fn execution_mode_cli(mode: ExecutionMode) -> &'static str {
     match mode {
         ExecutionMode::Default => "default",
         ExecutionMode::AcceptEdits => "acceptEdits",
+        ExecutionMode::Auto => "auto",
         ExecutionMode::Yolo => "bypassPermissions",
     }
 }

--- a/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
@@ -1349,6 +1349,12 @@ mod tests {
     }
 
     #[test]
+    fn auto_mode_passes_permission_mode_auto() {
+        let (args, _) = build_args(&spawn_opts(Some(ExecutionMode::Auto)), &None);
+        assert_eq!(mode_arg(&args), "auto");
+    }
+
+    #[test]
     fn yolo_mode_passes_permission_mode_bypass_permissions() {
         let (args, _) = build_args(&spawn_opts(Some(ExecutionMode::Yolo)), &None);
         assert_eq!(mode_arg(&args), "bypassPermissions");

--- a/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-claude/src/session.rs
@@ -1447,6 +1447,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_permission_mode_sends_auto_verbatim() {
+        let s = session();
+        let mut rx = spawned_with_stdin(&s);
+        s.set_permission_mode(ExecutionMode::Auto).await.unwrap();
+        let payload = read_json(&mut rx);
+        assert_eq!(payload["request"]["subtype"], "set_permission_mode");
+        assert_eq!(payload["request"]["mode"], "auto");
+    }
+
+    #[tokio::test]
+    async fn leaving_plan_mode_restores_auto() {
+        let s = session();
+        let mut rx = spawned_with_stdin(&s);
+        s.set_permission_mode(ExecutionMode::Auto).await.unwrap();
+        assert_eq!(read_json(&mut rx)["request"]["mode"], "auto");
+
+        s.set_plan_mode(true).await.unwrap();
+        assert_eq!(read_json(&mut rx)["request"]["mode"], "plan");
+
+        s.set_plan_mode(false).await.unwrap();
+        assert_eq!(read_json(&mut rx)["request"]["mode"], "auto");
+    }
+
+    #[tokio::test]
     async fn set_plan_mode_true_sends_plan() {
         let s = session();
         let mut rx = spawned_with_stdin(&s);

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/adapter.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/adapter.rs
@@ -162,7 +162,10 @@ impl Adapter for CodexAdapter {
         "Codex"
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: true }
+        AdapterCapabilities {
+            plan_mode: true,
+            auto_mode: false,
+        }
     }
 
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {

--- a/packages/core-rs/crates/mainframe-adapter-codex/src/session.rs
+++ b/packages/core-rs/crates/mainframe-adapter-codex/src/session.rs
@@ -161,11 +161,7 @@ impl CodexSession {
     }
 
     fn map_permission_mode(&self, mode: ExecutionMode) -> (String, String) {
-        if mode == ExecutionMode::Yolo {
-            ("never".to_string(), "danger-full-access".to_string())
-        } else {
-            ("on-request".to_string(), "workspace-write".to_string())
-        }
+        permission_mode_policy(mode)
     }
 
     fn map_sandbox_policy(&self, sandbox: &str) -> Value {
@@ -243,6 +239,25 @@ impl CodexSession {
             .clone()
             .on_init(&new_thread_id);
         Ok(())
+    }
+}
+
+/// Codex has no CLI-native `auto` mode, so it coerces to the same
+/// (`on-request`, `workspace-write`) pair as Interactive rather than falling
+/// through to the danger pair meant for Yolo. A free function so the mapping
+/// is unit-testable without constructing a `CodexSession`.
+fn permission_mode_policy(mode: ExecutionMode) -> (String, String) {
+    match mode {
+        ExecutionMode::Yolo => ("never".to_string(), "danger-full-access".to_string()),
+        ExecutionMode::Default | ExecutionMode::AcceptEdits => {
+            ("on-request".to_string(), "workspace-write".to_string())
+        }
+        ExecutionMode::Auto => {
+            tracing::warn!(
+                "chat is set to the Claude-only `auto` permission mode; Codex runs it as Interactive"
+            );
+            ("on-request".to_string(), "workspace-write".to_string())
+        }
     }
 }
 
@@ -841,6 +856,20 @@ mod tests {
             .and_then(|(_, v)| v)
             .map(|v| v.to_string_lossy().into_owned());
         assert_eq!(path.as_deref(), Some("/opt/homebrew/bin:/usr/bin"));
+    }
+
+    /// Codex has no `auto` mode of its own; a chat carrying it (spawned on
+    /// Claude, then switched to a Codex step) must coerce to the same policy
+    /// as Interactive rather than falling through to the danger pair.
+    #[test]
+    fn permission_mode_policy_coerces_auto_to_interactive() {
+        let interactive = ("on-request".to_string(), "workspace-write".to_string());
+        assert_eq!(permission_mode_policy(ExecutionMode::Default), interactive);
+        assert_eq!(permission_mode_policy(ExecutionMode::Auto), interactive);
+        assert_eq!(
+            permission_mode_policy(ExecutionMode::Yolo),
+            ("never".to_string(), "danger-full-access".to_string())
+        );
     }
 }
 

--- a/packages/core-rs/crates/mainframe-adapter-mock/src/adapter.rs
+++ b/packages/core-rs/crates/mainframe-adapter-mock/src/adapter.rs
@@ -90,7 +90,10 @@ impl Adapter for MockCliAdapter {
         "Mock CLI"
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: true }
+        AdapterCapabilities {
+            plan_mode: true,
+            auto_mode: false,
+        }
     }
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
         Box::pin(async { Ok(true) })

--- a/packages/core-rs/crates/mainframe-chat/src/context_tracker.rs
+++ b/packages/core-rs/crates/mainframe-chat/src/context_tracker.rs
@@ -418,7 +418,10 @@ mod tests {
             "Claude"
         }
         fn capabilities(&self) -> mainframe_types::adapter::AdapterCapabilities {
-            mainframe_types::adapter::AdapterCapabilities { plan_mode: false }
+            mainframe_types::adapter::AdapterCapabilities {
+                plan_mode: false,
+                auto_mode: false,
+            }
         }
         fn is_installed(
             &self,

--- a/packages/core-rs/crates/mainframe-db/tests/chats.rs
+++ b/packages/core-rs/crates/mainframe-db/tests/chats.rs
@@ -9,6 +9,7 @@ use mainframe_db::schema::initialize_schema;
 use mainframe_db::{ChatListFilters, ChatUpdate, ChatsRepository, ProjectsRepository};
 use mainframe_types::adapter::EffortLevel;
 use mainframe_types::chat::{ChatStatus, TodoItem, TodoStatus};
+use mainframe_types::settings::ExecutionMode;
 
 fn setup_with_conn() -> (ChatsRepository, ProjectsRepository, Rc<Connection>) {
     let conn = Connection::open_in_memory().unwrap();
@@ -327,4 +328,34 @@ fn chat_effort_reads_back_none_for_a_bogus_stored_value() {
 
     let fetched = chats.get(&chat.id).unwrap().unwrap();
     assert_eq!(fetched.effort, None);
+}
+
+#[test]
+fn permission_mode_auto_survives_a_reopen() {
+    let (chats, projects, conn) = setup_with_conn();
+    let p = projects.create("/project/mode-auto", None).unwrap();
+    let chat = chats
+        .create(&p.id, "claude", None, Some("auto"), None)
+        .unwrap();
+
+    // A second repository over the same connection stands in for a daemon
+    // restart re-opening the same on-disk database.
+    let reopened = ChatsRepository::new(Rc::clone(&conn), None);
+    let fetched = reopened.get(&chat.id).unwrap().unwrap();
+    assert_eq!(fetched.permission_mode, Some(ExecutionMode::Auto));
+}
+
+#[test]
+fn permission_mode_reads_back_none_for_a_bogus_stored_value() {
+    let (chats, projects, conn) = setup_with_conn();
+    let p = projects.create("/project/mode-bogus", None).unwrap();
+    let chat = chats.create(&p.id, "claude", None, None, None).unwrap();
+    conn.execute(
+        "UPDATE chats SET permission_mode = 'turbo' WHERE id = ?",
+        rusqlite::params![chat.id],
+    )
+    .unwrap();
+
+    let fetched = chats.get(&chat.id).unwrap().unwrap();
+    assert_eq!(fetched.permission_mode, None);
 }

--- a/packages/core-rs/crates/mainframe-server/src/routes/chat_commands.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/chat_commands.rs
@@ -307,6 +307,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn update_chat_config_body_accepts_auto() {
+        let body = parse_body::<UpdateChatConfigBody>(&axum::body::Bytes::from(
+            r#"{"permissionMode":"auto"}"#,
+        ));
+        assert!(matches!(
+            body.and_then(|b| b.permission_mode),
+            Some(ExecutionMode::Auto)
+        ));
+    }
+
+    #[test]
+    fn update_chat_config_body_rejects_unknown_mode() {
+        let body = parse_body::<UpdateChatConfigBody>(&axum::body::Bytes::from(
+            r#"{"permissionMode":"turbo"}"#,
+        ));
+        assert!(body.is_none());
+    }
+
     #[tokio::test]
     async fn interrupt_missing_chat_404() {
         let ctx = AppCtx::test_ctx();

--- a/packages/core-rs/crates/mainframe-server/src/routes/session_transcripts.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/session_transcripts.rs
@@ -152,7 +152,10 @@ mod tests {
             &self.adapter_id
         }
         fn capabilities(&self) -> AdapterCapabilities {
-            AdapterCapabilities { plan_mode: false }
+            AdapterCapabilities {
+                plan_mode: false,
+                auto_mode: false,
+            }
         }
         fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
             Box::pin(async { Ok(true) })
@@ -195,7 +198,10 @@ mod tests {
             &self.adapter_id
         }
         fn capabilities(&self) -> AdapterCapabilities {
-            AdapterCapabilities { plan_mode: false }
+            AdapterCapabilities {
+                plan_mode: false,
+                auto_mode: false,
+            }
         }
         fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
             Box::pin(async { Ok(true) })

--- a/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
@@ -22,8 +22,8 @@ use mainframe_db::DbError;
 use mainframe_services::settings::normalize_saved_default_model;
 use mainframe_types::adapter::{AdapterInfo, AdapterModel, EffortLevel};
 use mainframe_types::settings::{
-    GeneralConfig, NotificationChatConfig, NotificationConfig, NotificationOtherConfig,
-    NotificationPermissionConfig,
+    ExecutionMode, GeneralConfig, NotificationChatConfig, NotificationConfig,
+    NotificationOtherConfig, NotificationPermissionConfig,
 };
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -488,8 +488,18 @@ fn is_effort_or_clear(value: &Option<String>) -> bool {
     }
 }
 
+/// `None` → true (absent is always valid); otherwise the value must deserialize
+/// as an `ExecutionMode`, so this can't drift from the enum the way the old
+/// hardcoded `["default", "acceptEdits", "yolo"]` list did.
+fn is_execution_mode(value: &Option<String>) -> bool {
+    match value {
+        None => true,
+        Some(v) => serde_json::from_value::<ExecutionMode>(Value::String(v.clone())).is_ok(),
+    }
+}
+
 fn validate_provider_patch(p: &ProviderPatch) -> bool {
-    in_enum(&p.default_mode, &["default", "acceptEdits", "yolo"])
+    is_execution_mode(&p.default_mode)
         && in_enum(&p.default_plan_mode, &["true", "false"])
         && is_effort_or_clear(&p.default_effort)
         && in_enum(&p.default_fast, &["true", "false", ""])

--- a/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/settings.rs
@@ -646,7 +646,7 @@ mod tests {
             "description": "",
             "installed": true,
             "models": models,
-            "capabilities": { "planMode": true },
+            "capabilities": { "planMode": true, "autoMode": false },
         }))
         .unwrap()
     }

--- a/packages/core-rs/crates/mainframe-server/tests/chat_default_model_catalog.rs
+++ b/packages/core-rs/crates/mainframe-server/tests/chat_default_model_catalog.rs
@@ -52,7 +52,10 @@ impl Adapter for CatalogAdapter {
         &self.id
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: false }
+        AdapterCapabilities {
+            plan_mode: false,
+            auto_mode: false,
+        }
     }
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
         Box::pin(async { Ok(true) })

--- a/packages/core-rs/crates/mainframe-server/tests/routes_settings.rs
+++ b/packages/core-rs/crates/mainframe-server/tests/routes_settings.rs
@@ -316,6 +316,20 @@ async fn provider_put_clears_skip_permissions_on_default_mode() {
 }
 
 #[tokio::test]
+async fn provider_put_accepts_auto_default_mode() {
+    let server = spawn_test_server(None).await;
+    let resp = client()
+        .put(server.http_url("/api/settings/providers/claude"))
+        .json(&json!({ "defaultMode": "auto" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = get_json(&server, "/api/settings/providers").await;
+    assert_eq!(body["data"]["claude"]["defaultMode"], "auto");
+}
+
+#[tokio::test]
 async fn provider_put_rejects_invalid_default_mode() {
     let server = spawn_test_server(None).await;
     let resp = client()

--- a/packages/core-rs/crates/mainframe-server/tests/transcript_presence_support/mod.rs
+++ b/packages/core-rs/crates/mainframe-server/tests/transcript_presence_support/mod.rs
@@ -63,7 +63,10 @@ impl Adapter for StubAdapter {
         &self.adapter_id
     }
     fn capabilities(&self) -> AdapterCapabilities {
-        AdapterCapabilities { plan_mode: false }
+        AdapterCapabilities {
+            plan_mode: false,
+            auto_mode: false,
+        }
     }
     fn is_installed(&self) -> BoxFuture<'_, Result<bool, AdapterError>> {
         Box::pin(async { Ok(true) })

--- a/packages/core-rs/crates/mainframe-types/src/adapter.rs
+++ b/packages/core-rs/crates/mainframe-types/src/adapter.rs
@@ -300,6 +300,8 @@ pub enum CatalogSource {
 #[serde(rename_all = "camelCase")]
 pub struct AdapterCapabilities {
     pub plan_mode: bool,
+    /// Whether this adapter supports the CLI's native `auto` permission mode.
+    pub auto_mode: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/packages/core-rs/crates/mainframe-types/src/settings.rs
+++ b/packages/core-rs/crates/mainframe-types/src/settings.rs
@@ -2,9 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const EXECUTION_MODES: [ExecutionMode; 3] = [
+pub const EXECUTION_MODES: [ExecutionMode; 4] = [
     ExecutionMode::Default,
     ExecutionMode::AcceptEdits,
+    ExecutionMode::Auto,
     ExecutionMode::Yolo,
 ];
 
@@ -13,6 +14,7 @@ pub const EXECUTION_MODES: [ExecutionMode; 3] = [
 pub enum ExecutionMode {
     Default,
     AcceptEdits,
+    Auto,
     Yolo,
 }
 
@@ -23,6 +25,7 @@ pub enum ExecutionMode {
 pub enum PermissionMode {
     Default,
     AcceptEdits,
+    Auto,
     Yolo,
     Plan,
 }
@@ -230,6 +233,39 @@ mod tests {
             serde_json::to_string(&ExecutionMode::Yolo).unwrap(),
             "\"yolo\""
         );
+        assert_eq!(
+            serde_json::to_string(&ExecutionMode::Auto).unwrap(),
+            "\"auto\""
+        );
+    }
+
+    #[test]
+    fn permission_mode_auto_serializes_as_auto() {
+        assert_eq!(
+            serde_json::to_string(&PermissionMode::Auto).unwrap(),
+            "\"auto\""
+        );
+    }
+
+    #[test]
+    fn execution_mode_auto_round_trips() {
+        assert_eq!(
+            serde_json::from_str::<ExecutionMode>("\"auto\"").unwrap(),
+            ExecutionMode::Auto
+        );
+    }
+
+    #[test]
+    fn execution_modes_constant_lists_four_modes_in_permissiveness_order() {
+        assert_eq!(
+            EXECUTION_MODES,
+            [
+                ExecutionMode::Default,
+                ExecutionMode::AcceptEdits,
+                ExecutionMode::Auto,
+                ExecutionMode::Yolo,
+            ]
+        );
     }
 
     #[test]
@@ -323,3 +359,6 @@ mod tests {
 // `defaultAdapterId: string | null`) has no skip_serializing_if, so it always
 // serializes (as `null` when unset) — matches the TS route always including the
 // key via the GENERAL_DEFAULTS spread.
+// catch-up (#325): ExecutionMode and PermissionMode gained a fourth/fifth variant,
+// Auto, mirroring the Claude CLI's native `auto` permission mode. EXECUTION_MODES
+// is now `[Default, AcceptEdits, Auto, Yolo]`.

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -238,6 +238,8 @@ export interface AdapterInfo {
   catalogSource?: 'probed' | 'fallback';
   capabilities: {
     planMode: boolean;
+    /** Supports the CLI's native `auto` permission mode. Absent means unsupported (mobile-additive). */
+    autoMode?: boolean;
   };
 }
 
@@ -357,6 +359,8 @@ export interface Adapter {
   name: string;
   readonly capabilities: {
     planMode: boolean;
+    /** Supports the CLI's native `auto` permission mode. Absent means unsupported (mobile-additive). */
+    autoMode?: boolean;
   };
 
   isInstalled(): Promise<boolean>;

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,6 +1,6 @@
 import type { EffortLevel } from './adapter.js';
 
-export const EXECUTION_MODES = ['default', 'acceptEdits', 'yolo'] as const;
+export const EXECUTION_MODES = ['default', 'acceptEdits', 'auto', 'yolo'] as const;
 export type ExecutionMode = (typeof EXECUTION_MODES)[number];
 export type PermissionMode = ExecutionMode | 'plan';
 

--- a/packages/ui/src/features/automations/steps/AgentConfig.tsx
+++ b/packages/ui/src/features/automations/steps/AgentConfig.tsx
@@ -54,7 +54,7 @@ export function AgentConfig({ step, onChange, tokens, testId }: AgentConfigProps
       >
         <div className="flex min-w-0 items-center gap-1">
           <ModelMenu adapterId={step.adapterId} model={step.model} onChange={patch} testId={testId} />
-          <PermissionMenu value={step.permissionMode} onChange={patch} testId={testId} />
+          <PermissionMenu adapterId={step.adapterId} value={step.permissionMode} onChange={patch} testId={testId} />
           <WorktreeMenu worktree={step.worktree} onChange={patch} tokens={tokens} testId={testId} />
         </div>
         <AdvancedToggle open={advancedOpen} onToggle={() => setAdvancedOpen((o) => !o)} testId={testId} />

--- a/packages/ui/src/features/automations/steps/agent/ChipButton.tsx
+++ b/packages/ui/src/features/automations/steps/agent/ChipButton.tsx
@@ -27,12 +27,20 @@ export interface ChipButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
   label: string;
   testId: string;
   destructive?: boolean;
+  /** A wrong-but-not-broken setting — outranked by `destructive` when both are set. */
+  caution?: boolean;
   chevron?: boolean;
   children: ReactNode;
 }
 
+function tintClass(destructive: boolean | undefined, caution: boolean | undefined): string {
+  if (destructive) return 'text-destructive';
+  if (caution) return 'text-warning';
+  return 'text-muted-foreground';
+}
+
 export const ChipButton = forwardRef<HTMLButtonElement, ChipButtonProps>(function ChipButton(
-  { icon: Icon, label, testId, destructive, chevron, children, className, type, ...props },
+  { icon: Icon, label, testId, destructive, caution, chevron, children, className, type, ...props },
   ref,
 ) {
   return (
@@ -41,7 +49,7 @@ export const ChipButton = forwardRef<HTMLButtonElement, ChipButtonProps>(functio
       type={type ?? 'button'}
       data-testid={testId}
       aria-label={label}
-      className={cn(CHIP_BASE, destructive ? 'text-destructive' : 'text-muted-foreground', className)}
+      className={cn(CHIP_BASE, tintClass(destructive, caution), className)}
       {...props}
     >
       <Icon size={12} className="shrink-0" aria-hidden />

--- a/packages/ui/src/features/automations/steps/agent/ModelMenu.tsx
+++ b/packages/ui/src/features/automations/steps/agent/ModelMenu.tsx
@@ -20,16 +20,13 @@ import { Hint } from '@/components/ui/hint';
 import { useAdapters } from '@/store/adapters';
 import type { AskAgentStep } from '../../contract';
 import { ChipButton } from './ChipButton';
+import { resolveStepAdapter } from './resolve-step-adapter';
 
 export interface ModelMenuProps {
   adapterId: string | undefined;
   model: string | undefined;
   onChange: (patch: Pick<AskAgentStep, 'adapterId' | 'model'>) => void;
   testId: string;
-}
-
-function resolveAdapter(adapters: AdapterInfo[], adapterId: string | undefined): AdapterInfo | undefined {
-  return adapters.find((a) => a.id === adapterId) ?? adapters.find((a) => a.installed) ?? adapters[0];
 }
 
 function resolveModel(adapter: AdapterInfo | undefined, model: string | undefined) {
@@ -39,7 +36,7 @@ function resolveModel(adapter: AdapterInfo | undefined, model: string | undefine
 
 export function ModelMenu({ adapterId, model, onChange, testId }: ModelMenuProps) {
   const adapters = useAdapters();
-  const activeAdapter = resolveAdapter(adapters, adapterId);
+  const activeAdapter = resolveStepAdapter(adapters, adapterId);
   const activeModel = resolveModel(activeAdapter, model);
 
   // A disabled button swallows pointer events, so the hint wraps the chip rather than triggering on it.

--- a/packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx
+++ b/packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx
@@ -25,6 +25,7 @@ import { ChipButton } from './ChipButton';
 const MODE_COPY: Record<ExecutionMode, { label: string; hint: string }> = {
   default: { label: 'Interactive', hint: 'Approve every action' },
   acceptEdits: { label: 'Auto-Edits', hint: 'Edits auto-applied; commands ask' },
+  auto: { label: 'Auto', hint: 'Claude decides which actions need approval' },
   yolo: { label: 'Unattended', hint: 'Runs without prompts' },
 };
 

--- a/packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx
+++ b/packages/ui/src/features/automations/steps/agent/PermissionMenu.tsx
@@ -1,11 +1,15 @@
 /**
  * PermissionMenu — the Agent card's execution-scope chip (todo #234 T15).
  * Modes and their order come from the contract's `EXECUTION_MODES`, not a
- * local list, so a mode added to the wire type surfaces here automatically;
- * only the copy is local.
+ * local list; only the copy is local. What the menu *offers* is narrower:
+ * `auto` is the Claude CLI's own mode, so it appears only for a provider
+ * whose adapter advertises `capabilities.autoMode` (todo #325). The active
+ * mode is still resolved against the whole list, so a step carrying a mode
+ * its provider cannot offer reads as that mode rather than silently
+ * relabelling itself.
  *
  * Labels match the composer's `config-toolbar/PermissionSelect` verbatim —
- * the same three modes should never read differently in two surfaces. Left
+ * the same modes should never read differently in two surfaces. Left
  * duplicated rather than extracted at two call sites (the shared-helper rule
  * is 3+).
  */
@@ -18,9 +22,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Hint } from '@/components/ui/hint';
+import { useAdapters } from '@/store/adapters';
 import type { AskAgentStep } from '../../contract';
 import { EXECUTION_MODES } from '../../contract';
 import { ChipButton } from './ChipButton';
+import { resolveStepAdapter } from './resolve-step-adapter';
 
 const MODE_COPY: Record<ExecutionMode, { label: string; hint: string }> = {
   default: { label: 'Interactive', hint: 'Approve every action' },
@@ -30,13 +36,18 @@ const MODE_COPY: Record<ExecutionMode, { label: string; hint: string }> = {
 };
 
 export interface PermissionMenuProps {
+  /** The step's provider — which modes it can offer. Unset resolves the same way the model chip does. */
+  adapterId: string | undefined;
   /** `AskAgentStep.permissionMode` is a bare wire `string`; anything off the mode list falls back to the first. */
   value: string | undefined;
   onChange: (patch: Pick<AskAgentStep, 'permissionMode'>) => void;
   testId: string;
 }
 
-export function PermissionMenu({ value, onChange, testId }: PermissionMenuProps) {
+export function PermissionMenu({ adapterId, value, onChange, testId }: PermissionMenuProps) {
+  const adapters = useAdapters();
+  const autoAllowed = resolveStepAdapter(adapters, adapterId)?.capabilities.autoMode === true;
+  const offered = EXECUTION_MODES.filter((mode) => mode !== 'auto' || autoAllowed);
   const active = EXECUTION_MODES.find((mode) => mode === value) ?? EXECUTION_MODES[0];
   const { label } = MODE_COPY[active];
 
@@ -51,13 +62,14 @@ export function PermissionMenu({ value, onChange, testId }: PermissionMenuProps)
             label={`Permission: ${label}`}
             testId={`${testId}-permission`}
             destructive={active === 'yolo'}
+            caution={active === 'auto'}
           >
             {label}
           </ChipButton>
         </DropdownMenuTrigger>
       </Hint>
       <DropdownMenuContent data-testid={`${testId}-permission-menu`} align="start" sideOffset={6} className="min-w-44">
-        {EXECUTION_MODES.map((mode) => (
+        {offered.map((mode) => (
           <DropdownMenuItem
             key={mode}
             data-testid={`${testId}-permission-option-${mode}`}

--- a/packages/ui/src/features/automations/steps/agent/__tests__/ChipButton.test.tsx
+++ b/packages/ui/src/features/automations/steps/agent/__tests__/ChipButton.test.tsx
@@ -51,6 +51,23 @@ describe('ChipButton', () => {
     expect(screen.getByTestId('agent-a-permission').className).toContain('text-destructive');
   });
 
+  it('renders caution as a warning tint, and lets destructive outrank it', () => {
+    const { rerender } = render(
+      <ChipButton icon={Sparkles} label="Permission" testId="agent-a-permission" caution>
+        Auto
+      </ChipButton>,
+    );
+    expect(screen.getByTestId('agent-a-permission').className).toContain('text-warning');
+    expect(screen.getByTestId('agent-a-permission').className).not.toContain('text-destructive');
+
+    rerender(
+      <ChipButton icon={Sparkles} label="Permission" testId="agent-a-permission" caution destructive>
+        Unattended
+      </ChipButton>,
+    );
+    expect(screen.getByTestId('agent-a-permission').className).toContain('text-destructive');
+  });
+
   it('forwards clicks and native button props', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/packages/ui/src/features/automations/steps/agent/__tests__/PermissionMenu.test.tsx
+++ b/packages/ui/src/features/automations/steps/agent/__tests__/PermissionMenu.test.tsx
@@ -1,52 +1,96 @@
 /**
  * PermissionMenu — the Agent card's execution-scope chip (todo #234 T15),
  * over the contract's own `EXECUTION_MODES`. Unattended is the one mode that
- * runs without a human in the loop, so the chip goes destructive on it.
+ * runs without a human in the loop, so the chip goes destructive on it; Auto
+ * is a caution, and it only appears for a provider whose adapter advertises
+ * `capabilities.autoMode` (todo #325).
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import { resetAdapters, seedAdapters } from '@/store/adapters';
 import { EXECUTION_MODES } from '../../../contract';
 import { PermissionMenu } from '../PermissionMenu';
 
+function adapter(id: string, name: string, capabilities: AdapterInfo['capabilities']): AdapterInfo {
+  return { id, name, description: '', installed: true, models: [], capabilities };
+}
+
+const CLAUDE = adapter('claude', 'Claude', { planMode: true, autoMode: true });
+/** No `autoMode` key at all — absent means unsupported, the mobile-additive case. */
+const CODEX = adapter('codex', 'Codex', { planMode: false });
+
+beforeEach(() => {
+  resetAdapters();
+  seedAdapters([CLAUDE, CODEX]);
+});
+
+afterEach(() => {
+  resetAdapters();
+});
+
 describe('PermissionMenu', () => {
   it('defaults to the first execution mode when the step carries none', () => {
-    render(<PermissionMenu value={undefined} onChange={vi.fn()} testId="agent-a" />);
+    render(<PermissionMenu adapterId="claude" value={undefined} onChange={vi.fn()} testId="agent-a" />);
     const chip = screen.getByTestId('agent-a-permission');
     expect(chip).toHaveTextContent('Interactive');
     expect(chip).toHaveAttribute('aria-label', 'Permission: Interactive');
   });
 
   it('falls back to the first mode when the wire carries one this build does not know', () => {
-    render(<PermissionMenu value="plan" onChange={vi.fn()} testId="agent-a" />);
+    render(<PermissionMenu adapterId="claude" value="plan" onChange={vi.fn()} testId="agent-a" />);
     expect(screen.getByTestId('agent-a-permission')).toHaveTextContent('Interactive');
   });
 
-  it('offers every contract execution mode', async () => {
+  it('offers every contract execution mode on a provider that supports them all', async () => {
     const user = userEvent.setup();
-    render(<PermissionMenu value="default" onChange={vi.fn()} testId="agent-a" />);
+    render(<PermissionMenu adapterId="claude" value="default" onChange={vi.fn()} testId="agent-a" />);
     await user.click(screen.getByTestId('agent-a-permission'));
     for (const mode of EXECUTION_MODES) {
       expect(screen.getByTestId(`agent-a-permission-option-${mode}`)).toBeInTheDocument();
     }
   });
 
+  it('omits Auto for a provider whose adapter does not advertise it', async () => {
+    const user = userEvent.setup();
+    render(<PermissionMenu adapterId="codex" value="default" onChange={vi.fn()} testId="agent-a" />);
+    await user.click(screen.getByTestId('agent-a-permission'));
+    expect(screen.queryByTestId('agent-a-permission-option-auto')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-a-permission-option-yolo')).toBeInTheDocument();
+  });
+
   it('patches the permission mode on pick', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<PermissionMenu value="default" onChange={onChange} testId="agent-a" />);
+    render(<PermissionMenu adapterId="claude" value="default" onChange={onChange} testId="agent-a" />);
     await user.click(screen.getByTestId('agent-a-permission'));
     await user.click(screen.getByTestId('agent-a-permission-option-acceptEdits'));
     expect(onChange).toHaveBeenCalledExactlyOnceWith({ permissionMode: 'acceptEdits' });
   });
 
   it('renders the chip destructive on yolo only', () => {
-    const { rerender } = render(<PermissionMenu value="acceptEdits" onChange={vi.fn()} testId="agent-a" />);
+    const { rerender } = render(
+      <PermissionMenu adapterId="claude" value="acceptEdits" onChange={vi.fn()} testId="agent-a" />,
+    );
     expect(screen.getByTestId('agent-a-permission').className).not.toContain('text-destructive');
 
-    rerender(<PermissionMenu value="yolo" onChange={vi.fn()} testId="agent-a" />);
+    rerender(<PermissionMenu adapterId="claude" value="yolo" onChange={vi.fn()} testId="agent-a" />);
     const chip = screen.getByTestId('agent-a-permission');
     expect(chip).toHaveTextContent('Unattended');
     expect(chip.className).toContain('text-destructive');
+  });
+
+  it('renders the chip as a caution on auto, never as destructive', () => {
+    render(<PermissionMenu adapterId="claude" value="auto" onChange={vi.fn()} testId="agent-a" />);
+    const chip = screen.getByTestId('agent-a-permission');
+    expect(chip).toHaveTextContent('Auto');
+    expect(chip.className).toContain('text-warning');
+    expect(chip.className).not.toContain('text-destructive');
+  });
+
+  it('still labels a stored auto mode on a provider that cannot offer it', () => {
+    render(<PermissionMenu adapterId="codex" value="auto" onChange={vi.fn()} testId="agent-a" />);
+    expect(screen.getByTestId('agent-a-permission')).toHaveTextContent('Auto');
   });
 });

--- a/packages/ui/src/features/automations/steps/agent/resolve-step-adapter.ts
+++ b/packages/ui/src/features/automations/steps/agent/resolve-step-adapter.ts
@@ -1,0 +1,10 @@
+/**
+ * Which provider an Agent step's chips describe. Shared by the model chip and
+ * the permission chip: a step whose `adapterId` is unset still runs somewhere,
+ * and the two chips disagreeing about where would be a visible bug.
+ */
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+
+export function resolveStepAdapter(adapters: AdapterInfo[], adapterId: string | undefined): AdapterInfo | undefined {
+  return adapters.find((a) => a.id === adapterId) ?? adapters.find((a) => a.installed) ?? adapters[0];
+}

--- a/packages/ui/src/features/chat/composer/config-toolbar/ComposerToolbar.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/ComposerToolbar.tsx
@@ -62,7 +62,12 @@ export function ComposerToolbar() {
         setEffort={setEffort}
         setFeature={setFeature}
       />
-      <PermissionSelect chat={chat} setPermissionMode={setPermissionMode} providerDefaults={providerDefaults} />
+      <PermissionSelect
+        chat={chat}
+        adapter={adapter}
+        setPermissionMode={setPermissionMode}
+        providerDefaults={providerDefaults}
+      />
       {adapter != null && <PlanModeToggle chat={chat} adapter={adapter} setPlanMode={setPlanMode} />}
       <WorktreePopover chat={chat} hasMessages={hasMessages} busy={disabled} />
       <TuningWarningDialog

--- a/packages/ui/src/features/chat/composer/config-toolbar/PermissionSelect.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/PermissionSelect.tsx
@@ -3,8 +3,11 @@
 /**
  * PermissionSelect — Shield-icon trigger + dropdown of execution modes.
  *
- * Fixed list: Interactive / Auto-Edits / Unattended (mirrors desktop PERMISSION_MODES).
- * When the selected mode is 'yolo', the trigger is tinted text-destructive.
+ * Interactive / Auto-Edits / Auto / Unattended, least to most permissive. Auto is
+ * the Claude CLI's own mode and shows only for an adapter advertising
+ * capabilities.autoMode; the label is still resolved off the unfiltered list so a
+ * chat carrying a mode this adapter can't offer never renders the raw wire string.
+ * Tone tints the trigger and the option label: Unattended destructive, Auto caution.
  * NOT disabled while the chat is running — can be changed for the next turn.
  *
  * A floating list of choices is a native DropdownMenu (ledger rule, 2026-08-05).
@@ -14,7 +17,7 @@
 
 import { useState } from 'react';
 import { ChevronDown, Shield } from 'lucide-react';
-import type { Chat, ExecutionMode, ProviderConfig } from '@qlan-ro/mainframe-types';
+import type { AdapterInfo, Chat, ExecutionMode, ProviderConfig } from '@qlan-ro/mainframe-types';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -29,19 +32,34 @@ export interface PermissionSelectProps {
   chat: Chat;
   setPermissionMode: (mode: ExecutionMode) => void;
   providerDefaults?: ProviderConfig;
+  /** Resolved adapter for this chat; gates the Auto option. Null/absent while the catalog loads. */
+  adapter?: AdapterInfo | null;
 }
 
-const PERMISSION_MODES: { id: ExecutionMode; label: string; description: string }[] = [
+type ModeTone = 'caution' | 'destructive' | undefined;
+
+const PERMISSION_MODES: { id: ExecutionMode; label: string; description: string; tone?: ModeTone }[] = [
   { id: 'default', label: 'Interactive', description: 'Approve every action' },
   { id: 'acceptEdits', label: 'Auto-Edits', description: 'Edits auto-applied; commands ask' },
-  { id: 'yolo', label: 'Unattended', description: 'Runs without prompts' },
+  { id: 'auto', label: 'Auto', description: 'Claude decides which actions need approval', tone: 'caution' },
+  { id: 'yolo', label: 'Unattended', description: 'Runs without prompts', tone: 'destructive' },
 ];
 
-export function PermissionSelect({ chat, setPermissionMode, providerDefaults }: PermissionSelectProps) {
+const TONE_INK: Record<'caution' | 'destructive', string> = {
+  caution: 'text-warning',
+  destructive: 'text-destructive',
+};
+
+function toneInk(tone: ModeTone): string {
+  return tone == null ? 'text-muted-foreground' : TONE_INK[tone];
+}
+
+export function PermissionSelect({ chat, setPermissionMode, providerDefaults, adapter }: PermissionSelectProps) {
   const [open, setOpen] = useState(false);
   const currentMode: ExecutionMode = chat.permissionMode ?? providerDefaults?.defaultMode ?? 'default';
-  const isYolo = currentMode === 'yolo';
-  const currentLabel = PERMISSION_MODES.find((m) => m.id === currentMode)?.label ?? currentMode;
+  const current = PERMISSION_MODES.find((m) => m.id === currentMode);
+  const currentLabel = current?.label ?? currentMode;
+  const offered = PERMISSION_MODES.filter((m) => m.id !== 'auto' || adapter?.capabilities.autoMode === true);
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -59,7 +77,7 @@ export function PermissionSelect({ chat, setPermissionMode, providerDefaults }: 
               open && 'border-primary bg-sidebar-selection',
               'transition-colors',
               'focus-visible:outline-none',
-              isYolo ? 'text-destructive' : 'text-muted-foreground',
+              toneInk(current?.tone),
             )}
           >
             <Shield size={12} className="shrink-0" />
@@ -71,7 +89,7 @@ export function PermissionSelect({ chat, setPermissionMode, providerDefaults }: 
 
       <DropdownMenuContent align="start" side="top" sideOffset={6} className="min-w-40">
         <DropdownMenuGroup>
-          {PERMISSION_MODES.map((mode) => (
+          {offered.map((mode) => (
             <DropdownMenuItem
               key={mode.id}
               data-testid={`composer-permission-mode-select-option-${mode.id}`}
@@ -82,7 +100,7 @@ export function PermissionSelect({ chat, setPermissionMode, providerDefaults }: 
               )}
             >
               <span className="flex min-w-0 flex-col">
-                <span className="font-medium">{mode.label}</span>
+                <span className={cn('font-medium', mode.tone != null && TONE_INK[mode.tone])}>{mode.label}</span>
                 <span className="text-xs leading-snug text-muted-foreground">{mode.description}</span>
               </span>
             </DropdownMenuItem>

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/ComposerToolbar.test.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/ComposerToolbar.test.tsx
@@ -7,9 +7,11 @@
  *
  * Behaviors covered:
  *  1. toolbar renders nothing when chat is null
+ *  2. the resolved adapter reaches PermissionSelect, so a Claude-only mode is
+ *     offered on an adapter that advertises it (todo #325)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 // ---------------------------------------------------------------------------
@@ -148,5 +150,32 @@ describe('ComposerToolbar — no render when chat is null', () => {
     const { container } = renderToolbar();
 
     expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. the resolved adapter reaches PermissionSelect (todo #325)
+// ---------------------------------------------------------------------------
+
+describe('ComposerToolbar — adapter capabilities reach the permission picker', () => {
+  it('offers Auto when the resolved adapter advertises capabilities.autoMode', async () => {
+    const composerTuningMod = await import('../use-composer-tuning');
+    const base = vi.mocked(composerTuningMod.useComposerTuning).getMockImplementation();
+    vi.mocked(composerTuningMod.useComposerTuning).mockReturnValue({
+      ...base!([]),
+      adapter: {
+        id: 'claude',
+        name: 'Claude',
+        description: '',
+        installed: true,
+        models: [],
+        capabilities: { planMode: true, autoMode: true },
+      },
+    });
+
+    renderToolbar();
+    fireEvent.pointerDown(screen.getByTestId('composer-permission-mode-select'), { button: 0 });
+
+    expect(await screen.findByTestId('composer-permission-mode-select-option-auto')).toBeTruthy();
   });
 });

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/PermissionSelect.test.tsx
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/PermissionSelect.test.tsx
@@ -9,11 +9,15 @@
  *    is unset — the composer must not silently show "Interactive" for a user
  *    who configured "Unattended" (yolo) as their default.
  *  - An explicit chat.permissionMode always wins over providerDefaults.defaultMode.
+ *  - Todo #325: the Claude-only 'auto' mode is offered only when the resolved
+ *    adapter advertises capabilities.autoMode, its label still resolves when the
+ *    option is filtered out, and it reads as a caution rather than as the
+ *    destructive treatment Unattended keeps.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import type { Chat, ProviderConfig } from '@qlan-ro/mainframe-types';
+import type { AdapterInfo, Chat, ProviderConfig } from '@qlan-ro/mainframe-types';
 import { PermissionSelect } from '../PermissionSelect';
 
 // ---------------------------------------------------------------------------
@@ -36,12 +40,29 @@ function makeChat(overrides?: Partial<Chat>): Chat {
   };
 }
 
-function renderSelect(chat: Chat, providerDefaults?: ProviderConfig) {
+function makeAdapter(capabilities: AdapterInfo['capabilities']): AdapterInfo {
+  return {
+    id: 'claude',
+    name: 'Claude',
+    description: '',
+    installed: true,
+    models: [],
+    capabilities,
+  };
+}
+
+function renderSelect(chat: Chat, providerDefaults?: ProviderConfig, adapter?: AdapterInfo) {
   return render(
     <TooltipProvider>
-      <PermissionSelect chat={chat} setPermissionMode={vi.fn()} providerDefaults={providerDefaults} />
+      <PermissionSelect chat={chat} setPermissionMode={vi.fn()} providerDefaults={providerDefaults} adapter={adapter} />
     </TooltipProvider>,
   );
+}
+
+/** Radix menus open on pointerdown, not click. */
+async function openMenu(): Promise<void> {
+  fireEvent.pointerDown(screen.getByTestId('composer-permission-mode-select'), { button: 0 });
+  await screen.findByTestId('composer-permission-mode-select-option-default');
 }
 
 // ---------------------------------------------------------------------------
@@ -71,5 +92,66 @@ describe('PermissionSelect — explicit chat.permissionMode wins over providerDe
   it('shows "Auto-Edits" (chat mode) even when providerDefaults.defaultMode is yolo', () => {
     renderSelect(makeChat({ permissionMode: 'acceptEdits' }), { defaultMode: 'yolo' });
     expect(screen.getByTestId('composer-permission-mode-select').textContent).toContain('Auto-Edits');
+  });
+});
+
+describe('PermissionSelect — Auto is gated on the adapter capability (todo #325)', () => {
+  it('offers Auto when the adapter advertises capabilities.autoMode', async () => {
+    renderSelect(makeChat(), undefined, makeAdapter({ planMode: true, autoMode: true }));
+    await openMenu();
+    expect(screen.getByTestId('composer-permission-mode-select-option-auto')).toBeTruthy();
+  });
+
+  it('omits Auto when the adapter reports autoMode: false', async () => {
+    renderSelect(makeChat(), undefined, makeAdapter({ planMode: true, autoMode: false }));
+    await openMenu();
+    expect(screen.queryByTestId('composer-permission-mode-select-option-auto')).toBeNull();
+  });
+
+  it('omits Auto when the capabilities object has no autoMode key (placeholder adapter)', async () => {
+    renderSelect(makeChat(), undefined, makeAdapter({ planMode: false }));
+    await openMenu();
+    expect(screen.queryByTestId('composer-permission-mode-select-option-auto')).toBeNull();
+  });
+
+  it('omits Auto when no adapter is resolved yet', async () => {
+    renderSelect(makeChat());
+    await openMenu();
+    expect(screen.queryByTestId('composer-permission-mode-select-option-auto')).toBeNull();
+  });
+
+  it('labels the trigger "Auto" for a stored auto mode even with no adapter resolved', () => {
+    renderSelect(makeChat({ permissionMode: 'auto' }));
+    expect(screen.getByTestId('composer-permission-mode-select').textContent).toContain('Auto');
+    expect(screen.getByTestId('composer-permission-mode-select').textContent).not.toContain('auto');
+  });
+});
+
+describe('PermissionSelect — Auto reads as caution, Unattended stays destructive (todo #325)', () => {
+  it('tints the trigger text-warning when Auto is the current mode', () => {
+    renderSelect(makeChat({ permissionMode: 'auto' }));
+    const trigger = screen.getByTestId('composer-permission-mode-select');
+    expect(trigger.className).toContain('text-warning');
+    expect(trigger.className).not.toContain('text-destructive');
+  });
+
+  it('keeps the trigger text-destructive when Unattended is the current mode', () => {
+    renderSelect(makeChat({ permissionMode: 'yolo' }));
+    const trigger = screen.getByTestId('composer-permission-mode-select');
+    expect(trigger.className).toContain('text-destructive');
+    expect(trigger.className).not.toContain('text-warning');
+  });
+
+  it('gives the Auto option the warning tint and Unattended the destructive one', async () => {
+    renderSelect(makeChat(), undefined, makeAdapter({ planMode: true, autoMode: true }));
+    await openMenu();
+
+    const autoLabel = within(screen.getByTestId('composer-permission-mode-select-option-auto')).getByText('Auto');
+    expect(autoLabel.className).toContain('text-warning');
+    expect(autoLabel.className).not.toContain('text-destructive');
+
+    const yoloLabel = within(screen.getByTestId('composer-permission-mode-select-option-yolo')).getByText('Unattended');
+    expect(yoloLabel.className).toContain('text-destructive');
+    expect(yoloLabel.className).not.toContain('text-warning');
   });
 });

--- a/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/__tests__/synthesize-draft-chat.test.ts
@@ -29,13 +29,16 @@ describe('synthesizeDraftChat — maps base fields', () => {
     expect(chat.model).toBe('claude-3-sonnet');
   });
 
-  it.each(['default', 'acceptEdits', 'yolo'] as const)('maps permissionMode "%s" directly', (permissionMode) => {
-    const draft: DraftCfg = { projectId: 'p1', adapterId: 'claude', permissionMode };
+  it.each(['default', 'acceptEdits', 'auto', 'yolo'] as const)(
+    'maps permissionMode "%s" directly',
+    (permissionMode) => {
+      const draft: DraftCfg = { projectId: 'p1', adapterId: 'claude', permissionMode };
 
-    const chat = synthesizeDraftChat('__LOCALID_x', draft);
+      const chat = synthesizeDraftChat('__LOCALID_x', draft);
 
-    expect(chat.permissionMode).toBe(permissionMode);
-  });
+      expect(chat.permissionMode).toBe(permissionMode);
+    },
+  );
 
   it('preserves an unset permissionMode so the toolbar can show the provider default', () => {
     const draft: DraftCfg = { projectId: 'p1', adapterId: 'claude' };

--- a/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
+++ b/packages/ui/src/features/chat/composer/config-toolbar/synthesize-draft-chat.ts
@@ -8,14 +8,12 @@
  * they read only adapterId/model/permissionMode/planMode/effort + the feature
  * flags. The non-config fields are inert placeholders the controls never read.
  */
-import type { Chat } from '@qlan-ro/mainframe-types';
+import { EXECUTION_MODES, type Chat } from '@qlan-ro/mainframe-types';
 import type { DraftCfg } from '@/features/sessions/runtime/draft-config';
-
-const EXEC_MODES = ['default', 'acceptEdits', 'yolo'] as const;
 
 export function synthesizeDraftChat(id: string, d: DraftCfg): Chat {
   const permissionMode: Chat['permissionMode'] =
-    d.permissionMode !== undefined && (EXEC_MODES as readonly string[]).includes(d.permissionMode)
+    d.permissionMode !== undefined && (EXECUTION_MODES as readonly string[]).includes(d.permissionMode)
       ? (d.permissionMode as Chat['permissionMode'])
       : d.permissionMode === 'plan'
         ? 'default'

--- a/packages/ui/src/features/chat/gates/ChatGateMount.tsx
+++ b/packages/ui/src/features/chat/gates/ChatGateMount.tsx
@@ -1,4 +1,5 @@
-import { useChatPermissionFront } from '../runtime/use-chat-thread-runtime';
+import { useChatExtras, useChatPermissionFront } from '../runtime/use-chat-thread-runtime';
+import { useAdapters } from '@/store/adapters';
 import { PermissionGate } from './PermissionGate';
 import { AskUserQuestionGate } from './AskUserQuestionGate';
 import { PlanGate } from './PlanGate';
@@ -10,13 +11,24 @@ import { PlanGate } from './PlanGate';
  * An answered gate just unmounts: the daemon shifts the pending permission, so
  * the delivery re-read finds nothing to restore. An approved plan's durable
  * record is the transcript's PlanBubble, not this card.
+ *
+ * The chat's adapter is resolved here rather than in `PlanGate`, which stays
+ * prop-driven: the plan gate offers the CLI's `auto` execution mode only when
+ * that adapter advertises `capabilities.autoMode`.
  */
 export function ChatGateMount() {
   const { front, reply } = useChatPermissionFront();
+  const extras = useChatExtras();
+  const adapters = useAdapters();
+
   if (!front) return null;
+
+  const adapterId = extras?.state.chatConfig?.adapterId;
+  const adapter = adapters.find((a) => a.id === adapterId);
 
   const { toolName } = front.request;
   if (toolName === 'AskUserQuestion') return <AskUserQuestionGate entry={front} reply={reply} />;
-  if (toolName === 'ExitPlanMode') return <PlanGate entry={front} reply={reply} />;
+  if (toolName === 'ExitPlanMode')
+    return <PlanGate entry={front} reply={reply} autoAllowed={adapter?.capabilities.autoMode === true} />;
   return <PermissionGate entry={front} reply={reply} />;
 }

--- a/packages/ui/src/features/chat/gates/PlanExecModeControl.tsx
+++ b/packages/ui/src/features/chat/gates/PlanExecModeControl.tsx
@@ -1,4 +1,4 @@
-import { ShieldIcon, PencilIcon, ZapIcon } from 'lucide-react';
+import { ShieldIcon, PencilIcon, SparklesIcon, ZapIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Hint } from '@/components/ui/hint';
 import type { ComponentType } from 'react';
@@ -14,12 +14,22 @@ interface ExecModeOption {
 const EXEC_MODE_OPTIONS: ExecModeOption[] = [
   { id: 'default', label: 'Interactive', Icon: ShieldIcon, desc: 'Ask before each tool' },
   { id: 'acceptEdits', label: 'Auto-edits', Icon: PencilIcon, desc: 'Apply edits, ask to run' },
+  { id: 'auto', label: 'Auto', Icon: SparklesIcon, desc: 'Claude decides which actions need approval' },
   { id: 'yolo', label: 'Unattended', Icon: ZapIcon, desc: 'Run everything, no prompts' },
 ];
+
+/** Selected ink per mode; anything unlisted reads as the neutral `text-primary`.
+ *  Auto is a caution, not a hazard — only Unattended keeps the destructive ink. */
+const SELECTED_INK: Partial<Record<ExecutionMode, string>> = {
+  auto: 'text-warning',
+  yolo: 'text-destructive',
+};
 
 export interface PlanExecModeControlProps {
   value: ExecutionMode;
   onChange: (m: ExecutionMode) => void;
+  /** Only an adapter advertising `capabilities.autoMode` gets the Auto segment. */
+  autoAllowed?: boolean;
 }
 
 /**
@@ -30,12 +40,13 @@ export interface PlanExecModeControlProps {
  * `role="radio"`/`aria-checked`, which an e2e case pins. Chrome is the ledger's
  * segmented recipe: a `bg-muted` pad, active item `bg-background shadow-sm`.
  */
-export function PlanExecModeControl({ value, onChange }: PlanExecModeControlProps) {
+export function PlanExecModeControl({ value, onChange, autoAllowed }: PlanExecModeControlProps) {
+  const options = EXEC_MODE_OPTIONS.filter((o) => o.id !== 'auto' || autoAllowed === true);
+
   return (
     <div className="inline-flex gap-0.5 rounded-md border border-border bg-muted p-0.5">
-      {EXEC_MODE_OPTIONS.map(({ id, label, Icon, desc }) => {
+      {options.map(({ id, label, Icon, desc }) => {
         const selected = value === id;
-        const isYolo = id === 'yolo';
 
         return (
           <Hint key={id} label={desc}>
@@ -47,8 +58,7 @@ export function PlanExecModeControl({ value, onChange }: PlanExecModeControlProp
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1',
                 'text-xs font-semibold transition-colors',
-                selected && isYolo && 'bg-background text-destructive shadow-sm',
-                selected && !isYolo && 'bg-background text-primary shadow-sm',
+                selected && ['bg-background shadow-sm', SELECTED_INK[id] ?? 'text-primary'],
                 !selected && 'text-muted-foreground hover:text-foreground',
               )}
             >

--- a/packages/ui/src/features/chat/gates/PlanGate.tsx
+++ b/packages/ui/src/features/chat/gates/PlanGate.tsx
@@ -23,6 +23,8 @@ const REMARK_PLUGINS = [remarkGfm, remarkAppLinks, remarkBreaks];
 export interface PlanGateProps {
   entry: ChatPermissionEntry;
   reply: ReplyFn;
+  /** Resolved by the mount from the chat's adapter; omitted means no Auto segment. */
+  autoAllowed?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,15 +50,17 @@ function ControlsPanel({
   setExecMode,
   clearContext,
   setClearContext,
+  autoAllowed,
 }: {
   execMode: ExecutionMode;
   setExecMode: (m: ExecutionMode) => void;
   clearContext: boolean;
   setClearContext: (v: boolean) => void;
+  autoAllowed?: boolean;
 }) {
   return (
     <div className="mx-4 my-3 flex flex-wrap items-center gap-3 rounded-md border border-border bg-muted px-3 py-2.5">
-      <PlanExecModeControl value={execMode} onChange={setExecMode} />
+      <PlanExecModeControl value={execMode} onChange={setExecMode} autoAllowed={autoAllowed} />
       <div className="flex-1" />
       <PlanClearContextCheck checked={clearContext} onChange={setClearContext} />
     </div>
@@ -132,7 +136,7 @@ function ReviseRow({
 // PlanGate
 // ---------------------------------------------------------------------------
 
-export function PlanGate({ entry, reply }: PlanGateProps) {
+export function PlanGate({ entry, reply, autoAllowed }: PlanGateProps) {
   const [execMode, setExecMode] = useState<ExecutionMode>('default');
   const [clearContext, setClearContext] = useState(false);
   const [revising, setRevising] = useState(false);
@@ -168,6 +172,7 @@ export function PlanGate({ entry, reply }: PlanGateProps) {
           setExecMode={setExecMode}
           clearContext={clearContext}
           setClearContext={setClearContext}
+          autoAllowed={autoAllowed}
         />
         {revising ? (
           <ReviseRow

--- a/packages/ui/src/features/chat/gates/__tests__/ChatGateMount.test.tsx
+++ b/packages/ui/src/features/chat/gates/__tests__/ChatGateMount.test.tsx
@@ -2,10 +2,11 @@
  * ChatGateMount — behavior tests.
  *
  * Strategy:
- *  - Only `useChatPermissionFront` is mocked — the real gate components are
- *    used so that routing decisions are verified through observable DOM state
- *    (data-testids), not through inspecting which JSX branch the component
- *    chose.
+ *  - The runtime module is mocked for its two hooks (`useChatPermissionFront`
+ *    and `useChatExtras`) — the real gate components are used so that routing
+ *    decisions are verified through observable DOM state (data-testids), not
+ *    through inspecting which JSX branch the component chose.
+ *  - The adapters store is the real one, seeded per case.
  *  - All expected values are hardcoded; no logic mirrors the dispatch table
  *    inside ChatGateMount.
  *
@@ -23,19 +24,27 @@
  *  6. An answered plan gate unmounts when the queue front clears — nothing is
  *     retained past the answer.
  *  7. Routing keeps working after a plan gate was answered.
+ *  8. The plan gate's Auto exec-mode segment follows the chat adapter's
+ *     `capabilities.autoMode` — present for an adapter that advertises it,
+ *     absent for one that does not.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import type { AdapterInfo } from '@qlan-ro/mainframe-types';
+import { resetAdapters, seedAdapters } from '@/store/adapters';
 import type { ChatPermissionEntry } from '../../controller/chat-thread-state';
+import type { ChatRuntimeExtras } from '../../runtime/use-chat-thread-runtime';
 
 vi.mock('../../runtime/use-chat-thread-runtime', () => ({
   useChatPermissionFront: vi.fn(),
+  useChatExtras: vi.fn(),
 }));
-import { useChatPermissionFront } from '../../runtime/use-chat-thread-runtime';
+import { useChatExtras, useChatPermissionFront } from '../../runtime/use-chat-thread-runtime';
 import { ChatGateMount } from '../ChatGateMount';
 
 const mockFront = vi.mocked(useChatPermissionFront);
+const mockExtras = vi.mocked(useChatExtras);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -49,6 +58,14 @@ function entry(toolName: string, input: Record<string, unknown>): ChatPermission
     askedAt: 1,
     request: { requestId: 'r1', toolName, toolUseId: 'tu1', input, suggestions: [] },
   };
+}
+
+function adapter(id: string, capabilities: AdapterInfo['capabilities']): AdapterInfo {
+  return { id, name: id, description: '', installed: true, models: [], capabilities };
+}
+
+function extrasWithAdapter(adapterId: string): ChatRuntimeExtras {
+  return { state: { chatConfig: { adapterId } } } as unknown as ChatRuntimeExtras;
 }
 
 const permissionEntry = entry('Bash', { command: 'ls' });
@@ -70,6 +87,9 @@ function wrap(ui: React.ReactElement) {
 describe('ChatGateMount', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does not drop a mockReturnValue, so each case restates it.
+    mockExtras.mockReturnValue(undefined);
+    resetAdapters();
   });
 
   // --- Behavior 1: front undefined → renders nothing ---
@@ -178,5 +198,28 @@ describe('ChatGateMount', () => {
     );
     expect(screen.getByTestId('chat-permission-gate')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-question-gate')).toBeNull();
+  });
+
+  // --- Behavior 8: the plan gate's Auto segment follows the chat adapter ---
+
+  it('offers the Auto exec-mode segment when the chat adapter advertises autoMode', () => {
+    seedAdapters([adapter('claude', { planMode: true, autoMode: true })]);
+    mockExtras.mockReturnValue(extrasWithAdapter('claude'));
+    mockFront.mockReturnValue({ front: planEntry, reply });
+
+    wrap(<ChatGateMount />);
+
+    expect(screen.getByTestId('chat-plan-execmode-auto')).toBeInTheDocument();
+  });
+
+  it('omits the Auto exec-mode segment when the chat adapter does not advertise autoMode', () => {
+    seedAdapters([adapter('codex', { planMode: true })]);
+    mockExtras.mockReturnValue(extrasWithAdapter('codex'));
+    mockFront.mockReturnValue({ front: planEntry, reply });
+
+    wrap(<ChatGateMount />);
+
+    expect(screen.getByTestId('chat-plan-gate')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-plan-execmode-auto')).toBeNull();
   });
 });

--- a/packages/ui/src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx
+++ b/packages/ui/src/features/chat/gates/__tests__/PlanExecModeControl.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * PlanExecModeControl — behavior tests.
+ *
+ * Strategy:
+ *  - Fully prop-driven; the only context is TooltipProvider, which every
+ *    Hint-wrapped segment needs.
+ *  - Expected testids, labels and tint classes are hardcoded — never derived
+ *    from the option table inside the component.
+ *
+ * Behaviors covered:
+ *  1. The three always-on segments render in permissiveness order.
+ *  2. Auto renders only when `autoAllowed` is true — absent when false and when
+ *     the prop is omitted (an adapter that does not advertise the capability).
+ *  3. Auto sits between Auto-edits and Unattended.
+ *  4. A selected Auto reads as a caution (`text-warning`) and never carries the
+ *     destructive tint a selected Unattended keeps.
+ *  5. Clicking Auto reports `auto` to the caller.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { PlanExecModeControl } from '../PlanExecModeControl';
+import type { ExecutionMode } from '@qlan-ro/mainframe-types';
+
+function wrap(props: { value: ExecutionMode; onChange?: (m: ExecutionMode) => void; autoAllowed?: boolean }) {
+  return render(
+    <TooltipProvider>
+      <PlanExecModeControl
+        value={props.value}
+        onChange={props.onChange ?? (() => {})}
+        autoAllowed={props.autoAllowed}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe('PlanExecModeControl', () => {
+  // --- Behavior 1: the always-on segments ---
+
+  it('renders Interactive, Auto-edits and Unattended regardless of the auto capability', () => {
+    wrap({ value: 'default' });
+
+    expect(screen.getByTestId('chat-plan-execmode-default')).toHaveTextContent('Interactive');
+    expect(screen.getByTestId('chat-plan-execmode-acceptEdits')).toHaveTextContent('Auto-edits');
+    expect(screen.getByTestId('chat-plan-execmode-yolo')).toHaveTextContent('Unattended');
+  });
+
+  // --- Behavior 2: capability gating ---
+
+  it('renders the Auto segment when autoAllowed is true', () => {
+    wrap({ value: 'default', autoAllowed: true });
+
+    expect(screen.getByTestId('chat-plan-execmode-auto')).toHaveTextContent('Auto');
+  });
+
+  it('omits the Auto segment when autoAllowed is false', () => {
+    wrap({ value: 'default', autoAllowed: false });
+
+    expect(screen.queryByTestId('chat-plan-execmode-auto')).toBeNull();
+  });
+
+  it('omits the Auto segment when autoAllowed is not passed at all', () => {
+    wrap({ value: 'default' });
+
+    expect(screen.queryByTestId('chat-plan-execmode-auto')).toBeNull();
+  });
+
+  // --- Behavior 3: order ---
+
+  it('places Auto between Auto-edits and Unattended', () => {
+    wrap({ value: 'default', autoAllowed: true });
+
+    const ids = Array.from(document.querySelectorAll('button[data-testid^="chat-plan-execmode-"]')).map((b) =>
+      b.getAttribute('data-testid'),
+    );
+
+    expect(ids).toEqual([
+      'chat-plan-execmode-default',
+      'chat-plan-execmode-acceptEdits',
+      'chat-plan-execmode-auto',
+      'chat-plan-execmode-yolo',
+    ]);
+  });
+
+  // --- Behavior 4: caution tint, not destructive ---
+
+  it('tints a selected Auto with the warning ink and never the destructive one', () => {
+    wrap({ value: 'auto', autoAllowed: true });
+
+    const auto = screen.getByTestId('chat-plan-execmode-auto');
+    expect(auto).toHaveClass('text-warning');
+    expect(auto).not.toHaveClass('text-destructive');
+    expect(auto).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps the destructive tint on a selected Unattended', () => {
+    wrap({ value: 'yolo', autoAllowed: true });
+
+    const yolo = screen.getByTestId('chat-plan-execmode-yolo');
+    expect(yolo).toHaveClass('text-destructive');
+    expect(yolo).not.toHaveClass('text-warning');
+  });
+
+  it('leaves an unselected Auto on the muted ink', () => {
+    wrap({ value: 'default', autoAllowed: true });
+
+    const auto = screen.getByTestId('chat-plan-execmode-auto');
+    expect(auto).toHaveClass('text-muted-foreground');
+    expect(auto).not.toHaveClass('text-warning');
+  });
+
+  // --- Behavior 5: selection ---
+
+  it('reports auto to onChange when the Auto segment is clicked', () => {
+    const onChange = vi.fn();
+    wrap({ value: 'default', autoAllowed: true, onChange });
+
+    fireEvent.click(screen.getByTestId('chat-plan-execmode-auto'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('auto');
+  });
+});

--- a/packages/ui/src/features/chat/messages/PlanBubble.tsx
+++ b/packages/ui/src/features/chat/messages/PlanBubble.tsx
@@ -26,6 +26,7 @@ const REMARK_PLUGINS = [remarkGfm, remarkAppLinks, remarkBreaks];
 const EXEC_MODE_LABELS: Record<ExecutionMode, string> = {
   default: 'Interactive',
   acceptEdits: 'Auto-edits',
+  auto: 'Auto',
   yolo: 'Unattended',
 };
 

--- a/packages/ui/src/features/settings/panes/providers/ProviderConfigForm.tsx
+++ b/packages/ui/src/features/settings/panes/providers/ProviderConfigForm.tsx
@@ -136,7 +136,7 @@ export function ProviderConfigForm({ port, adapterId, label, adapter }: Provider
         <CodexTuningDefaults adapterId={adapterId} model={defaultModel} config={config} onChange={update} />
       )}
 
-      <SessionModeRadio adapterId={adapterId} config={config} onChange={update} />
+      <SessionModeRadio adapterId={adapterId} adapter={adapter} config={config} onChange={update} />
 
       {adapterId === 'claude' && (
         <CliProxyStatus adapterId={adapterId} models={adapter.models} config={config} onChange={update} />

--- a/packages/ui/src/features/settings/panes/providers/SessionModeRadio.tsx
+++ b/packages/ui/src/features/settings/panes/providers/SessionModeRadio.tsx
@@ -1,16 +1,19 @@
 import { MODE_OPTIONS } from '../../settings-tabs';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import type { ProviderConfig, ProviderConfigUpdate } from '@qlan-ro/mainframe-types';
+import type { AdapterInfo, ProviderConfig, ProviderConfigUpdate } from '@qlan-ro/mainframe-types';
 
 interface SessionModeRadioProps {
   adapterId: string;
+  adapter: AdapterInfo;
   config: ProviderConfig;
   onChange: (patch: ProviderConfigUpdate) => void;
 }
 
-/** Three-option radio group for the provider's default session mode. */
-export function SessionModeRadio({ adapterId, config, onChange }: SessionModeRadioProps) {
+/** Radio group for the provider's default session mode.
+ *  Auto is offered only for adapters advertising the `autoMode` capability. */
+export function SessionModeRadio({ adapterId, adapter, config, onChange }: SessionModeRadioProps) {
+  const modes = MODE_OPTIONS.filter((m) => m.id !== 'auto' || adapter.capabilities.autoMode === true);
   return (
     <div className="flex flex-col gap-1.5">
       <Label className="text-xs font-medium text-muted-foreground">Default Session Mode</Label>
@@ -19,7 +22,7 @@ export function SessionModeRadio({ adapterId, config, onChange }: SessionModeRad
         onValueChange={(v) => onChange({ defaultMode: v as NonNullable<ProviderConfig['defaultMode']> })}
         className="gap-1"
       >
-        {MODE_OPTIONS.map((mode) => (
+        {modes.map((mode) => (
           <label
             key={mode.id}
             className="flex items-start gap-2.5 px-3 py-2 rounded-md cursor-pointer hover:bg-accent transition-colors"
@@ -27,10 +30,10 @@ export function SessionModeRadio({ adapterId, config, onChange }: SessionModeRad
             <RadioGroupItem
               data-testid={`settings-${adapterId}-mode-option-${mode.id}`}
               value={mode.id}
-              className={`mt-0.5 ${mode.danger ? 'border-destructive/50 text-destructive [&_svg]:fill-destructive' : ''}`}
+              className={`mt-0.5 ${itemToneClass(mode)}`}
             />
             <div className="flex-1">
-              <span className={`text-sm ${mode.danger ? 'text-destructive' : 'text-foreground'}`}>{mode.label}</span>
+              <span className={`text-sm ${labelToneClass(mode)}`}>{mode.label}</span>
               <p className="text-xs text-muted-foreground">{mode.description}</p>
             </div>
           </label>
@@ -38,4 +41,20 @@ export function SessionModeRadio({ adapterId, config, onChange }: SessionModeRad
       </RadioGroup>
     </div>
   );
+}
+
+type ModeOption = (typeof MODE_OPTIONS)[number];
+
+/** The indicator dot is hard-coded `fill-primary` in the primitive, so a tinted
+ *  ring needs the matching fill override or the two inks disagree. */
+function itemToneClass(mode: ModeOption): string {
+  if (mode.danger) return 'border-destructive/50 text-destructive [&_svg]:fill-destructive';
+  if (mode.caution) return 'border-warning/50 text-warning [&_svg]:fill-warning';
+  return '';
+}
+
+function labelToneClass(mode: ModeOption): string {
+  if (mode.danger) return 'text-destructive';
+  if (mode.caution) return 'text-warning';
+  return 'text-foreground';
 }

--- a/packages/ui/src/features/settings/panes/providers/__tests__/SessionModeRadio.test.tsx
+++ b/packages/ui/src/features/settings/panes/providers/__tests__/SessionModeRadio.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { AdapterInfo, ProviderConfig } from '@qlan-ro/mainframe-types';
+import { SessionModeRadio } from '../SessionModeRadio';
+
+const config = {} as ProviderConfig;
+
+function adapterWith(capabilities: Record<string, boolean>): AdapterInfo {
+  return { id: 'claude', label: 'Claude', capabilities, models: [] } as unknown as AdapterInfo;
+}
+
+const withAuto = adapterWith({ planMode: true, autoMode: true });
+const withoutAuto = adapterWith({ planMode: true, autoMode: false });
+const capabilitiesOmitAuto = adapterWith({ planMode: true });
+
+describe('SessionModeRadio', () => {
+  it('offers Auto when the adapter advertises the capability', () => {
+    render(<SessionModeRadio adapterId="claude" adapter={withAuto} config={config} onChange={vi.fn()} />);
+    expect(screen.getByTestId('settings-claude-mode-option-auto')).toBeTruthy();
+  });
+
+  it('hides Auto when the adapter reports autoMode: false', () => {
+    render(<SessionModeRadio adapterId="claude" adapter={withoutAuto} config={config} onChange={vi.fn()} />);
+    expect(screen.queryByTestId('settings-claude-mode-option-auto')).toBeNull();
+  });
+
+  it('hides Auto when the capabilities object omits the key entirely', () => {
+    render(<SessionModeRadio adapterId="claude" adapter={capabilitiesOmitAuto} config={config} onChange={vi.fn()} />);
+    expect(screen.queryByTestId('settings-claude-mode-option-auto')).toBeNull();
+  });
+
+  it('tints Auto as a caution and keeps the destructive treatment for Unattended', () => {
+    render(<SessionModeRadio adapterId="claude" adapter={withAuto} config={config} onChange={vi.fn()} />);
+    const auto = screen.getByTestId('settings-claude-mode-option-auto');
+    expect(auto.className).toContain('border-warning/50');
+    // The primitive's own base classes carry aria-invalid destructive rings, so
+    // pin the tone classes the row adds rather than the substring.
+    expect(auto.className).not.toContain('border-destructive/50');
+    expect(auto.className).not.toContain('text-destructive');
+    const autoLabel = auto.closest('label')?.querySelector('span');
+    expect(autoLabel?.className).toContain('text-warning');
+
+    const yolo = screen.getByTestId('settings-claude-mode-option-yolo');
+    expect(yolo.className).toContain('border-destructive/50');
+    const yoloLabel = yolo.closest('label')?.querySelector('span');
+    expect(yoloLabel?.className).toContain('text-destructive');
+  });
+
+  it('leaves the Auto description on the muted ink, like the destructive row', () => {
+    render(<SessionModeRadio adapterId="claude" adapter={withAuto} config={config} onChange={vi.fn()} />);
+    const description = screen.getByTestId('settings-claude-mode-option-auto').closest('label')?.querySelector('p');
+    expect(description?.className).toContain('text-muted-foreground');
+    expect(description?.textContent).toBe('Claude decides which actions need approval');
+  });
+
+  it('selecting Auto emits the config update', () => {
+    const onChange = vi.fn();
+    render(<SessionModeRadio adapterId="claude" adapter={withAuto} config={config} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('settings-claude-mode-option-auto'));
+    expect(onChange).toHaveBeenCalledWith({ defaultMode: 'auto' });
+  });
+});

--- a/packages/ui/src/features/settings/settings-tabs.ts
+++ b/packages/ui/src/features/settings/settings-tabs.ts
@@ -17,12 +17,19 @@ export const MODE_OPTIONS: {
   label: string;
   description: string;
   danger?: boolean;
+  caution?: boolean;
 }[] = [
   { id: 'default', label: 'Interactive', description: 'Prompts for everything' },
   {
     id: 'acceptEdits',
     label: 'Auto-Accept Edits',
     description: 'Silently applies file edits, still prompts for bash',
+  },
+  {
+    id: 'auto',
+    label: 'Auto',
+    description: 'Claude decides which actions need approval',
+    caution: true,
   },
   {
     id: 'yolo',

--- a/packages/ui/src/store/adapters.ts
+++ b/packages/ui/src/store/adapters.ts
@@ -68,7 +68,9 @@ export function applyAdapterModels(
         byId: { ...s.byId, [adapterId]: { ...withInstall, models, modelsRevision, catalogSource: 'probed' } },
       };
     }
-    // Placeholder identity (planMode:false / id-as-name) that BRIEFLY lies until
+    // Placeholder identity that under-reports on purpose (every capability false,
+    // id-as-name), so a capability-gated control hides rather than offers a mode the
+    // real adapter may not support. It BRIEFLY lies until
     // the seed that follows reset-on-connect refreshes it via seedAdapters (blocker #11). The
     // ordering guarantee: seedAdaptersFor always fires getAdapters right after resetRevisionBaseline,
     // so the real snapshot overwrites identity within a few ms.
@@ -80,7 +82,7 @@ export function applyAdapterModels(
       models,
       modelsRevision,
       catalogSource: 'probed',
-      capabilities: { planMode: false },
+      capabilities: { planMode: false, autoMode: false },
     };
     return { byId: { ...s.byId, [adapterId]: partial } };
   });


### PR DESCRIPTION
## Summary
Adds the Claude CLI's native `auto` permission mode as a fourth, capability-gated execution mode alongside Default/Auto-Edits/Unattended. Auto is Claude-only, gated by a new `autoMode` flag on the adapter capabilities contract (mirrored across TypeScript and Rust, persisted in SQLite, and carried on the daemon wire), and surfaces in the composer picker, provider default-mode settings, the automations Ask-Agent permission chip, and the plan gate — filtered consistently by the same capability everywhere it appears.

Artifact links:
- Spec: docs/specs/2026-08-14-todo-325-claude-auto-permissions-mode.md
- Plan: docs/plans/2026-08-14-todo-325-claude-auto-permissions-mode.md

Review verdict: APPROVED (2 rounds). QA: 8/8.

## Key decisions
- `auto` is a fourth value of the one canonical execution mode (not Claude-local), mirrored in Rust and persisted in SQLite/wire — hard to reverse once rows exist.
- Auto is gated by `capabilities.autoMode` (the `planMode` precedent), never by adapter-id comparison — hard to reverse once the wire-visible capabilities object is read by UI and mobile.
- Native CLI `auto`, verified live in CLI 2.1.224; no CLI version probe today, so a minimum version is documented instead.
- A Codex session carrying `auto` runs as Interactive with an explicit match arm and logs the coercion, rather than falling through an `else`.
- UI copy describes the mechanism ("Claude decides which actions need approval"), promising no specific prompt-count reduction.
- Caution (warning) tint for Auto; destructive tint stays reserved for Unattended, per the user's 2026-08-14 ruling.
- Provider default-mode settings also offer Auto, filtered by the same capability so the two mode lists never disagree.
- Auto sits between Auto-Edits and Unattended in the picker (least-to-most-permissive order preserved).
- The automations Ask-Agent permission picker is filtered by the step's resolved provider, so Auto doesn't leak into Codex steps.

## Test plan
- [x] `cargo test --workspace` (full suite, all crates)
- [x] `pnpm --filter @qlan-ro/mainframe-types build`
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck`
- [x] Vitest coverage for capability-gated Auto across composer, settings, automations, and plan gate surfaces
- [x] QA: 8/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>