### PR TITLE
fix(release): install libdbus for the Linux daemon builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The daemon links libdbus through keyring's secret-service backend, so
+      # the Linux legs of this matrix need the dev package or cargo dies in
+      # libdbus-sys' build.rs. macOS uses its own keychain and needs nothing.
+      - name: Linux system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - uses: pnpm/action-setup@v6
         with:
           version: 10


### PR DESCRIPTION
Release [32246874157](https://github.com/qlan-ro/mainframe/actions/runs/32246874157) failed on both Linux legs of `build-daemon`; macOS passed.

`libdbus-sys`' build.rs panicked because `dbus-1.pc` is absent. The daemon links libdbus through `keyring`'s secret-service backend, which arrived with the provider-connections work, and `build-daemon` installs no system dependencies. My earlier fix added the package to `build-app-tauri` — a different job, and one that only runs on macOS, so it never applied here.

Conditioned on `runner.os` so the macOS leg is untouched: it uses the system keychain and needs nothing.

## Worth deciding separately

This makes the build pass, but it leaves the shipped Linux daemon dynamically linked against `libdbus-1.so.3`. The credential store already probes and falls back to the file store when a keyring is unusable, so a headless box degrades correctly at runtime — but a missing shared library fails at load, before any of that code runs.

If the Linux daemon is expected to run somewhere without dbus, the better fix is dropping `sync-secret-service` from its keyring features so Linux uses the file store and links nothing. That is a product call about where credentials live on Linux, not a build fix, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)