### PR TITLE
fix(ui): stop the zero-projects boot from looping on reloadProjects

### DIFF
--- a/.changeset/projects-store-thundering-herd.md
+++ b/.changeset/projects-store-thundering-herd.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Fix the zero-projects first-run screen never appearing: `reloadProjects` now shares one in-flight request across concurrently-mounted `useProjects()` consumers instead of firing a redundant fetch per mount, and `loading` now reflects only the initial load rather than flipping true on every reload — the latter previously caused an infinite mount/unmount loop between the first-run hero and the welcome screen on a fresh, project-less workspace.

--- a/packages/ui/src/features/sessions/__tests__/use-projects.test.tsx
+++ b/packages/ui/src/features/sessions/__tests__/use-projects.test.tsx
@@ -136,6 +136,22 @@ it('projects stays [] and loading becomes false without an unhandled rejection w
   expect(result.current.projects).toEqual([]);
 });
 
+it('mounting several consumers together issues exactly one getProjects call', async () => {
+  mockGetProjects.mockResolvedValue([]);
+
+  const instances = [
+    renderHook(() => useProjects(), { wrapper }),
+    renderHook(() => useProjects(), { wrapper }),
+    renderHook(() => useProjects(), { wrapper }),
+  ];
+
+  await waitFor(() => {
+    for (const { result } of instances) expect(result.current.loading).toBe(false);
+  });
+
+  expect(mockGetProjects).toHaveBeenCalledTimes(1);
+});
+
 it('a reload from one mounted instance is visible to a second, independently-mounted instance', async () => {
   mockGetProjects.mockResolvedValue([]);
 

--- a/packages/ui/src/store/__tests__/projects.test.ts
+++ b/packages/ui/src/store/__tests__/projects.test.ts
@@ -43,6 +43,7 @@ describe('ui projects store', () => {
   });
 
   it('applies only the most recently-issued reload, even if an earlier one resolves last', async () => {
+    // Different ports so the second call can't dedupe onto the first's in-flight request.
     let resolveFirst: (list: ReturnType<typeof project>[]) => void = () => undefined;
     mockGetProjects.mockImplementationOnce(
       () =>
@@ -53,7 +54,7 @@ describe('ui projects store', () => {
     const first = reloadProjects(31415);
 
     mockGetProjects.mockResolvedValueOnce([project('p2')]);
-    const second = reloadProjects(31415);
+    const second = reloadProjects(31416);
     await second;
     expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
 
@@ -61,5 +62,60 @@ describe('ui projects store', () => {
     await first;
     // The stale first response must not overwrite the newer second one.
     expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('dedupes concurrent calls on the same port into a single request', async () => {
+    let resolveFetch: (list: ReturnType<typeof project>[]) => void = () => undefined;
+    mockGetProjects.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveFetch = res;
+        }),
+    );
+
+    const first = reloadProjects(31415);
+    const second = reloadProjects(31415);
+    const third = reloadProjects(31415);
+    expect(mockGetProjects).toHaveBeenCalledTimes(1);
+
+    resolveFetch([project('p1')]);
+    await Promise.all([first, second, third]);
+
+    expect(mockGetProjects).toHaveBeenCalledTimes(1);
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p1']);
+  });
+
+  it('issues a fresh fetch for a reload requested after the previous one settled', async () => {
+    mockGetProjects.mockResolvedValueOnce([project('p1')]).mockResolvedValueOnce([project('p2')]);
+
+    await reloadProjects(31415);
+    await reloadProjects(31415);
+
+    expect(mockGetProjects).toHaveBeenCalledTimes(2);
+    expect(useProjectsStore.getState().projects.map((p) => p.id)).toEqual(['p2']);
+  });
+
+  it('does not flip loading back to true for a reload issued after the initial load settled', async () => {
+    // `loading` means "the initial load hasn't resolved yet" — a component gated on
+    // it (e.g. ChatSurface's first-run hero) must not see it bounce back to true on
+    // every later reload, or a fresh mount of that same gate re-fires its own reload
+    // and the two flip each other forever (the sessions-draft.spec.ts regression).
+    mockGetProjects.mockResolvedValueOnce([project('p1')]);
+    await reloadProjects(31415);
+    expect(useProjectsStore.getState().loading).toBe(false);
+
+    let resolveSecond: (list: ReturnType<typeof project>[]) => void = () => undefined;
+    mockGetProjects.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveSecond = res;
+        }),
+    );
+    const second = reloadProjects(31415);
+    expect(useProjectsStore.getState().loading).toBe(false);
+
+    resolveSecond([project('p2')]);
+    await second;
+    expect(useProjectsStore.getState().loading).toBe(false);
   });
 });

--- a/packages/ui/src/store/projects.ts
+++ b/packages/ui/src/store/projects.ts
@@ -7,6 +7,26 @@
  * moving the list here (out of `useProjects`'s old per-caller `useState`) is
  * that a reload from ANY one call site (e.g. the first-run "Add project" CTA)
  * is now visible to every other mounted consumer without a remount.
+ *
+ * Because every mounted consumer reloads on mount, a screen with many
+ * consumers (11+, as of the sessions sidebar) fires that many concurrent
+ * `getProjects` HTTP calls at once. `reloadProjects` dedupes same-port calls
+ * that overlap an in-flight request onto that request's promise; a call for a
+ * different port, or one that starts after the previous request settled
+ * (e.g. after a mutation like "Add project"), always gets a fresh fetch.
+ *
+ * `loading` means "the initial load hasn't resolved yet", not "a fetch is
+ * currently in flight" — it flips false on the first settle and stays there. A
+ * consumer gated on it (ChatSurface's first-run hero vs. the normal thread
+ * view) mounts/unmounts a DIFFERENT subtree depending on its value; if a later
+ * reload set it back to `true`, that swap would unmount the current subtree
+ * and mount the other one, whose own `useProjects()` fires yet another reload
+ * — flipping `loading` back and forth forever. This is exactly what produced
+ * ~9500 mount/unmount cycles and thousands of `/api/projects` calls in a
+ * single zero-projects boot (the actual mechanism behind the release-blocking
+ * sessions-draft.spec.ts failure; request dedup alone reduces the herd per
+ * cycle but can't break the cycle itself, since each cycle's requests settle
+ * before the next mount fires).
  */
 import { create } from 'zustand';
 import type { Project } from '@qlan-ro/mainframe-types';
@@ -24,23 +44,33 @@ export function removeProjectFromList(projectId: string): void {
 }
 
 let reloadGeneration = 0;
+let inFlight: { port: number; token: object; promise: Promise<void> } | null = null;
 
 /** Only the most recently-issued call is allowed to apply its result, so a slow
  *  response from an earlier reload can't clobber a fresher one that resolved first. */
 export async function reloadProjects(port: number): Promise<void> {
+  if (inFlight && inFlight.port === port) return inFlight.promise;
+
   const generation = ++reloadGeneration;
-  useProjectsStore.setState({ loading: true });
-  try {
-    const projects = await getProjects(port);
-    if (generation === reloadGeneration) useProjectsStore.setState({ projects, loading: false });
-  } catch (e: unknown) {
-    console.warn('[store/projects] getProjects failed', e);
-    if (generation === reloadGeneration) useProjectsStore.setState({ loading: false });
-  }
+  const token = {};
+  const promise = (async () => {
+    try {
+      const projects = await getProjects(port);
+      if (generation === reloadGeneration) useProjectsStore.setState({ projects, loading: false });
+    } catch (e: unknown) {
+      console.warn('[store/projects] getProjects failed', e);
+      if (generation === reloadGeneration) useProjectsStore.setState({ loading: false });
+    } finally {
+      if (inFlight?.token === token) inFlight = null;
+    }
+  })();
+  inFlight = { port, token, promise };
+  return promise;
 }
 
 /** Reserved for tests — mirrors resetAdapters/resetQuota. */
 export function resetProjectsStore(): void {
   reloadGeneration = 0;
+  inFlight = null;
   useProjectsStore.setState({ projects: [], loading: true });
 }


### PR DESCRIPTION
## Summary

Release-blocking e2e failure: `sessions-draft.spec.ts:647`/`:656` ("a workspace with no projects shows the FirstRunState hero") never rendered the first-run hero on a fresh, project-less boot.

- **Amplifier (the task's stated hypothesis, confirmed real):** every mounted `useProjects()` consumer independently fires `reloadProjects(port)` → a real `fetch()`. A screen with 11+ consumers (the sessions sidebar) turns a single mount into a thundering herd of concurrent `GET /api/projects` calls. `reloadProjects` now shares one in-flight promise per port across overlapping calls; a call for a different port, or one issued after the previous request already settled (e.g. after "Add project"), still gets a fresh fetch.
- **Driver (found during e2e verification, not in the original bug report):** deduping concurrent requests alone did not make the failing test pass. Instrumented locally: ~9500 mount/unmount cycles and 8500+ sequential `/api/projects` calls in a single boot, all `200 OK` — not a fetch failure, a render loop. Root cause: `ChatSurface` renders a *structurally different* subtree depending on `useProjects().loading` (first-run hero vs. the normal thread view). `reloadProjects` reset `loading` to `true` on every call, so each freshly-mounted subtree's own reload flipped `loading` back, remounting the other subtree — whose own `useProjects()` call restarted the cycle. `loading` now means "the initial load hasn't resolved yet" and only ever transitions `true → false`, once.

## Test plan
- [x] `pnpm --filter @qlan-ro/mainframe-ui typecheck` — clean
- [x] `store/__tests__/projects.test.ts` (dedup, generation-counter, and the new `loading`-semantics regression test) — pass
- [x] `features/sessions/__tests__/use-projects.test.tsx` (new: 3 concurrently-mounted consumers → 1 `getProjects` call) — pass
- [x] `sessions-draft.spec.ts` full file, `E2E_MODE=mock` mock daemon — 15/15 pass, including `:647` (15ms) and `:656` (223ms), both previously failing
- [x] Related suites (`use-add-project`, `use-modal-project-scope`, `ChatSurface`) — pass, no regressions from the `loading` semantics change (grepped all `useProjects()` call sites; `ChatSurface` is the only consumer that reads `loading`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)