### PR TITLE
fix(ui): share the project list so adding one updates every surface

### DIFF
--- a/.changeset/fix-project-list-shared-store.md
+++ b/.changeset/fix-project-list-shared-store.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix a project added from the empty first-run state never appearing until a full reload. `useProjects()` moved from a per-caller `useState` to a shared `store/projects.ts` store, so a reload issued from one mounted consumer (e.g. the "Add project" CTA) now updates every other one — the sidebar and chat surface included.

--- a/packages/ui/src/features/sessions/__tests__/use-projects.test.tsx
+++ b/packages/ui/src/features/sessions/__tests__/use-projects.test.tsx
@@ -1,5 +1,5 @@
 /**
- * useProjects — behavior tests (TDD red phase).
+ * useProjects — behavior tests.
  *
  * Behaviors covered:
  *  - On mount, getProjects is called exactly once with port 31415.
@@ -8,11 +8,14 @@
  *    (id 'p1') and loading is false.
  *  - When getProjects rejects, projects stays [] and loading becomes false
  *    (no unhandled rejection).
+ *  - Two independently-mounted instances share one list (the shared-store
+ *    regression this hook exists to prevent — see store/projects.ts).
  */
 import { it, expect, vi, beforeEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { DaemonPortProvider } from '../runtime/daemon-port-context';
+import { resetProjectsStore } from '@/store/projects';
 
 // ---------------------------------------------------------------------------
 // Mocks — hoisted so vi.mock factories run before imports
@@ -45,6 +48,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetProjectsStore();
 });
 
 it('invokes getProjects(31415) exactly once on mount', async () => {
@@ -130,4 +134,26 @@ it('projects stays [] and loading becomes false without an unhandled rejection w
   });
 
   expect(result.current.projects).toEqual([]);
+});
+
+it('a reload from one mounted instance is visible to a second, independently-mounted instance', async () => {
+  mockGetProjects.mockResolvedValue([]);
+
+  const a = renderHook(() => useProjects(), { wrapper });
+  const b = renderHook(() => useProjects(), { wrapper });
+
+  await waitFor(() => {
+    expect(a.result.current.loading).toBe(false);
+    expect(b.result.current.loading).toBe(false);
+  });
+
+  mockGetProjects.mockResolvedValueOnce([
+    { id: 'p1', name: 'mainframe', path: '/r/mf', createdAt: '', lastOpenedAt: '' },
+  ]);
+  await act(async () => {
+    await a.result.current.reloadProjects();
+  });
+
+  expect(a.result.current.projects.map((p) => p.id)).toEqual(['p1']);
+  expect(b.result.current.projects.map((p) => p.id)).toEqual(['p1']);
 });

