### PR TITLE
fix(preview): stop a previewed Mainframe from hanging on the daemon gate

### DIFF
--- a/.changeset/preview-webview-runtime-detection.md
+++ b/.changeset/preview-webview-runtime-detection.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-ui': patch
+'@qlan-ro/mainframe-app-tauri': patch
+---
+
+Previewing a Mainframe dev server no longer hangs on "Connecting to the daemon". The nested app was mistaking the preview webview for the host app.

--- a/packages/app-tauri/src-tauri/src/preview/mod.rs
+++ b/packages/app-tauri/src-tauri/src/preview/mod.rs
@@ -85,6 +85,25 @@ pub(crate) fn is_allowed_external_scheme(url: &str) -> bool {
         .any(|s| lower.starts_with(&format!("{s}://")) || lower.starts_with(&format!("{s}:")))
 }
 
+/// The initialization script every preview child webview loads before the page's
+/// own scripts.
+///
+/// `__mfPreviewWebview` tells the page it is being previewed rather than hosting
+/// the app. Tauri injects `__TAURI_INTERNALS__` into EVERY webview it creates,
+/// this one included, so a Mainframe UI opened in a preview (previewing a dev
+/// server that happens to be Mainframe) would otherwise take itself for the host
+/// app, call daemon commands this webview's capability never granted, and hang on
+/// its connecting overlay. `isTauriRuntime()` in packages/ui reads the flag.
+///
+/// `__mfPreviewTabId` bakes this tab's id in so BRIDGE_JS can stamp
+/// navigation/inspect events with it on first load, before any picker installs.
+fn preview_init_script(tab_id_json: &str) -> String {
+    format!(
+        "window.__mfPreviewWebview=true;window.__mfPreviewTabId={tab_id_json};\n{}",
+        crate::preview::bridge::BRIDGE_JS
+    )
+}
+
 // ── PreviewManager ─────────────────────────────────────────────────────────────
 
 /// Entry stored for each live preview tab.
