### PR TITLE
fix(automations): tell GitHub's two connect buttons apart

### DIFF
--- a/.changeset/github-connect-two-buttons.md
+++ b/.changeset/github-connect-two-buttons.md
@@ -1,0 +1,9 @@
+---
+'@qlan-ro/mainframe-ui': patch
+---
+
+Tell GitHub's two connect buttons apart
+
+With a GitHub App client ID configured, the credential field offered two buttons that both read "Connect GitHub…" — one starting device-flow sign-in, one opening the token field. Nothing distinguished them.
+
+Sign-in now leads as the primary action and says "Sign in with GitHub"; the token path sits below it as "Use a personal access token…". With no client ID configured, the token button is the only one and reads "Connect GitHub…" as before.

--- a/packages/ui/src/features/automations/steps/GithubCredentialConnect.tsx
+++ b/packages/ui/src/features/automations/steps/GithubCredentialConnect.tsx
@@ -6,6 +6,10 @@
  * The token path is never hidden behind the nicer one — this restores the
  * only way to authenticate GitHub left after a prior release shipped
  * device-flow-only with no client ID configured (2026-08-19 regression fix).
+ *
+ * Both paths visible means both need labels that say which is which: sign-in
+ * leads as the primary action, and the token trigger drops the generic
+ * `Connect GitHub…` the two shared when device flow is present.
  */
 import { useEffect, useState } from 'react';
 import { useAutomationsStore } from '../data/use-automations-store';
@@ -33,8 +37,13 @@ export function GithubCredentialConnect({ onChange, testId }: GithubCredentialCo
 
   return (
     <div className="flex flex-col gap-1.5">
-      <TokenCredentialField service="github" onChange={onChange} testId={testId} />
       {deviceFlowConfigured && <GithubDeviceConnect onChange={onChange} testId={`${testId}-device`} />}
+      <TokenCredentialField
+        service="github"
+        onChange={onChange}
+        testId={testId}
+        connectLabel={deviceFlowConfigured ? 'Use a personal access token…' : undefined}
+      />
     </div>
   );
 }

--- a/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
+++ b/packages/ui/src/features/automations/steps/GithubDeviceConnect.tsx
@@ -11,7 +11,7 @@
  * ever mounted out of sync with the parent's client-ID check.
  */
 import { useEffect, useRef, useState } from 'react';
-import { Check, Copy, ExternalLink, Plug } from 'lucide-react';
+import { Check, Copy, ExternalLink, LogIn, Plug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { openExternal } from '@/lib/tauri/bridge';
 import type { GithubDeviceStart } from '@/lib/api/automations';
@@ -123,8 +123,8 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
         data-testid={`${testId}-unavailable`}
         className="flex flex-col gap-1 rounded-md border-[0.5px] border-border bg-card p-2.5 text-xs text-muted-foreground"
       >
-        <span className="font-medium text-foreground">GitHub connection isn't available yet</span>
-        <span>Use the token field above — sign-in with GitHub is coming soon.</span>
+        <span className="font-medium text-foreground">Signing in with GitHub isn't available yet</span>
+        <span>Use the personal access token below instead.</span>
       </div>
     );
   }
@@ -197,17 +197,19 @@ export function GithubDeviceConnect({ onChange, testId }: GithubDeviceConnectPro
     );
   }
 
+  // Named for what it does, not for the provider: the token field next to it
+  // also connects GitHub, and two buttons reading "Connect GitHub…" left the
+  // user with no way to tell them apart.
   return (
     <Button
-      variant="outline"
       size="sm"
       data-testid={`${testId}-connect`}
       onClick={() => void start()}
       disabled={phase.kind === 'starting'}
-      className="gap-1.5 border-[0.5px] bg-card font-semibold text-primary"
+      className="gap-1.5 font-semibold"
     >
-      <Plug size={12} aria-hidden />
-      Connect GitHub…
+      <LogIn size={12} aria-hidden />
+      Sign in with GitHub
     </Button>
   );
 }

--- a/packages/ui/src/features/automations/steps/TokenCredentialField.tsx
+++ b/packages/ui/src/features/automations/steps/TokenCredentialField.tsx
@@ -18,13 +18,15 @@ export interface TokenCredentialFieldProps {
   service: string;
   onChange: (label: string | undefined) => void;
   testId: string;
+  /** Overrides the collapsed trigger's `Connect {name}…`, for a provider that offers a second connect path this one has to be distinguishable from. */
+  connectLabel?: string;
 }
 
 function errorMessage(err: unknown): string | undefined {
   return err instanceof Error ? err.message : undefined;
 }
 
