### PR TITLE
feat(ui): rebind keyboard shortcuts in Settings

### DIFF
--- a/.changeset/keybinding-overrides.md
+++ b/.changeset/keybinding-overrides.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': minor
+---
+
+Rebind any keyboard shortcut in Settings → Keybindings. Recording a chord another action holds offers to take it, and the loser is left unassigned rather than silently sharing the key.

--- a/packages/ui/src/features/palette/palette-commands.ts
+++ b/packages/ui/src/features/palette/palette-commands.ts
@@ -15,19 +15,19 @@ export function getPaletteCommands(): PaletteCommand[] {
     {
       id: 'review',
       label: 'Review changes…',
-      hint: chordHint('app.review'),
+      hint: chordHint('app.review') ?? undefined,
       run: () => emitSurfaceIntent({ type: 'open-review' }),
     },
     {
       id: 'settings',
       label: 'Open Settings…',
-      hint: chordHint('app.settings'),
+      hint: chordHint('app.settings') ?? undefined,
       run: () => emitSurfaceIntent({ type: 'open-settings' }),
     },
     {
       id: 'sidebar',
       label: 'Toggle Sidebar',
-      hint: chordHint('sessions.toggle-sidebar'),
+      hint: chordHint('sessions.toggle-sidebar') ?? undefined,
       run: () => emitSurfaceIntent({ type: 'toggle-sidebar' }),
     },
     { id: 'files', label: 'Toggle Files', run: () => emitSurfaceIntent({ type: 'toggle-workspace-files' }) },
@@ -39,7 +39,7 @@ export function getPaletteCommands(): PaletteCommand[] {
     {
       id: 'keyboard-shortcuts',
       label: 'Keyboard Shortcuts',
-      hint: chordHint('app.cheat-sheet'),
+      hint: chordHint('app.cheat-sheet') ?? undefined,
       // Opens directly rather than through `toggleCheatSheet()`: the palette is
       // itself a Dialog, so the toggle's "another modal is open" guard would
       // stand down against the palette's own still-mounted content.

--- a/packages/ui/src/features/sessions/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/SessionSidebar.tsx
@@ -47,10 +47,11 @@ const TRAFFIC_LIGHTS_WIDTH = 80;
 
 function HeaderActions() {
   const openSettings = useSettingsStore((s) => s.open);
+  const settingsHint = chordHint('app.settings');
 
   return (
     <div className="flex items-center gap-0.5 text-muted-foreground">
-      <Hint label={`Settings · ${chordHint('app.settings')}`}>
+      <Hint label={settingsHint == null ? 'Settings' : `Settings · ${settingsHint}`}>
         <Button
           variant="ghost"
           size="icon-sm"

--- a/packages/ui/src/features/settings/SettingsContent.tsx
+++ b/packages/ui/src/features/settings/SettingsContent.tsx
@@ -4,6 +4,7 @@ import { NotificationsPane } from './panes/notifications/NotificationsPane';
 import { AboutPane } from './panes/about/AboutPane';
 import { ProvidersPane } from './panes/providers/ProvidersPane';
 import { RemoteAccessPane } from './panes/remote-access/RemoteAccessPane';
+import { KeybindingsPane } from './panes/keybindings/KeybindingsPane';
 
 export function SettingsContent({ port }: { port: number }) {
   const activeTab = useSettingsStore((s) => s.activeTab);
@@ -12,6 +13,8 @@ export function SettingsContent({ port }: { port: number }) {
       return <GeneralPane port={port} />;
     case 'providers':
       return <ProvidersPane port={port} />;
+    case 'keybindings':
+      return <KeybindingsPane />;
     case 'notifications':
       return <NotificationsPane port={port} />;
     case 'remote-access':

--- a/packages/ui/src/features/settings/__tests__/SettingsDialog.test.tsx
+++ b/packages/ui/src/features/settings/__tests__/SettingsDialog.test.tsx
@@ -34,7 +34,9 @@ describe('SettingsDialog', () => {
     expect(screen.getByTestId('settings-dialog')).toBeInTheDocument();
     expect(screen.getByTestId('settings-nav-general')).toBeInTheDocument();
     expect(screen.getByTestId('settings-nav-providers')).toBeInTheDocument();
-    expect(screen.queryByTestId('settings-nav-keybindings')).toBeNull(); // S4 dropped
+    // S4 dropped this as an empty placeholder; it is a real pane again now
+    // that the registry has an override layer behind it.
+    expect(screen.getByTestId('settings-nav-keybindings')).toBeInTheDocument();
   });
   it('clicking a nav row routes the content pane', async () => {
     render(<SettingsDialog port={31415} />);

--- a/packages/ui/src/features/settings/panes/keybindings/KeybindingRow.tsx
+++ b/packages/ui/src/features/settings/panes/keybindings/KeybindingRow.tsx
@@ -1,0 +1,126 @@
+/**
+ * One shortcut in the Keybindings pane: its label, its current chord, and the
+ * recorder that changes it.
+ *
+ * data-testid:
+ *   settings-keybinding-row-<id>      — the row
+ *   settings-keybinding-record-<id>   — the chord button / live recorder
+ *   settings-keybinding-reset-<id>    — back to the registry default
+ *   settings-keybinding-conflict-<id> — the holder warning + steal
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { Chord, ShortcutDescriptor } from '@/features/shortcuts/shortcut-types';
+import type { EffectiveBinding } from '@/features/shortcuts/effective-bindings';
+import { chordFromEvent } from '@/features/shortcuts/chord-from-event';
+import { renderEntryChord } from '@/features/shortcuts/render-chord';
+
+interface KeybindingRowProps {
+  binding: EffectiveBinding;
+  isMac: boolean;
+  /** Who currently answers to a candidate chord — drives the steal prompt. */
+  holderOf: (chord: Chord) => ShortcutDescriptor | null;
+  onBind: (chord: Chord, steal: boolean) => void;
+  onReset: () => void;
+}
+
+export function KeybindingRow({ binding, isMac, holderOf, onBind, onReset }: KeybindingRowProps) {
+  const { entry, chord, isDefault, rebindable } = binding;
+  const [recording, setRecording] = useState(false);
+  const [candidate, setCandidate] = useState<Chord | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  const holder = candidate ? holderOf(candidate) : null;
+
+  useEffect(() => {
+    if (!recording) return;
+    function onKeyDown(event: KeyboardEvent) {
+      // Every keystroke belongs to the recorder while it is armed, including
+      // chords the app itself binds — otherwise ⌘F opens Find mid-recording.
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.code === 'Escape') {
+        setRecording(false);
+        setCandidate(null);
+        return;
+      }
+      const next = chordFromEvent(event, isMac);
+      if (next == null) return;
+      setCandidate(next);
+      setRecording(false);
+      // A free chord commits immediately; a taken one waits for the steal.
+      if (holderOf(next) == null) {
+        onBind(next, false);
+        setCandidate(null);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [recording, isMac, holderOf, onBind]);
+
+  const label = chord === null ? 'Unassigned' : renderEntryChord({ ...entry, chord }, isMac);
+
+  return (
+    <div
+      data-testid={`settings-keybinding-row-${entry.id}`}
+      className="flex items-center justify-between gap-3 rounded-md px-2 py-1 hover:bg-muted"
+    >
+      <span className="min-w-0 flex-1 truncate text-sm">{entry.label}</span>
+
+      {holder && candidate && (
+        <span
+          data-testid={`settings-keybinding-conflict-${entry.id}`}
+          className="shrink-0 text-xs text-muted-foreground"
+        >
+          Already {holder.label}
+        </span>
+      )}
+
+      {holder && candidate ? (
+        <Button
+          data-testid={`settings-keybinding-steal-${entry.id}`}
+          variant="ghost"
+          size="sm"
+          className="shrink-0 text-xs"
+          onClick={() => {
+            onBind(candidate, true);
+            setCandidate(null);
+          }}
+        >
+          Use it anyway
+        </Button>
+      ) : null}
+
+      <Button
+        ref={buttonRef}
+        data-testid={`settings-keybinding-record-${entry.id}`}
+        variant="ghost"
+        size="sm"
+        disabled={!rebindable}
+        onClick={() => {
+          setCandidate(null);
+          setRecording(true);
+        }}
+        className={cn(
+          'shrink-0 rounded border bg-muted px-1 py-0.5 font-mono text-xs',
+          recording ? 'text-primary' : 'text-muted-foreground',
+          !rebindable && 'opacity-60',
+        )}
+      >
+        {recording ? 'Press a chord…' : label}
+      </Button>
+
+      <Button
+        data-testid={`settings-keybinding-reset-${entry.id}`}
+        variant="ghost"
+        size="sm"
+        className="shrink-0 text-xs"
+        disabled={isDefault}
+        onClick={onReset}
+      >
+        Reset
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/features/settings/panes/keybindings/KeybindingsPane.tsx
+++ b/packages/ui/src/features/settings/panes/keybindings/KeybindingsPane.tsx
@@ -1,0 +1,91 @@
+/**
+ * Settings → Keybindings. Rebinds the shortcut registry per machine.
+ *
+ * The registry stays the defaults; this pane only writes overrides, so a
+ * shortcut added to `registry.ts` shows up here with no change to this file —
+ * the same property the cheat sheet has.
+ *
+ * data-testid:
+ *   settings-keybindings-pane
+ *   settings-keybindings-group-<group>
+ *   settings-keybindings-reset-all
+ */
+import { useCallback, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { SectionHeader } from '@/components/ui/section-header';
+import { SHORTCUTS, visibleShortcuts } from '@/features/shortcuts/registry';
+import type { Chord, ShortcutGroup } from '@/features/shortcuts/shortcut-types';
+import { isMacPlatform } from '@/features/shortcuts/platform';
+import { useKeybindingsStore } from '@/features/shortcuts/keybindings-store';
+import { bindWithSteal, chordHolder, effectiveBindings } from '@/features/shortcuts/effective-bindings';
+import { KeybindingRow } from './KeybindingRow';
+
+const GROUP_ORDER: readonly ShortcutGroup[] = ['Sessions', 'Chat', 'Workspace', 'App'];
+
+export function KeybindingsPane() {
+  const overrides = useKeybindingsStore((s) => s.overrides);
+  const setOverrides = useKeybindingsStore((s) => s.setOverrides);
+  const reset = useKeybindingsStore((s) => s.reset);
+  const resetAll = useKeybindingsStore((s) => s.resetAll);
+  const isMac = isMacPlatform();
+
+  const visible = useMemo(() => visibleShortcuts(SHORTCUTS, { dev: import.meta.env.DEV }), []);
+  const bindings = useMemo(() => effectiveBindings(visible, overrides), [visible, overrides]);
+  const anyOverridden = bindings.some((binding) => !binding.isDefault);
+
+  const holderFor = useCallback(
+    (selfId: string) => (chord: Chord) => chordHolder(bindings, chord, isMac, selfId),
+    [bindings, isMac],
+  );
+
+  const bind = useCallback(
+    (id: string, chord: Chord, steal: boolean) => {
+      // Both paths go through bindWithSteal: without a holder it is a plain
+      // write, so there is one code path rather than two that can diverge.
+      if (!steal && chordHolder(bindings, chord, isMac, id) != null) return;
+      setOverrides(bindWithSteal(overrides, visible, id, chord, isMac));
+    },
+    [bindings, overrides, visible, isMac, setOverrides],
+  );
+
+  const sections = GROUP_ORDER.map((group) => ({
+    group,
+    rows: bindings.filter((binding) => binding.entry.group === group),
+  })).filter(({ rows }) => rows.length > 0);
+
+  return (
+    <div data-testid="settings-keybindings-pane" className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          Shortcuts are stored on this Mac. Recording a chord another action holds offers to take it.
+        </p>
+        <Button
+          data-testid="settings-keybindings-reset-all"
+          variant="ghost"
+          size="sm"
+          className="shrink-0 text-xs"
+          disabled={!anyOverridden}
+          onClick={resetAll}
+        >
+          Restore defaults
+        </Button>
+      </div>
+
+      {sections.map(({ group, rows }) => (
+        <section key={group} data-testid={`settings-keybindings-group-${group.toLowerCase()}`}>
+          <SectionHeader>{group}</SectionHeader>
+          {rows.map((binding) => (
+            <KeybindingRow
+              key={binding.entry.id}
+              binding={binding}
+              isMac={isMac}
+              holderOf={holderFor(binding.entry.id)}
+              onBind={(chord, steal) => bind(binding.entry.id, chord, steal)}
+              onReset={() => reset(binding.entry.id)}
+            />
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/features/settings/settings-tabs.ts
+++ b/packages/ui/src/features/settings/settings-tabs.ts
@@ -1,12 +1,12 @@
-import { SlidersHorizontal, Cpu, Bell, Globe, Info } from 'lucide-react';
+import { SlidersHorizontal, Cpu, Keyboard, Bell, Globe, Info } from 'lucide-react';
 import type React from 'react';
 import type { ProviderConfig } from '@qlan-ro/mainframe-types';
 import type { SettingsTab } from '../../store/settings';
 
-// No 'keybindings' tab — S4 drops the placeholder pane.
 export const SETTINGS_TABS: { id: SettingsTab; label: string; icon: React.ElementType }[] = [
   { id: 'general', label: 'General', icon: SlidersHorizontal },
   { id: 'providers', label: 'Providers', icon: Cpu },
+  { id: 'keybindings', label: 'Keybindings', icon: Keyboard },
   { id: 'notifications', label: 'Notifications', icon: Bell },
   { id: 'remote-access', label: 'Remote Access', icon: Globe },
   { id: 'about', label: 'About', icon: Info },

--- a/packages/ui/src/features/shortcuts/ShortcutsCheatSheet.tsx
+++ b/packages/ui/src/features/shortcuts/ShortcutsCheatSheet.tsx
@@ -19,20 +19,29 @@ import { SHORTCUTS, visibleShortcuts } from './registry';
 import { renderEntryChord } from './render-chord';
 import { isMacPlatform } from './platform';
 import { useCheatSheetStore } from './cheat-sheet-store';
+import { effectiveBindings, type EffectiveBinding } from './effective-bindings';
+import { useKeybindingsStore } from './keybindings-store';
 
 /** Display order; a group with no visible entry is skipped. */
 const GROUP_ORDER: readonly ShortcutGroup[] = ['Sessions', 'Chat', 'Workspace', 'App'];
 
-function ShortcutRow({ entry, isMac }: { entry: ShortcutDescriptor; isMac: boolean }) {
+function ShortcutRow({ binding, isMac }: { binding: EffectiveBinding; isMac: boolean }) {
+  const { entry, chord } = binding;
   return (
     <div
       data-testid={`shortcuts-cheat-sheet-row-${entry.id}`}
       className="flex items-center justify-between gap-3 rounded-md px-2 py-1 hover:bg-muted"
     >
       <span className="min-w-0 flex-1 truncate text-sm">{entry.label}</span>
-      <kbd className="shrink-0 rounded border bg-muted px-1 py-0.5 font-mono text-xs text-muted-foreground">
-        {renderEntryChord(entry, isMac)}
-      </kbd>
+      {chord === null ? (
+        // An unassigned action still earns a row: it is a thing you can bind,
+        // and hiding it would make the cheat sheet disagree with Settings.
+        <span className="shrink-0 text-xs text-muted-foreground">Unassigned</span>
+      ) : (
+        <kbd className="shrink-0 rounded border bg-muted px-1 py-0.5 font-mono text-xs text-muted-foreground">
+          {renderEntryChord({ ...entry, chord }, isMac)}
+        </kbd>
+      )}
     </div>
   );
 }
@@ -49,12 +58,16 @@ export function ShortcutsCheatSheet({ entries = SHORTCUTS, dev = import.meta.env
   const setOpen = useCheatSheetStore((s) => s.setOpen);
   const isMac = isMacPlatform();
 
+  const overrides = useKeybindingsStore((s) => s.overrides);
+
   const sections = useMemo(() => {
     const visible = visibleShortcuts(entries, { dev });
-    return GROUP_ORDER.map((group) => ({ group, rows: visible.filter((entry) => entry.group === group) })).filter(
-      ({ rows }) => rows.length > 0,
-    );
-  }, [entries, dev]);
+    const bindings = effectiveBindings(visible, overrides);
+    return GROUP_ORDER.map((group) => ({
+      group,
+      rows: bindings.filter((binding) => binding.entry.group === group),
+    })).filter(({ rows }) => rows.length > 0);
+  }, [entries, dev, overrides]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -76,8 +89,8 @@ export function ShortcutsCheatSheet({ entries = SHORTCUTS, dev = import.meta.env
           {sections.map(({ group, rows }) => (
             <section key={group} data-testid={`shortcuts-cheat-sheet-group-${group.toLowerCase()}`}>
               <SectionHeader>{group}</SectionHeader>
-              {rows.map((entry) => (
-                <ShortcutRow key={entry.id} entry={entry} isMac={isMac} />
+              {rows.map((binding) => (
+                <ShortcutRow key={binding.entry.id} binding={binding} isMac={isMac} />
               ))}
             </section>
           ))}

--- a/packages/ui/src/features/shortcuts/__tests__/chord-from-event.test.ts
+++ b/packages/ui/src/features/shortcuts/__tests__/chord-from-event.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { chordFromEvent } from '../chord-from-event';
+
+const press = (over: Partial<Parameters<typeof chordFromEvent>[0]>) => ({
+  code: 'KeyK',
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...over,
+});
+
+describe('chordFromEvent', () => {
+  it('records ⌘ as mod on macOS', () => {
+    expect(chordFromEvent(press({ metaKey: true }), true)).toEqual({ code: 'KeyK', mod: true });
+  });
+
+  it('records Ctrl as mod off macOS, never as a literal ctrl', () => {
+    const chord = chordFromEvent(press({ ctrlKey: true }), false);
+
+    expect(chord).toEqual({ code: 'KeyK', mod: true });
+    expect(chord?.ctrl).toBeUndefined();
+  });
+
+  it('keeps ⌃ as a literal control on macOS, where it is distinct from ⌘', () => {
+    expect(chordFromEvent(press({ ctrlKey: true }), true)).toEqual({ code: 'KeyK', ctrl: true });
+  });
+
+  it('carries alt and shift', () => {
+    expect(chordFromEvent(press({ metaKey: true, altKey: true, shiftKey: true }), true)).toEqual({
+      code: 'KeyK',
+      mod: true,
+      alt: true,
+      shift: true,
+    });
+  });
+
+  it('rejects a modifier held alone — the user is still reaching', () => {
+    expect(chordFromEvent(press({ code: 'MetaLeft', metaKey: true }), true)).toBeNull();
+    expect(chordFromEvent(press({ code: 'ShiftRight', shiftKey: true }), true)).toBeNull();
+  });
+
+  it('rejects a bare key, which would fire while typing', () => {
+    expect(chordFromEvent(press({}), true)).toBeNull();
+    expect(chordFromEvent(press({ shiftKey: true }), true)).toBeNull();
+  });
+
+  it('accepts alt alone as a modifier', () => {
+    expect(chordFromEvent(press({ altKey: true }), true)).toEqual({ code: 'KeyK', alt: true });
+  });
+
+  it('records the physical code, so a shifted chord survives a layout change', () => {
+    expect(chordFromEvent(press({ code: 'Backslash', metaKey: true, shiftKey: true }), true)).toEqual({
+      code: 'Backslash',
+      mod: true,
+      shift: true,
+    });
+  });
+});

--- a/packages/ui/src/features/shortcuts/__tests__/effective-bindings.test.ts
+++ b/packages/ui/src/features/shortcuts/__tests__/effective-bindings.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The override layer: defaults, rebinds, unassignment, and the steal.
+ *
+ * These are the rules the pane and the dispatcher both depend on, so they are
+ * pinned here against fixtures rather than through either consumer.
+ */
+import { describe, expect, it } from 'vitest';
+import type { ShortcutDescriptor } from '../shortcut-types';
+import {
+  bindWithSteal,
+  chordHolder,
+  dispatchableShortcuts,
+  effectiveBindings,
+  isRebindable,
+} from '../effective-bindings';
+
+const ENTRIES: ShortcutDescriptor[] = [
+  { id: 'a.one', chord: { code: 'KeyO', mod: true }, label: 'One', group: 'App' },
+  { id: 'a.two', chord: { code: 'KeyT', mod: true }, label: 'Two', group: 'App' },
+  {
+    id: 'a.family',
+    chord: [
+      { code: 'Digit1', mod: true },
+      { code: 'Digit2', mod: true },
+    ],
+    label: 'Family',
+    group: 'Sessions',
+  },
+];
+
+const byId = (id: string) => ENTRIES.find((e) => e.id === id) as ShortcutDescriptor;
+
+describe('isRebindable', () => {
+  it('is false for a multi-chord family — one recorder cannot express nine chords', () => {
+    expect(isRebindable(byId('a.one'))).toBe(true);
+    expect(isRebindable(byId('a.family'))).toBe(false);
+  });
+});
+
+describe('effectiveBindings', () => {
+  it('uses the registry default when there is no override', () => {
+    const [one] = effectiveBindings([byId('a.one')], {});
+
+    expect(one?.isDefault).toBe(true);
+    expect(one?.chord).toEqual({ code: 'KeyO', mod: true });
+  });
+
+  it('applies a rebind and marks it non-default', () => {
+    const [one] = effectiveBindings([byId('a.one')], { 'a.one': { code: 'KeyK', mod: true } });
+
+    expect(one?.isDefault).toBe(false);
+    expect(one?.chord).toEqual({ code: 'KeyK', mod: true });
+  });
+
+  it('treats a null override as unassigned, not as absent', () => {
+    const [one] = effectiveBindings([byId('a.one')], { 'a.one': null });
+
+    expect(one?.chord).toBeNull();
+    expect(one?.isDefault).toBe(false);
+  });
+
+  it('ignores an override aimed at a multi-chord family', () => {
+    const [family] = effectiveBindings([byId('a.family')], { 'a.family': { code: 'KeyZ', mod: true } });
+
+    expect(family?.isDefault).toBe(true);
+    expect(family?.chord).toEqual(byId('a.family').chord);
+  });
+});
+
+describe('dispatchableShortcuts', () => {
+  it('drops an unassigned action so its old chord stops firing', () => {
+    const ids = dispatchableShortcuts(ENTRIES, { 'a.one': null }).map((e) => e.id);
+
+    expect(ids).toEqual(['a.two', 'a.family']);
+  });
+
+  it('hands the dispatcher the rebound chord, not the default', () => {
+    const entry = dispatchableShortcuts(ENTRIES, { 'a.one': { code: 'KeyK', mod: true } }).find(
+      (e) => e.id === 'a.one',
+    );
+
+    expect(entry?.chord).toEqual({ code: 'KeyK', mod: true });
+  });
+});
+
+describe('chordHolder', () => {
+  const bindings = effectiveBindings(ENTRIES, {});
+
+  it('names the action already answering to a chord', () => {
+    expect(chordHolder(bindings, { code: 'KeyT', mod: true }, true, 'a.one')?.id).toBe('a.two');
+  });
+
+  it('ignores the action doing the asking', () => {
+    expect(chordHolder(bindings, { code: 'KeyO', mod: true }, true, 'a.one')).toBeNull();
+  });
+
+  it('finds a holder inside a multi-chord family', () => {
+    expect(chordHolder(bindings, { code: 'Digit2', mod: true }, true, 'a.one')?.id).toBe('a.family');
+  });
+
+  it('returns null for a free chord', () => {
+    expect(chordHolder(bindings, { code: 'KeyQ', mod: true, shift: true }, true, 'a.one')).toBeNull();
+  });
+});
+
+describe('bindWithSteal', () => {
+  it('binds a free chord without touching anyone else', () => {
+    const next = bindWithSteal({}, ENTRIES, 'a.one', { code: 'KeyQ', mod: true }, true);
+
+    expect(next).toEqual({ 'a.one': { code: 'KeyQ', mod: true } });
+  });
+
+  it('unassigns the previous holder rather than leaving two claims', () => {
+    const next = bindWithSteal({}, ENTRIES, 'a.one', { code: 'KeyT', mod: true }, true);
+
+    expect(next['a.one']).toEqual({ code: 'KeyT', mod: true });
+    expect(next['a.two']).toBeNull();
+  });
+
+  it('leaves the loser unassigned, not back on its default — that would re-create the conflict', () => {
+    const next = bindWithSteal({}, ENTRIES, 'a.one', { code: 'KeyT', mod: true }, true);
+    const bindings = effectiveBindings(ENTRIES, next);
+
+    expect(bindings.find((b) => b.entry.id === 'a.two')?.chord).toBeNull();
+    expect(chordHolder(bindings, { code: 'KeyT', mod: true }, true, 'a.one')).toBeNull();
+  });
+});

--- a/packages/ui/src/features/shortcuts/chord-from-event.ts
+++ b/packages/ui/src/features/shortcuts/chord-from-event.ts
@@ -1,0 +1,54 @@
+/**
+ * Turning a keypress into a bindable chord — the recorder's whole contract.
+ *
+ * Matching reads `KeyboardEvent.code` (the physical key), so recording must
+ * store the same thing: capture the character instead and a shifted chord
+ * stops working the moment the layout changes.
+ */
+import type { Chord } from './shortcut-types';
+
+/** Held alone these are not a chord, they are the user still reaching. */
+const MODIFIER_CODES = new Set([
+  'MetaLeft',
+  'MetaRight',
+  'ControlLeft',
+  'ControlRight',
+  'AltLeft',
+  'AltRight',
+  'ShiftLeft',
+  'ShiftRight',
+  'CapsLock',
+]);
+
+export interface RecordableKeydown {
+  code: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * The chord this keypress would bind, or `null` if it is not bindable.
+ *
+ * Rejects modifier-only presses and anything without a modifier: a bare letter
+ * would fire while typing, and the dispatcher's text-field rule only exempts
+ * chords that carry one.
+ */
+export function chordFromEvent(event: RecordableKeydown, isMac: boolean): Chord | null {
+  if (MODIFIER_CODES.has(event.code)) return null;
+
+  // `mod` is ⌘ on macOS and Ctrl elsewhere, so a literal `ctrl` is only
+  // meaningful on macOS — off it, Ctrl IS mod and setting both would resolve
+  // to the same flag twice.
+  const mod = isMac ? event.metaKey : event.ctrlKey;
+  const ctrl = isMac ? event.ctrlKey : false;
+  if (!mod && !ctrl && !event.altKey) return null;
+
+  const chord: Chord = { code: event.code };
+  if (mod) chord.mod = true;
+  if (ctrl) chord.ctrl = true;
+  if (event.altKey) chord.alt = true;
+  if (event.shiftKey) chord.shift = true;
+  return chord;
+}

--- a/packages/ui/src/features/shortcuts/chord-hint.ts
+++ b/packages/ui/src/features/shortcuts/chord-hint.ts
@@ -4,11 +4,23 @@
  * Every hint the app shows — palette rows, toolbar chips, tooltips — reads its
  * glyphs from the registry through here, so a re-chorded shortcut can never
  * leave a stale label behind (the sidebar hint read ⌘\ against a ⌘B binding).
+ * That now includes USER rebinds: the override layer is resolved here too,
+ * which is why this reads the store rather than the raw registry.
  */
 import { isMacPlatform } from './platform';
 import { shortcutById, type ShortcutId } from './registry';
 import { renderEntryChord } from './render-chord';
+import { effectiveBindings } from './effective-bindings';
+import { useKeybindingsStore } from './keybindings-store';
 
-export function chordHint(id: ShortcutId): string {
-  return renderEntryChord(shortcutById(id), isMacPlatform());
+/** The chord to show for `id`, or `null` when the user left it unassigned. */
+export function chordHint(id: ShortcutId): string | null {
+  const entry = shortcutById(id);
+  // A plain function, not a hook: call sites are menu items and tooltips that
+  // re-render with their parent, so a snapshot read is enough and keeps this
+  // usable outside React.
+  const { overrides } = useKeybindingsStore.getState();
+  const binding = effectiveBindings([entry], overrides)[0];
+  if (binding == null || binding.chord === null) return null;
+  return renderEntryChord({ ...entry, chord: binding.chord }, isMacPlatform());
 }

--- a/packages/ui/src/features/shortcuts/effective-bindings.ts
+++ b/packages/ui/src/features/shortcuts/effective-bindings.ts
@@ -1,0 +1,93 @@
+/**
+ * Where registry defaults and user overrides become one answer.
+ *
+ * Everything that spells or dispatches a chord reads through here — the
+ * dispatcher, the cheat sheet, `chordHint` — so a rebind reaches the toolbar
+ * hint and the palette in the same render. Splitting that was what let the
+ * sidebar advertise ⌘\ against a ⌘B binding.
+ */
+import { chordKey, chordList, resolveChord } from './chord';
+import type { Chord, PlatformChord, ShortcutDescriptor } from './shortcut-types';
+import type { Overrides } from './keybindings-store';
+
+/**
+ * A multi-chord entry is ONE action holding nine chords (⌘1…⌘9). A single
+ * recorder cannot express that, so the family stays at its defaults for now
+ * rather than pretending otherwise in the UI.
+ */
+export function isRebindable(entry: ShortcutDescriptor): boolean {
+  return !Array.isArray(entry.chord);
+}
+
+export interface EffectiveBinding {
+  entry: ShortcutDescriptor;
+  /** `null` when the user left this action unassigned. */
+  chord: ShortcutDescriptor['chord'] | null;
+  /** False once a user override is in play — what drives the Reset affordance. */
+  isDefault: boolean;
+  rebindable: boolean;
+}
+
+export function effectiveBindings(entries: readonly ShortcutDescriptor[], overrides: Overrides): EffectiveBinding[] {
+  return entries.map((entry) => {
+    const rebindable = isRebindable(entry);
+    // `hasOwnProperty`, not a truthy check: `null` is a real value here
+    // (unassigned) and must not read as "no override".
+    const overridden = rebindable && Object.prototype.hasOwnProperty.call(overrides, entry.id);
+    if (!overridden) return { entry, chord: entry.chord, isDefault: true, rebindable };
+    return { entry, chord: overrides[entry.id] ?? null, isDefault: false, rebindable };
+  });
+}
+
+/** The dispatcher's view: the entries that currently have a chord to match. */
+export function dispatchableShortcuts(
+  entries: readonly ShortcutDescriptor[],
+  overrides: Overrides,
+): ShortcutDescriptor[] {
+  return effectiveBindings(entries, overrides)
+    .filter((binding) => binding.chord !== null)
+    .map((binding) => ({ ...binding.entry, chord: binding.chord as ShortcutDescriptor['chord'] }));
+}
+
+/** Every resolved chord key an effective binding currently answers to. */
+function keysOf(binding: EffectiveBinding, isMac: boolean): string[] {
+  if (binding.chord === null) return [];
+  const entry = { ...binding.entry, chord: binding.chord } as ShortcutDescriptor;
+  return chordList(entry).map((chord) => chordKey(resolveChord(chord, isMac)));
+}
+
+/**
+ * Which action already answers to `chord`, ignoring `selfId`. The recorder
+ * needs the holder by name — "⌘K is already Open command palette" beats
+ * "that chord is taken".
+ */
+export function chordHolder(
+  bindings: readonly EffectiveBinding[],
+  chord: Chord,
+  isMac: boolean,
+  selfId: string,
+): ShortcutDescriptor | null {
+  const key = chordKey(resolveChord(chord as PlatformChord, isMac));
+  const hit = bindings.find((binding) => binding.entry.id !== selfId && keysOf(binding, isMac).includes(key));
+  return hit?.entry ?? null;
+}
+
+/**
+ * Bind `id` to `chord`, unassigning whoever held it — the "use it anyway"
+ * steal. Pure: the caller hands the result to the store.
+ *
+ * The loser becomes explicitly unassigned rather than dropping back to its
+ * default, which would silently recreate the very conflict the steal resolved.
+ */
+export function bindWithSteal(
+  overrides: Overrides,
+  entries: readonly ShortcutDescriptor[],
+  id: string,
+  chord: Chord,
+  isMac: boolean,
+): Overrides {
+  const holder = chordHolder(effectiveBindings(entries, overrides), chord, isMac, id);
+  const next: Overrides = { ...overrides, [id]: chord };
+  if (holder) next[holder.id] = null;
+  return next;
+}

--- a/packages/ui/src/features/shortcuts/keybindings-store.ts
+++ b/packages/ui/src/features/shortcuts/keybindings-store.ts
@@ -1,0 +1,45 @@
+/**
+ * User overrides for the shortcut registry — the one mutable layer over
+ * `registry.ts`, which stays pure declarative defaults.
+ *
+ * Per machine, not per account: a keymap belongs to the keyboard in front of
+ * you, and syncing it would need a daemon contract change co-owned with a
+ * mobile client that has no hardware keyboard to bind.
+ *
+ * An id absent from `overrides` uses its registry default. An id mapped to
+ * `null` is one the user left UNASSIGNED — distinct from "default", and the
+ * state a chord lands in after another action steals it.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Chord } from './shortcut-types';
+
+/** A rebound chord, or `null` for an intentionally unassigned shortcut. */
+export type Binding = Chord | null;
+
+export type Overrides = Record<string, Binding>;
+
+interface KeybindingsStore {
+  overrides: Overrides;
+  setOverrides: (next: Overrides) => void;
+  /** Drop one id's override, returning it to the registry default. */
+  reset: (id: string) => void;
+  resetAll: () => void;
+}
+
+export const useKeybindingsStore = create<KeybindingsStore>()(
+  persist(
+    (set) => ({
+      overrides: {},
+      setOverrides: (next) => set({ overrides: next }),
+      reset: (id) =>
+        set((s) => {
+          const next = { ...s.overrides };
+          delete next[id];
+          return { overrides: next };
+        }),
+      resetAll: () => set({ overrides: {} }),
+    }),
+    { name: 'mf:keybindings' },
+  ),
+);

--- a/packages/ui/src/features/shortcuts/use-shortcut-dispatcher.ts
+++ b/packages/ui/src/features/shortcuts/use-shortcut-dispatcher.ts
@@ -14,13 +14,21 @@ import { chordList, matchesChord, resolveChord } from './chord';
 import { isEligibleTarget } from './eligibility';
 import { isMacPlatform } from './platform';
 import { SHORTCUTS, visibleShortcuts } from './registry';
+import { dispatchableShortcuts } from './effective-bindings';
+import { useKeybindingsStore } from './keybindings-store';
 
 export function useShortcutDispatcher(): void {
+  // Rebinding has to re-arm the listener, so the overrides are a dependency
+  // rather than a one-time read at mount.
+  const overrides = useKeybindingsStore((s) => s.overrides);
+
   useEffect(() => {
     const isMac = isMacPlatform();
     // The dev gate is applied at this one mount site, so `dev: true` entries
     // need no second guard in the feature that owns them.
-    const entries = visibleShortcuts(SHORTCUTS, { dev: import.meta.env.DEV }).map((entry) => ({
+    const entries = visibleShortcuts(dispatchableShortcuts(SHORTCUTS, overrides), {
+      dev: import.meta.env.DEV,
+    }).map((entry) => ({
       entry,
       chords: chordList(entry).map((chord) => resolveChord(chord, isMac)),
     }));
@@ -40,5 +48,5 @@ export function useShortcutDispatcher(): void {
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [overrides]);
 }

--- a/packages/ui/src/layout/MainToolbar.tsx
+++ b/packages/ui/src/layout/MainToolbar.tsx
@@ -72,7 +72,7 @@ export function MainToolbar({ leadingInset, sidebarRendered, onExpandSidebar, pr
 
       {/* Right: controls — search │ project tools │ workspace. */}
       <div className="flex shrink-0 items-center gap-0.5">
-        <Hint label={`Search (${searchChord})`}>
+        <Hint label={searchChord == null ? 'Search' : `Search (${searchChord})`}>
           <Button
             data-testid="main-toolbar-search"
             variant="ghost"
@@ -81,12 +81,16 @@ export function MainToolbar({ leadingInset, sidebarRendered, onExpandSidebar, pr
             className="text-muted-foreground"
           >
             <Search className="size-4" />
-            <kbd
-              data-testid="main-toolbar-search-hint"
-              className="pointer-events-none inline-flex items-center rounded-sm border bg-muted px-1 font-mono text-sm font-medium text-muted-foreground"
-            >
-              {searchChord}
-            </kbd>
+            {/* No chip at all when the action is unassigned — an empty kbd box
+                reads as a broken control rather than an absent shortcut. */}
+            {searchChord != null && (
+              <kbd
+                data-testid="main-toolbar-search-hint"
+                className="pointer-events-none inline-flex items-center rounded-sm border bg-muted px-1 font-mono text-sm font-medium text-muted-foreground"
+              >
+                {searchChord}
+              </kbd>
+            )}
           </Button>
         </Hint>
         <Separator orientation="vertical" className="mx-1 h-4 data-vertical:self-center" />

--- a/packages/ui/src/store/settings.ts
+++ b/packages/ui/src/store/settings.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import type { ProviderConfig, GeneralConfig, NotificationConfig } from '@qlan-ro/mainframe-types';
 import { GENERAL_DEFAULTS } from '@qlan-ro/mainframe-types';
 
-export type SettingsTab = 'general' | 'providers' | 'notifications' | 'remote-access' | 'about';
+export type SettingsTab = 'general' | 'providers' | 'keybindings' | 'notifications' | 'remote-access' | 'about';
 
 interface SettingsState {
   isOpen: boolean;


### PR DESCRIPTION
**Stacked on #635** (`todo/324-keyboard-shortcuts`) — that PR builds the registry this one makes editable. Retarget to `main` once #635 merges.

#324's spec deliberately shipped "no user-customizable keymap". This adds it.

## Model

One override layer over the registry, which stays pure defaults:

| store state | meaning |
|---|---|
| id absent | registry default |
| id → `Chord` | rebound |
| id → `null` | **unassigned** — the state a chord lands in after another action steals it |

`null` is a real value, so the resolver uses `hasOwnProperty` rather than a truthy check.

**Persistence is localStorage, per machine** (`mf:keybindings`, the `ui-prefs` pattern). A keymap belongs to the keyboard in front of you, and syncing it would need a daemon contract change co-owned with a mobile client that has no hardware keyboard to bind.

## One resolution path

The dispatcher, the cheat sheet and `chordHint` all read `effective-bindings`, so a rebind reaches the toolbar hint and the palette in the same render. That's the drift `chordHint` was written to prevent — it now covers user rebinds too.

`chordHint` returns `null` for an unassigned action, so its four call sites drop the hint rather than advertise a chord that no longer fires (the toolbar renders no `kbd` chip at all, since an empty one reads as a broken control).

## Conflicts

Recording a taken chord names the holder — "Already Open command palette" — and won't commit. **Use it anyway** completes the steal, leaving the loser explicitly *unassigned* rather than back on its default, which would silently recreate the conflict the steal just resolved.

## Scope

The nine ⌘1…⌘9 tab chords are one action with nine chords; a single recorder can't express that, so the row renders read-only (`⌘1 … ⌘9`) rather than pretending otherwise.

## Testing

22 unit tests over the two pure modules — resolution, unassignment, the family carve-out, holder lookup, and the steal's unassign-the-loser rule; plus `chordFromEvent`'s capture rules (modifier-only and bare keys rejected, physical `code` recorded, `mod` vs literal `⌃` per platform).

877 tests green across the 109 affected files; `tsc --noEmit` clean. `SettingsDialog.test.tsx` had an assertion that the keybindings nav row is absent ("S4 dropped") — inverted deliberately, since the placeholder is a real pane again.

Verified live in a dev app: rebound ⌘F → ⌘⇧Y and confirmed from a clean baseline that **⌘F no longer opens Find and ⌘⇧Y does**; the steal moved ⌘O to Settings and left the palette showing "Unassigned", persisted as `null`; the ⌘1…⌘9 row is disabled; Restore defaults enables only once an override exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)