### PR TITLE
feat(automations): GitHub App sign-in, and a token field that always works

### DIFF
--- a/.changeset/github-app-auth.md
+++ b/.changeset/github-app-auth.md
@@ -1,6 +1,6 @@
 ---
-'@qlan-ro/mainframe-types': minor
-'@qlan-ro/mainframe-ui': minor
+'@qlan-ro/mainframe-types': patch
+'@qlan-ro/mainframe-ui': patch
 ---
 
 Connect GitHub by signing in, or by pasting a token.

--- a/.changeset/github-app-auth.md
+++ b/.changeset/github-app-auth.md
@@ -1,0 +1,12 @@
+---
+'@qlan-ro/mainframe-types': minor
+'@qlan-ro/mainframe-ui': minor
+---
+
+Connect GitHub by signing in, or by pasting a token.
+
+The previous release removed the `gh` command-line tool and left sign-in as the only option, before any app existed to sign in to — so GitHub actions could not be authenticated at all, and the editor told you to ask an administrator who does not exist on your own machine. GitHub now always accepts a pasted token, like Notion and Azure DevOps, with sign-in offered alongside it.
+
+Sign-in uses a GitHub App, whose access lasts eight hours and is renewed automatically in the background, so a scheduled automation running overnight keeps working.
+
+A GitHub App also has to be installed on the repositories you want it to touch, which is easy to miss because signing in appears to succeed. If a step then fails, it now says the app is not installed on that organization and links you to the install page, rather than reporting a plain "not found".

--- a/docs/guides/AUTOMATIONS.md
+++ b/docs/guides/AUTOMATIONS.md
@@ -82,8 +82,9 @@ All responses use the WS4 envelope (`{success, data}` or `{success:false, error}
 | `GET` | `/api/automation-credentials/:label` | Get a credential's kind (never its value) |
 | `PUT` | `/api/automation-credentials/:label` | Store a credential token |
 | `DELETE` | `/api/automation-credentials/:label` | Delete a credential |
-| `POST` | `/api/automation-credentials/github/device/start` | Start a GitHub OAuth device-flow session |
-| `POST` | `/api/automation-credentials/github/device/poll` | One poll attempt against the pending device-flow session (`{deviceCode}`); a `connected` result stores the token under the `github` label |
+| `GET` | `/api/automation-credentials/github/device/status` | `{configured}` — whether a GitHub App client ID is registered; the editor uses this to decide whether to offer sign-in-with-GitHub alongside the always-available token field |
+| `POST` | `/api/automation-credentials/github/device/start` | Start a GitHub App device-flow session |
+| `POST` | `/api/automation-credentials/github/device/poll` | One poll attempt against the pending device-flow session (`{deviceCode}`); a `connected` result stores the token (plus, for a GitHub App, its refresh token and expiry) under the `github` label |
 | `POST` | `/api/automation-webhooks/:hookId` | Webhook ingress (see below) |
 | `POST` | `/api/notifications` | Raise a standalone, run-less notification (`{title, body, links?}`) — see below |
 
@@ -93,11 +94,15 @@ Step timeline entries truncate their output preview at 32 KB.
 
 `POST /api/notifications` broadcasts `notification.created` and mirrors it to
 mobile push, best-effort (a push failure never fails the request). It exists
-for work launched *outside* an automation run that still needs to notify
-natively — an `ask_agent` step spawns a Claude CLI session, which has no
-`PushNotification` harness tool, so a todo-lane run scheduled by an
-automation would otherwise be silent. `~/.claude/skills/todo-lane/scripts/lane_apply.py`
-posts here from its `start`/`finish` stage transitions.
+for callers that have no notification tool of their own — a Codex session
+(its adapter intercepts nothing), a plain script, cron, CI.
+
+It is deliberately NOT the path for a Claude session. The Claude adapter
+already intercepts that session's `PushNotification` tool call
+(`assistant_event.rs` `scan_attention_requests`) and turns it into a desktop
+notification plus a high-priority mobile push stamped with the `chat_id`, so
+it deep-links back to the chat. A bare POST carries no identity and cannot,
+which makes the existing path strictly better wherever it applies.
 
 Like the webhook route, a loopback caller reaches this with no token
 (`middleware/auth.rs` — loopback is never rejected); unlike the webhook
@@ -173,20 +178,58 @@ the wire; a no-output action has an empty outputs list.
 
 The two `github.*` actions call the GitHub REST API directly (`POST
 /repos/:repo/pulls`, `GET /search/issues`) with a bearer token stored under
-the `github` credential label — same shape as `notion`/`ado`, connected via
-the editor's GitHub device-flow button rather than a pasted token. A step
-saved before this migration carries no `credential` label (the old manifest
-declared `auth: none`, since `gh` held the token); `run_action` defaults a
-`credential`-less GitHub step to the well-known `github` label so it resolves
-against whatever is connected instead of running unauthenticated.
+the `github` credential label — same shape as `notion`/`ado`. GitHub always
+offers a pasted-token field, exactly like Notion and Azure DevOps; once a
+GitHub App client ID is registered, the editor *also* offers sign-in with
+GitHub as the nicer alternative, side by side with the token field — the
+token path is never hidden behind it. A step saved before the REST migration
+carries no `credential` label (the old manifest declared `auth: none`, since
+`gh` held the token); `run_action` defaults a `credential`-less GitHub step
+to the well-known `github` label so it resolves against whatever is
+connected instead of running unauthenticated.
 
-GitHub is the only provider that gets OAuth: its device flow needs no client
-secret and no redirect URI. Notion and Azure DevOps get a token-paste field
-instead — Notion's token endpoint requires a server-side secret this app
-can't ship, and Azure DevOps' legacy OAuth platform stopped accepting new
-registrations in April 2025. The Azure DevOps token must be
-organization-scoped: Microsoft stops issuing global PATs on 2026-03-15 and
-decommissions them on 2026-12-01.
+GitHub is the only provider with an app-based connect flow: device flow
+needs no client secret and no redirect URI. Notion and Azure DevOps only
+ever get a token-paste field — Notion's token endpoint requires a
+server-side secret this app can't ship, and Azure DevOps' legacy OAuth
+platform stopped accepting new registrations in April 2025. The Azure
+DevOps token must be organization-scoped: Microsoft stops issuing global
+PATs on 2026-03-15 and decommissions them on 2026-12-01.
+
+### GitHub token refresh
+
+A GitHub App user token expires after 8 hours; device flow also returns a
+refresh token valid 6 months. `RefreshingCredentialStore`
+(`packages/core-rs/crates/mainframe-automations/src/credentials/refreshing.rs`)
+sits above the raw credential store on the `run_action` execution path: it
+refreshes a token within 5 minutes of expiry and persists the result before
+a step runs, so a long-running automation never hits a stale token mid-run.
+Refresh needs only `client_id` — GitHub's docs mark `client_secret` "Required
+unless the user access token was generated using the device flow," and this
+connector only ever generates via device flow, so no secret ships in the
+binary. **If token generation ever moves off device flow, refresh starts
+requiring a secret and this design no longer works.**
+
+Refresh is serialized per credential label: GitHub invalidates a refresh
+token the instant a new one is issued, so a `repeat` block with
+`concurrency` running several GitHub steps at once would otherwise stampede
+the refresh endpoint and log the connection out. A refresh failure surfaces
+as a step failure naming the credential and the remedy (reconnect GitHub),
+the same message style as a missing credential. A pasted PAT carries no
+refresh token or expiry and is never touched by this path.
+
+### GitHub App installation
+
+A GitHub App must be **installed** on a repository or organization, not
+just authorized — finishing device flow only grants the *user* token; it
+says nothing about which repos the app can reach. A token that authorizes
+fine but targets an uninstalled repo/org gets a 404 from every repo
+endpoint. `github.create_pr` detects this case (a 404 against a token that
+carries `expires_at`, i.e. a GitHub-App-issued token, not a pasted PAT) and
+reports "Mainframe isn't installed on '\<org\>'" with a link to
+`https://github.com/settings/installations`, instead of a bare HTTP
+failure — this is the single most likely support question, so it gets its
+own message rather than surfacing as a generic 404.
 
 `run_command` spawns via `zsh -lc` (array args, never string-interpolated
 shell). Chips inside the script are never spliced into shell source: each
@@ -201,16 +244,26 @@ payloads, PR titles) can't inject shell commands.
 | `AUTOMATIONS_MCP_ENABLED` | Enables MCP server discovery and `mcp:<server>:<tool>` actions in the catalog | off (post-launch feature, not yet wired) |
 | `DESCRIBE_ENABLED` | Enables the "describe it" natural-language drafting entry point in the editor | off (no drafting endpoint yet) |
 
-## GitHub OAuth App setup
+## GitHub App setup
 
-The GitHub device-flow connect button needs a registered OAuth App with
-device flow enabled. Until one is registered, `GITHUB_OAUTH_CLIENT_ID` in
+Sign-in with GitHub needs a registered **GitHub App** (not an OAuth App —
+only a GitHub App issues the expiring, refreshable user tokens this
+connector relies on) with device flow enabled and token expiration left
+**on**. Until one is registered, `GITHUB_APP_CLIENT_ID` in
 `packages/core-rs/crates/mainframe-automations/src/github_device.rs` is
-empty and `POST /api/automation-credentials/github/device/start` answers
-501; the editor shows GitHub as unavailable rather than failing obscurely.
-Register the app (device flow enabled, no redirect URI needed — it never
-redirects) and set the constant to its client ID, which is a public
-identifier and carries no secret.
+empty, `GET .../device/status` reports `{configured: false}`, and
+`POST .../device/start` answers 501 if reached directly — the editor shows
+only the pasted-token field rather than failing obscurely or offering a
+button that can't work. This degrades gracefully: nothing about GitHub
+requires the app to be registered, since the token field always works.
+
+To register: create the GitHub App, enable device flow, leave token
+expiration on (needed for `RefreshingCredentialStore` above), and set the
+constant to its client ID — a public identifier, not a secret. Device flow
+needs no client secret to exchange or refresh, so none is stored anywhere
+in this app. After registering, remind users to **install** the app on
+their org/repos (see "GitHub App installation" above) — authorizing via
+device flow alone is not enough.
 
 ## Spec
 

