### PR TITLE
fix(ui): centre the traffic lights on the title-bar row, seat the Update pill beside them

### DIFF
--- a/.changeset/traffic-lights-centred-update-pill-left.md
+++ b/.changeset/traffic-lights-centred-update-pill-left.md
@@ -1,0 +1,6 @@
+---
+'@qlan-ro/mainframe-app-tauri': patch
+'@qlan-ro/mainframe-ui': patch
+---
+
+Centre the macOS traffic lights on the sidebar header row, and move the Update pill to sit beside them. The lights sat 5px below the row's 24px midline in packaged builds: macOS 26 renders the classic button metrics for binaries linked against SDK ≤ 15 (every release build — the CI runner is macos-14), where the cluster centre lands at y + 2, while a locally built dev app links SDK 26 and centres at y − 2. Tuning by eye against a dev window therefore misaligned every release. tauri.conf.json now carries the packaged-correct y (22) and tauri:dev patches it to 26, so both builds centre on the same midline.

--- a/packages/app-tauri/scripts/tauri-dev.mjs
+++ b/packages/app-tauri/scripts/tauri-dev.mjs
@@ -10,7 +10,7 @@
  * static config. The dev overlay file (withGlobalTauri) is still merged first.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -48,6 +48,25 @@ provisionSidecarIfMissing();
 const port = process.env.VITE_PORT ?? '5174';
 const devUrl = `http://localhost:${port}`;
 
+/**
+ * Dev builds also override the traffic-light y. macOS 26 gates the button
+ * metrics on the SDK a binary links: the packaged app (release runner is
+ * macos-14, SDK 14.x) gets the classic buttons, whose cluster centre lands at
+ * y + 2 from the window top; a local dev build links the current SDK (26+)
+ * and gets the new metrics, centre = y − 2. tauri.conf.json carries the
+ * packaged value (22 → centre 24, the sidebar header's midline); dev patches
+ * it to 26 so a dev window centres identically. The override patches the
+ * windows array read from the real config, so every other window property
+ * stays single-sourced. Retune both values together when the sidebar header
+ * row moves (see SessionSidebar.tsx) or the release runner's Xcode reaches
+ * SDK 26.
+ */
+const DEV_TRAFFIC_LIGHT_Y = 26;
+const conf = JSON.parse(readFileSync(join(here, '..', 'src-tauri', 'tauri.conf.json'), 'utf8'));
+const windows = conf.app.windows.map((w) =>
+  w.trafficLightPosition ? { ...w, trafficLightPosition: { ...w.trafficLightPosition, y: DEV_TRAFFIC_LIGHT_Y } } : w,
+);
+
 try {
   execFileSync(
     'cargo',
@@ -59,7 +78,7 @@ try {
       '--config',
       'src-tauri/tauri.dev.conf.json',
       '--config',
-      JSON.stringify({ build: { devUrl } }),
+      JSON.stringify({ build: { devUrl }, app: { windows } }),
     ],
     { stdio: 'inherit' },
   );

--- a/packages/app-tauri/src-tauri/tauri.conf.json
+++ b/packages/app-tauri/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
         "minHeight": 600,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 20, "y": 27 },
+        "trafficLightPosition": { "x": 20, "y": 22 },
         "backgroundColor": "#e9e7e2"
       }
     ],

--- a/packages/ui/src/features/sessions/SessionSidebar.tsx
+++ b/packages/ui/src/features/sessions/SessionSidebar.tsx
@@ -42,7 +42,18 @@ import { SidebarActions } from './SidebarActions';
 import { TagFilterBar } from './TagFilterBar';
 import { useRemoveProject } from '@/features/sessions/use-remove-project';
 