--- a/packages/ui/src/features/sessions/new-thread/__tests__/FirstRunState.shared-store.test.tsx
+++ b/packages/ui/src/features/sessions/new-thread/__tests__/FirstRunState.shared-store.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * FirstRunState — shared-store regression.
+ *
+ * FirstRunState.test.tsx mocks `useProjects` entirely, which is exactly why the
+ * original bug (adding a project from the empty first-run state left the
+ * sidebar/chat surface stuck on the empty hero until a full reload) went
+ * uncaught: a mocked hook can't exercise the cross-instance update path. This
+ * file renders FirstRunState next to a sibling consumer of the SAME real
+ * `useProjects()` hook and asserts the sibling sees the new project — without
+ * either component remounting — once Add project completes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DaemonPortProvider } from '../../runtime/daemon-port-context';
+import { resetProjectsStore } from '@/store/projects';
+import { useProjects } from '../../use-projects';
+import { FirstRunState } from '../FirstRunState';
+
+const NEW_PROJECT = { id: 'p1', name: 'mainframe', path: '/r/mf', createdAt: '', lastOpenedAt: '' };
+
+const getProjects = vi.fn();
+const createProject = vi.fn();
+vi.mock('@/lib/api/projects', () => ({
+  getProjects: (...args: unknown[]) => getProjects(...args),
+  createProject: (...args: unknown[]) => createProject(...args),
+}));
+
+const pickDirectory = vi.fn();
+vi.mock('@/features/files/use-directory-picker', () => ({
+  useDirectoryPicker: (selector: (s: { pickDirectory: typeof pickDirectory }) => unknown) =>
+    selector({ pickDirectory }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  mfToast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+// A sibling call site — a SEPARATE mounted instance of the same real hook,
+// standing in for SessionSidebar/ChatSurface/etc.
+function SiblingProjectCount() {
+  const { projects } = useProjects();
+  return <div data-testid="sibling-project-count">{projects.length}</div>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetProjectsStore();
+});
+
+describe('FirstRunState — shared project store', () => {
+  it('updates a sibling useProjects() consumer after Add project, without remounting either component', async () => {
+    getProjects.mockResolvedValue([]);
+    pickDirectory.mockResolvedValue('/r/mf');
+    createProject.mockResolvedValue({ project: NEW_PROJECT, alreadyExists: false });
+
+    render(
+      <DaemonPortProvider port={31415}>
+        <FirstRunState />
+        <SiblingProjectCount />
+      </DaemonPortProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sibling-project-count')).toHaveTextContent('0');
+    });
+
+    getProjects.mockResolvedValueOnce([NEW_PROJECT]);
+    fireEvent.click(screen.getByTestId('sessions-firstrun-add-project'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sibling-project-count')).toHaveTextContent('1');
+    });
+  });
+});

--- a/packages/ui/src/features/sessions/use-add-project.ts
+++ b/packages/ui/src/features/sessions/use-add-project.ts
@@ -2,10 +2,10 @@
  * useAddProject — the add-project orchestration: pick a directory, register it
  * with the daemon, then refetch the project list and toast the outcome.
  *
- * `reloadProjects` is passed in (not pulled from a local `useProjects()`) so the
- * refetch hits the CALLER's rendered `useProjects` instance — `useProjects` is
- * local `useState` per caller, so a fresh instance here would update nothing the
- * sidebar renders. Per decision, the active filter is left untouched on add.
+ * `reloadProjects` is injected rather than pulled from a fresh `useProjects()`
+ * call, for testability — `useProjects` now reads the shared `store/projects.ts`
+ * store, so any caller's `reloadProjects()` updates every mounted consumer.
+ * Per decision, the active filter is left untouched on add.
  */
 import { useCallback } from 'react';
 import { createProject } from '@/lib/api/projects';

--- a/packages/ui/src/features/sessions/use-projects.ts
+++ b/packages/ui/src/features/sessions/use-projects.ts
@@ -1,14 +1,20 @@
 /**
- * useProjects — loads the daemon's project list once, keyed off the runtime port.
+ * useProjects — a thin selector over the shared `store/projects.ts` store.
  *
  * The single project source for the sessions feature: consumed by SessionSidebar
  * (filter pills + grouping) and the new-session picker / welcome flow (project
- * select). Reads the port from DaemonPortContext so it works inside aui's
- * runtime binder.
+ * select). Every call site reads the SAME list, so a reload issued from one
+ * mounted consumer (e.g. the first-run "Add project" CTA) is visible to every
+ * other one without a remount. Reads the port from DaemonPortContext so it
+ * works inside aui's runtime binder.
  */
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import type { Project } from '@qlan-ro/mainframe-types';
-import { getProjects } from '@/lib/api/projects';
+import {
+  useProjectsStore,
+  reloadProjects as reloadProjectsAction,
+  removeProjectFromList as removeProjectFromListAction,
+} from '@/store/projects';
 import { useDaemonPort } from './runtime/daemon-port-context';
 
 export interface UseProjectsResult {
@@ -20,42 +26,17 @@ export interface UseProjectsResult {
 
 export function useProjects(): UseProjectsResult {
   const port = useDaemonPort();
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  async function reloadProjects(): Promise<void> {
-    setLoading(true);
-    try {
-      setProjects(await getProjects(port));
-    } catch (e: unknown) {
-      console.warn('[useProjects] getProjects failed', e);
-    } finally {
-      setLoading(false);
-    }
-  }
+  const projects = useProjectsStore((s) => s.projects);
+  const loading = useProjectsStore((s) => s.loading);
 
   useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    getProjects(port)
-      .then((list) => {
-        if (!cancelled) setProjects(list);
-      })
-      .catch((e: unknown) => {
-        console.warn('[useProjects] getProjects failed', e);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    void reloadProjectsAction(port);
   }, [port]);
 
   return {
     projects,
     loading,
-    reloadProjects,
-    removeProjectFromList: (projectId) => setProjects((list) => list.filter((project) => project.id !== projectId)),
+    reloadProjects: () => reloadProjectsAction(port),
+    removeProjectFromList: removeProjectFromListAction,
   };
 }

--- a/packages/ui/src/features/sessions/use-remove-project.ts
+++ b/packages/ui/src/features/sessions/use-remove-project.ts
@@ -6,10 +6,10 @@
  * dialog: the Tauri webview implements no JavaScript confirm panel, so a native
  * call resolves false without rendering and the removal never happens.
  *
- * `removeProjectFromList` is passed in (not pulled from a local `useProjects()`)
- * so the row drops from the CALLER's rendered instance — `useProjects` is local
- * `useState` per caller, so a fresh instance here would update nothing the
- * sidebar renders.
+ * `removeProjectFromList` is injected rather than pulled from a fresh
+ * `useProjects()` call, for testability — `useProjects` now reads the shared
+ * `store/projects.ts` store, so any caller's `removeProjectFromList()` updates
+ * every mounted consumer.
  */
 import { useCallback } from 'react';
 import type { Project } from '@qlan-ro/mainframe-types';

--- a/packages/ui/src/store/__tests__/projects.test.ts
+++ b/packages/ui/src/store/__tests__/projects.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/api/projects', () => ({ getProjects: vi.fn() }));
+
+import { getProjects } from '@/lib/api/projects';
+import { useProjectsStore, reloadProjects, removeProjectFromList, resetProjectsStore } from '../projects.js';
+
+const mockGetProjects = vi.mocked(getProjects);
+
+const project = (id: string) => ({ id, name: id, path: `/r/${id}`, createdAt: '', lastOpenedAt: '' });
+
+describe('ui projects store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProjectsStore();
+  });
+
+  it('starts empty and loading', () => {
+    expect(useProjectsStore.getState()).toEqual({ projects: [], loading: true });
+  });
+
+  it('reloadProjects fetches and applies the list', async () => {
+    mockGetProjects.mockResolvedValue([project('p1')]);
+    await reloadProjects(31415);
+    expect(mockGetProjects).toHaveBeenCalledWith(31415);
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p1']);
+    expect(useProjectsStore.getState().loading).toBe(false);
+  });
+
+  it('leaves the list empty and clears loading when the fetch rejects', async () => {
+    mockGetProjects.mockRejectedValue(new Error('boom'));
+    await reloadProjects(31415);
+    expect(useProjectsStore.getState().projects).toEqual([]);
+    expect(useProjectsStore.getState().loading).toBe(false);
+  });
+
+  it('removeProjectFromList drops the matching id', async () => {
+    mockGetProjects.mockResolvedValue([project('p1'), project('p2')]);
+    await reloadProjects(31415);
+    removeProjectFromList('p1');
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('applies only the most recently-issued reload, even if an earlier one resolves last', async () => {
+    let resolveFirst: (list: ReturnType<typeof project>[]) => void = () => undefined;
+    mockGetProjects.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveFirst = res;
+        }),
+    );
+    const first = reloadProjects(31415);
+
+    mockGetProjects.mockResolvedValueOnce([project('p2')]);
+    const second = reloadProjects(31415);
+    await second;
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
+
+    resolveFirst([project('p1')]);
+    await first;
+    // The stale first response must not overwrite the newer second one.
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
+  });
+});