--- a/packages/core-rs/crates/mainframe-automations/src/actions/github.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/github.rs
@@ -29,6 +29,27 @@ pub(super) fn parse_json<T: serde::de::DeserializeOwned>(
         .map_err(|err| ActionError(format!("{op} failed: unexpected response ({err})")))
 }
 
+/// A GitHub App must be INSTALLED on a repo/org, not just authorized — a
+/// user can finish device flow and still get a bare 404 from every repo
+/// endpoint if installation never happened. A 404 against a GitHub-App-
+/// issued token (`expires_at` set — a pasted PAT has no such concept) is
+/// mapped to this actionable message instead of the generic `http_failure`;
+/// a real "repo doesn't exist" 404 reads identically from the HTTP layer,
+/// but "app not installed" is by far the likelier cause for a token this
+/// connector itself just minted.
+fn not_installed_error(op: &str, repo: &str) -> ActionError {
+    let org = repo.split('/').next().unwrap_or(repo);
+    ActionError(format!(
+        "{op} failed: Mainframe isn't installed on '{org}' — install it at https://github.com/settings/installations"
+    ))
+}
+
+fn is_app_issued(ctx: &ActionCtx) -> bool {
+    ctx.creds
+        .as_ref()
+        .is_some_and(|creds| creds.expires_at.is_some())
+}
+
 /// `owner/repo`, the only shape a `/repos/<repo>/…` path segment can take.
 /// Rejecting anything else keeps a user-supplied value from reshaping the
 /// endpoint path (extra segments, `..`, a query string).
@@ -166,6 +187,9 @@ impl Action for GithubCreatePrAction {
                 .text()
                 .await
                 .map_err(|err| ActionError(format!("{OP} failed: {err}")))?;
+            if status == 404 && is_app_issued(ctx) {
+                return Err(not_installed_error(OP, &input.repo));
+            }
             if status >= 400 {
                 return Err(http_failure(OP, status, ctx, &body));
             }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/github_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/github_tests.rs
@@ -24,11 +24,28 @@ fn ctx(token: &str) -> ActionCtx {
             kind: CredentialKind::Token,
             token: token.to_string(),
             extra: None,
+            refresh_token: None,
+            expires_at: None,
         }),
         credential_label: Some("github".to_string()),
         idempotency_key: "run-1:step-1".to_string(),
         project_root: "/tmp".to_string(),
         worktree_path: None,
+    }
+}
+
+/// A GitHub-App-issued token (has `expires_at`) — as opposed to a pasted PAT,
+/// which never does.
+fn app_ctx(token: &str) -> ActionCtx {
+    ActionCtx {
+        creds: Some(Credentials {
+            kind: CredentialKind::Token,
+            token: token.to_string(),
+            extra: None,
+            refresh_token: Some("ghr_refresh".to_string()),
+            expires_at: Some(9_999_999_999_999),
+        }),
+        ..ctx(token)
     }
 }
 
@@ -182,6 +199,49 @@ async fn strict_inputs_reject_unknown_and_missing_fields() {
         "{}",
         err.0
     );
+}
+
+#[tokio::test]
+async fn a_404_against_an_app_issued_token_reports_not_installed_with_the_install_url() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/qlan/mainframe/pulls"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let err = GithubCreatePrAction::with_base_url(server.uri())
+        .execute(
+            &json!({"repo": "qlan/mainframe", "title": "t", "head": "h", "base": "b"}),
+            &app_ctx("ghu_1"),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.0,
+        "GitHub create PR failed: Mainframe isn't installed on 'qlan' — install it at https://github.com/settings/installations"
+    );
+}
+
+#[tokio::test]
+async fn a_404_against_a_pasted_pat_stays_the_generic_http_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/qlan/mainframe/pulls"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let err = GithubCreatePrAction::with_base_url(server.uri())
+        .execute(
+            &json!({"repo": "qlan/mainframe", "title": "t", "head": "h", "base": "b"}),
+            &ctx("ghp_1"),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.0, "GitHub create PR failed (404): Not Found");
 }
 
 #[tokio::test]

--- a/packages/core-rs/crates/mainframe-automations/src/actions/http_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/http_tests.rs
@@ -29,6 +29,8 @@ fn ctx_with_token(token: &str) -> ActionCtx {
             kind: CredentialKind::Token,
             token: token.to_string(),
             extra: None,
+            refresh_token: None,
+            expires_at: None,
         }),
         ..ctx()
     }

--- a/packages/core-rs/crates/mainframe-automations/src/actions/notion_ado_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/notion_ado_tests.rs
@@ -22,6 +22,8 @@ fn ctx(label: &str, token: &str) -> ActionCtx {
             kind: CredentialKind::Token,
             token: token.to_string(),
             extra: None,
+            refresh_token: None,
+            expires_at: None,
         }),
         credential_label: Some(label.to_string()),
         idempotency_key: "run-1:step-1".to_string(),

--- a/packages/core-rs/crates/mainframe-automations/src/actions/user_agent_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/actions/user_agent_tests.rs
@@ -24,6 +24,8 @@ fn ctx() -> ActionCtx {
             kind: CredentialKind::Token,
             token: "token".to_string(),
             extra: None,
+            refresh_token: None,
+            expires_at: None,
         }),
         credential_label: Some("label".to_string()),
         idempotency_key: "run-1:step-1".to_string(),

--- a/packages/core-rs/crates/mainframe-automations/src/credentials/boot_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials/boot_tests.rs
@@ -57,6 +57,8 @@ fn creds(token: &str) -> Credentials {
         kind: CredentialKind::Token,
         token: token.to_string(),
         extra: None,
+        refresh_token: None,
+        expires_at: None,
     }
 }
 

--- a/packages/core-rs/crates/mainframe-automations/src/credentials/keyring_store_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials/keyring_store_tests.rs
@@ -38,6 +38,8 @@ fn creds(token: &str) -> Credentials {
         kind: CredentialKind::Token,
         token: token.to_string(),
         extra: None,
+        refresh_token: None,
+        expires_at: None,
     }
 }
 

--- a/packages/core-rs/crates/mainframe-automations/src/credentials/mod.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials/mod.rs
@@ -21,13 +21,17 @@ use crate::engine::BoxFuture;
 
 mod boot;
 mod keyring_store;
+mod refreshing;
 
 pub use boot::build_credential_store;
+pub use refreshing::RefreshingCredentialStore;
 
 #[cfg(test)]
 mod boot_tests;
 #[cfg(test)]
 mod keyring_store_tests;
+#[cfg(test)]
+mod refreshing_tests;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,6 +40,13 @@ pub struct Credentials {
     pub token: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra: Option<BTreeMap<String, String>>,
+    /// Set only for a GitHub-App-issued token (device flow); absent for a
+    /// pasted PAT, which means "never refresh" (`RefreshingCredentialStore`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    /// Epoch ms. Absent alongside `refresh_token` for a pasted PAT.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -44,8 +55,9 @@ pub enum CredentialKind {
     Token,
 }
 
-/// Manual Debug: `token` and `extra` values are secret material and must not
-/// reach logs or error messages (plan T6.1).
+/// Manual Debug: `token`, `extra`, and `refresh_token` are secret material
+/// and must not reach logs or error messages (plan T6.1; refresh_token added
+/// by the 2026-08-19 GitHub App migration).
 impl fmt::Debug for Credentials {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Credentials")
@@ -59,6 +71,11 @@ impl fmt::Debug for Credentials {
                         .collect::<BTreeMap<_, _>>()
                 }),
             )
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[redacted]"),
+            )
+            .field("expires_at", &self.expires_at)
             .finish()
     }
 }
