### PR TITLE
fix(ui): clamp the tutorial popover against the right viewport edge

### DIFF
--- a/.changeset/tutorial-popover-right-clip.md
+++ b/.changeset/tutorial-popover-right-clip.md
@@ -1,0 +1,8 @@
+---
+"@qlan-ro/mainframe-ui": patch
+---
+
+Fixed the first-run tutorial popover clipping off the right edge of the
+viewport on step 4 ("Open the workspace"), whose anchor sits near the right
+edge of the toolbar. The label card's horizontal position is now clamped
+against both viewport edges, not just the left.

--- a/packages/ui/src/features/tour/TutorialOverlay.tsx
+++ b/packages/ui/src/features/tour/TutorialOverlay.tsx
@@ -58,27 +58,36 @@ const PAD = 6;
 const LW = 268;
 const GAP = 18;
 
-function computeLabelStyle(rect: TargetRect, side: TourStep['side']): CSSProperties {
+// Clamps the label card's left edge between the viewport's left and right
+// edges (falls back to the left clamp alone if the viewport is narrower than
+// the card, so the card never reports a left more restrictive than 8px).
+export function clampLabelLeft(left: number, viewportWidth: number): number {
+  const maxLeft = Math.max(8, viewportWidth - LW - 8);
+  return Math.min(Math.max(8, left), maxLeft);
+}
+
+export function computeLabelStyle(rect: TargetRect, side: TourStep['side']): CSSProperties {
   const h = {
     top: rect.top - PAD,
     left: rect.left - PAD,
     w: rect.width + PAD * 2,
     height: rect.height + PAD * 2,
   };
+  const viewportWidth = window.innerWidth;
   if (side === 'right') {
-    return { top: Math.max(8, h.top), left: h.left + h.w + GAP };
+    return { top: Math.max(8, h.top), left: clampLabelLeft(h.left + h.w + GAP, viewportWidth) };
   }
   if (side === 'above') {
     return {
       top: h.top - GAP,
-      left: Math.max(8, h.left + h.w / 2 - LW / 2),
+      left: clampLabelLeft(h.left + h.w / 2 - LW / 2, viewportWidth),
       transform: 'translateY(-100%)',
     };
   }
   // below
   return {
     top: h.top + h.height + GAP,
-    left: Math.max(8, h.left + h.w / 2 - LW / 2),
+    left: clampLabelLeft(h.left + h.w / 2 - LW / 2, viewportWidth),
   };
 }
 

--- a/packages/ui/src/features/tour/__tests__/computeLabelStyle.test.tsx
+++ b/packages/ui/src/features/tour/__tests__/computeLabelStyle.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * computeLabelStyle.test.ts
+ *
+ * Regression coverage for the tutorial popover clipping off the right edge
+ * of the viewport (step 4 / "workspace", side: 'below', anchors a 32px
+ * toggle near the right edge of the toolbar).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { clampLabelLeft, computeLabelStyle } from '../TutorialOverlay';
+
+const LW = 268;
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+}
+
+const originalInnerWidth = window.innerWidth;
+
+afterEach(() => {
+  setViewportWidth(originalInnerWidth);
+});
+
+describe('clampLabelLeft', () => {
+  it('clamps to the left edge (8px minimum)', () => {
+    expect(clampLabelLeft(-50, 1440)).toBe(8);
+  });
+
+  it('clamps to the right edge so the card stays fully on-screen', () => {
+    setViewportWidth(1440);
+    const left = clampLabelLeft(1400, 1440);
+    expect(left).toBe(1440 - LW - 8);
+    expect(left + LW).toBeLessThanOrEqual(1440);
+  });
+
+  it('leaves an unclamped value untouched', () => {
+    expect(clampLabelLeft(500, 1440)).toBe(500);
+  });
+
+  it('falls back to the left clamp when the viewport is narrower than the card', () => {
+    // viewportWidth - LW - 8 goes negative; the left floor (8) must win.
+    expect(clampLabelLeft(50, 200)).toBe(8);
+  });
+});
+
+describe('computeLabelStyle', () => {
+  // Mirrors the workspace toggle: a 32px-wide icon sitting near the right
+  // edge of the toolbar, at a few representative viewport widths.
+  const widths = [1280, 1440, 1728];
+
+  it.each(widths)('keeps the "below" card fully on-screen at %dpx wide', (width) => {
+    setViewportWidth(width);
+    const rect = { top: 40, left: width - 40, width: 32, height: 28 };
+    const style = computeLabelStyle(rect, 'below');
+    const left = style.left as number;
+    expect(left).toBeGreaterThanOrEqual(8);
+    expect(left + LW).toBeLessThanOrEqual(width);
+  });
+
+  it.each(widths)('keeps the "above" card fully on-screen at %dpx wide', (width) => {
+    setViewportWidth(width);
+    const rect = { top: 200, left: width - 40, width: 32, height: 28 };
+    const style = computeLabelStyle(rect, 'above');
+    const left = style.left as number;
+    expect(left).toBeGreaterThanOrEqual(8);
+    expect(left + LW).toBeLessThanOrEqual(width);
+  });
+
+  it.each(widths)('keeps the "right" card fully on-screen at %dpx wide', (width) => {
+    setViewportWidth(width);
+    const rect = { top: 200, left: width - 20, width: 12, height: 12 };
+    const style = computeLabelStyle(rect, 'right');
+    const left = style.left as number;
+    expect(left).toBeGreaterThanOrEqual(8);
+    expect(left + LW).toBeLessThanOrEqual(width);
+  });
+
+  it('does not clamp a "below" card anchored away from the right edge', () => {
+    setViewportWidth(1440);
+    const rect = { top: 40, left: 100, width: 32, height: 28 };
+    const style = computeLabelStyle(rect, 'below');
+    // center: 100-6=94 (h.left) + (32+12)/2 -134 = 94+22-134 = -18 -> clamps to 8 (left edge, not right)
+    expect(style.left).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary
- Step 4 of the tutorial (anchored to the workspace toggle, near the right edge of the toolbar) rendered its label card ~70px off-screen — `computeLabelStyle` only clamped against the left viewport edge.
- Adds a symmetric right-edge clamp to all three `computeLabelStyle` branches (`right`/`above`/`below`).

## Test plan
- [x] New test file with 14 cases at three viewport widths (1280/1440/1728) for an anchor shaped like the workspace toggle
- [x] Existing `TutorialOverlay.test.tsx` still passes — 25/25 total
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)