@@ -210,10 +229,7 @@ pub async fn preview_create(
     // Bake this tab's id into the page so BRIDGE_JS can stamp navigation/inspect
     // events with it on first load (before any picker install sets it).
     let tab_id_json = serde_json::to_string(&tab_id).unwrap_or_else(|_| "\"\"".to_string());
-    let init_script = format!(
-        "window.__mfPreviewTabId={tab_id_json};\n{}",
-        crate::preview::bridge::BRIDGE_JS
-    );
+    let init_script = preview_init_script(&tab_id_json);
     let builder = tauri::webview::WebviewBuilder::new(&tab_id, WebviewUrl::External(parsed))
         .initialization_script(&init_script);
 
@@ -350,6 +366,35 @@ pub async fn preview_eval(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Initialization script ─────────────────────────────────────────────────
+
+    #[test]
+    fn init_script_marks_the_webview_as_a_preview() {
+        let script = preview_init_script("\"tab-1\"");
+
+        // The UI's isTauriRuntime() keys off this exact name; renaming one side
+        // alone silently restores the hang it exists to prevent.
+        assert!(script.contains("window.__mfPreviewWebview=true"));
+    }
+
+    #[test]
+    fn init_script_marks_the_preview_before_the_bridge_runs() {
+        let script = preview_init_script("\"tab-1\"");
+        let flag = script.find("__mfPreviewWebview").expect("flag present");
+        let bridge = script.find("(function ()").expect("bridge present");
+
+        // The page reads the flag during its own boot, so it has to be assigned
+        // ahead of everything else the script carries.
+        assert!(flag < bridge, "the preview flag must precede BRIDGE_JS");
+    }
+
+    #[test]
+    fn init_script_still_bakes_the_tab_id() {
+        let script = preview_init_script("\"tab-7\"");
+
+        assert!(script.contains("window.__mfPreviewTabId=\"tab-7\""));
+    }
 
     // ── PreviewManager bookkeeping ────────────────────────────────────────────
 

--- a/packages/ui/src/lib/host/__tests__/detect.test.ts
+++ b/packages/ui/src/lib/host/__tests__/detect.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+/**
+ * Runtime detection, and the preview carve-out in particular.
+ *
+ * A Mainframe UI can end up loaded inside Mainframe's own preview webview —
+ * previewing a dev server that happens to be Mainframe. Tauri injects its
+ * internals there too, so without the carve-out that nested app picks the Tauri
+ * adapter, asks for a daemon port the preview capability never granted, and
+ * hangs on the connecting overlay.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { isElectronRuntime, isTauriRuntime } from '../detect';
+
+type Mutable = Record<string, unknown>;
+
+afterEach(() => {
+  delete (window as unknown as Mutable).__TAURI_INTERNALS__;
+  delete (window as unknown as Mutable).__mfPreviewWebview;
+  delete (window as unknown as Mutable).mainframe;
+});
+
+describe('isTauriRuntime', () => {
+  it('is false in a plain browser', () => {
+    expect(isTauriRuntime()).toBe(false);
+  });
+
+  it('is true in the app webview', () => {
+    (window as unknown as Mutable).__TAURI_INTERNALS__ = {};
+
+    expect(isTauriRuntime()).toBe(true);
+  });
+
+  it('is false in a preview webview, which carries the internals too', () => {
+    (window as unknown as Mutable).__TAURI_INTERNALS__ = {};
+    (window as unknown as Mutable).__mfPreviewWebview = true;
+
+    expect(isTauriRuntime()).toBe(false);
+  });
+
+  it('stays false in a preview even if the flag is set falsy — presence is the signal', () => {
+    (window as unknown as Mutable).__TAURI_INTERNALS__ = {};
+    (window as unknown as Mutable).__mfPreviewWebview = false;
+
+    expect(isTauriRuntime()).toBe(false);
+  });
+});
+
+describe('isElectronRuntime', () => {
+  it('is true only with the preload bridge present', () => {
+    expect(isElectronRuntime()).toBe(false);
+    (window as unknown as Mutable).mainframe = {};
+    expect(isElectronRuntime()).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/host/detect.ts
+++ b/packages/ui/src/lib/host/detect.ts
@@ -3,7 +3,15 @@
  * into its webview; it is absent in a plain browser / vitest jsdom.
  */
 export function isTauriRuntime(): boolean {
-  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+  if (typeof window === 'undefined') return false;
+  // Tauri injects its internals into EVERY webview it creates — including the
+  // preview's child webviews, which load someone else's page. A Mainframe UI
+  // opened in a preview would otherwise take itself for the host app, call
+  // daemon commands that webview's capability never granted, and sit on
+  // "Connecting to the daemon" forever. The preview stamps this flag from its
+  // initialization script, so it is set before any page script runs.
+  if ('__mfPreviewWebview' in window) return false;
+  return '__TAURI_INTERNALS__' in window;
 }
 
 /**


### PR DESCRIPTION
## The bug

Previewing a Mainframe dev server (`http://localhost:<vite-port>`) in the workspace URL tab hangs forever on **"Starting up… Connecting to the daemon."** The same URL opens fine in an external browser.

## Root cause

Tauri injects `__TAURI_INTERNALS__` into **every** webview it creates — preview child webviews included, which is how `BRIDGE_JS` calls `window.__TAURI_INTERNALS__.invoke(...)` from a remote origin.

`isTauriRuntime()` was `'__TAURI_INTERNALS__' in window`, so a Mainframe UI loaded *inside* a preview concluded it was the host app:

1. `getHost()` picks `TauriAdapter` (`lib/host/index.ts:24`).
2. `useConnectionState` calls `getHost().daemon.port()` (`useConnectionState.ts:108`) — a command the preview capability (`capabilities/preview.json`, scoped to `preview-bridge`) never grants.
3. `acquirePort()` catches the rejection, sets `disconnected`, and retries on a timer **forever** (`useConnectionState.ts:115-121`).
4. `port` stays `null`, so App's `ready && port != null` gate (`App.tsx:132`) never opens and `app-waiting-daemon` shows indefinitely.

In a browser there are no internals → `FakeHostBridge` → `DEV_DAEMON_PORT` → the app boots. That's the split.

## The fix

The preview's initialization script — which runs **before** any page script — now stamps `window.__mfPreviewWebview`, and `isTauriRuntime()` excludes it. A previewed Mainframe falls through to the browser adapter and boots normally.

The script construction moved into `preview_init_script()` so the ordering guarantee is assertable rather than inline in an async command.

## Testing

- 3 Rust tests: the flag is stamped, it **precedes** `BRIDGE_JS`, and the existing `__mfPreviewTabId` bake is untouched.
- 5 TS tests for `detect.ts`, including the preview carve-out. Verified they **fail** when the carve-out is removed (2 failures), so they can catch a regression rather than merely passing.
- `cargo test --lib preview::` 24 passed · `vitest src/lib/host` 116 passed · `tsc --noEmit` clean.

Not verified end-to-end in a running app: the tauri-mcp bridge dies once a child webview exists (`Window 'main' not found`), so the nested overlay couldn't be driven from automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)