### PR TITLE
fix(ui): focus the terminal when one is opened

### DIFF
--- a/.changeset/tidy-terminals-focus.md
+++ b/.changeset/tidy-terminals-focus.md
@@ -1,0 +1,5 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Focus the terminal when you open one, so ⌘J (or a click on a terminal tab) leaves you ready to type.

--- a/packages/ui/src/features/terminal/TerminalInstance.tsx
+++ b/packages/ui/src/features/terminal/TerminalInstance.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { getOrCreate } from './terminal-cache';
+import { getCachedTerminal, getOrCreate } from './terminal-cache';
+import { claimTerminalFocus, onTerminalFocusRequest } from './terminal-focus';
 
 interface Props {
   terminalId: string;
@@ -61,6 +62,18 @@ export function TerminalInstance({ terminalId, visible }: Props): React.ReactEle
     );
     return () => cancelAnimationFrame(frame);
   }, [visible]);
+
+  // Claim a deliberate open (⌘J, add menu, tab click). Runs once for the current
+  // visibility, then stays subscribed so a request arriving while this terminal
+  // is already the active tab focuses it too.
+  useEffect(() => {
+    const apply = (): void => {
+      if (!visible) return;
+      if (claimTerminalFocus(terminalId)) getCachedTerminal(terminalId)?.term.focus();
+    };
+    apply();
+    return onTerminalFocusRequest(apply);
+  }, [terminalId, visible]);
 
   return (
     <div

--- a/packages/ui/src/features/terminal/__tests__/TerminalInstance.test.tsx
+++ b/packages/ui/src/features/terminal/__tests__/TerminalInstance.test.tsx
@@ -1,21 +1,47 @@
 import { render, screen, cleanup } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 
-const fitSpy = vi.fn();
-const wrapper = document.createElement('div');
-const getOrCreateSpy = vi.fn(() => ({ wrapper, term: {}, fitAddon: { fit: fitSpy }, disposers: [] }));
+interface MockEntry {
+  wrapper: HTMLDivElement;
+  term: { focus: ReturnType<typeof vi.fn> };
+  fitAddon: { fit: ReturnType<typeof vi.fn> };
+  disposers: never[];
+}
+
+// A per-id entry factory so focus tests can assert on the RIGHT terminal's
+// term.focus without cross-talk between ids.
+const entries = new Map<string, MockEntry>();
+function makeEntry(): MockEntry {
+  return {
+    wrapper: document.createElement('div'),
+    term: { focus: vi.fn() },
+    fitAddon: { fit: vi.fn() },
+    disposers: [],
+  };
+}
+const getOrCreateSpy = vi.fn((id: string) => entries.get(id) ?? entries.set(id, makeEntry()).get(id)!);
+const getCachedTerminalSpy = vi.fn((id: string) => entries.get(id));
 const disposeSpy = vi.fn();
 
 vi.mock('../terminal-cache', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getOrCreate: (id: string) => (getOrCreateSpy as any)(id),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCachedTerminal: (id: string) => (getCachedTerminalSpy as any)(id),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   disposeCachedTerminal: (id: string) => (disposeSpy as any)(id),
 }));
 
 import { TerminalInstance } from '../TerminalInstance';
