### PR TITLE
fix(ci): install libdbus for the e2e-mock daemon build

### DIFF
--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -33,6 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # This job builds the daemon (build:app:tauri), which links libdbus via
+      # keyring's secret-service backend — without the dev package cargo dies
+      # in libdbus-sys' build.rs.
+      - name: System dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
       - uses: pnpm/action-setup@v6
         with:
           version: 10


### PR DESCRIPTION
The v2.1.0 release re-run got all three `build-daemon` legs green, then failed in `e2e / e2e-mock` — same `libdbus-sys` build.rs panic. That job builds the daemon through `build:app:tauri`.

This is the third job I've fixed one red run at a time, so I swept every workflow instead of patching where the error surfaced. Jobs that build Rust on Linux:

| workflow / job | status |
|---|---|
| `rust-port.yml` · check | fixed earlier |
| `release.yml` · build-daemon | fixed earlier |
| `e2e-mock.yml` · e2e-mock | **this PR** |
| `release.yml` · build-app-tauri | macOS-only matrix — n/a |
| `ci.yml` · all Linux jobs | no cargo — n/a |

That should be the last of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)