### PR TITLE
fix(ui): keep the traffic lights visible when a blurred window's theme differs from the system

### DIFF
--- a/.changeset/traffic-lights-inactive-theme.md
+++ b/.changeset/traffic-lights-inactive-theme.md
@@ -1,0 +1,12 @@
+---
+"@qlan-ro/mainframe-types": patch
+"@qlan-ro/mainframe-ui": patch
+"@qlan-ro/mainframe-app-tauri": patch
+---
+
+The macOS traffic lights no longer vanish when the window loses focus in a
+theme that differs from the system appearance. macOS draws the inactive
+buttons for the window's appearance, and with the overlay title bar their
+backdrop is the app content — dark-appearance inactive buttons are white,
+invisible on the light theme. The native window theme now tracks the app
+theme (`setWindowTheme` on the host bridge; System follows the OS).

--- a/packages/app-tauri/src-tauri/capabilities/main.json
+++ b/packages/app-tauri/src-tauri/capabilities/main.json
@@ -7,6 +7,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-theme",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/packages/types/src/host/host-bridge.ts
+++ b/packages/types/src/host/host-bridge.ts
@@ -175,6 +175,15 @@ export interface HostBridge {
    * never overflows (unlike the CSS `zoom` property).
    */
   setZoom(factor: number): void;
+  /**
+   * Sync the native window appearance with the app's rendered theme, or follow
+   * the OS (`null`). macOS draws inactive title-bar controls (traffic lights)
+   * for the WINDOW's appearance; with an overlay title bar their backdrop is
+   * the web content, so a mismatch (dark window appearance over a light theme,
+   * or vice versa) renders them invisible when the window is not focused.
+   * Tauri: `window.setTheme`; browser/fake: no-op.
+   */
+  setWindowTheme(theme: 'light' | 'dark' | null): void;
   /** Tauri installs the window-drag listener here; Electron is a CSS no-op. */
   init?(): void;
 }

--- a/packages/ui/src/app/ThemeEffect.tsx
+++ b/packages/ui/src/app/ThemeEffect.tsx
@@ -10,11 +10,17 @@ import { getHost } from '@/lib/host';
  * nothing.
  */
 export function ThemeEffect() {
+  const mode = useTheme((s) => s.mode);
   const resolvedMode = useTheme((s) => s.resolvedMode);
   useEffect(() => {
     document.documentElement.classList.toggle('dark', resolvedMode === 'dark');
     invalidateShikiTheme();
-  }, [resolvedMode]);
+    // Keep the native window appearance on the rendered theme. macOS draws the
+    // INACTIVE traffic lights for the window's appearance over our overlay
+    // title bar, so a mismatch (dark window, light content) leaves them
+    // invisible whenever the window is blurred.
+    getHost().setWindowTheme(mode === 'system' ? null : resolvedMode);
+  }, [mode, resolvedMode]);
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return;

--- a/packages/ui/src/app/__tests__/ThemeEffect.test.tsx
+++ b/packages/ui/src/app/__tests__/ThemeEffect.test.tsx
@@ -3,10 +3,13 @@ import { act, render } from '@testing-library/react';
 import { ThemeEffect } from '../ThemeEffect';
 import { useTheme, UI_SCALE_FACTORS } from '@/store/theme';
 
-// The zoom effect delegates to the host's native page zoom (no-op in jsdom);
-// mock the host so we can assert the factor setZoom is called with.
-const { setZoomMock } = vi.hoisted(() => ({ setZoomMock: vi.fn() }));
-vi.mock('@/lib/host', () => ({ getHost: () => ({ setZoom: setZoomMock }) }));
+// The zoom and window-theme effects delegate to native host calls (no-ops in
+// jsdom); mock the host so we can assert what they're called with.
+const { setZoomMock, setWindowThemeMock } = vi.hoisted(() => ({
+  setZoomMock: vi.fn(),
+  setWindowThemeMock: vi.fn(),
+}));
+vi.mock('@/lib/host', () => ({ getHost: () => ({ setZoom: setZoomMock, setWindowTheme: setWindowThemeMock }) }));
 
 let colorSchemeListener: ((event: MediaQueryListEvent) => void) | undefined;
 const addEventListenerMock = vi.fn();