+// Real module — this is the integration under test, not a collaborator to mock.
+import { requestTerminalFocus } from '../terminal-focus';
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  // Drain whatever is pending so it can't leak into the next test. No test in
+  // this file uses '__unclaimed__' as a terminalId, so this never gets claimed.
+  requestTerminalFocus('__unclaimed__');
+});
 
 describe('TerminalInstance', () => {
   it('renders a container with the scoped data-testid', () => {
@@ -26,12 +52,59 @@ describe('TerminalInstance', () => {
   it('mounts the cached wrapper into its container', () => {
     render(<TerminalInstance terminalId="abc" visible />);
     expect(getOrCreateSpy).toHaveBeenCalledWith('abc');
-    expect(screen.getByTestId('run-terminal-abc').contains(wrapper)).toBe(true);
+    expect(screen.getByTestId('run-terminal-abc').contains(entries.get('abc')!.wrapper)).toBe(true);
   });
 
   it('does NOT dispose the cache on unmount (output preserved)', () => {
     const { unmount } = render(<TerminalInstance terminalId="abc" visible />);
     unmount();
     expect(disposeSpy).not.toHaveBeenCalled();
+  });
+
+  describe('focus requests', () => {
+    it('does NOT focus when merely mounted visible with no pending request (regression guard: session switches / surface reveals must not steal focus from the composer)', () => {
+      render(<TerminalInstance terminalId="reg-guard" visible />);
+      expect(entries.get('reg-guard')!.term.focus).not.toHaveBeenCalled();
+    });
+
+    it('focuses a terminal mounted visible with a pending request, and consumes the request so a second mount does not re-focus', () => {
+      requestTerminalFocus('claim-me');
+      const { unmount } = render(<TerminalInstance terminalId="claim-me" visible />);
+      const focus = entries.get('claim-me')!.term.focus;
+      expect(focus).toHaveBeenCalledTimes(1);
+
+      unmount();
+      render(<TerminalInstance terminalId="claim-me" visible />);
+      expect(focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('focuses an already-mounted, already-visible terminal when a request arrives (pill click on the active tab)', () => {
+      render(<TerminalInstance terminalId="already-active" visible />);
+      const focus = entries.get('already-active')!.term.focus;
+      expect(focus).not.toHaveBeenCalled();
+
+      requestTerminalFocus('already-active');
+      expect(focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not focus a different terminal than the one requested', () => {
+      render(<TerminalInstance terminalId="term-a" visible />);
+      render(<TerminalInstance terminalId="term-b" visible />);
+
+      requestTerminalFocus('term-a');
+
+      expect(entries.get('term-a')!.term.focus).toHaveBeenCalledTimes(1);
+      expect(entries.get('term-b')!.term.focus).not.toHaveBeenCalled();
+    });
+
+    it('does not claim a pending request while hidden; claims it once it becomes visible', () => {
+      requestTerminalFocus('hidden-then-visible');
+      const { rerender } = render(<TerminalInstance terminalId="hidden-then-visible" visible={false} />);
+      const focus = entries.get('hidden-then-visible')!.term.focus;
+      expect(focus).not.toHaveBeenCalled();
+
+      rerender(<TerminalInstance terminalId="hidden-then-visible" visible />);
+      expect(focus).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/ui/src/features/terminal/__tests__/terminal-cache.test.ts
+++ b/packages/ui/src/features/terminal/__tests__/terminal-cache.test.ts
@@ -25,6 +25,8 @@ vi.mock('@xterm/addon-fit', () => ({
 vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 
 import { getOrCreate, disposeCachedTerminal, getCachedTerminal } from '../terminal-cache';
+// Real module — verifying disposeCachedTerminal's effect on it is the point of these tests.
+import { requestTerminalFocus, claimTerminalFocus } from '../terminal-focus';
 
 describe('terminal-cache', () => {
   beforeEach(() => {
@@ -60,5 +62,19 @@ describe('terminal-cache', () => {
     const b = getOrCreate('t4');
     expect(a).not.toBe(b);
     disposeCachedTerminal('t4');
+  });
+
+  it('disposeCachedTerminal clears a pending focus request for that id', () => {
+    getOrCreate('t5');
+    requestTerminalFocus('t5');
+    disposeCachedTerminal('t5');
+    expect(claimTerminalFocus('t5')).toBe(false);
+  });
+
+  it('disposeCachedTerminal leaves a pending request for a different id alone', () => {
+    getOrCreate('t6');
+    requestTerminalFocus('other-id');
+    disposeCachedTerminal('t6');
+    expect(claimTerminalFocus('other-id')).toBe(true);
   });
 });

--- a/packages/ui/src/features/terminal/terminal-cache.ts
+++ b/packages/ui/src/features/terminal/terminal-cache.ts
@@ -1,6 +1,7 @@
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
+import { clearTerminalFocus } from './terminal-focus';
 
 export interface CachedTerminal {
   wrapper: HTMLDivElement;
@@ -71,4 +72,5 @@ export function disposeCachedTerminal(id: string): void {
   entry.term.dispose();
   entry.wrapper.remove();
   cache.delete(id);
+  clearTerminalFocus(id);
 }

--- a/packages/ui/src/features/terminal/terminal-focus.ts
+++ b/packages/ui/src/features/terminal/terminal-focus.ts
@@ -1,0 +1,39 @@
+/**
+ * features/terminal/terminal-focus.ts — a one-slot request that hands keyboard
+ * focus to a terminal the user deliberately opened (⌘J, the add menu, a tab
+ * click), so they can type straight away.
+ *
+ * It is a request rather than a `visible` side-effect on purpose: the workspace
+ * remounts terminal tabs whenever the launch scope changes (session switch) or
+ * the surface is revealed, and focusing on those would yank the caret out of the
+ * composer. Only a deliberate open claims focus.
+ */
+
+let pending: string | null = null;
+const listeners = new Set<() => void>();
+
+/** Ask for `id` to take focus once it is mounted and visible. */
+export function requestTerminalFocus(id: string): void {
+  pending = id;
+  for (const listener of listeners) listener();
+}
+
+/** Take the pending request for `id`, if it is the one outstanding. */
+export function claimTerminalFocus(id: string): boolean {
+  if (pending !== id) return false;
+  pending = null;
+  return true;
+}
+
+/** Drop a request `id` will never claim (its terminal was disposed). */
+export function clearTerminalFocus(id: string): void {
+  if (pending === id) pending = null;
+}
+
+/** Notified when a request arrives, so a mounted terminal can claim it. */
+export function onTerminalFocusRequest(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/packages/ui/src/layout/WorkspaceTabPill.tsx
+++ b/packages/ui/src/layout/WorkspaceTabPill.tsx
@@ -25,6 +25,7 @@ import { Hint } from '@/components/ui/hint';
 import { cn } from '@/lib/utils';
 import { useLayoutStore } from '@/store/layout';
 import { isLaunchStatusLive } from '@/features/run/derive-launch-control';
+import { requestTerminalFocus } from '@/features/terminal/terminal-focus';
 import type { RunPane, RunTab } from '@/store/run-pane';
 
 const GLYPHS: Record<RunTab['kind'], typeof Eye> = {
@@ -63,7 +64,10 @@ export function WorkspaceTabPill({ pane, tab, configs, scopeStatuses, onStop }: 
       data-testid={`workspace-tab-${tab.id}`}
       role="tab"
       aria-selected={isActive}
-      onClick={() => activateRunTab(pane.id, tab.id)}
+      onClick={() => {
+        activateRunTab(pane.id, tab.id);
+        if (tab.kind === 'terminal') requestTerminalFocus(tab.id);
+      }}
       onDoubleClick={() => promoteFileTab(tab.id)}
       className={cn(
         'group flex h-6 max-w-40 min-w-0 shrink-0 cursor-pointer items-center gap-1.5 rounded-md pr-1 pl-2 text-xs select-none',

--- a/packages/ui/src/layout/__tests__/WorkspaceTabPill.test.tsx
+++ b/packages/ui/src/layout/__tests__/WorkspaceTabPill.test.tsx
@@ -10,12 +10,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLayoutStore } from '@/store/layout';
 import { WorkspaceTabPill } from '../WorkspaceTabPill';
 import type { RunPane, RunTab } from '@/store/run-pane';
+// Real module — asserting the pill's click handler requested focus is the point.
+import { claimTerminalFocus } from '@/features/terminal/terminal-focus';
 
 // v2 `Hint` needs the v2 TooltipProvider — the v1 provider satisfies nothing.
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: TooltipProvider });
 
 const preview: RunTab = { id: 'tab-a', kind: 'code', title: 'a.ts', path: 'a.ts', mode: 'preview' };
 const permanent: RunTab = { id: 'tab-b', kind: 'code', title: 'b.ts', path: 'b.ts', mode: 'permanent' };
+const terminal: RunTab = { id: 'tab-term', kind: 'terminal', title: 'Terminal' };
 
 function seed(tabs: RunTab[], active = tabs[0]!.id): RunPane {
   const pane: RunPane = { id: 'pane-1', tabs, active };
@@ -73,5 +76,23 @@ describe('WorkspaceTabPill — activation and close', () => {
     const run = useLayoutStore.getState().run!;
     expect(run.panes[0]!.tabs.map((t) => t.id)).toEqual(['tab-b']);
     expect(run.panes[0]!.active).toBe('tab-b');
+  });
+});
+
+describe('WorkspaceTabPill — terminal focus request', () => {
+  it('clicking a terminal tab requests focus for that tab', () => {
+    const pane = seed([terminal], 'tab-b');
+    render(pill(pane, terminal));
+
+    fireEvent.click(screen.getByTestId('workspace-tab-tab-term'));
+    expect(claimTerminalFocus('tab-term')).toBe(true);
+  });
+
+  it('clicking a non-terminal tab does not request terminal focus', () => {
+    const pane = seed([permanent, preview], 'tab-b');
+    render(pill(pane, preview));
+
+    fireEvent.click(screen.getByTestId('workspace-tab-tab-a'));
+    expect(claimTerminalFocus('tab-a')).toBe(false);
   });
 });

--- a/packages/ui/src/store/__tests__/terminal-intent-subscriber.test.ts
+++ b/packages/ui/src/store/__tests__/terminal-intent-subscriber.test.ts
@@ -13,6 +13,11 @@ vi.mock('@/features/terminal/terminal-cache', () => ({
   disposeCachedTerminal: (...a: unknown[]) => disposeSpy(...a),
 }));
 
+const requestFocusSpy = vi.fn();
+vi.mock('@/features/terminal/terminal-focus', () => ({
+  requestTerminalFocus: (...a: unknown[]) => requestFocusSpy(...a),
+}));
+
 import { emitSurfaceIntent } from '../surface-intents';
 import { useActiveBasesStore } from '../active-bases-store';
 import { useLayoutStore } from '../layout';
@@ -76,5 +81,20 @@ describe('subscribeToTerminalIntents', () => {
   it('ignores non-terminal intents', () => {
     emitSurfaceIntent({ type: 'open-file-picker' });
     expect(createSessionSpy).not.toHaveBeenCalled();
+  });
+
+  it('requests terminal focus when addRunTab succeeds', async () => {
+    vi.spyOn(useLayoutStore.getState(), 'addRunTab').mockReturnValue(true);
+    emitSurfaceIntent({ type: 'new-terminal' });
+    await vi.waitFor(() => expect(requestFocusSpy).toHaveBeenCalledWith('term-1'));
+  });
+
+  // M6 dispose path: the target pane vanished during the async create, so the
+  // terminal is disposed rather than shown — it must never steal focus.
+  it('does not request terminal focus when addRunTab returns false', async () => {
+    vi.spyOn(useLayoutStore.getState(), 'addRunTab').mockReturnValue(false);
+    emitSurfaceIntent({ type: 'new-terminal', paneId: 'pane-gone' });
+    await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledWith('term-1'));
+    expect(requestFocusSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/store/terminal-intent-subscriber.ts
+++ b/packages/ui/src/store/terminal-intent-subscriber.ts
@@ -10,6 +10,7 @@
  */
 import { createTerminalSession } from '@/features/terminal/create-terminal';
 import { disposeCachedTerminal } from '@/features/terminal/terminal-cache';
+import { requestTerminalFocus } from '@/features/terminal/terminal-focus';
 import { resolveCwd } from '@/features/terminal/terminal-cwd';
 import { getHost } from '@/lib/host';
 import { onSurfaceIntent } from './surface-intents';
@@ -51,7 +52,9 @@ async function spawnTerminal(paneId: string | undefined): Promise<void> {
     const added = useLayoutStore
       .getState()
       .addRunTab({ id, kind: 'terminal', title, scopeKey: scopeKey ?? undefined }, paneId);
-    if (!added) {
+    if (added) {
+      requestTerminalFocus(id);
+    } else {
       disposeCachedTerminal(id);
     }
   } catch (err) {


### PR DESCRIPTION
⌘J and the add menu spawned a terminal and made its tab active, but nothing handed it the keyboard — the first thing typed still went to the composer.

A terminal now takes focus when the user deliberately opens it.

## Changes

- **`features/terminal/terminal-focus.ts`** (new) — a one-slot focus request: `requestTerminalFocus` / `claimTerminalFocus` / `clearTerminalFocus` / `onTerminalFocusRequest`.
- **`store/terminal-intent-subscriber.ts`** — requests focus once the tab is added (⌘J and the add menu both route through the `new-terminal` intent); the dispose path is unchanged.
- **`layout/WorkspaceTabPill.tsx`** — clicking a terminal tab requests focus, including the tab that is already active.
- **`features/terminal/TerminalInstance.tsx`** — claims a pending request once mounted and visible.
- **`features/terminal/terminal-cache.ts`** — disposal drops a request its terminal will never claim.

## Why a request, not a `visible` side-effect

The workspace remounts terminal tabs on every launch-scope switch and surface reveal. Focusing whenever a terminal becomes visible would pull the caret out of the chat composer on a session switch — the first test in the suite pins that.

## Verification

- 27 tests across 4 files, run individually: `TerminalInstance` (8), `terminal-cache` (6), `terminal-intent-subscriber` (6), `WorkspaceTabPill` (7).
- `pnpm --filter @qlan-ro/mainframe-ui typecheck` clean.
- Not live-run: launching the Tauri app here would take over the production daemon on :31415.

## Out of scope

Dragging a terminal tab to another pane activates it without requesting focus — hands are already on the mouse there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)