--- a/packages/ui/src/store/projects.ts
+++ b/packages/ui/src/store/projects.ts
@@ -1,0 +1,46 @@
+/**
+ * store/projects.ts — the shared project list.
+ *
+ * Unlike adapters/quota, the daemon has no push event for project changes, so
+ * this store is refreshed only by an explicit `reloadProjects(port)` call —
+ * every `useProjects()` instance issues one on mount/port-change. The point of
+ * moving the list here (out of `useProjects`'s old per-caller `useState`) is
+ * that a reload from ANY one call site (e.g. the first-run "Add project" CTA)
+ * is now visible to every other mounted consumer without a remount.
+ */
+import { create } from 'zustand';
+import type { Project } from '@qlan-ro/mainframe-types';
+import { getProjects } from '@/lib/api/projects';
+
+interface ProjectsState {
+  projects: Project[];
+  loading: boolean;
+}
+
+export const useProjectsStore = create<ProjectsState>(() => ({ projects: [], loading: true }));
+
+export function removeProjectFromList(projectId: string): void {
+  useProjectsStore.setState((s) => ({ projects: s.projects.filter((p) => p.id !== projectId) }));
+}
+
+let reloadGeneration = 0;
+
+/** Only the most recently-issued call is allowed to apply its result, so a slow
+ *  response from an earlier reload can't clobber a fresher one that resolved first. */
+export async function reloadProjects(port: number): Promise<void> {
+  const generation = ++reloadGeneration;
+  useProjectsStore.setState({ loading: true });
+  try {
+    const projects = await getProjects(port);
+    if (generation === reloadGeneration) useProjectsStore.setState({ projects, loading: false });
+  } catch (e: unknown) {
+    console.warn('[store/projects] getProjects failed', e);
+    if (generation === reloadGeneration) useProjectsStore.setState({ loading: false });
+  }
+}
+
+/** Reserved for tests — mirrors resetAdapters/resetQuota. */
+export function resetProjectsStore(): void {
+  reloadGeneration = 0;
+  useProjectsStore.setState({ projects: [], loading: true });
+}


### PR DESCRIPTION
## Summary
- `useProjects()` was per-caller `useState` with no shared store and no daemon push event, so adding a project from the empty first-run state refreshed only that throwaway instance — the sidebar/chat surface stayed on the empty state until a full reload.
- Lifts `projects` into a shared zustand store (`store/projects.ts`, matching sibling stores' pattern); `useProjects()` becomes a thin selector with an unchanged external API, so all 11+ consumers fix themselves with no call-site changes.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck`
- [x] New integration test renders `FirstRunState` next to a sibling `useProjects()` consumer, clicks "Add project," asserts the sibling updates without remounting — verified red against the pre-fix code, green after
- [x] 144 tests across 17 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)