@@ -71,6 +88,13 @@ pub enum CredentialError {
     Json(#[from] serde_json::Error),
     #[error("keychain store failed: {0}")]
     Keyring(String),
+    /// A `RefreshingCredentialStore` couldn't renew an expired GitHub-App
+    /// token — surfaced verbatim as a step failure (contract: matches the
+    /// `credential '<label>' not found` naming style).
+    #[error(
+        "credential '{label}' expired and refresh failed: {reason} — reconnect GitHub in Settings"
+    )]
+    RefreshFailed { label: String, reason: String },
 }
 
 pub trait CredentialStore: Send + Sync {

--- a/packages/core-rs/crates/mainframe-automations/src/credentials/refreshing.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials/refreshing.rs
@@ -1,0 +1,178 @@
+//! Token refresh for GitHub-App-issued credentials (2026-08-19
+//! GitHub-App-with-refresh plan). GitHub App user tokens expire after 8h; a
+//! pasted PAT (or a plain OAuth App token) never carries `expires_at` and is
+//! passed through untouched — see `github_device.rs`'s module doc for why
+//! `client_id` alone is enough to refresh (device flow needs no secret).
+//!
+//! A per-label lock is mandatory, not an optimization: GitHub invalidates
+//! the old refresh token the moment a new one is issued, so two concurrent
+//! refreshes for the same label (e.g. a `repeat` block with `concurrency`
+//! running GitHub steps) would have the loser present an already-dead
+//! refresh token and log the user out. Every `get()` for a label queues
+//! behind the same lock and re-checks expiry after acquiring it, so a
+//! stampede produces exactly one live refresh call.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::USER_AGENT;
+use crate::github_device::{GITHUB_APP_CLIENT_ID, TOKEN_URL};
+use crate::ports::Clock;
+
+use super::{CredentialError, CredentialStore, Credentials};
+
+/// Refresh once expiry is within 5 minutes — comfortably inside the 8h user
+/// token lifetime, so a step never races the deadline mid-run.
+const REFRESH_SKEW_MS: i64 = 5 * 60 * 1000;
+
+pub struct RefreshingCredentialStore {
+    inner: Arc<dyn CredentialStore>,
+    clock: Arc<dyn Clock>,
+    client: reqwest::Client,
+    token_url: String,
+    client_id: &'static str,
+    label_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl RefreshingCredentialStore {
+    pub fn new(inner: Arc<dyn CredentialStore>, clock: Arc<dyn Clock>) -> Self {
+        Self::with_token_url(inner, clock, TOKEN_URL.to_string(), GITHUB_APP_CLIENT_ID)
+    }
+
+    pub fn with_token_url(
+        inner: Arc<dyn CredentialStore>,
+        clock: Arc<dyn Clock>,
+        token_url: String,
+        client_id: &'static str,
+    ) -> Self {
+        let client = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            inner,
+            clock,
+            client,
+            token_url,
+            client_id,
+            label_locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Refreshes and persists an expiring credential before returning it. A
+    /// PAT (no `refresh_token`/`expires_at`) passes through unchanged.
+    pub async fn get(&self, label: &str) -> Result<Option<Credentials>, CredentialError> {
+        let Some(creds) = self.inner.get(label).await else {
+            return Ok(None);
+        };
+        if !self.needs_refresh(&creds) {
+            return Ok(Some(creds));
+        }
+
+        let lock = self.label_lock(label).await;
+        let _guard = lock.lock().await;
+
+        // Re-read under the lock: a concurrent waiter may already have
+        // refreshed and persisted while this call queued behind it.
+        let Some(creds) = self.inner.get(label).await else {
+            return Ok(None);
+        };
+        if !self.needs_refresh(&creds) {
+            return Ok(Some(creds));
+        }
+
+        let refreshed = self.refresh(label, &creds).await?;
+        self.inner.set(label, refreshed.clone()).await?;
+        Ok(Some(refreshed))
+    }
+
+    fn needs_refresh(&self, creds: &Credentials) -> bool {
+        let (Some(_), Some(expires_at)) = (&creds.refresh_token, creds.expires_at) else {
+            return false;
+        };
+        expires_at - self.clock.now().timestamp_millis() <= REFRESH_SKEW_MS
+    }
+
+    async fn label_lock(&self, label: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.label_locks.lock().await;
+        locks
+            .entry(label.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    async fn refresh(
+        &self,
+        label: &str,
+        creds: &Credentials,
+    ) -> Result<Credentials, CredentialError> {
+        if self.client_id.is_empty() {
+            return Err(refresh_failed(
+                label,
+                "no GitHub App client ID is configured",
+            ));
+        }
+        let refresh_token = creds.refresh_token.as_deref().unwrap_or_default();
+        let response = self
+            .client
+            .post(&self.token_url)
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", self.client_id),
+                ("grant_type", "refresh_token"),
+                ("refresh_token", refresh_token),
+            ])
+            .send()
+            .await
+            .map_err(|err| refresh_failed(label, &err.to_string()))?;
+        let body = response
+            .text()
+            .await
+            .map_err(|err| refresh_failed(label, &err.to_string()))?;
+        let parsed: RefreshBody = serde_json::from_str(&body)
+            .map_err(|err| refresh_failed(label, &format!("unexpected response ({err})")))?;
+        let Some(access_token) = parsed.access_token else {
+            let reason = parsed
+                .error_description
+                .or(parsed.error)
+                .unwrap_or_else(|| "no access token in response".to_string());
+            return Err(refresh_failed(label, &reason));
+        };
+        let expires_at = parsed
+            .expires_in
+            .map(|secs| self.clock.now().timestamp_millis() + secs as i64 * 1000);
+        Ok(Credentials {
+            kind: creds.kind,
+            token: access_token,
+            extra: creds.extra.clone(),
+            refresh_token: parsed.refresh_token.or_else(|| creds.refresh_token.clone()),
+            expires_at,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshBody {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_in: Option<u64>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+fn refresh_failed(label: &str, reason: &str) -> CredentialError {
+    CredentialError::RefreshFailed {
+        label: label.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+// PORT STATUS: greenfield (2026-08-19 GitHub-App-with-refresh plan), not a TS port
+// confidence: high
+// todos: 0
+// notes: sits above CredentialStore rather than implementing it — only
+//        RunActionVerb (the execution path) needs refresh; the admin/UI
+//        accessor and webhook secret lookups keep reading the raw store.

--- a/packages/core-rs/crates/mainframe-automations/src/credentials/refreshing_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials/refreshing_tests.rs
@@ -1,0 +1,203 @@
+//! `RefreshingCredentialStore` over wiremock (`notion_ado_tests.rs`-style):
+//! refresh-near-expiry, the stampede lock, refresh failure, and the PAT
+//! passthrough that must stay untouched.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, FixedOffset};
+use tempfile::tempdir;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::credentials::{CredentialKind, CredentialStore, Credentials, FileCredentialStore};
+use crate::ports::Clock;
+
+use super::RefreshingCredentialStore;
+
+const NOW_MS: i64 = 1_700_000_000_000;
+
+struct FixedClock(i64);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<FixedOffset> {
+        DateTime::from_timestamp_millis(self.0)
+            .expect("valid instant")
+            .fixed_offset()
+    }
+}
+
+async fn inner_store_with(label: &str, creds: Credentials) -> Arc<FileCredentialStore> {
+    let dir = tempdir().unwrap();
+    let store = Arc::new(FileCredentialStore::load(dir.path().join("creds.json")).await);
+    store.set(label, creds).await.unwrap();
+    store
+}
+
+fn expiring_soon(refresh_token: &str) -> Credentials {
+    Credentials {
+        kind: CredentialKind::Token,
+        token: "ghu_stale".to_string(),
+        extra: None,
+        refresh_token: Some(refresh_token.to_string()),
+        // One minute out — inside the 5-minute skew window.
+        expires_at: Some(NOW_MS + 60_000),
+    }
+}
+
+fn pat_with_no_expiry() -> Credentials {
+    Credentials {
+        kind: CredentialKind::Token,
+        token: "ghp_pasted".to_string(),
+        extra: None,
+        refresh_token: None,
+        expires_at: None,
+    }
+}
+
+#[tokio::test]
+async fn refreshes_a_credential_expiring_within_the_skew_window() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains("refresh_token=old-refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "ghu_fresh",
+            "refresh_token": "ghr_fresh",
+            "expires_in": 28800,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let inner = inner_store_with("github", expiring_soon("old-refresh")).await;
+    let store = RefreshingCredentialStore::with_token_url(
+        inner.clone(),
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    let refreshed = store.get("github").await.unwrap().unwrap();
+
+    assert_eq!(refreshed.token, "ghu_fresh");
+    assert_eq!(refreshed.refresh_token, Some("ghr_fresh".to_string()));
+    assert_eq!(refreshed.expires_at, Some(NOW_MS + 28_800_000));
+    // Persisted through the inner store, not just returned.
+    assert_eq!(inner.get("github").await.unwrap().token, "ghu_fresh");
+}
+
+#[tokio::test]
+async fn concurrent_get_refreshes_exactly_once() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "ghu_fresh",
+            "refresh_token": "ghr_fresh",
+            "expires_in": 28800,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let inner = inner_store_with("github", expiring_soon("old-refresh")).await;
+    let store = Arc::new(RefreshingCredentialStore::with_token_url(
+        inner,
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    ));
+
+    let tasks: Vec<_> = (0..5)
+        .map(|_| {
+            let store = store.clone();
+            tokio::spawn(async move { store.get("github").await.unwrap().unwrap().token })
+        })
+        .collect();
+    let mut results = Vec::new();
+    for task in tasks {
+        results.push(task.await.unwrap());
+    }
+
+    assert!(results.iter().all(|token| token == "ghu_fresh"));
+    // `.expect(1)` above is verified when `server` drops at the end of this
+    // test — without the per-label lock, all 5 tasks would refresh
+    // concurrently and this assertion (and the mock's expectation) would fail.
+}
+
+#[tokio::test]
+async fn refresh_failure_produces_an_actionable_error_naming_the_credential() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "error": "bad_refresh_token",
+            "error_description": "The refresh token passed is incorrect or expired.",
+        })))
+        .mount(&server)
+        .await;
+    let inner = inner_store_with("github", expiring_soon("old-refresh")).await;
+    let store = RefreshingCredentialStore::with_token_url(
+        inner,
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    let err = store.get("github").await.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "credential 'github' expired and refresh failed: The refresh token passed is incorrect or expired. — reconnect GitHub in Settings"
+    );
+}
+
+#[tokio::test]
+async fn a_pat_with_no_expiry_never_attempts_refresh() {
+    let server = MockServer::start().await;
+    // No mock mounted — a request here would panic wiremock's unhandled-call guard.
+    let inner = inner_store_with("github", pat_with_no_expiry()).await;
+    let store = RefreshingCredentialStore::with_token_url(
+        inner,
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    let creds = store.get("github").await.unwrap().unwrap();
+
+    assert_eq!(creds.token, "ghp_pasted");
+}
+
+#[tokio::test]
+async fn a_credential_expiring_well_outside_the_skew_window_is_left_alone() {
+    let server = MockServer::start().await;
+    // No mock mounted — refreshing this far ahead of expiry would be a bug.
+    let mut creds = expiring_soon("old-refresh");
+    creds.expires_at = Some(NOW_MS + 60 * 60 * 1000); // one hour out
+    let inner = inner_store_with("github", creds).await;
+    let store = RefreshingCredentialStore::with_token_url(
+        inner,
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    let result = store.get("github").await.unwrap().unwrap();
+
+    assert_eq!(result.token, "ghu_stale");
+}
+
+#[tokio::test]
+async fn a_missing_label_returns_none_without_attempting_refresh() {
+    let server = MockServer::start().await;
+    let dir = tempdir().unwrap();
+    let inner = Arc::new(FileCredentialStore::load(dir.path().join("creds.json")).await);
+    let store = RefreshingCredentialStore::with_token_url(
+        inner,
+        Arc::new(FixedClock(NOW_MS)),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    assert_eq!(store.get("github").await.unwrap(), None);
+}

--- a/packages/core-rs/crates/mainframe-automations/src/credentials_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/credentials_tests.rs
@@ -12,6 +12,8 @@ fn token_creds(token: &str) -> Credentials {
         kind: CredentialKind::Token,
         token: token.to_string(),
         extra: None,
+        refresh_token: None,
+        expires_at: None,
     }
 }
 
@@ -54,6 +56,8 @@ async fn persists_across_reload_in_node_compatible_shape() {
             "organization".to_string(),
             "qlan".to_string(),
         )])),
+        refresh_token: None,
+        expires_at: None,
     };
     store.set("ado", creds.clone()).await.unwrap();
     drop(store);
@@ -121,9 +125,35 @@ fn debug_never_prints_secret_material() {
             "password".to_string(),
             "hunter2".to_string(),
         )])),
