### PR TITLE
fix(ui): order session list by recent activity in every grouping (#331)

### DIFF
--- a/.changeset/session-list-order-by-activity.md
+++ b/.changeset/session-list-order-by-activity.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Sort the sidebar's session list by recent activity in every grouping. Grouping by project used to list each project's sessions in the order the app happened to receive them — an order that changed between restarts — and the name and status modes left their ties there too. Each section now leads with the most recently active session, and every mode resolves ties the same way.

--- a/docs/plans/2026-08-14-session-list-order-by-activity-plan.md
+++ b/docs/plans/2026-08-14-session-list-order-by-activity-plan.md
@@ -30,6 +30,10 @@ sidebar destroys it by design (see Established facts), so a daemon-side change c
 - Pure logic stays in the view-model module, not in a React component or hook body. `arrangeSessions` keeps its
   `now`-injected signature so tests stay deterministic.
 - `noUncheckedIndexedAccess: true` (`packages/ui/tsconfig.json:19`) — avoid raw index reads in test helpers.
+- `noUnusedLocals` / `noUnusedParameters: true` (`packages/ui/tsconfig.json:16-17`) and `"include": ["src"]` (`:26`),
+  which covers `__tests__`. **Every helper, constant, and function must land in the same task as its first
+  consumer** — an intermediate commit that adds an unused module-scope declaration fails `typecheck` with TS6133,
+  and the same rule kills any "introduce it now, wire it up next task" split on the implementation side.
 - A changeset is required before commit; the pre-push hook rejects without one.
 - No `@ts-ignore`, no dead code, no deferred cleanups.
 
@@ -135,53 +139,62 @@ from `/Users/doruchiulan/Projects/qlan/mainframe/.worktrees/todo-331-session-lis
 - `docs/plans/` is gitignored, so this plan is committed with `git add -f`. Receipt: `.gitignore:53`.
 - The UI package compiles with `noUncheckedIndexedAccess: true`, so a test helper must not read array slots by
   index without a guard. Receipt: `packages/ui/tsconfig.json:19`.
+- The same options block sets `noUnusedLocals`/`noUnusedParameters: true` (`:16-17`) and `"include": ["src"]` (`:26`),
+  so the test file is typechecked and **any** unused top-level declaration — `const` fixtures included, not only
+  functions — is a hard error. Receipt: dropping a throwaway file with one unused `const` and one unused function
+  into `src/features/sessions/view-model/__tests__/` and running the repo's own `packages/ui/node_modules/.bin/tsc
+  --noEmit` reported `error TS6133: 'UNUSED_CONST' is declared but its value is never read.` and the same for the
+  function. This is why the task list has no "add helpers" step of its own.
+- Only one pre-existing assertion orders two sessions that share the default `updatedAt` (`TODAY_1100` from the
+  `item()` helper): `group-sessions.test.ts:155` (`idsOf(groups, 'Beta')` → `['b1','b2']`). Every other multi-item
+  assertion uses distinct timestamps, titles, or statuses, so the new `id` tiebreak cannot silently flip them.
+  Receipts: `group-sessions.test.ts:88,122,129,155,193`.
+- `arrangeByProject` already sorts the Pinned group (`group-sessions.ts:94`), so project-mode Pinned ordering is a
+  regression guard, not a red test. `arrangeFlat` (`:69`) does not, so name-mode and status-mode Pinned ordering
+  does start red.
 
 ## Tasks
 
 ### Group: tests (red phase)
 
-All five tasks edit **one** file:
+All four tasks edit **one** file:
 `packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts`.
 Run with `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/group-sessions.test.ts`.
 
 These tests must be written and observed **failing** before `group-sessions.ts` changes. Do not touch
 `group-sessions.ts` in this group.
 
-**Task 1 — Add the deterministic shuffle helper and tie-carrying fixtures.**
-Add to the existing helper block at the top of the file:
-- A `mulberry32(seed: number): () => number` PRNG (no `Math.random`, so failures reproduce).
-- `seededShuffle(items: SessionItem[], seed: number): SessionItem[]` implemented as a decorate–sort–undecorate
-  (`items.map((it) => ({ it, k: rand() })).sort((a, b) => a.k - b.k).map((e) => e.it)`) — no indexed swaps, which
-  `noUncheckedIndexedAccess` rejects.
-- A `serialize(groups)` helper returning `groups.map((g) => [g.label, g.items.map((i) => i.id)])` for whole-output
-  comparison.
-- Timestamp constants for a multi-project fixture with **deliberate ties**: at least one pair of sessions sharing
-  an identical `updatedAt`, one pair sharing an identical `title`, and several sharing `displayStatus`.
+There is deliberately **no "add the helpers" task**. `noUnusedLocals` (see Constraints) makes an unused helper a
+typecheck error, so each helper and fixture constant is introduced by the task that first uses it.
 
-*Verification:* the file still typechecks (`pnpm --filter @qlan-ro/mainframe-ui typecheck`) and the pre-existing
-tests still run. New helpers may be unused at this point.
-
-**Task 2 — Update the existing project-mode assertion that reads as array order.**
+**Task 1 — Update the existing project-mode assertion that reads as array order.**
 The test at `group-sessions.test.ts:147-157` ("emits one section per project…") builds `b1`/`b2` with the fixture's
 default `updatedAt`, so `expect(idsOf(groups, 'Beta')).toEqual(['b1', 'b2'])` asserts nothing about ordering. Give
-`b1` an *older* `updatedAt` than `b2` and assert `['b2', 'b1']`.
+`b1` an *older* `updatedAt` than `b2` and assert `['b2', 'b1']`. This is the only pre-existing assertion that
+orders same-timestamp sessions (see Established facts), so no other existing test needs a fixture change.
 
-*Verification:* that test fails against today's implementation with `['b1','b2']` received.
+*Verification:* that test fails against today's implementation with `['b1','b2']` received; every other test in the
+file still passes.
 
-**Task 3 — Add project-mode ordering tests.**
-In the `arrangeSessions mode 'project'` describe block:
+**Task 2 — Add project-mode ordering tests.**
+In the `arrangeSessions mode 'project'` describe block. Introduce the timestamp constants these fixtures need in
+this task (at least one pair of sessions sharing an identical `updatedAt`, for the ghost-tiebreak case):
 - Sessions inside a project section are ordered newest-activity first (≥3 sessions, distinct timestamps,
   inserted in a non-recency input order).
 - The unknown-project fallback section is ordered by the same rule.
 - With **two** ghost projects, the ghost sections themselves are ordered by their newest session's activity,
   descending, and still trail every known-project section.
 - Two ghost buckets whose newest activity is identical are ordered by `projectId` ascending.
-- Pinned interaction: a pinned session is lifted out of its project section (that section still renders its
-  remaining sessions in recency order), and a multi-session Pinned group is itself recency-ordered.
+- Pinned interaction: a pinned session is lifted out of its project section and that section still renders its
+  remaining sessions in recency order.
+- Regression guard (**passes today**): a multi-session Pinned group in project mode is recency-ordered.
+  `arrangeByProject` already sorts Pinned at `group-sessions.ts:94`; this assertion exists so Tasks 5 and 8,
+  which both rewrite that function, cannot regress it.
 
-*Verification:* every new assertion in this task fails against today's implementation; record which.
+*Verification:* every assertion above **except** the last one fails against today's implementation; the
+regression guard passes from the moment it is written. Record the observed failures.
 
-**Task 4 — Add name-mode and status-mode tie tests.**
+**Task 3 — Add name-mode and status-mode tie tests.**
 - `name`: two sessions with the identical title resolve by `updatedAt` descending; the overall A–Z ordering is
   unchanged for distinct titles.
 - `name`: the Pinned group with ≥2 pinned sessions is ordered by `updatedAt` descending.
@@ -189,13 +202,23 @@ In the `arrangeSessions mode 'project'` describe block:
   working → waiting → idle rank order is unchanged.
 - `status`: the Pinned group with ≥2 pinned sessions is ordered by `updatedAt` descending.
 
-*Verification:* the four new assertions fail today (unsorted pinned; ties in incoming order).
+*Verification:* the four new assertions fail today — `arrangeFlat` (`group-sessions.ts:69`) pushes Pinned
+unsorted, and both rest sorts leave ties in incoming order.
 
-**Task 5 — Add the shuffle-invariance property test.**
-One `describe('arrangeSessions is independent of input order')` block:
+**Task 4 — Add the shuffle-invariance property test, with its helpers.**
+One `describe('arrangeSessions is independent of input order')` block. Add the helpers it consumes in this same
+task — they have no other consumer, and adding them earlier would fail `typecheck` under `noUnusedLocals`:
+- A `mulberry32(seed: number): () => number` PRNG (no `Math.random`, so failures reproduce).
+- `seededShuffle(items: SessionItem[], seed: number): SessionItem[]` implemented as a decorate–sort–undecorate
+  (`items.map((it) => ({ it, k: rand() })).sort((a, b) => a.k - b.k).map((e) => e.it)`) — no indexed swaps, which
+  `noUncheckedIndexedAccess` rejects.
+- A `serialize(groups)` helper returning `groups.map((g) => [g.label, g.items.map((i) => i.id)])` for whole-output
+  comparison.
+
+The test body:
 - Build one fixture of ~10 sessions spanning: 2 known projects (`PROJECTS`), 2 ghost projects, ≥2 pinned
-  sessions, all three `displayStatus` values, sessions in today/yesterday/earlier buckets, **and** the planted
-  ties from Task 1 (equal `updatedAt`, equal titles).
+  sessions, all three `displayStatus` values, sessions in today/yesterday/earlier buckets, and **planted ties** —
+  an equal-`updatedAt` pair and an equal-`title` pair.
 - For each mode in `['recent', 'name', 'status', 'project']` and each seed in a fixed list (e.g. `[1, 2, 3, 7, 42]`),
   assert `serialize(arrangeSessions(seededShuffle(fixture, seed), mode, NOW, PROJECTS))` equals
   `serialize(arrangeSessions(fixture, mode, NOW, PROJECTS))`.
@@ -207,31 +230,35 @@ re-break it.
 
 ### Group: impl
 
-Tasks 6–9 edit **one** file: `packages/ui/src/features/sessions/view-model/group-sessions.ts`.
-Task 10 adds one new changeset file. Task 11 is the verification gate.
+Tasks 5–8 edit **one** file: `packages/ui/src/features/sessions/view-model/group-sessions.ts`.
+Task 9 adds one new changeset file. Task 10 is the verification gate.
 
-**Task 6 — Introduce the total comparator.**
+**Task 5 — Replace `byUpdatedDesc` with the total comparator.**
 In `group-sessions.ts`, replace `byUpdatedDesc` (`:41-43`) with `byRecency` per the Design section, plus a
-module-private `compareIds`. One short comment on `byRecency` explaining *why* the id tiebreak exists (the
-incoming array order is not a trustworthy fallback). Delete `byUpdatedDesc`; leave no alias behind.
+module-private `compareIds`, **and switch all three existing call sites in the same edit** — `arrangeRecent`
+(`:60-63`, four sorts) and `arrangeByProject` (`:94`). Deleting the old function without its callers leaves the
+file uncompilable, and introducing the new one without callers trips `noUnusedLocals`. One short comment on
+`byRecency` explaining *why* the id tiebreak exists (the incoming array order is not a trustworthy fallback).
+Leave no alias behind.
 
-*Verification:* `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes; no reference to `byUpdatedDesc` remains
-(`grep -Rn byUpdatedDesc packages/ui/src` is empty).
+*Verification:* `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes; `grep -Rn byUpdatedDesc packages/ui/src`
+is empty; the test run introduces **no new failures** — the `recent`-mode tests and the Task 2 regression guard
+stay green, and the red tests from Tasks 1–4 stay red except where recency ties in already-sorted groups now
+resolve.
 
-**Task 7 — Sort every group in the `recent` and flat paths.**
-- `arrangeRecent` (`:45-65`): the three buckets and the Pinned group all sort with `byRecency`.
-- `arrangeFlat` (`:67-72`): the Pinned group is sorted with `byRecency` instead of being pushed as received.
-  Sort a copy; never mutate the caller's array.
+**Task 6 — Sort the Pinned group on the flat paths.**
+`arrangeFlat` (`:67-72`) pushes `pinned` as received; sort it with `byRecency`. Sort a copy; never mutate the
+caller's array.
 
-*Verification:* the `recent` mode tests and the two new Pinned tests from Task 4 pass.
+*Verification:* the two new Pinned tests from Task 3 pass.
 
-**Task 8 — Give `name` and `status` deterministic tiebreaks.**
+**Task 7 — Give `name` and `status` deterministic tiebreaks.**
 - `name` (`:123-126`): `(a.title ?? '').localeCompare(b.title ?? '') || byRecency(a, b)`.
 - `status` (`:128-133`): `(rankA - rankB) || byRecency(a, b)`, keeping the existing `?? 3` unknown-status rank.
 
-*Verification:* the Task 4 tests pass; the pre-existing name/status tests still pass.
+*Verification:* the Task 3 tests pass; the pre-existing name/status tests still pass.
 
-**Task 9 — Order project sections' contents and the ghost run.**
+**Task 8 — Order project sections' contents and the ghost run.**
 In `arrangeByProject` (`:85-108`):
 - Sort each known-project section's items with `byRecency` before pushing.
 - Collect the leftover ghost buckets, sort their items with `byRecency`, and emit the sections ordered by each
@@ -240,9 +267,9 @@ In `arrangeByProject` (`:85-108`):
   replaces.
 Keep the function under 50 lines; extract a small `ghostSections(...)` helper if it would exceed that.
 
-*Verification:* every project-mode test (Tasks 2, 3) and the shuffle test (Task 5) passes.
+*Verification:* every project-mode test (Tasks 1, 2) and the shuffle test (Task 4) passes.
 
-**Task 10 — Add the changeset.**
+**Task 9 — Add the changeset.**
 Create `.changeset/session-list-order-by-activity.md` with front matter `'@qlan-ro/mainframe-ui': patch` and a
 one-paragraph, user-facing description: grouping sessions by project now lists each project's sessions
 most-recently-active first, and every sort mode resolves ties the same way instead of falling back to whatever
@@ -251,7 +278,7 @@ order the app happened to receive.
 *Verification:* the file exists and its YAML front matter parses (matches the shape of any existing
 `.changeset/*.md`).
 
-**Task 11 — Full verification gate.**
+**Task 10 — Full verification gate.**
 - `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/group-sessions.test.ts` — all green.
 - `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/project-activity.test.ts src/features/sessions/view-model/__tests__/archived-sessions.test.ts` — unchanged neighbours still green.
 - `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean (it includes test files).
@@ -262,11 +289,11 @@ order the app happened to receive.
 
 | Criterion | Covered by |
 |---|---|
-| Project sections list sessions newest-activity first | Tasks 3, 9 |
-| The unknown-project fallback section follows the same rule | Tasks 3, 9 |
-| Section order unchanged; Pinned still leads | Tasks 3, 9 (assertions), `project-activity.ts` untouched |
-| A send moves the session to the top of its section, no restart | Task 3 + the reload receipt in Established facts |
-| Shuffled input yields identical output, every mode | Tasks 5, 6–9 |
-| Name and status ties resolve by last activity descending | Tasks 4, 8 |
-| Existing array-order assertions updated to recency | Task 2 |
-| Unit tests cover buckets, fallback, pinned, shuffle invariance | Tasks 2–5 |
+| Project sections list sessions newest-activity first | Tasks 2, 8 |
+| The unknown-project fallback section follows the same rule | Tasks 2, 8 |
+| Section order unchanged; Pinned still leads | Tasks 2, 8 (assertions), `project-activity.ts` untouched |
+| A send moves the session to the top of its section, no restart | Task 2 + the reload receipt in Established facts |
+| Shuffled input yields identical output, every mode | Tasks 4, 5–8 |
+| Name and status ties resolve by last activity descending | Tasks 3, 7 |
+| Existing array-order assertions updated to recency | Task 1 |
+| Unit tests cover buckets, fallback, pinned, shuffle invariance | Tasks 1–4 |

--- a/docs/plans/2026-08-14-session-list-order-by-activity-plan.md
+++ b/docs/plans/2026-08-14-session-list-order-by-activity-plan.md
@@ -1,0 +1,272 @@
+# Session list: order every group by recent activity (todo #331)
+
+## Goal
+
+The sessions sidebar's "Project" sort mode groups sessions into one section per project but never sorts a
+section's contents, so each project's rows appear in whatever order the client first saw them — an order that
+differs between app restarts and drifts as the app runs. Make `arrangeSessions` order every group it emits by
+last-activity timestamp descending, and make every sort mode produce a *total* order so no mode can inherit the
+incoming array's order for ties. The change is confined to one pure view-model module in `packages/ui` and its
+unit test file: the daemon already returns the right order, and the thread-list runtime between the wire and the
+sidebar destroys it by design (see Established facts), so a daemon-side change could not reach the screen.
+
+## Scope
+
+**Touched files (all of them):**
+
+| File | Change |
+|---|---|
+| `packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts` | Update 1 assertion, add ordering + shuffle-invariance tests |
+| `packages/ui/src/features/sessions/view-model/group-sessions.ts` | Add a total comparator; apply it in all four modes |
+| `.changeset/session-list-order-by-activity.md` | New — patch bump for `@qlan-ro/mainframe-ui` |
+
+**Not touched, deliberately:** the Rust daemon (already orders `pinned DESC, updated_at DESC`), `chats-remote-adapter.ts`,
+`project-activity.ts` (section ordering is already shuffle-invariant), `archived-sessions.ts`, `SessionSidebar.tsx`,
+`SessionsSection.tsx`, `SessionSortMenu.tsx`, `SESSION_SORTS`, the E2E suite (no spec asserts sidebar ordering —
+`packages/e2e/tests` has no reference to `sessions-sort-*`).
+
+**Constraints from CLAUDE.md that bind this change:**
+- Max 300 lines/file, 50 lines/function. `group-sessions.ts` is 141 lines today and lands around 175 — no split needed.
+- Pure logic stays in the view-model module, not in a React component or hook body. `arrangeSessions` keeps its
+  `now`-injected signature so tests stay deterministic.
+- `noUncheckedIndexedAccess: true` (`packages/ui/tsconfig.json:19`) — avoid raw index reads in test helpers.
+- A changeset is required before commit; the pre-push hook rejects without one.
+- No `@ts-ignore`, no dead code, no deferred cleanups.
+
+## Design
+
+### The total comparator
+
+Add one module-private comparator to `group-sessions.ts` and route every sort through it:
+
+```
+byRecency(a, b) = (b.custom.updatedAt - a.custom.updatedAt) || compareIds(a, b)
+compareIds(a, b) = a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+```
+
+`compareIds` uses raw `<`/`>` (UTF-16 code-unit order), not `localeCompare`, so the result cannot vary with the
+host locale. `byRecency` replaces the existing `byUpdatedDesc`, which is deleted — it has no remaining caller.
+
+### Per-mode application
+
+| Mode | Rest ordering | Pinned ordering |
+|---|---|---|
+| `recent` | `byRecency` inside each of Today / Yesterday / Earlier (unchanged key, now total) | `byRecency` (unchanged) |
+| `name` | `(a.title ?? '').localeCompare(b.title ?? '') \|\| byRecency(a, b)` | `byRecency` (**was unsorted**) |
+| `status` | `rankDelta \|\| byRecency(a, b)` | `byRecency` (**was unsorted**) |
+| `project` | `byRecency` inside every section, known and ghost (**was unsorted**) | `byRecency` (unchanged) |
+
+`arrangeFlat` currently pushes `pinned` straight through (`group-sessions.ts:69`), which is the same array-order
+leak on the `name` and `status` modes. It takes a sorted `pinned` from the caller, or sorts internally — either
+is fine, as long as the leak is gone.
+
+### Ghost sections (projects absent from the project list)
+
+Known-project sections stay in `sortedProjects` order and still lead; ghost sections still trail all of them.
+Within the ghost run, order by the bucket's newest `updatedAt` descending, then by `projectId` ascending
+(UTF-16 order). The current "first appearance" rule is array-order-derived and cannot survive the shuffle
+criterion. The module doc comment on `arrangeByProject` says "in order of first appearance" — update it.
+
+### Decisions taken while planning
+
+1. **Pinned is ordered by recency in every mode, not by the mode's own key.** The brief says the Pinned section
+   "keeps its existing behavior (pinned sessions lifted out, sorted by the same key)", and the two modes that
+   already sort it (`recent`, `project`) sort it by recency. Making name-mode Pinned alphabetical would be a
+   larger, unrequested behavior change. Recency everywhere is the minimal reading that also closes the leak.
+2. **Ghost sections are ordered by bucket recency, then `projectId`.** Not named in the brief, but the
+   shuffle-invariance criterion covers group *order* as well as group contents, and "first appearance" is exactly
+   the array-order dependence the brief forbids.
+3. **`id` is the final tiebreak, beyond the brief's explicit asks.** The brief asks for "a total order"; two
+   sessions can genuinely share an `updatedAt` (it is an ISO string rendered to ms), and without a final key such
+   a pair falls back to array order. `SessionItem.id` is the stable thread-list mapping id, so it is a safe,
+   unique last resort.
+4. **The comparator stays local to `group-sessions.ts`.** The `updatedAt`-descending expression also appears in
+   `archived-sessions.ts:19` — two sites, below the repo's 3+ extraction threshold. Extracting it would change
+   the archived dialog's ordering (adding the id tiebreak) and its tests, which is scope creep on a bug fix.
+
+### Out of scope (do not "fix" these in this pass)
+
+- `arrangeFlat` emits its `A–Z` / `By status` group even when `rest` is empty. Pre-existing, unrelated to
+  ordering, and shuffle-invariant either way.
+- Persisting the sort mode across restarts; new sort modes; running-first or unread-first ordering; the rail
+  Tasks panel (#334); the daemon's chat list route; the thread-list runtime's record merge.
+
+## Established facts
+
+Every line below was verified in this repo or in resolved `node_modules` while planning. Paths are repo-relative
+from `/Users/doruchiulan/Projects/qlan/mainframe/.worktrees/todo-331-session-list-order-by-activity`.
+
+- The array the sidebar consumes is built with `Object.keys(runtimeState.threadItems).map(...)` — its order is the
+  record's key-insertion order, not any sort. Receipt: `node_modules/@assistant-ui/core/dist/store/runtime-clients/thread-list-runtime-client.js:46`.
+- `threadItems` is that record: `get threadItems() { return this._state.value.threadData; }`, typed
+  `Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>`. Receipts:
+  `node_modules/@assistant-ui/core/dist/react/runtimes/RemoteThreadListThreadListRuntimeCore.js:35-37`,
+  `.../RemoteThreadListThreadListRuntimeCore.d.ts:29`.
+- Each list refresh merges by spread — `threadData: { ...state.threadData, ...fresh.threadData }` — so an existing
+  chat's entry is refreshed **in place** (keeping its key position) and a newly seen chat's key is **appended**.
+  This is why rendered order equals "order this client first saw each session". Receipt:
+  `node_modules/@assistant-ui/core/dist/react/runtimes/RemoteThreadListThreadListRuntimeCore.js:63-70` (same
+  pattern for `loadMore` at `:101-115`).
+- `@assistant-ui/react` is pinned at `0.15.13`. Receipt: `node_modules/@assistant-ui/react/package.json` (`version`).
+- The daemon does return the right order; it is discarded downstream. Receipts:
+  `packages/core-rs/crates/mainframe-db/src/chats.rs:144` (`ORDER BY pinned DESC, updated_at DESC`), `:153`
+  (`... , rowid DESC`), `:201`.
+- The daemon bumps `chats.updated_at` on message send and on turn results, so it reads as "last turn activity".
+  Receipts: `packages/core-rs/crates/mainframe-chat/src/chat_manager/send_entry.rs:120-127` (`set_working`
+  writes `updated_at: Some(now)`), `packages/core-rs/crates/mainframe-chat/src/event_handler.rs:814-822`
+  (result handler writes `updated_at: Some(now.clone())`).
+- `updated_at` is written only when a caller passes it — `ChatUpdate.updated_at` is an explicit `Option<String>`
+  field, so config edits (pin/rename/tuning) that omit it do not bump the timestamp. Receipts:
+  `packages/core-rs/crates/mainframe-db/src/chats.rs:65` (field), `:374-376` (the conditional `SET`).
+- `chat.updated` triggers `threads.reload()` (coalesced), so a live send re-lists and refreshes `updatedAt` in
+  place — no restart needed for a row to move. Receipts:
+  `packages/ui/src/features/sessions/ws/use-session-list-router.ts:7-8,112-124`.
+- The ordering key reaches the UI as epoch ms: `updatedAt: new Date(chat.updatedAt).getTime()`. Receipt:
+  `packages/ui/src/features/sessions/view-model/chat-to-thread-custom.ts:72`.
+- Project *section* order is already shuffle-invariant: max `updatedAt` per project descending, tiebroken by the
+  project list's own index. Receipt: `packages/ui/src/features/sessions/view-model/project-activity.ts:4-19`,
+  called at `packages/ui/src/features/sessions/SessionSidebar.tsx:103` and passed into `arrangeSessions` at `:112`.
+- `arrangeSessions` has exactly one production caller. Receipt: `packages/ui/src/features/sessions/SessionSidebar.tsx:112`.
+- `Array.prototype.sort` is stable (ES2019+), so the existing sorts do not scramble ties — they *preserve* the
+  untrustworthy incoming order, which is the defect. Receipt: verified on this machine's Node v24.13.1 —
+  sorting 12 equal-key records by `(x, y) => x.k - y.k` returned them in the original index order `0..11`.
+- `@qlan-ro/mainframe-types` and `@qlan-ro/mainframe-ui` are version-locked, so a UI-only patch changeset is
+  correct and the release tooling bumps both. Receipt: `.changeset/config.json` → `"fixed": [["@qlan-ro/mainframe-types", "@qlan-ro/mainframe-ui"]]`.
+- `docs/plans/` is gitignored, so this plan is committed with `git add -f`. Receipt: `.gitignore:53`.
+- The UI package compiles with `noUncheckedIndexedAccess: true`, so a test helper must not read array slots by
+  index without a guard. Receipt: `packages/ui/tsconfig.json:19`.
+
+## Tasks
+
+### Group: tests (red phase)
+
+All five tasks edit **one** file:
+`packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts`.
+Run with `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/group-sessions.test.ts`.
+
+These tests must be written and observed **failing** before `group-sessions.ts` changes. Do not touch
+`group-sessions.ts` in this group.
+
+**Task 1 — Add the deterministic shuffle helper and tie-carrying fixtures.**
+Add to the existing helper block at the top of the file:
+- A `mulberry32(seed: number): () => number` PRNG (no `Math.random`, so failures reproduce).
+- `seededShuffle(items: SessionItem[], seed: number): SessionItem[]` implemented as a decorate–sort–undecorate
+  (`items.map((it) => ({ it, k: rand() })).sort((a, b) => a.k - b.k).map((e) => e.it)`) — no indexed swaps, which
+  `noUncheckedIndexedAccess` rejects.
+- A `serialize(groups)` helper returning `groups.map((g) => [g.label, g.items.map((i) => i.id)])` for whole-output
+  comparison.
+- Timestamp constants for a multi-project fixture with **deliberate ties**: at least one pair of sessions sharing
+  an identical `updatedAt`, one pair sharing an identical `title`, and several sharing `displayStatus`.
+
+*Verification:* the file still typechecks (`pnpm --filter @qlan-ro/mainframe-ui typecheck`) and the pre-existing
+tests still run. New helpers may be unused at this point.
+
+**Task 2 — Update the existing project-mode assertion that reads as array order.**
+The test at `group-sessions.test.ts:147-157` ("emits one section per project…") builds `b1`/`b2` with the fixture's
+default `updatedAt`, so `expect(idsOf(groups, 'Beta')).toEqual(['b1', 'b2'])` asserts nothing about ordering. Give
+`b1` an *older* `updatedAt` than `b2` and assert `['b2', 'b1']`.
+
+*Verification:* that test fails against today's implementation with `['b1','b2']` received.
+
+**Task 3 — Add project-mode ordering tests.**
+In the `arrangeSessions mode 'project'` describe block:
+- Sessions inside a project section are ordered newest-activity first (≥3 sessions, distinct timestamps,
+  inserted in a non-recency input order).
+- The unknown-project fallback section is ordered by the same rule.
+- With **two** ghost projects, the ghost sections themselves are ordered by their newest session's activity,
+  descending, and still trail every known-project section.
+- Two ghost buckets whose newest activity is identical are ordered by `projectId` ascending.
+- Pinned interaction: a pinned session is lifted out of its project section (that section still renders its
+  remaining sessions in recency order), and a multi-session Pinned group is itself recency-ordered.
+
+*Verification:* every new assertion in this task fails against today's implementation; record which.
+
+**Task 4 — Add name-mode and status-mode tie tests.**
+- `name`: two sessions with the identical title resolve by `updatedAt` descending; the overall A–Z ordering is
+  unchanged for distinct titles.
+- `name`: the Pinned group with ≥2 pinned sessions is ordered by `updatedAt` descending.
+- `status`: two sessions with the same `displayStatus` resolve by `updatedAt` descending; the
+  working → waiting → idle rank order is unchanged.
+- `status`: the Pinned group with ≥2 pinned sessions is ordered by `updatedAt` descending.
+
+*Verification:* the four new assertions fail today (unsorted pinned; ties in incoming order).
+
+**Task 5 — Add the shuffle-invariance property test.**
+One `describe('arrangeSessions is independent of input order')` block:
+- Build one fixture of ~10 sessions spanning: 2 known projects (`PROJECTS`), 2 ghost projects, ≥2 pinned
+  sessions, all three `displayStatus` values, sessions in today/yesterday/earlier buckets, **and** the planted
+  ties from Task 1 (equal `updatedAt`, equal titles).
+- For each mode in `['recent', 'name', 'status', 'project']` and each seed in a fixed list (e.g. `[1, 2, 3, 7, 42]`),
+  assert `serialize(arrangeSessions(seededShuffle(fixture, seed), mode, NOW, PROJECTS))` equals
+  `serialize(arrangeSessions(fixture, mode, NOW, PROJECTS))`.
+- Shuffle only the session array; keep `PROJECTS` fixed (its order is a separate, already-deterministic input).
+
+*Verification:* the test fails today for at least the `project`, `name`, and `status` modes. Planted ties are what
+make it meaningful — confirm by reasoning that removing the id tiebreak from the eventual implementation would
+re-break it.
+
+### Group: impl
+
+Tasks 6–9 edit **one** file: `packages/ui/src/features/sessions/view-model/group-sessions.ts`.
+Task 10 adds one new changeset file. Task 11 is the verification gate.
+
+**Task 6 — Introduce the total comparator.**
+In `group-sessions.ts`, replace `byUpdatedDesc` (`:41-43`) with `byRecency` per the Design section, plus a
+module-private `compareIds`. One short comment on `byRecency` explaining *why* the id tiebreak exists (the
+incoming array order is not a trustworthy fallback). Delete `byUpdatedDesc`; leave no alias behind.
+
+*Verification:* `pnpm --filter @qlan-ro/mainframe-ui typecheck` passes; no reference to `byUpdatedDesc` remains
+(`grep -Rn byUpdatedDesc packages/ui/src` is empty).
+
+**Task 7 — Sort every group in the `recent` and flat paths.**
+- `arrangeRecent` (`:45-65`): the three buckets and the Pinned group all sort with `byRecency`.
+- `arrangeFlat` (`:67-72`): the Pinned group is sorted with `byRecency` instead of being pushed as received.
+  Sort a copy; never mutate the caller's array.
+
+*Verification:* the `recent` mode tests and the two new Pinned tests from Task 4 pass.
+
+**Task 8 — Give `name` and `status` deterministic tiebreaks.**
+- `name` (`:123-126`): `(a.title ?? '').localeCompare(b.title ?? '') || byRecency(a, b)`.
+- `status` (`:128-133`): `(rankA - rankB) || byRecency(a, b)`, keeping the existing `?? 3` unknown-status rank.
+
+*Verification:* the Task 4 tests pass; the pre-existing name/status tests still pass.
+
+**Task 9 — Order project sections' contents and the ghost run.**
+In `arrangeByProject` (`:85-108`):
+- Sort each known-project section's items with `byRecency` before pushing.
+- Collect the leftover ghost buckets, sort their items with `byRecency`, and emit the sections ordered by each
+  bucket's newest `updatedAt` descending, tiebroken by `projectId` ascending — still after every known section.
+- Update the function's doc comment: it currently promises "in order of first appearance", which this task
+  replaces.
+Keep the function under 50 lines; extract a small `ghostSections(...)` helper if it would exceed that.
+
+*Verification:* every project-mode test (Tasks 2, 3) and the shuffle test (Task 5) passes.
+
+**Task 10 — Add the changeset.**
+Create `.changeset/session-list-order-by-activity.md` with front matter `'@qlan-ro/mainframe-ui': patch` and a
+one-paragraph, user-facing description: grouping sessions by project now lists each project's sessions
+most-recently-active first, and every sort mode resolves ties the same way instead of falling back to whatever
+order the app happened to receive.
+
+*Verification:* the file exists and its YAML front matter parses (matches the shape of any existing
+`.changeset/*.md`).
+
+**Task 11 — Full verification gate.**
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/group-sessions.test.ts` — all green.
+- `pnpm --filter @qlan-ro/mainframe-ui exec vitest run src/features/sessions/view-model/__tests__/project-activity.test.ts src/features/sessions/view-model/__tests__/archived-sessions.test.ts` — unchanged neighbours still green.
+- `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean (it includes test files).
+- `wc -l packages/ui/src/features/sessions/view-model/group-sessions.ts` — under 300.
+- `git diff --stat` shows exactly the three files in the Scope table.
+
+## Acceptance criteria (from the brief, mapped to tasks)
+
+| Criterion | Covered by |
+|---|---|
+| Project sections list sessions newest-activity first | Tasks 3, 9 |
+| The unknown-project fallback section follows the same rule | Tasks 3, 9 |
+| Section order unchanged; Pinned still leads | Tasks 3, 9 (assertions), `project-activity.ts` untouched |
+| A send moves the session to the top of its section, no restart | Task 3 + the reload receipt in Established facts |
+| Shuffled input yields identical output, every mode | Tasks 5, 6–9 |
+| Name and status ties resolve by last activity descending | Tasks 4, 8 |
+| Existing array-order assertions updated to recency | Task 2 |
+| Unit tests cover buckets, fallback, pinned, shuffle invariance | Tasks 2–5 |

--- a/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { SessionItem, SessionCustom } from '../chat-to-thread-custom';
 import { arrangeSessions, SESSION_SORTS } from '../group-sessions';
+import type { SortMode, SessionGroupResult } from '../group-sessions';
 
 // ---------------------------------------------------------------------------
 // Fixed reference clock — 2026-06-07T12:00:00 local time.
@@ -296,4 +297,75 @@ describe("arrangeSessions mode 'status'", () => {
     const groups = arrangeSessions(items, 'status', NOW);
     expect(idsOf(groups, 'Pinned')).toEqual(['p-new', 'p-old']);
   });
+});
+
+// ---------------------------------------------------------------------------
+// arrangeSessions is independent of input order (shuffle invariance)
+// ---------------------------------------------------------------------------
+
+/** Deterministic PRNG (no Math.random, so a failing seed reproduces). */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Decorate-sort-undecorate shuffle — no indexed swaps, which noUncheckedIndexedAccess rejects. */
+function seededShuffle(items: SessionItem[], seed: number): SessionItem[] {
+  const rand = mulberry32(seed);
+  return items
+    .map((it) => ({ it, k: rand() }))
+    .sort((a, b) => a.k - b.k)
+    .map((e) => e.it);
+}
+
+function serialize(groups: SessionGroupResult[]): [string, string[]][] {
+  return groups.map((g) => [g.label, g.items.map((i) => i.id)]);
+}
+
+describe('arrangeSessions is independent of input order', () => {
+  const PROJECTS = [
+    { id: 'proj-a', name: 'Alpha' },
+    { id: 'proj-b', name: 'Beta' },
+  ];
+
+  const fixture: SessionItem[] = [
+    item('p1', { projectId: 'proj-a', pinned: true, updatedAt: TODAY_1100, displayStatus: 'working', title: 'Zulu' }),
+    item('p2', {
+      projectId: 'proj-b',
+      pinned: true,
+      updatedAt: YESTERDAY_1000,
+      displayStatus: 'idle',
+      title: 'Yankee',
+    }),
+    item('a1', { projectId: 'proj-a', updatedAt: TODAY_0900, displayStatus: 'working', title: 'Bravo' }),
+    item('a2', { projectId: 'proj-a', updatedAt: EARLIER_MON, displayStatus: 'waiting', title: 'Echo' }),
+    // a2/a3 share updatedAt (planted tie).
+    item('a3', { projectId: 'proj-a', updatedAt: EARLIER_MON, displayStatus: 'idle', title: 'Foxtrot' }),
+    item('b1', { projectId: 'proj-b', updatedAt: TODAY_1100, displayStatus: 'idle', title: 'Same Title' }),
+    // b1/b2 share a title (planted tie).
+    item('b2', { projectId: 'proj-b', updatedAt: YESTERDAY_1000, displayStatus: 'working', title: 'Same Title' }),
+    item('g1', { projectId: 'proj-ghost1', updatedAt: TODAY_0900, displayStatus: 'waiting', title: 'Golf' }),
+    item('g2', { projectId: 'proj-ghost2', updatedAt: EARLIER_MON, displayStatus: 'working', title: 'Hotel' }),
+    item('g3', { projectId: 'proj-ghost1', updatedAt: EARLIER_MON, displayStatus: 'idle', title: 'India' }),
+  ];
+
+  const MODES: SortMode[] = ['recent', 'name', 'status', 'project'];
+  const SEEDS = [1, 2, 3, 7, 42];
+
+  for (const mode of MODES) {
+    for (const seed of SEEDS) {
+      it(`mode '${mode}' seed ${seed}: shuffled input yields identical output`, () => {
+        const expected = serialize(arrangeSessions(fixture, mode, NOW, PROJECTS));
+        const shuffled = seededShuffle(fixture, seed);
+        const actual = serialize(arrangeSessions(shuffled, mode, NOW, PROJECTS));
+        expect(actual).toEqual(expected);
+      });
+    }
+  }
 });

--- a/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
@@ -147,12 +147,12 @@ describe("arrangeSessions mode 'project'", () => {
   it('emits one section per project, labeled by project name, in project-list order', () => {
     const items = [
       item('a1', { projectId: 'proj-a' }),
-      item('b1', { projectId: 'proj-b' }),
-      item('b2', { projectId: 'proj-b' }),
+      item('b1', { projectId: 'proj-b', updatedAt: YESTERDAY_1000 }),
+      item('b2', { projectId: 'proj-b', updatedAt: TODAY_1100 }),
     ];
     const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
     expect(labels(groups)).toEqual(['Beta', 'Alpha']);
-    expect(idsOf(groups, 'Beta')).toEqual(['b1', 'b2']);
+    expect(idsOf(groups, 'Beta')).toEqual(['b2', 'b1']);
     expect(idsOf(groups, 'Alpha')).toEqual(['a1']);
   });
 

--- a/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
@@ -179,6 +179,64 @@ describe("arrangeSessions mode 'project'", () => {
   it('returns an empty array for no items', () => {
     expect(arrangeSessions([], 'project', NOW, PROJECTS)).toEqual([]);
   });
+
+  it('orders a project section by updatedAt, newest first', () => {
+    const items = [
+      item('a-old', { projectId: 'proj-a', updatedAt: EARLIER_MON }),
+      item('a-new', { projectId: 'proj-a', updatedAt: TODAY_1100 }),
+      item('a-mid', { projectId: 'proj-a', updatedAt: YESTERDAY_1000 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(idsOf(groups, 'Alpha')).toEqual(['a-new', 'a-mid', 'a-old']);
+  });
+
+  it('orders the unknown-project fallback section by updatedAt, newest first', () => {
+    const items = [
+      item('g-old', { projectId: 'proj-ghost', updatedAt: EARLIER_MON }),
+      item('g-new', { projectId: 'proj-ghost', updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(idsOf(groups, 'proj-ghost')).toEqual(['g-new', 'g-old']);
+  });
+
+  it('orders multiple ghost-project sections by their newest session, after every known-project section', () => {
+    const items = [
+      item('a1', { projectId: 'proj-a', updatedAt: TODAY_1100 }),
+      item('gh1-old', { projectId: 'proj-ghost1', updatedAt: EARLIER_MON }),
+      item('gh2-new', { projectId: 'proj-ghost2', updatedAt: TODAY_0900 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(labels(groups)).toEqual(['Alpha', 'proj-ghost2', 'proj-ghost1']);
+  });
+
+  it('tiebreaks ghost sections with identical newest activity by projectId ascending', () => {
+    const items = [
+      item('ghz1', { projectId: 'proj-ghost-z', updatedAt: TODAY_1100 }),
+      item('ghy1', { projectId: 'proj-ghost-y', updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(labels(groups)).toEqual(['proj-ghost-y', 'proj-ghost-z']);
+  });
+
+  it('lifts a pinned session out of its project section and still orders the remainder by recency', () => {
+    const items = [
+      item('a-old', { projectId: 'proj-a', updatedAt: EARLIER_MON }),
+      item('a-pin', { projectId: 'proj-a', pinned: true, updatedAt: YESTERDAY_1000 }),
+      item('a-new', { projectId: 'proj-a', updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(idsOf(groups, 'Pinned')).toEqual(['a-pin']);
+    expect(idsOf(groups, 'Alpha')).toEqual(['a-new', 'a-old']);
+  });
+
+  it('orders a multi-session Pinned group by recency in project mode (regression guard)', () => {
+    const items = [
+      item('pin-old', { projectId: 'proj-a', pinned: true, updatedAt: EARLIER_MON }),
+      item('pin-new', { projectId: 'proj-b', pinned: true, updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'project', NOW, PROJECTS);
+    expect(idsOf(groups, 'Pinned')).toEqual(['pin-new', 'pin-old']);
+  });
 });
 
 describe("arrangeSessions mode 'status'", () => {

--- a/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
+++ b/packages/ui/src/features/sessions/view-model/__tests__/group-sessions.test.ts
@@ -128,6 +128,25 @@ describe("arrangeSessions mode 'name'", () => {
     expect(labels(groups)).toEqual(['A–Z']);
     expect(idsOf(groups, 'A–Z')).toEqual(['a', 'b']);
   });
+
+  it('resolves identical titles by updatedAt descending while distinct titles stay alphabetical', () => {
+    const items = [
+      item('c', { title: 'Charlie' }),
+      item('a-old', { title: 'Alpha', updatedAt: EARLIER_MON }),
+      item('a-new', { title: 'Alpha', updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'name', NOW);
+    expect(idsOf(groups, 'A–Z')).toEqual(['a-new', 'a-old', 'c']);
+  });
+
+  it('orders a multi-session Pinned group by recency in name mode', () => {
+    const items = [
+      item('p-old', { pinned: true, updatedAt: EARLIER_MON, title: 'B' }),
+      item('p-new', { pinned: true, updatedAt: TODAY_1100, title: 'A' }),
+    ];
+    const groups = arrangeSessions(items, 'name', NOW);
+    expect(idsOf(groups, 'Pinned')).toEqual(['p-new', 'p-old']);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -257,5 +276,24 @@ describe("arrangeSessions mode 'status'", () => {
     expect(labels(groups)).toEqual(['Pinned', 'By status']);
     expect(idsOf(groups, 'Pinned')).toEqual(['pin1']);
     expect(idsOf(groups, 'By status')).toEqual(['idle1']);
+  });
+
+  it('resolves same-status ties by updatedAt descending while rank order stays working/waiting/idle', () => {
+    const items = [
+      item('w1', { displayStatus: 'working', updatedAt: TODAY_0900 }),
+      item('i-old', { displayStatus: 'idle', updatedAt: EARLIER_MON }),
+      item('i-new', { displayStatus: 'idle', updatedAt: TODAY_1100 }),
+    ];
+    const groups = arrangeSessions(items, 'status', NOW);
+    expect(idsOf(groups, 'By status')).toEqual(['w1', 'i-new', 'i-old']);
+  });
+
+  it('orders a multi-session Pinned group by recency in status mode', () => {
+    const items = [
+      item('p-old', { pinned: true, updatedAt: EARLIER_MON, displayStatus: 'idle' }),
+      item('p-new', { pinned: true, updatedAt: TODAY_1100, displayStatus: 'idle' }),
+    ];
+    const groups = arrangeSessions(items, 'status', NOW);
+    expect(idsOf(groups, 'Pinned')).toEqual(['p-new', 'p-old']);
   });
 });

--- a/packages/ui/src/features/sessions/view-model/group-sessions.ts
+++ b/packages/ui/src/features/sessions/view-model/group-sessions.ts
@@ -126,13 +126,15 @@ export function arrangeSessions(
   const rest = items.filter((i) => !i.custom.pinned);
 
   if (mode === 'name') {
-    const sorted = [...rest].sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
+    const sorted = [...rest].sort((a, b) => (a.title ?? '').localeCompare(b.title ?? '') || byRecency(a, b));
     return arrangeFlat(pinned, sorted, 'A–Z');
   }
 
   if (mode === 'status') {
     const sorted = [...rest].sort(
-      (a, b) => (SESSION_STATUS_RANK[a.custom.displayStatus] ?? 3) - (SESSION_STATUS_RANK[b.custom.displayStatus] ?? 3),
+      (a, b) =>
+        (SESSION_STATUS_RANK[a.custom.displayStatus] ?? 3) - (SESSION_STATUS_RANK[b.custom.displayStatus] ?? 3) ||
+        byRecency(a, b),
     );
     return arrangeFlat(pinned, sorted, 'By status');
   }

--- a/packages/ui/src/features/sessions/view-model/group-sessions.ts
+++ b/packages/ui/src/features/sessions/view-model/group-sessions.ts
@@ -38,13 +38,14 @@ function dayKey(ts: number): number {
   return d.getFullYear() * 10000 + d.getMonth() * 100 + d.getDate();
 }
 
-function compareIds(a: SessionItem, b: SessionItem): number {
-  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+/** Code-unit order, not `localeCompare`, so the result cannot vary with the host locale. */
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /** Newest first; id breaks ties because incoming array order is only "when this client first saw it". */
 function byRecency(a: SessionItem, b: SessionItem): number {
-  return b.custom.updatedAt - a.custom.updatedAt || compareIds(a, b);
+  return b.custom.updatedAt - a.custom.updatedAt || compareStrings(a.id, b.id);
 }
 
 function arrangeRecent(pinned: SessionItem[], rest: SessionItem[], now: number): SessionGroupResult[] {
@@ -86,8 +87,7 @@ function ghostSections(buckets: Map<string, SessionItem[]>): SessionGroupResult[
   const sections = [...buckets].map(([projectId, items]) => ({ label: projectId, items: items.sort(byRecency) }));
   return sections.sort(
     (a, b) =>
-      (b.items[0]?.custom.updatedAt ?? 0) - (a.items[0]?.custom.updatedAt ?? 0) ||
-      (a.label < b.label ? -1 : a.label > b.label ? 1 : 0),
+      (b.items[0]?.custom.updatedAt ?? 0) - (a.items[0]?.custom.updatedAt ?? 0) || compareStrings(a.label, b.label),
   );
 }
 

--- a/packages/ui/src/features/sessions/view-model/group-sessions.ts
+++ b/packages/ui/src/features/sessions/view-model/group-sessions.ts
@@ -71,7 +71,7 @@ function arrangeRecent(pinned: SessionItem[], rest: SessionItem[], now: number):
 
 function arrangeFlat(pinned: SessionItem[], rest: SessionItem[], label: string): SessionGroupResult[] {
   const out: SessionGroupResult[] = [];
-  if (pinned.length > 0) out.push({ label: 'Pinned', items: pinned });
+  if (pinned.length > 0) out.push({ label: 'Pinned', items: [...pinned].sort(byRecency) });
   out.push({ label, items: rest });
   return out;
 }

--- a/packages/ui/src/features/sessions/view-model/group-sessions.ts
+++ b/packages/ui/src/features/sessions/view-model/group-sessions.ts
@@ -38,8 +38,13 @@ function dayKey(ts: number): number {
   return d.getFullYear() * 10000 + d.getMonth() * 100 + d.getDate();
 }
 
-function byUpdatedDesc(a: SessionItem, b: SessionItem): number {
-  return b.custom.updatedAt - a.custom.updatedAt;
+function compareIds(a: SessionItem, b: SessionItem): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/** Newest first; id breaks ties because incoming array order is only "when this client first saw it". */
+function byRecency(a: SessionItem, b: SessionItem): number {
+  return b.custom.updatedAt - a.custom.updatedAt || compareIds(a, b);
 }
 
 function arrangeRecent(pinned: SessionItem[], rest: SessionItem[], now: number): SessionGroupResult[] {
@@ -57,10 +62,10 @@ function arrangeRecent(pinned: SessionItem[], rest: SessionItem[], now: number):
   }
 
   const out: SessionGroupResult[] = [];
-  if (pinned.length > 0) out.push({ label: 'Pinned', items: [...pinned].sort(byUpdatedDesc) });
-  if (today.length > 0) out.push({ label: 'Today', items: today.sort(byUpdatedDesc) });
-  if (yesterday.length > 0) out.push({ label: 'Yesterday', items: yesterday.sort(byUpdatedDesc) });
-  if (earlier.length > 0) out.push({ label: 'Earlier', items: earlier.sort(byUpdatedDesc) });
+  if (pinned.length > 0) out.push({ label: 'Pinned', items: [...pinned].sort(byRecency) });
+  if (today.length > 0) out.push({ label: 'Today', items: today.sort(byRecency) });
+  if (yesterday.length > 0) out.push({ label: 'Yesterday', items: yesterday.sort(byRecency) });
+  if (earlier.length > 0) out.push({ label: 'Earlier', items: earlier.sort(byRecency) });
   return out;
 }
 
@@ -91,7 +96,7 @@ function arrangeByProject(pinned: SessionItem[], rest: SessionItem[], projects: 
   }
 
   const out: SessionGroupResult[] = [];
-  if (pinned.length > 0) out.push({ label: 'Pinned', items: [...pinned].sort(byUpdatedDesc) });
+  if (pinned.length > 0) out.push({ label: 'Pinned', items: [...pinned].sort(byRecency) });
 
   for (const project of projects) {
     const bucket = byProject.get(project.id);

--- a/packages/ui/src/features/sessions/view-model/group-sessions.ts
+++ b/packages/ui/src/features/sessions/view-model/group-sessions.ts
@@ -81,11 +81,21 @@ export interface ProjectRef {
   name: string;
 }
 
+/** Sections for projectIds absent from the project list: newest bucket first, then by projectId. */
+function ghostSections(buckets: Map<string, SessionItem[]>): SessionGroupResult[] {
+  const sections = [...buckets].map(([projectId, items]) => ({ label: projectId, items: items.sort(byRecency) }));
+  return sections.sort(
+    (a, b) =>
+      (b.items[0]?.custom.updatedAt ?? 0) - (a.items[0]?.custom.updatedAt ?? 0) ||
+      (a.label < b.label ? -1 : a.label > b.label ? 1 : 0),
+  );
+}
+
 /**
- * One section per project, ordered by the given project list. Sessions whose
- * `projectId` isn't in `projects` (a removed/unknown project) still get a
- * trailing section keyed by that id, in order of first appearance — grouping
- * never silently drops a session.
+ * One section per project, ordered by the given project list, each listing its
+ * sessions newest-activity first. Sessions whose `projectId` isn't in `projects`
+ * (a removed/unknown project) still get a trailing section keyed by that id —
+ * grouping never silently drops a session.
  */
 function arrangeByProject(pinned: SessionItem[], rest: SessionItem[], projects: ProjectRef[]): SessionGroupResult[] {
   const byProject = new Map<string, SessionItem[]>();
@@ -101,14 +111,11 @@ function arrangeByProject(pinned: SessionItem[], rest: SessionItem[], projects: 
   for (const project of projects) {
     const bucket = byProject.get(project.id);
     if (bucket) {
-      out.push({ label: project.name, items: bucket });
+      out.push({ label: project.name, items: bucket.sort(byRecency) });
       byProject.delete(project.id);
     }
   }
-  // Remaining buckets: projectIds absent from the given list, kept in first-seen order.
-  for (const [projectId, bucket] of byProject) {
-    out.push({ label: projectId, items: bucket });
-  }
+  out.push(...ghostSections(byProject));
   return out;
 }
 


### PR DESCRIPTION
## Summary

Sort the sidebar's session list by recent activity in every grouping. Grouping by project used to list each project's sessions in the order the app happened to receive them — an order that changed between restarts — and the name and status modes left their ties there too. Each section now leads with the most recently active session, and every mode resolves ties the same way.

Artifact links: docs/plans/2026-08-14-session-list-order-by-activity-plan.md

Review verdict: APPROVED (1 round)
QA: 3/3

## Decisions

- [plan] Pinned is sorted by recency in ALL four modes, not by each mode's own key. The brief says Pinned keeps "the same key" (last activity), and the two modes that already sort it (recent, project) sort by recency; making name-mode Pinned alphabetical would be a larger, unrequested change. This also closes a second array-order leak I found: arrangeFlat pushes the pinned array unsorted (group-sessions.ts:69), so name and status modes render Pinned in incoming order today.
- [plan] Ghost sections (projects absent from the project list) are ordered by their bucket's newest updatedAt descending, tiebroken by projectId ascending, still trailing all known-project sections. Not named in the brief, but the shuffle-invariance criterion covers group ORDER as well as group contents, and the current "first appearance" rule is exactly the array-order dependence the brief forbids. The arrangeByProject doc comment that promises first-appearance order gets updated.
- [plan] SessionItem.id is the final tiebreak in the comparator, beyond the brief's explicit asks. The brief demands "a total order"; two sessions can genuinely share an updatedAt, and without a last key such a pair falls back to array order. Comparison uses raw </> (UTF-16), not localeCompare, so the result cannot vary with host locale.
- [plan] The comparator stays local to group-sessions.ts rather than being extracted to a shared module. The updatedAt-descending expression also lives in archived-sessions.ts:19 — two sites, below the repo's 3+ extraction threshold — and extracting it would change the archived dialog's ordering and its tests, which is scope creep on a bug fix.
- [implement] Did not touch group-sessions.ts in this group, per the plan's explicit instruction for the tests (red phase) group.
- [implement] Task 2/3/4 fixtures reused the existing timestamp constants (NOW, TODAY_0900, TODAY_1100, YESTERDAY_1000, EARLIER_MON) rather than introducing new ones — they were sufficient for every planted tie and ordering case, so no new module-scope constants were needed (avoids any noUnusedLocals risk from constants introduced ahead of their first task).
- [implement] For every tie/ordering assertion, the fixture's input array order was deliberately set to differ from (or be the reverse of) the asserted recency order, so that today's stable-sort/array-order-preserving implementation is guaranteed to fail the assertion rather than pass it by accident of insertion order — this was verified empirically by running vitest after each task and reading the actual failure output, not just reasoned about.
- [implement] The name-mode/seed-7 shuffle assertion passes today by coincidence rather than by a real fix; recorded as a decision so the impl-group reviewer doesn't misread it as evidence the red phase is incomplete. Reasoning verified: the only name-mode-relevant planted tie is the b1/b2 equal-title pair (a2/a3's equal-updatedAt tie doesn't affect name-mode output since their titles differ), and seed 7's permutation happens to preserve b1-before-b2's relative order after the shuffle. The other 4 name-mode seeds fail today, so the property is still meaningfully exercised, and the test remains forward-valid because once byRecency lands, seed 7 will pass for the correct reason instead of the lucky one.
- [implement] No foreign-path staging incidents occurred across any of the four commits — git diff --cached --stat listed only the one owned test file every time.
- [implement] Deviation from the plan's literal design: after Task 8 I extracted compareStrings(a: string, b: string) and dropped the plan's named compareIds(a, b) — byRecency now calls compareStrings(a.id, b.id) and the ghost tiebreak calls compareStrings(a.label, b.label) (the ghost label IS the projectId). Behaviorally identical and covered by the existing tests; it is a 2-site extraction where the repo threshold is 3+, but it removes a duplicated locale-independent compare idiom that the plan had appearing twice inline. Committed separately as 2262f360 so it can be reverted alone.
- [implement] No foreign staged paths appeared: git diff --cached --stat was run immediately before all six commits and listed only group-sessions.ts or the changeset. lint-staged never swept a sibling group's work into a commit.
- [implement] Skipped the mainframe-design-system skill: this task writes no markup and no class names — it is pure TypeScript in a non-React view-model module.
- [implement] The plan's ## Established facts all held as written; I found no external-library or protocol behavior the plan missed, so there is nothing new to record. One implementation detail worth a receipt: byRecency stays a valid comparator even if updatedAt is NaN, because NaN is falsy and || falls through to the string compare (packages/ui/src/features/sessions/view-model/group-sessions.ts:46-48).
- [implement] Ghost sections read their newest timestamp as items[0]?.custom.updatedAt ?? 0 after the bucket is sorted, rather than a separate max scan — the ?? 0 exists only to satisfy noUncheckedIndexedAccess; a bucket is never empty by construction (packages/ui/src/features/sessions/view-model/group-sessions.ts:85-92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>