@@ -37,6 +40,7 @@ describe('ThemeEffect', () => {
     document.documentElement.className = '';
     useTheme.setState({ mode: 'light', resolvedMode: 'light', uiScale: 'normal' });
     setZoomMock.mockClear();
+    setWindowThemeMock.mockClear();
     addEventListenerMock.mockReset();
     removeEventListenerMock.mockReset();
     installMatchMedia(false);
@@ -80,5 +84,36 @@ describe('ThemeEffect', () => {
     useTheme.setState({ uiScale: 'large' });
     render(<ThemeEffect />);
     expect(setZoomMock).toHaveBeenCalledWith(UI_SCALE_FACTORS.large);
+  });
+
+  describe('native window theme sync', () => {
+    it('syncs the native window to a fixed light mode', () => {
+      useTheme.setState({ mode: 'light', resolvedMode: 'light' });
+      render(<ThemeEffect />);
+      expect(setWindowThemeMock).toHaveBeenCalledWith('light');
+    });
+
+    it('syncs the native window to a fixed dark mode', () => {
+      useTheme.setState({ mode: 'dark', resolvedMode: 'dark' });
+      render(<ThemeEffect />);
+      expect(setWindowThemeMock).toHaveBeenCalledWith('dark');
+    });
+
+    it('lets the OS drive the native window in system mode', () => {
+      useTheme.setState({ mode: 'system', resolvedMode: 'dark' });
+      render(<ThemeEffect />);
+      expect(setWindowThemeMock).toHaveBeenCalledWith(null);
+    });
+
+    it('keeps the native window on null across an OS theme change in system mode', () => {
+      useTheme.setState({ mode: 'system', resolvedMode: 'light' });
+      render(<ThemeEffect />);
+      expect(setWindowThemeMock).toHaveBeenLastCalledWith(null);
+
+      act(() => colorSchemeListener?.({ matches: true } as MediaQueryListEvent));
+
+      expect(useTheme.getState().resolvedMode).toBe('dark');
+      expect(setWindowThemeMock).toHaveBeenLastCalledWith(null);
+    });
   });
 });

--- a/packages/ui/src/lib/host/fake-adapter.ts
+++ b/packages/ui/src/lib/host/fake-adapter.ts
@@ -82,6 +82,10 @@ export class FakeHostBridge implements HostBridge {
     /* no-op in browser/dev — page zoom is a native-shell capability */
   }
 
+  setWindowTheme(_theme: 'light' | 'dark' | null): void {
+    /* no-op in browser/dev — window appearance is a native-shell capability */
+  }
+
   terminal = {
     create: (): Promise<TerminalHandle> => notSupported('terminal.create'),
   };

--- a/packages/ui/src/lib/host/tauri-adapter.ts
+++ b/packages/ui/src/lib/host/tauri-adapter.ts
@@ -107,6 +107,12 @@ export class TauriAdapter implements HostBridge {
     void bridge.setUiZoom(factor);
   }
 
+  setWindowTheme(theme: 'light' | 'dark' | null): void {
+    getCurrentWebviewWindow()
+      .setTheme(theme)
+      .catch((err) => console.warn('[host] setTheme failed', err));
+  }
+
   /**
    * Install the window-drag listener (relocated from bridge.ts module scope).
    * Tauri 2 does not auto-wire mousedown → startDragging for [data-drag-region].


### PR DESCRIPTION
## The bug

The native macOS traffic lights vanished completely — not dimmed — whenever the window lost focus, in light theme only, on a dark-mode system.

## Root cause (pixel-verified, not the prior layer-promotion theory)

macOS draws the **inactive** traffic lights for the *window's* `NSAppearance`, as translucent monochrome discs meant to sit on a same-appearance title bar. With `titleBarStyle: Overlay` their backdrop is the app's own content, and the app never synced the native window appearance to its CSS theme — the window stayed on the system appearance. On a dark-mode system with the app in light theme, the inactive buttons are painted **white on the near-white toolbar** (`#FFFFFF` on `#F5F5F8`): invisible. The focused and hovered states are colored, which is why the buttons "reappeared" on hover.

Pixel matrix from an isolated dev instance (own-window `CGWindowListCreateImage`, sampling the button row):

| window appearance | app theme | blurred buttons | visible |
|---|---|---|---|
| dark (system) | light | `FFFFFF` on `F5F5F8` | **no — the bug** |
| dark (system) | dark | `595959` on `2A2A2A` | yes |
| light (forced) | light | `C6C6C9` on `F5F5F8` | **yes — the fix** |
| light (forced) | dark | `000000` on `2A2A2A` | no — reverse bug, also fixed |

This disproves the earlier "WKWebView layer promoted above native chrome" interpretation: the buttons are painted in every state, in near-backdrop colors. It also explains why every native repaint hack (`displayIfNeeded`, frame re-assertion, resize, `macOSPrivateApi: false`) changed nothing.

## The fix

Track the rendered theme on the native window: `ThemeEffect` calls the new `HostBridge.setWindowTheme` (Tauri `window.setTheme`, which sets the app-level `NSAppearance` — the same mechanism as Electron's `nativeTheme.themeSource`, the documented fix for the identical Electron bug electron/electron#44034). System mode passes `null` so the OS drives the appearance. Requires the `core:window:allow-set-theme` capability.

## Why it "suddenly started"

No library changed: tauri/tao/wry have been pinned (2.11.2 / 0.35.3 / 0.55.1) since July 7, and no macOS update landed in the window. Dark theme shipped in #612 (rc.24, Aug 12) — mixing a light app theme with a dark system appearance is the newly-reachable state that exposes the mismatch.

## Verification

- Re-ran the pixel probe with the fix: blurred light-theme buttons now paint `C6C6C9` (visible gray) instead of `FFFFFF`; dark theme unchanged-correct.
- `ThemeEffect` tests extended (9/9), types host tests 33/33, ui + types typechecks green, `cargo check` validates the capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)