+        refresh_token: Some("ghr_refreshsecret".to_string()),
+        expires_at: Some(1_700_000_000_000),
     };
     let debug = format!("{creds:?}");
     assert!(!debug.contains("ghp_supersecret"), "leaked token: {debug}");
     assert!(!debug.contains("hunter2"), "leaked extra value: {debug}");
+    assert!(
+        !debug.contains("ghr_refreshsecret"),
+        "leaked refresh token: {debug}"
+    );
     assert!(debug.contains("[redacted]"));
+}
+
+#[tokio::test]
+async fn a_pre_refresh_credential_file_deserializes_unchanged() {
+    // Credentials persisted before refresh_token/expires_at existed carry
+    // neither field — the new fields must default rather than fail to parse.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("automation-credentials.json");
+    std::fs::write(
+        &path,
+        serde_json::json!({
+            "github": {"kind": "token", "token": "ghp_old"}
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let store = FileCredentialStore::load(path).await;
+
+    assert_eq!(store.get("github").await, Some(token_creds("ghp_old")));
 }

--- a/packages/core-rs/crates/mainframe-automations/src/engine/run_action_verb.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/engine/run_action_verb.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use serde_json::{Map, Value};
 
 use crate::actions::{ActionCtx, ActionRegistry};
-use crate::credentials::CredentialStore;
+use crate::credentials::RefreshingCredentialStore;
 use crate::domain::{ChipPart, ChipText, RunActionStep};
 use crate::ports::ProjectRegistry;
 use crate::store::{AutomationStore, RunStore};
@@ -21,7 +21,9 @@ const ACTIONS_WITH_OUTPUT_AS: [&str; 2] = ["run_command", "files.read"];
 
 pub struct RunActionVerb {
     registry: Arc<ActionRegistry>,
-    credentials: Arc<dyn CredentialStore>,
+    /// Wraps the raw store with expiry-refresh — the only consumer that
+    /// needs it (a step is where an expired GitHub App token would 401).
+    credentials: Arc<RefreshingCredentialStore>,
     projects: Arc<dyn ProjectRegistry>,
     runs: RunStore,
     automations: AutomationStore,
@@ -30,7 +32,7 @@ pub struct RunActionVerb {
 impl RunActionVerb {
     pub fn new(
         registry: Arc<ActionRegistry>,
-        credentials: Arc<dyn CredentialStore>,
+        credentials: Arc<RefreshingCredentialStore>,
         projects: Arc<dyn ProjectRegistry>,
         runs: RunStore,
         automations: AutomationStore,
@@ -63,12 +65,17 @@ impl RunActionVerb {
         let creds = match &credential_label {
             None => None,
             Some(label) => match self.credentials.get(label).await {
-                Some(creds) => Some(creds),
-                None => {
+                Ok(Some(creds)) => Some(creds),
+                Ok(None) => {
                     return StepOutcome::Failed {
                         error: format!(
                             "credential '{label}' not found — add it via PUT /api/automation-credentials/{label}"
                         ),
+                    };
+                }
+                Err(err) => {
+                    return StepOutcome::Failed {
+                        error: err.to_string(),
                     };
                 }
             },

--- a/packages/core-rs/crates/mainframe-automations/src/engine/run_action_verb_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/engine/run_action_verb_tests.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use serde_json::json;
 
 use crate::actions::{ActionRegistry, register_all_actions};
-use crate::credentials::{CredentialKind, CredentialStore, Credentials, FileCredentialStore};
+use crate::credentials::{
+    CredentialKind, CredentialStore, Credentials, FileCredentialStore, RefreshingCredentialStore,
+};
 use crate::domain::{OutputAs, RunActionStep};
 use crate::engine::run_action_verb::{RunActionVerb, build_action_input};
 use crate::engine::test_support::{FakeClock, harness, text, token};
@@ -110,7 +112,10 @@ async fn missing_credential_fails_with_an_actionable_error() {
     let automations = crate::store::AutomationStore::new(h.db.clone());
     let verb = RunActionVerb::new(
         Arc::new(registry),
-        credentials,
+        Arc::new(RefreshingCredentialStore::new(
+            credentials,
+            Arc::new(FakeClock),
+        )),
         Arc::new(FixedProjects(dir.path().to_string_lossy().into_owned())),
         h.store.clone(),
         automations,
@@ -189,6 +194,8 @@ async fn a_pre_migration_github_step_resolves_the_default_credential_label() {
                 kind: CredentialKind::Token,
                 token: "ghp_migrated".to_string(),
                 extra: None,
+                refresh_token: None,
+                expires_at: None,
             },
         )
         .await
@@ -196,7 +203,10 @@ async fn a_pre_migration_github_step_resolves_the_default_credential_label() {
     let automations = crate::store::AutomationStore::new(h.db.clone());
     let verb = RunActionVerb::new(
         Arc::new(registry),
-        credentials,
+        Arc::new(RefreshingCredentialStore::new(
+            credentials,
+            Arc::new(FakeClock),
+        )),
         Arc::new(FixedProjects(dir.path().to_string_lossy().into_owned())),
         h.store.clone(),
         automations,
@@ -237,7 +247,10 @@ async fn a_pre_migration_github_step_with_no_connection_names_the_default_label(
     let automations = crate::store::AutomationStore::new(h.db.clone());
     let verb = RunActionVerb::new(
         Arc::new(registry),
-        credentials,
+        Arc::new(RefreshingCredentialStore::new(
+            credentials,
+            Arc::new(FakeClock),
+        )),
         Arc::new(FixedProjects(dir.path().to_string_lossy().into_owned())),
         h.store.clone(),
         automations,

--- a/packages/core-rs/crates/mainframe-automations/src/github_device.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_device.rs
@@ -1,29 +1,45 @@
-//! GitHub OAuth device flow (2026-08-19 provider-connections plan,
-//! Deliverable 3) — the one provider that gets real OAuth, because device
-//! flow's token exchange needs only `client_id`, `device_code`, and
-//! `grant_type`; GitHub's docs state the client secret is "not needed for
-//! the device flow". No redirect URI, no PKCE, no `state` — none of that
-//! applies to a flow that never redirects.
+//! GitHub App device flow (2026-08-19 provider-connections plan, Deliverable
+//! 3; reversed from OAuth App to GitHub App for token refresh — 2026-08-19
+//! GitHub-App-with-refresh plan). Device flow's token exchange needs only
+//! `client_id`, `device_code`, and `grant_type`; GitHub's docs state the
+//! client secret is "not needed for the device flow". No redirect URI, no
+//! PKCE, no `state` — none of that applies to a flow that never redirects.
 //!
-//! `GITHUB_OAUTH_CLIENT_ID` is the single place the registered OAuth App's
+//! **Load-bearing fact:** GitHub's refresh-token docs list `client_secret`
+//! as "Required unless the user access token was generated using the device
+//! flow." Because token generation here IS device flow, `credentials::
+//! refreshing` can refresh with `client_id` alone — no secret ships in the
+//! binary. Moving token generation off device flow would make refresh start
+//! requiring a secret, and the no-secret design collapses.
+//!
+//! `GITHUB_APP_CLIENT_ID` is the single place the registered GitHub App's
 //! client ID goes once it exists; empty means "not configured yet" and
 //! `start()` reports that explicitly rather than making a doomed request.
 //!
 //! `poll_once` makes exactly one probe against GitHub's token endpoint and
 //! maps the response to a `PollOutcome` — it does not loop or sleep itself.
 //! The caller (the daemon route) drives the interval; `SlowDown` carries the
-//! new interval GitHub asked for, per the docs' "5 extra seconds" rule.
+//! new interval GitHub asked for, per the docs' "5 extra seconds" rule. A
+//! GitHub App's response additionally carries `expires_in`/`refresh_token`
+//! (a plain OAuth App's does not) — `Connected` carries both as optional so
+//! the route can persist them without this module caring which app kind is
+//! configured.
 
 use serde::Deserialize;
 
 use crate::USER_AGENT;
 
-/// Set this once the GitHub OAuth App (device flow enabled) is registered —
-/// see the daemon operator docs. Empty = device flow is unavailable.
-pub const GITHUB_OAUTH_CLIENT_ID: &str = "";
+/// The registered GitHub App's client ID. Public by design — it ships in the
+/// binary and identifies the app on GitHub's consent screen; the secret it is
+/// paired with never leaves GitHub, because device flow does not use one.
+/// Empty = device flow is unavailable and the editor falls back to the token
+/// field.
+pub const GITHUB_APP_CLIENT_ID: &str = "Iv23liJciR5mmjd0cFYE";
 
 const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
-const TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+/// Also the refresh-token endpoint (`credentials::refreshing`) — GitHub
+/// reuses one token endpoint for both the initial exchange and refresh.
+pub(crate) const TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
 
 #[derive(Debug, Clone, PartialEq)]
@@ -46,7 +62,7 @@ struct DeviceStartBody {
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum DeviceFlowError {
-    #[error("GitHub connection isn't set up yet — no OAuth App client ID is configured")]
+    #[error("GitHub connection isn't set up yet — no GitHub App client ID is configured")]
     NotConfigured,
     #[error("GitHub device flow request failed: {0}")]
     Network(String),
@@ -60,13 +76,17 @@ pub enum DeviceFlowError {
 pub enum PollOutcome {
     Connected {
         token: String,
+        /// Seconds until the token expires — set for a GitHub App user
+        /// token (8h), absent for a plain OAuth App token (never expires).
+        expires_in: Option<u64>,
+        /// Present alongside `expires_in` on a GitHub App token; absent
+        /// means the caller must not attempt to refresh this credential.
+        refresh_token: Option<String>,
     },
     /// The user hasn't entered the code yet — keep polling at `interval`.
     Pending,
     /// Poll faster than allowed; wait `new_interval` seconds from now on.
-    SlowDown {
-        new_interval: u64,
-    },
+    SlowDown { new_interval: u64 },
     /// The device/user code expired (15 minutes) — start over.
     Expired,
     /// The user clicked cancel.
@@ -84,7 +104,14 @@ pub struct GithubDeviceFlow {
 
 impl GithubDeviceFlow {
     pub fn new() -> Self {
-        Self::with_urls(DEVICE_CODE_URL, TOKEN_URL, GITHUB_OAUTH_CLIENT_ID)
+        Self::with_urls(DEVICE_CODE_URL, TOKEN_URL, GITHUB_APP_CLIENT_ID)
+    }
+
+    /// Whether a GitHub App client ID is registered — the UI's signal for
+    /// whether to offer sign-in-with-GitHub alongside the always-available
+    /// pasted-token path (`GithubCredentialConnect.tsx`).
+    pub fn is_configured(&self) -> bool {
+        !self.client_id.is_empty()
     }
 
     pub fn with_urls(
@@ -166,13 +193,19 @@ struct PollBody {
     access_token: Option<String>,
     error: Option<String>,
     interval: Option<u64>,
+    expires_in: Option<u64>,
+    refresh_token: Option<String>,
 }
 
 fn parse_poll_response(body: &str) -> Result<PollOutcome, DeviceFlowError> {
     let parsed: PollBody = serde_json::from_str(body)
         .map_err(|err| DeviceFlowError::UnexpectedResponse(format!("{err}: {body}")))?;
     if let Some(token) = parsed.access_token {
-        return Ok(PollOutcome::Connected { token });
+        return Ok(PollOutcome::Connected {
+            token,
+            expires_in: parsed.expires_in,
+            refresh_token: parsed.refresh_token,
+        });
     }
     Ok(match parsed.error.as_deref() {
         Some("authorization_pending") => PollOutcome::Pending,

--- a/packages/core-rs/crates/mainframe-automations/src/github_device_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/github_device_tests.rs
@@ -156,7 +156,40 @@ async fn poll_connected_carries_the_access_token() {
     assert_eq!(
         outcome,
         PollOutcome::Connected {
-            token: "ghu_abc123".to_string()
+            token: "ghu_abc123".to_string(),
+            expires_in: None,
+            refresh_token: None,
+        }
+    );
+}
+
+#[tokio::test]
+async fn poll_connected_carries_the_github_app_expiry_and_refresh_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/login/oauth/access_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "ghu_abc123",
+            "token_type": "bearer",
+            "expires_in": 28800,
+            "refresh_token": "ghr_refresh123",
+            "refresh_token_expires_in": 15811200,
+        })))
+        .mount(&server)
+        .await;
+
+    let outcome = flow(&server, "test-client")
+        .await
+        .poll_once("dc-1")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        PollOutcome::Connected {
+            token: "ghu_abc123".to_string(),
+            expires_in: Some(28800),
+            refresh_token: Some("ghr_refresh123".to_string()),
         }
     );
 }

--- a/packages/core-rs/crates/mainframe-automations/src/service.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/service.rs
@@ -217,10 +217,25 @@ impl AutomationsEngine {
     }
 
     pub async fn set_credential(&self, label: &str, token: String) -> Result<(), CredentialError> {
+        self.set_credential_full(label, token, None, None).await
+    }
+
+    /// Used by the GitHub device-flow route to persist a GitHub-App token's
+    /// refresh material alongside it; every other caller (a pasted PAT) goes
+    /// through `set_credential` above, which leaves both fields `None`.
+    pub async fn set_credential_full(
+        &self,
+        label: &str,
+        token: String,
+        refresh_token: Option<String>,
+        expires_at: Option<i64>,
+    ) -> Result<(), CredentialError> {
         let creds = Credentials {
             kind: CredentialKind::Token,
             token,
             extra: None,
+            refresh_token,
+            expires_at,
         };
         self.credentials.set(label, creds).await
     }

--- a/packages/core-rs/crates/mainframe-automations/src/service/build.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/service/build.rs
@@ -4,6 +4,7 @@
 use std::sync::{Arc, Mutex as StdMutex};
 
 use crate::actions::{ActionRegistry, register_all_actions};
+use crate::credentials::RefreshingCredentialStore;
 use crate::engine::{AgentVerb, Interpreter, InterpreterDeps, NotifyVerb, RunActionVerb};
 use crate::error::StoreError;
 use crate::interactions::{AskMeVerb, InteractionService};
@@ -34,6 +35,13 @@ pub(super) async fn build(
         }
     };
     let credentials = config.credentials;
+    // Only the execution path needs expiry-refresh — the admin/UI accessor
+    // (`AutomationsEngine::credentials()`) and webhook secrets keep reading
+    // `credentials` raw.
+    let refreshing_credentials = Arc::new(RefreshingCredentialStore::new(
+        credentials.clone(),
+        ports.clock.clone(),
+    ));
 
     let agent_verb = AgentVerb::new(ports.agent, runs.clone(), ports.events.clone());
     let verb_ports = EngineVerbPorts {
@@ -48,7 +56,7 @@ pub(super) async fn build(
         notify: NotifyVerb::new(runs.clone(), automations.clone(), ports.notifier.clone()),
         run_action: RunActionVerb::new(
             registry.clone(),
-            credentials.clone(),
+            refreshing_credentials,
             ports.projects.clone(),
             runs.clone(),
             automations.clone(),

--- a/packages/core-rs/crates/mainframe-automations/src/service/credentials_accessor_tests.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/service/credentials_accessor_tests.rs
@@ -22,6 +22,8 @@ async fn credentials_accessor_sees_writes_made_through_the_engine_instance() {
                 kind: CredentialKind::Token,
                 token: "ghp_test".to_string(),
                 extra: None,
+                refresh_token: None,
+                expires_at: None,
             },
         )
         .await

--- a/packages/core-rs/crates/mainframe-automations/src/triggers/webhook.rs
+++ b/packages/core-rs/crates/mainframe-automations/src/triggers/webhook.rs
@@ -195,6 +195,8 @@ pub async fn ensure_webhook_secret(
                 kind: CredentialKind::Token,
                 token: token.clone(),
                 extra: None,
+                refresh_token: None,
+                expires_at: None,
             },
         )
         .await?;

--- a/packages/core-rs/crates/mainframe-daemon/src/github_issues_port_tests.rs
+++ b/packages/core-rs/crates/mainframe-daemon/src/github_issues_port_tests.rs
@@ -39,6 +39,8 @@ impl CredentialStore for MutableCredentialStore {
                 kind: CredentialKind::Token,
                 token,
                 extra: None,
+                refresh_token: None,
+                expires_at: None,
             })
         })
     }

--- a/packages/core-rs/crates/mainframe-server/src/routes/automation_credentials_github.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/automation_credentials_github.rs
@@ -1,18 +1,24 @@
-//! GitHub OAuth device flow routes (2026-08-19 provider-connections plan,
-//! Deliverable 3) — the one connector that gets a real OAuth flow. `start`
-//! and `poll` each make exactly one call to GitHub; the client (the editor's
-//! connect UI) owns the interval-respecting retry loop. A successful poll
-//! persists the token under the well-known `github` credential label and
-//! never echoes it back — same rule as `PUT /api/automation-credentials`.
+//! GitHub App device flow routes (2026-08-19 provider-connections plan,
+//! Deliverable 3; token-refresh fields added by the GitHub-App-with-refresh
+//! plan) — the one connector that gets a real OAuth flow. `start` and `poll`
+//! each make exactly one call to GitHub; the client (the editor's connect
+//! UI) owns the interval-respecting retry loop. A successful poll persists
+//! the token (plus, for a GitHub App, its refresh token and expiry) under
+//! the well-known `github` credential label and never echoes it back — same
+//! rule as `PUT /api/automation-credentials`. `device/status` is a separate,
+//! no-op-cheap route the UI probes on mount to decide whether to offer the
+//! sign-in-with-GitHub button alongside the always-available token field
+//! (`GithubCredentialConnect.tsx`) — it never touches GitHub.
 
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::Router;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::Response;
-use axum::routing::post;
+use axum::routing::{get, post};
 use mainframe_automations::AutomationsEngine;
 use mainframe_automations::github_device::{
     DeviceFlowError, DeviceStart, GithubDeviceFlow, PollOutcome,
@@ -26,6 +32,17 @@ use crate::routes::automations::{engine, unavailable};
 use crate::routes::projects::parse_body;
 
 const GITHUB_CREDENTIAL_LABEL: &str = "github";
+
+async fn device_flow_status() -> Response {
+    device_flow_status_for(&GithubDeviceFlow::new()).await
+}
+
+/// Split from the handler so a test can pin the unconfigured contract with an
+/// injected client ID instead of depending on this repo's own app never being
+/// registered.
+async fn device_flow_status_for(flow: &GithubDeviceFlow) -> Response {
+    ok(json!({ "configured": flow.is_configured() }))
+}
 
 async fn start_device_flow(State(ctx): State<Arc<AppCtx>>) -> Response {
     if engine(&ctx).is_none() {
@@ -83,8 +100,16 @@ async fn poll_and_respond(
     engine: &AutomationsEngine,
 ) -> Response {
     match flow.poll_once(device_code).await {
-        Ok(PollOutcome::Connected { token }) => {
-            match engine.set_credential(GITHUB_CREDENTIAL_LABEL, token).await {
+        Ok(PollOutcome::Connected {
+            token,
+            expires_in,
+            refresh_token,
+        }) => {
+            let expires_at = expires_in.map(epoch_ms_after);
+            match engine
+                .set_credential_full(GITHUB_CREDENTIAL_LABEL, token, refresh_token, expires_at)
+                .await
+            {
                 Ok(()) => ok(json!({ "status": "connected" })),
                 Err(err) => {
                     tracing::error!(error = %err, "failed to persist the GitHub device-flow token");
@@ -106,8 +131,22 @@ async fn poll_and_respond(
     }
 }
 
+/// Wall-clock ms this many seconds from now, for a GitHub-App token's
+/// `expires_at` — GitHub reports expiry as a duration, not an instant.
+fn epoch_ms_after(seconds: u64) -> i64 {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    now_ms + seconds as i64 * 1000
+}
+
 pub fn router() -> Router<Arc<AppCtx>> {
     Router::new()
+        .route(
+            "/api/automation-credentials/github/device/status",
+            get(device_flow_status),
+        )
         .route(
             "/api/automation-credentials/github/device/start",
             post(start_device_flow),

--- a/packages/core-rs/crates/mainframe-server/src/routes/automation_credentials_github/automation_credentials_github_tests.rs
+++ b/packages/core-rs/crates/mainframe-server/src/routes/automation_credentials_github/automation_credentials_github_tests.rs
@@ -9,7 +9,7 @@ use mainframe_automations::github_device::GithubDeviceFlow;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::{poll_and_respond, start_response};
+use super::{device_flow_status_for, poll_and_respond, start_response};
 use crate::routes::automations_test_support::automations_ctx;
 
 async fn body_json(resp: axum::response::Response) -> (axum::http::StatusCode, serde_json::Value) {
@@ -18,12 +18,50 @@ async fn body_json(resp: axum::response::Response) -> (axum::http::StatusCode, s
     (status, serde_json::from_slice(&bytes).unwrap())
 }
 
+fn epoch_ms_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+#[tokio::test]
+async fn device_status_reports_unconfigured_when_no_client_id_is_set() {
+    // Injects an empty client ID rather than reading the shipped constant:
+    // this pins the UNCONFIGURED contract, which must keep holding after an
+    // app is registered — a test that breaks the day the product is
+    // configured is testing the constant, not the behaviour.
+    let flow = GithubDeviceFlow::with_urls("http://unused/code", "http://unused/token", "");
+
+    assert!(!flow.is_configured());
+    let (status, body) = body_json(device_flow_status_for(&flow).await).await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body["data"]["configured"], false);
+}
+
+#[tokio::test]
+async fn device_status_reports_configured_once_a_client_id_ships() {
+    let flow = GithubDeviceFlow::with_urls(
+        "http://unused/code",
+        "http://unused/token",
+        "Iv23lixxxxxxxxxxxxxx",
+    );
+
+    assert!(flow.is_configured());
+    let (status, body) = body_json(device_flow_status_for(&flow).await).await;
+
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body["data"]["configured"], true);
+}
+
 #[tokio::test]
 async fn start_reports_not_configured_when_no_client_id_is_set() {
-    // GITHUB_OAUTH_CLIENT_ID is empty until an operator registers the OAuth
-    // App — this is the only reachable state in this repo today, and the UI
-    // must read it as "unavailable", not a generic failure.
-    let (status, body) = body_json(start_response(GithubDeviceFlow::new().start().await)).await;
+    // Injected, not the shipped constant — a build with no app registered
+    // must read as "unavailable" rather than a generic failure, and that has
+    // to stay true regardless of whether this repo's own app is configured.
+    let flow = GithubDeviceFlow::with_urls("http://unused/code", "http://unused/token", "");
+    let (status, body) = body_json(start_response(flow.start().await)).await;
 
     assert_eq!(status, axum::http::StatusCode::NOT_IMPLEMENTED);
     assert_eq!(body["success"], false);
@@ -64,6 +102,41 @@ async fn poll_connected_persists_the_token_and_never_echoes_it() {
     assert_eq!(
         serde_json::to_value(kind).unwrap(),
         serde_json::json!("token")
+    );
+}
+
+#[tokio::test]
+async fn poll_connected_for_a_github_app_persists_the_refresh_token_and_expiry() {
+    let harness = automations_ctx().await;
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "ghu_secret",
+            "refresh_token": "ghr_secret",
+            "expires_in": 28800,
+        })))
+        .mount(&server)
+        .await;
+    let flow = GithubDeviceFlow::with_urls(
+        format!("{}/device", server.uri()),
+        format!("{}/token", server.uri()),
+        "test-client",
+    );
+
+    let before = epoch_ms_now();
+    let (status, _body) = body_json(poll_and_respond(&flow, "dc-1", &harness.engine).await).await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+
+    let creds = harness.engine.credentials().get("github").await.unwrap();
+    assert_eq!(creds.refresh_token, Some("ghr_secret".to_string()));
+    let expires_at = creds
+        .expires_at
+        .expect("expires_at set for a GitHub App token");
+    let expected = before + 28_800_000;
+    assert!(
+        (expected - 5_000..=expected + 5_000).contains(&expires_at),
+        "expires_at {expires_at} not within 5s of expected {expected}"
     );
 }
 

--- a/packages/ui/src/features/automations/data/__tests__/fake-gateway.ts
+++ b/packages/ui/src/features/automations/data/__tests__/fake-gateway.ts
@@ -47,6 +47,7 @@ export function createFakeGateway(overrides: Partial<AutomationsGateway> = {}): 
     pollGithubDeviceFlow: async () => {
       throw new Error('not implemented');
     },
+    githubDeviceFlowStatus: async () => ({ configured: false }),
     onEvent: () => () => {},
     ...overrides,
   };

--- a/packages/ui/src/features/automations/data/__tests__/http-gateway.test.ts
+++ b/packages/ui/src/features/automations/data/__tests__/http-gateway.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/lib/api/automations', () => ({
   deleteAutomationCredential: vi.fn(),
   startGithubDeviceFlow: vi.fn(),
   pollGithubDeviceFlow: vi.fn(),
+  getGithubDeviceFlowStatus: vi.fn(),
 }));
 
 import * as api from '@/lib/api/automations';

--- a/packages/ui/src/features/automations/data/gateway.ts
+++ b/packages/ui/src/features/automations/data/gateway.ts
@@ -60,6 +60,8 @@ export interface AutomationsGateway {
   /** GitHub's device flow (the only OAuth provider) — see `steps/GithubDeviceConnect.tsx`. */
   startGithubDeviceFlow(): Promise<GithubDeviceStart>;
   pollGithubDeviceFlow(deviceCode: string): Promise<GithubDevicePollResult>;
+  /** Whether a GitHub App client ID is configured — gates offering the device-flow button alongside the always-available token field (`GithubCredentialConnect.tsx`). */
+  githubDeviceFlowStatus(): Promise<{ configured: boolean }>;
 
   /**
    * Subscribe to the 5 `automation.*` DaemonEvent members. The fixture

--- a/packages/ui/src/features/automations/data/http-gateway.ts
+++ b/packages/ui/src/features/automations/data/http-gateway.ts
@@ -48,6 +48,7 @@ export function createHttpGateway(): AutomationsGateway {
 
     startGithubDeviceFlow: api.startGithubDeviceFlow,
     pollGithubDeviceFlow: api.pollGithubDeviceFlow,
+    githubDeviceFlowStatus: api.getGithubDeviceFlowStatus,
 
     onEvent(listener) {
       return daemonWs.onEvent((event: DaemonEvent) => {

--- a/packages/ui/src/features/automations/fixtures/fixture-gateway.ts
+++ b/packages/ui/src/features/automations/fixtures/fixture-gateway.ts
@@ -210,5 +210,12 @@ export function createFixtureGateway(): AutomationsGateway {
     async pollGithubDeviceFlow() {
       return { status: 'connected' as const };
     },
+
+    async githubDeviceFlowStatus() {
+      // The dev host never registers a GitHub App — mirrors production's
+      // default (empty client ID) so the fixture UI shows the same
+      // token-only state a fresh install sees.
+      return { configured: false };
+    },
   };
 }

--- a/packages/ui/src/features/automations/steps/CredentialConnect.tsx
+++ b/packages/ui/src/features/automations/steps/CredentialConnect.tsx
@@ -4,18 +4,19 @@
  * `WfCredentialField`, ported onto the real `useAutomationsStore`
  * credentials list + `AutomationsGateway` routes).
  *
- * Dispatches to the real per-provider connect flow: `GithubDeviceConnect`
- * (device flow — the one OAuth provider) for `github`, `TokenCredentialField`
- * (a pasted token, real since the 2026-08-19 provider-connections plan — no
- * more `placeholder-token-<service>`) for everything else. `onChange` patches
- * the OWNING step's `credential` field (top-level on `RunActionStep`, not
- * inside `params` — contract §1) with the label, or `undefined` on disconnect.
+ * Dispatches to the real per-provider connect flow: `GithubCredentialConnect`
+ * (a pasted token always, plus device flow once a GitHub App client ID is
+ * configured) for `github`, `TokenCredentialField` (a pasted token, real
+ * since the 2026-08-19 provider-connections plan — no more
+ * `placeholder-token-<service>`) for everything else. `onChange` patches the
+ * OWNING step's `credential` field (top-level on `RunActionStep`, not inside
+ * `params` — contract §1) with the label, or `undefined` on disconnect.
  */
 import { useState } from 'react';
 import { X } from 'lucide-react';
 import { mfToast } from '@/lib/toast';
 import { useAutomationsStore } from '../data/use-automations-store';
-import { GithubDeviceConnect } from './GithubDeviceConnect';
+import { GithubCredentialConnect } from './GithubCredentialConnect';
 import { providerDisplayName } from './provider-copy';
 import { TokenCredentialField } from './TokenCredentialField';
 
@@ -73,7 +74,7 @@ export function CredentialConnect({ service, onChange, testId }: CredentialConne
   }
 
   if (service === 'github') {
-    return <GithubDeviceConnect onChange={onChange} testId={testId} />;
+    return <GithubCredentialConnect onChange={onChange} testId={testId} />;
   }
   return <TokenCredentialField service={service} onChange={onChange} testId={testId} />;
 }

--- a/packages/ui/src/features/automations/steps/GithubCredentialConnect.tsx
+++ b/packages/ui/src/features/automations/steps/GithubCredentialConnect.tsx
@@ -1,0 +1,40 @@
+/**
+ * GithubCredentialConnect — GitHub's `CredentialConnect` branch. Unlike
+ * every other provider, GitHub can offer two connect paths: a pasted PAT
+ * (always available, like Notion/ADO) and, once a GitHub App client ID is
+ * registered, device-flow sign-in as the nicer alternative alongside it.
+ * The token path is never hidden behind the nicer one — this restores the
+ * only way to authenticate GitHub left after a prior release shipped
+ * device-flow-only with no client ID configured (2026-08-19 regression fix).
+ */
+import { useEffect, useState } from 'react';
+import { useAutomationsStore } from '../data/use-automations-store';
+import { GithubDeviceConnect } from './GithubDeviceConnect';
+import { TokenCredentialField } from './TokenCredentialField';
+
+export interface GithubCredentialConnectProps {
+  onChange: (label: string | undefined) => void;
+  testId: string;
+}
+
+export function GithubCredentialConnect({ onChange, testId }: GithubCredentialConnectProps) {
+  const gateway = useAutomationsStore((s) => s.gateway);
+  const [deviceFlowConfigured, setDeviceFlowConfigured] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void gateway.githubDeviceFlowStatus().then((status) => {
+      if (!cancelled) setDeviceFlowConfigured(status.configured);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [gateway]);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <TokenCredentialField service="github" onChange={onChange} testId={testId} />
+      {deviceFlowConfigured && <GithubDeviceConnect onChange={onChange} testId={`${testId}-device`} />}
+    </div>
+  );
+}

--- a/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
+++ b/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
@@ -1,13 +1,14 @@
 /**
- * GithubDeviceConnect — the device-flow half of `CredentialConnect`. GitHub
- * is the one provider that gets real OAuth (device flow needs no client
- * secret and no redirect URI); every other provider gets `TokenCredentialField`.
+ * GithubDeviceConnect — the device-flow half of GitHub's credential connect
+ * (`GithubCredentialConnect.tsx`), rendered only once the parent has
+ * confirmed a GitHub App client ID is configured; `TokenCredentialField`
+ * next to it is the always-available path, never gated behind this one.
  *
  * Each poll is one daemon round trip (`github_device.rs`'s `poll_once`); this
  * component owns the interval-respecting retry loop — `pending` keeps the
  * current interval, `slow_down` adopts the daemon's new one. `unavailable`
- * is a distinct, permanent state (no OAuth App client ID configured yet),
- * never conflated with a transient failure.
+ * is a defensive fallback for the 501 the daemon would still return if this
+ * ever mounted out of sync with the parent's client-ID check.
  */
 import { useEffect, useRef, useState } from 'react';
 import { Check, Copy, Plug } from 'lucide-react';
@@ -114,7 +115,7 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
         className="flex flex-col gap-1 rounded-md border-[0.5px] border-border bg-card p-2.5 text-xs text-muted-foreground"
       >
         <span className="font-medium text-foreground">GitHub connection isn't available yet</span>
-        <span>An administrator needs to register a GitHub OAuth App with device flow enabled first.</span>
+        <span>Use the token field above — sign-in with GitHub is coming soon.</span>
       </div>
     );
   }

--- a/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
+++ b/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
@@ -11,8 +11,9 @@
  * ever mounted out of sync with the parent's client-ID check.
  */
 import { useEffect, useRef, useState } from 'react';
-import { Check, Copy, Plug } from 'lucide-react';
+import { Check, Copy, ExternalLink, Plug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { openExternal } from '@/lib/tauri/bridge';
 import type { GithubDeviceStart } from '@/lib/api/automations';
 import { ApiRequestError } from '@/lib/api/http';
 import { useAutomationsStore } from '../data/use-automations-store';
@@ -49,6 +50,14 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
     },
     [],
   );
+
+  // Copy-then-open: `openExternal` reaches the system browser via Tauri's
+  // opener, where a bare anchor would open inside the webview — a bad place
+  // to type GitHub credentials.
+  async function openVerification(userCode: string, verificationUri: string) {
+    await copyCode(userCode);
+    await openExternal(verificationUri);
+  }
 
   function schedulePoll(deviceCode: string, intervalSeconds: number) {
     timer.current = setTimeout(() => void poll(deviceCode, intervalSeconds), intervalSeconds * 1000);
@@ -126,12 +135,7 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
         data-testid={`${testId}-waiting`}
         className="flex flex-col gap-1.5 rounded-md border-[0.5px] border-border bg-card p-2.5"
       >
-        <span className="text-xs text-muted-foreground">
-          Enter this code at{' '}
-          <a href={phase.start.verificationUri} target="_blank" rel="noreferrer" className="text-primary underline">
-            {phase.start.verificationUri}
-          </a>
-        </span>
+        <span className="text-xs text-muted-foreground">Copy this code, then approve it on GitHub:</span>
         <div className="flex items-center gap-1.5">
           <span
             data-testid={`${testId}-code`}
@@ -148,6 +152,19 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
           >
             {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
           </button>
+          {/* One action, not three: GitHub has no verification_uri_complete, so
+              the code can't ride in the URL — copying it as we open the page is
+              the closest we get to a single click. */}
+          <Button
+            type="button"
+            size="sm"
+            data-testid={`${testId}-open`}
+            onClick={() => void openVerification(phase.start.userCode, phase.start.verificationUri)}
+            className="h-[26px] gap-1.5 px-2.5 text-xs"
+          >
+            <ExternalLink size={12} aria-hidden />
+            Copy &amp; open GitHub
+          </Button>
         </div>
         <span className="text-xs text-muted-foreground">Waiting for authorization…</span>
       </div>

--- a/packages/ui/src/features/automations/steps/__tests__/CredentialConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/CredentialConnect.test.tsx
@@ -50,8 +50,8 @@ describe('CredentialConnect', () => {
     expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Connect Notion…');
   });
 
-  it('dispatches the github service to the device-flow connect button', () => {
+  it('dispatches the github service to the always-available token field', async () => {
     render(<CredentialConnect service="github" onChange={vi.fn()} testId="automations-credential-a" />);
-    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Connect GitHub…');
+    expect(await screen.findByTestId('automations-credential-a-connect')).toHaveTextContent('Connect GitHub…');
   });
 });

--- a/packages/ui/src/features/automations/steps/__tests__/GithubCredentialConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/GithubCredentialConnect.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * GithubCredentialConnect — the token field is always present; the
+ * device-flow button is additive, gated on the daemon reporting a
+ * configured GitHub App client ID.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useAutomationsStore } from '../../data/use-automations-store';
+import { createFakeGateway as fakeGateway } from '../../data/__tests__/fake-gateway';
+import { GithubCredentialConnect } from '../GithubCredentialConnect';
+
+describe('GithubCredentialConnect', () => {
+  it('renders only the token field when no GitHub App client ID is configured', async () => {
+    useAutomationsStore.setState({
+      credentials: [],
+      gateway: fakeGateway({ githubDeviceFlowStatus: async () => ({ configured: false }) }),
+    });
+    render(<GithubCredentialConnect onChange={vi.fn()} testId="automations-credential-a" />);
+
+    expect(await screen.findByTestId('automations-credential-a-connect')).toHaveTextContent('Connect GitHub…');
+    expect(screen.queryByTestId('automations-credential-a-device-connect')).not.toBeInTheDocument();
+  });
+
+  it('renders both the token field and the device-flow button when a client ID is configured', async () => {
+    useAutomationsStore.setState({
+      credentials: [],
+      gateway: fakeGateway({ githubDeviceFlowStatus: async () => ({ configured: true }) }),
+    });
+    render(<GithubCredentialConnect onChange={vi.fn()} testId="automations-credential-a" />);
+
+    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Connect GitHub…');
+    expect(await screen.findByTestId('automations-credential-a-device-connect')).toHaveTextContent('Connect GitHub…');
+  });
+});

--- a/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
@@ -1,8 +1,8 @@
 /**
  * GithubDeviceConnect — device-flow states: idle → starting → waiting
  * (shows the user code, polls at the daemon's interval) → connected/
- * expired/denied/error, plus the permanent `unavailable` state when no
- * OAuth App client ID is configured yet.
+ * expired/denied/error, plus the defensive `unavailable` fallback if the
+ * daemon still reports no GitHub App client ID configured.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
@@ -137,7 +137,7 @@ describe('GithubDeviceConnect', () => {
     expect(screen.getByTestId('automations-credential-a-status')).toHaveTextContent('incorrect_device_code');
   });
 
-  it('reports unavailable when no OAuth App client ID is configured, without a generic error', async () => {
+  it('reports unavailable when no GitHub App client ID is configured, without a generic error or an administrator dead end', async () => {
     const user = userEvent.setup({ delay: null });
     const startGithubDeviceFlow = vi.fn(async () => {
       throw new ApiRequestError('not configured', [], 501);
@@ -147,8 +147,8 @@ describe('GithubDeviceConnect', () => {
 
     await user.click(screen.getByTestId('automations-credential-a-connect'));
 
-    expect(await screen.findByTestId('automations-credential-a-unavailable')).toHaveTextContent(
-      "GitHub connection isn't available yet",
-    );
+    const unavailable = await screen.findByTestId('automations-credential-a-unavailable');
+    expect(unavailable).toHaveTextContent("GitHub connection isn't available yet");
+    expect(unavailable).not.toHaveTextContent(/administrator/i);
   });
 });

--- a/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
@@ -11,6 +11,9 @@ import { useAutomationsStore } from '../../data/use-automations-store';
 import { createFakeGateway as fakeGateway } from '../../data/__tests__/fake-gateway';
 import { ApiRequestError } from '@/lib/api/http';
 import { GithubDeviceConnect } from '../GithubDeviceConnect';
+import { openExternal } from '@/lib/tauri/bridge';
+
+vi.mock('@/lib/tauri/bridge', () => ({ openExternal: vi.fn(async () => {}) }));
 
 const START = {
   deviceCode: 'dc-1',
@@ -30,7 +33,7 @@ describe('GithubDeviceConnect', () => {
     vi.useRealTimers();
   });
 
-  it('starting shows the user code and verification URL', async () => {
+  it('starting shows the user code and the approve-on-GitHub action', async () => {
     const user = userEvent.setup({ delay: null });
     const startGithubDeviceFlow = vi.fn(async () => START);
     const pollGithubDeviceFlow = vi.fn(async () => ({ status: 'pending' as const }));
@@ -40,7 +43,7 @@ describe('GithubDeviceConnect', () => {
     await user.click(screen.getByTestId('automations-credential-a-connect'));
 
     expect(await screen.findByTestId('automations-credential-a-code')).toHaveTextContent('WDJB-MJHT');
-    expect(screen.getByText('https://github.com/login/device')).toBeInTheDocument();
+    expect(screen.getByTestId('automations-credential-a-open')).toBeInTheDocument();
   });
 
   it('a pending poll keeps polling at the given interval', async () => {
@@ -150,5 +153,26 @@ describe('GithubDeviceConnect', () => {
     const unavailable = await screen.findByTestId('automations-credential-a-unavailable');
     expect(unavailable).toHaveTextContent("GitHub connection isn't available yet");
     expect(unavailable).not.toHaveTextContent(/administrator/i);
+  });
+
+  it('copies the code and opens GitHub in the system browser from one click', async () => {
+    const user = userEvent.setup({ delay: null });
+    // jsdom exposes navigator.clipboard as a getter, and userEvent.setup()
+    // installs its own stub — so redefine after setup, not before.
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const startGithubDeviceFlow = vi.fn(async () => START);
+    const pollGithubDeviceFlow = vi.fn(async () => ({ status: 'pending' as const }));
+    useAutomationsStore.setState({ gateway: fakeGateway({ startGithubDeviceFlow, pollGithubDeviceFlow }) });
+    render(<GithubDeviceConnect onChange={vi.fn()} testId="automations-credential-a" />);
+
+    await user.click(screen.getByTestId('automations-credential-a-connect'));
+    await user.click(await screen.findByTestId('automations-credential-a-open'));
+
+    // One action has to do both, because GitHub has no verification_uri_complete
+    // to carry the code — and it must use the app's opener, not an anchor, or
+    // the user types GitHub credentials inside our webview.
+    expect(writeText).toHaveBeenCalledWith('WDJB-MJHT');
+    expect(vi.mocked(openExternal)).toHaveBeenCalledWith('https://github.com/login/device');
   });
 });

--- a/packages/ui/src/features/automations/steps/provider-copy.ts
+++ b/packages/ui/src/features/automations/steps/provider-copy.ts
@@ -13,11 +13,12 @@ export interface ProviderCopy {
 }
 
 export const PROVIDER_COPY: Record<string, ProviderCopy> = {
-  // No description/link: GitHub connects via device flow (`GithubDeviceConnect`),
-  // which owns its own explanatory copy — this entry exists only so the
-  // display name resolves to "GitHub", not the raw storage label.
   github: {
     displayName: 'GitHub',
+    description:
+      'Needs a personal access token that can create and list pull requests — classic tokens need the repo scope; fine-grained tokens need Contents: Read and write and Pull requests: Read and write.',
+    linkLabel: 'Create a GitHub personal access token',
+    linkHref: 'https://github.com/settings/tokens',
   },
   notion: {
     displayName: 'Notion',

--- a/packages/ui/src/lib/api/__tests__/api-automations.test.ts
+++ b/packages/ui/src/lib/api/__tests__/api-automations.test.ts
@@ -21,6 +21,7 @@ import {
   deleteAutomationCredential,
   startGithubDeviceFlow,
   pollGithubDeviceFlow,
+  getGithubDeviceFlowStatus,
 } from '../automations';
 import { setActiveDaemon } from '../../daemon/active-daemon';
 
@@ -345,6 +346,17 @@ describe('startGithubDeviceFlow', () => {
   it('throws an ApiRequestError with status 501 when unconfigured', async () => {
     mockFetchHttpError(501, "GitHub connection isn't set up yet");
     await expect(startGithubDeviceFlow()).rejects.toMatchObject({ status: 501 });
+  });
+});
+
+describe('getGithubDeviceFlowStatus', () => {
+  it('calls GET /api/automation-credentials/github/device/status', async () => {
+    mockFetchOk({ configured: true });
+    const result = await getGithubDeviceFlowStatus();
+    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:31415/api/automation-credentials/github/device/status', {
+      method: 'GET',
+    });
+    expect(result).toEqual({ configured: true });
   });
 });
 

--- a/packages/ui/src/lib/api/automations.ts
+++ b/packages/ui/src/lib/api/automations.ts
@@ -105,3 +105,7 @@ export const startGithubDeviceFlow = (): Promise<GithubDeviceStart> =>
 
 export const pollGithubDeviceFlow = (deviceCode: string): Promise<GithubDevicePollResult> =>
   request('POST', `${b()}/automation-credentials/github/device/poll`, { deviceCode });
+
+/** Whether a GitHub App client ID is registered — gates the sign-in-with-GitHub button. */
+export const getGithubDeviceFlowStatus = (): Promise<{ configured: boolean }> =>
+  request('GET', `${b()}/automation-credentials/github/device/status`);


### PR DESCRIPTION
Fixes a regression shipped in v2.1.0, and wires up GitHub App sign-in with the client ID now registered.

## The regression

Deleting the `gh` CLI left device flow as the only path, and `CredentialConnect` hard-branches `github` to it. With no app registered, there was **no way to authenticate GitHub at all** — while Notion and Azure DevOps could both paste a token. The engine accepted a token the whole time (`auth: Token`, `bearer_auth`); only the UI refused to take one.

The copy was its own dead end:

> "GitHub connection isn't available yet — An administrator needs to register a GitHub OAuth App with device flow enabled first."

There is no administrator. This is a local desktop app; the person reading that is the only operator.

GitHub now always shows the token field, with sign-in beside it when a client ID ships — never behind it. A cheap `GET .../device/status` probe decides, rather than calling `start` and reading a 501, which would mint a real device code on every mount.

## GitHub App, and why refresh exists now

Sign-in uses a GitHub App with expiring tokens, so refresh machinery is built — reversing an earlier decision not to. That call assumed OAuth App tokens, which never expire; GitHub App user tokens last **8 hours**.

The design survives on one specific carve-out, verified in GitHub's docs: the refresh endpoint requires a client secret *"unless the user access token was generated using the device flow."* Device flow is exempt, so refresh needs only the client ID and **no secret ships in the binary**. Moving token generation off device flow would break that — it is commented where someone might.

Refresh serializes per credential label. A concurrent `repeat` running GitHub steps would otherwise stampede the endpoint, and GitHub invalidates the old refresh token on use, so a stampede logs the user out. Proven by stripping the lock: the mock endpoint took 5 requests against `.expect(1)`. A pasted PAT has no expiry and is never refreshed.

## Install ≠ authorize

A GitHub App must be **installed** on the repos it touches. Users complete sign-in successfully and still get 404s. That now maps to "Mainframe isn't installed on `<org>`" with the install URL, instead of a bare "not found" — the support question this would otherwise generate daily.

## Two tests were pinning a constant, not behaviour

`device_status_reports_unconfigured…` and `start_reports_not_configured…` read the shipped `GITHUB_APP_CLIENT_ID` and failed the instant a real ID landed. The unconfigured contract has to keep holding *after* an app is registered, so both now inject an empty client ID, and there is a configured-case test beside them.

## Also

Corrects the guide, which claimed `lane_apply.py` posts to the notification route. That was reverted — a Claude session's own `PushNotification` is already intercepted by the adapter and carries the `chat_id`, which a bare POST cannot.

## Verification

`cargo test --workspace` across four full runs, clippy/fmt clean, types build clean, UI typecheck clean, and the full UI suite the way CI runs it (`vitest run --maxWorkers=4`) — 690 files / 6835 tests.

Unrelated, seen once and not from this branch: `todos_github::touch_tests::*` fails intermittently under the full parallel run (different test each time, clean in isolation). Worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)