-export function TokenCredentialField({ service, onChange, testId }: TokenCredentialFieldProps) {
+export function TokenCredentialField({ service, onChange, testId, connectLabel }: TokenCredentialFieldProps) {
   const gateway = useAutomationsStore((s) => s.gateway);
   const addCredential = useAutomationsStore((s) => s.addCredential);
   const [open, setOpen] = useState(false);
@@ -60,7 +62,7 @@ export function TokenCredentialField({ service, onChange, testId }: TokenCredent
         className="gap-1.5 border-[0.5px] bg-card font-semibold text-primary"
       >
         <Plug size={12} aria-hidden />
-        Connect {displayName}…
+        {connectLabel ?? `Connect ${displayName}…`}
       </Button>
     );
   }

--- a/packages/ui/src/features/automations/steps/__tests__/GithubCredentialConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/GithubCredentialConnect.test.tsx
@@ -1,7 +1,9 @@
 /**
  * GithubCredentialConnect — the token field is always present; the
  * device-flow button is additive, gated on the daemon reporting a
- * configured GitHub App client ID.
+ * configured GitHub App client ID. When both render, their labels must
+ * differ: shipping two buttons that both read "Connect GitHub…" left the
+ * user with no way to choose between them.
  */
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -21,14 +23,29 @@ describe('GithubCredentialConnect', () => {
     expect(screen.queryByTestId('automations-credential-a-device-connect')).not.toBeInTheDocument();
   });
 
-  it('renders both the token field and the device-flow button when a client ID is configured', async () => {
+  it('gives each path its own label when both render, so neither reads as the other', async () => {
     useAutomationsStore.setState({
       credentials: [],
       gateway: fakeGateway({ githubDeviceFlowStatus: async () => ({ configured: true }) }),
     });
     render(<GithubCredentialConnect onChange={vi.fn()} testId="automations-credential-a" />);
 
-    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Connect GitHub…');
-    expect(await screen.findByTestId('automations-credential-a-device-connect')).toHaveTextContent('Connect GitHub…');
+    expect(await screen.findByTestId('automations-credential-a-device-connect')).toHaveTextContent(
+      'Sign in with GitHub',
+    );
+    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Use a personal access token…');
+    expect(screen.queryAllByText('Connect GitHub…')).toHaveLength(0);
+  });
+
+  it('leads with sign-in, keeping the token path as the secondary choice below it', async () => {
+    useAutomationsStore.setState({
+      credentials: [],
+      gateway: fakeGateway({ githubDeviceFlowStatus: async () => ({ configured: true }) }),
+    });
+    render(<GithubCredentialConnect onChange={vi.fn()} testId="automations-credential-a" />);
+
+    const device = await screen.findByTestId('automations-credential-a-device-connect');
+    const token = screen.getByTestId('automations-credential-a-connect');
+    expect(device.compareDocumentPosition(token) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/GithubDeviceConnect.test.tsx
@@ -33,6 +33,12 @@ describe('GithubDeviceConnect', () => {
     vi.useRealTimers();
   });
 
+  it('names the action, not the provider, so it never collides with the token trigger', () => {
+    render(<GithubDeviceConnect onChange={vi.fn()} testId="automations-credential-a" />);
+
+    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Sign in with GitHub');
+  });
+
   it('starting shows the user code and the approve-on-GitHub action', async () => {
     const user = userEvent.setup({ delay: null });
     const startGithubDeviceFlow = vi.fn(async () => START);
@@ -151,8 +157,11 @@ describe('GithubDeviceConnect', () => {
     await user.click(screen.getByTestId('automations-credential-a-connect'));
 
     const unavailable = await screen.findByTestId('automations-credential-a-unavailable');
-    expect(unavailable).toHaveTextContent("GitHub connection isn't available yet");
+    expect(unavailable).toHaveTextContent("Signing in with GitHub isn't available yet");
     expect(unavailable).not.toHaveTextContent(/administrator/i);
+    // The token field renders under this fallback, so pointing "above" would
+    // send the user the wrong way.
+    expect(unavailable).toHaveTextContent(/token below/i);
   });
 
   it('copies the code and opens GitHub in the system browser from one click', async () => {

--- a/packages/ui/src/features/automations/steps/__tests__/TokenCredentialField.test.tsx
+++ b/packages/ui/src/features/automations/steps/__tests__/TokenCredentialField.test.tsx
@@ -27,6 +27,19 @@ describe('TokenCredentialField', () => {
     expect(screen.getByText(/server-side secret/i)).toBeInTheDocument();
   });
 
+  it('takes a caller-supplied trigger label, for a provider that offers a second connect path', () => {
+    render(
+      <TokenCredentialField
+        service="github"
+        onChange={vi.fn()}
+        testId="automations-credential-a"
+        connectLabel="Use a personal access token…"
+      />,
+    );
+
+    expect(screen.getByTestId('automations-credential-a-connect')).toHaveTextContent('Use a personal access token…');
+  });
+
   it("ado's copy names the org-scoped requirement and the PAT deprecation dates", async () => {
     const user = userEvent.setup();
     render(<TokenCredentialField service="ado" onChange={vi.fn()} testId="automations-credential-a" />);


### PR DESCRIPTION
With a GitHub App client ID configured, the credential field rendered two buttons that both read **"Connect GitHub…"** — one starting device-flow sign-in, one opening the token field. Nothing said which was which.

| | before | after |
|---|---|---|
| device flow | Connect GitHub… | **Sign in with GitHub** (leads) |
| token | Connect GitHub… | Use a personal access token… |

With no client ID configured the token button is the only one, and reads `Connect GitHub…` exactly as before — Notion and Azure DevOps are untouched.

Sign-in is the filled variant so it leads; the token trigger keeps the outline style every other provider's connect button uses. The token path is still fully visible, not tucked behind a disclosure.

Two leftovers fixed in the same pass: the device-flow `unavailable` fallback pointed at "the token field above", which the reorder makes wrong, and the old test asserted both buttons carried the same label — so it passed against the defect. It now asserts they differ.

Green: the 5 affected UI suites (35 tests), design-token audit, contrast, typecheck, eslint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)