-/** Reserves the native macOS traffic-lights cluster (3 × 12px + gaps + inset). */
+/**
+ * Reserves the native macOS traffic-lights cluster (3 buttons + gaps + inset).
+ * The cluster's vertical centring is native too: `trafficLightPosition.y` is
+ * tuned so the lights centre on this row's midline — SidebarHeader's 8px top
+ * pad + the 32px icon-sm row = 24px at UI scale 1.0. Nothing recomputes that
+ * y, and the y→centre mapping is SDK-gated: a binary linked against SDK ≤ 15
+ * (every packaged build — the release runner is macos-14) renders the classic
+ * buttons, centre = y + 2, so tauri.conf.json carries 22; a dev build linked
+ * against SDK 26+ renders the new metrics, centre = y − 2, so tauri-dev.mjs
+ * patches y to 26. Retune BOTH whenever this row's geometry changes, or when
+ * the release runner's Xcode reaches SDK 26.
+ */
 const TRAFFIC_LIGHTS_WIDTH = 80;
 
 function HeaderActions() {
@@ -137,8 +148,14 @@ export function SessionSidebar({ className }: { className?: string }) {
             empty run drags the window (buttons are auto-excluded by the host
             handler, so Settings/collapse still click). */}
         <div data-drag-region className="flex items-center justify-between">
-          <div aria-hidden style={{ width: TRAFFIC_LIGHTS_WIDTH }} />
-          <UpdatePill />
+          {/* The pill rides with the traffic lights: update chrome reads as
+              window chrome, and the row's slack stays a drag region. gap-1.5
+              keeps it clear of the zoom button, whose hit rect ends at 80px
+              under the new-SDK metrics — flush with the reserve. */}
+          <div className="flex min-w-0 items-center gap-1.5">
+            <div aria-hidden className="shrink-0" style={{ width: TRAFFIC_LIGHTS_WIDTH }} />
+            <UpdatePill />
+          </div>
           <HeaderActions />
         </div>
         <SidebarActions filterProjectId={filterProjectId} />


### PR DESCRIPTION
## The two fixes

**1. Traffic lights centred on the header row.** The cluster sat 5px below the sidebar header's 24px midline in the packaged app. `trafficLightPosition.y` drops from 27 to **22** in `tauri.conf.json`, and `tauri-dev.mjs` now patches it to **26** for dev runs (it rewrites the windows array read from the real config, so nothing else is duplicated).

**2. Update pill seated beside the traffic lights** (first-preference placement). It moves out of the header row's centre slot into a left group with the traffic-light reserve; Settings and the collapse toggle keep the right edge, and the row's slack stays a drag region. Measured live: pill centre at y=24, left edge at x=94 — 14px clear of the zoom button's hit rect, which ends at x=80.

## Why it kept "drifting" — the actual mechanism

The y → rendered-centre mapping is **SDK-gated on macOS 26**, so one static value cannot fit both builds:

| build | linked SDK | button metrics (measured) | cluster centre |
|---|---|---|---|
| packaged (CI = macos-14) | 14.5 (`otool -l` on the installed rc.27) | classic: 14×16 frame at local y=6 | **y + 2** |
| local dev | 26.2 | new: 14×14 frame at local y=9 | **y − 2** |

At the shipped y:27 the packaged app centres at **29** (5px below the 24px midline — exactly the screenshot) while a dev window centres at 25 (1px off, near-perfect). Tuning by eye against a dev window therefore misaligns every release, which is what happened to the previous tune (#565, 30→27). Both metric sets were measured empirically with a scratch AppKit window replicating tao's `inset_traffic_lights` (once SDK-26-linked, once under `UIDesignRequiresCompatibility`), and both are idempotent across re-application.

Why it surfaced now: the pill could never render before #614 — the packaged updater's HTTPS fetch always failed (`no TLS backend`), so no update was ever `available` in that row. #614 (Aug 12) let the pill appear next to the lights and made the offset conspicuous.

Ruled out: `tauri-plugin-window-state` (#612) — tao re-applies the configured inset from `ViewState` on every `draw_rect` (tao 0.35.3 `view.rs`), so no runtime restore can move the lights; and no committed geometry change to the header row since #565.

## Guard against a fourth tune

- The derivation contract lives on `TRAFFIC_LIGHTS_WIDTH` in `SessionSidebar.tsx` and in the `tauri-dev.mjs` header: retune **both** values together when the header row's geometry changes, or when the release runner's Xcode reaches SDK 26 (that flips the packaged mapping to y − 2).
- A runtime self-correcting y (read the button frame, call `set_traffic_light_position`) would be fully drift-proof, but tauri 2.11 only carries that setter on the internal runtime trait, not the public `Window` — not worth forking over.

Known limit: the midline is 24px at UI scale 1.0; compact scale (0.92) zooms the webview, so the row midline moves ~2px while the native lights stay put. That residual predates this change and no static y can fix it.

## Verification

- Isolated dev instance (`MAINFRAME_DATA_DIR=/tmp/… DAEMON_PORT=31418`), DOM measured via the tauri-mcp bridge: gear and collapse toggle at centre-y **24**, pill centre **24**, pill clear of the cluster; screenshot eyeballed.
- Relaunched through the edited `tauri-dev.mjs` to prove the merged `--config` windows override boots.
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` green (after rebuilding a stale `types/dist`), UpdatePill unit tests 4/4.
- Native positions computed from measured metrics: packaged y=22 → centre 24; dev y=26 → centre 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)